### PR TITLE
Feature/full json for case

### DIFF
--- a/eap_backend/eap_api/serializers.py
+++ b/eap_backend/eap_api/serializers.py
@@ -11,116 +11,39 @@ from .models import (
 )
 
 
-class AssuranceCaseSerializer(serializers.ModelSerializer):
-    goals = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+class EvidenceSerializer(serializers.ModelSerializer):
+    evidential_claim = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+#
+#    EvidentialClaimSerializer(many=True, read_only=True)
+#    evidential_claim_id = serializers.PrimaryKeyRelatedField(
+#        source="evidential_claim",
+#        queryset=EvidentialClaim.objects.all(),
+#        write_only=True,
+#        many=True
+ #   )
     class Meta:
-        model = AssuranceCase
-        fields = ("id", "name", "description", "created_date", "goals")
-
-
-class TopLevelNormativeGoalSerializer(serializers.ModelSerializer):
-    assurance_case = AssuranceCaseSerializer(many=False, read_only=True)
-    assurance_case_id = serializers.PrimaryKeyRelatedField(source="assurance_case",queryset=AssuranceCase.objects.all(),write_only=True)
-    context = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
-    system_description = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
-    class Meta:
-        model = TopLevelNormativeGoal
+        model = Evidence
         fields = (
             "id",
             "name",
             "short_description",
             "long_description",
-            "keywords",
-            "assurance_case",
-            "assurance_case_id",
-            "context",
-            "system_description"
-        )
-
-
-class ContextSerializer(serializers.ModelSerializer):
-    goal = TopLevelNormativeGoalSerializer(many=False, read_only=True)
-    goal_id = serializers.PrimaryKeyRelatedField(source="goal", queryset=TopLevelNormativeGoal.objects.all(), write_only=True)
-    class Meta:
-        model = Context
-        fields = (
-            "id",
-            "name",
-            "short_description",
-            "long_description",
-            "created_date",
-            "goal",
-            "goal_id"
-        )
-
-
-class SystemDescriptionSerializer(serializers.ModelSerializer):
-    goal = TopLevelNormativeGoalSerializer(many=False, read_only=True)
-    goal_id = serializers.PrimaryKeyRelatedField(source="goal", queryset=TopLevelNormativeGoal.objects.all(), write_only=True)
-    class Meta:
-        model = SystemDescription
-        fields = (
-            "id",
-            "name",
-            "short_description",
-            "long_description",
-            "goal",
-            "goal_id"
-        )
-
-
-class PropertyClaimSerializer(serializers.ModelSerializer):
-    goal = TopLevelNormativeGoalSerializer(many=False, read_only=True)
-    goal_id = serializers.PrimaryKeyRelatedField(
-        source="goal",
-        queryset=TopLevelNormativeGoal.objects.all(),
-        write_only=True
-    )
-    arguments = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
-    class Meta:
-        model = PropertyClaim
-        fields = (
-            "id",
-            "name",
-            "short_description",
-            "long_description",
-            "goal",
-            "goal_id",
-            "arguments"
-        )
-
-class ArgumentSerializer(serializers.ModelSerializer):
-    property_claim = PropertyClaimSerializer(many=True, read_only=True)
-    property_claim_id = serializers.PrimaryKeyRelatedField(
-        source="property_claim",
-        queryset = PropertyClaim.objects.all(),
-        write_only=True,
-        many=True
-    )
-    evidential_claims = serializers.PrimaryKeyRelatedField(
-        many=True, read_only=True
-    )
-    class Meta:
-        model = Argument
-        fields = (
-            "id",
-            "name",
-            "short_description",
-            "long_description",
-            "property_claim",
-            "property_claim_id",
-            "evidential_claims"
+            "URL",
+#            "evidential_claim",
+            "evidential_claim"
         )
 
 class EvidentialClaimSerializer(serializers.ModelSerializer):
-    argument = ArgumentSerializer(many=False, read_only=True)
-    argument_id = serializers.PrimaryKeyRelatedField(
-        source="argument",
-        queryset=Argument.objects.all(),
-        write_only=True,
-        many=False
-    )
-    evidence = serializers.PrimaryKeyRelatedField(
+#    argument = ArgumentSerializer(many=False, read_only=True)
+    argument_id = serializers.PrimaryKeyRelatedField(many=False, read_only=True)
+
+ #   serializers.PrimaryKeyRelatedField(
+  #      source="argument",
+   #     queryset=Argument.objects.all(),
+    #    write_only=True,
+     #   many=False
+   # )
+    evidence = EvidenceSerializer(
         many=True, read_only=True
     )
     class Meta:
@@ -130,28 +53,120 @@ class EvidentialClaimSerializer(serializers.ModelSerializer):
             "name",
             "short_description",
             "long_description",
-            "argument",
+#            "argument",
             "argument_id",
             "evidence"
         )
 
+class ArgumentSerializer(serializers.ModelSerializer):
+ #   property_claim = PropertyClaimSerializer(many=True, read_only=True)
+    property_claim = serializers.PrimaryKeyRelatedField(
+        many=True, read_only=True
+    )
 
-class EvidenceSerializer(serializers.ModelSerializer):
-    evidential_claim = EvidentialClaimSerializer(many=True, read_only=True)
-    evidential_claim_id = serializers.PrimaryKeyRelatedField(
-        source="evidential_claim",
-        queryset=EvidentialClaim.objects.all(),
-        write_only=True,
-        many=True
+#    serializers.PrimaryKeyRelatedField(
+ #       source="property_claim",
+ #       queryset = PropertyClaim.objects.all(),
+ #       write_only=True,
+ #       many=True
+ #   )
+    evidential_claims = EvidentialClaimSerializer(
+        many=True, read_only=True
     )
     class Meta:
-        model = Evidence
+        model = Argument
         fields = (
             "id",
             "name",
             "short_description",
             "long_description",
-            "URL",
-            "evidential_claim",
-            "evidential_claim_id"
+#            "property_claim",
+            "property_claim",
+            "evidential_claims"
         )
+
+
+class PropertyClaimSerializer(serializers.ModelSerializer):
+#    goal = TopLevelNormativeGoalSerializer(many=False, read_only=True)
+    goal = serializers.PrimaryKeyRelatedField(
+        many=False,
+ #       source="goal",
+ #       queryset=TopLevelNormativeGoal.objects.all(),
+        read_only=True
+    )
+    arguments = ArgumentSerializer(many=True, read_only=True)
+    class Meta:
+        model = PropertyClaim
+        fields = (
+            "id",
+            "name",
+            "short_description",
+            "long_description",
+#            "goal",
+            "goal",
+            "arguments"
+        )
+
+class SystemDescriptionSerializer(serializers.ModelSerializer):
+#    goal = TopLevelNormativeGoalSerializer(many=False, read_only=True)
+    goal_id = serializers.PrimaryKeyRelatedField(
+        many=False,
+#        source="goal",
+ #       queryset=TopLevelNormativeGoal.objects.all(),
+        read_only=True)
+    class Meta:
+        model = SystemDescription
+        fields = (
+            "id",
+            "name",
+            "short_description",
+            "long_description",
+         #   "goal",
+            "goal"
+        )
+
+class ContextSerializer(serializers.ModelSerializer):
+ #   goal = TopLevelNormativeGoalSerializer(many=False, read_only=True)
+    goal = serializers.PrimaryKeyRelatedField(
+        many=False,
+    #    source="goal",
+    #    queryset=TopLevelNormativeGoal.objects.all(),
+        read_only=True)
+    class Meta:
+        model = Context
+        fields = (
+            "id",
+            "name",
+            "short_description",
+            "long_description",
+            "created_date",
+ #           "goal",
+            "goal"
+        )
+
+
+class TopLevelNormativeGoalSerializer(serializers.ModelSerializer):
+    assurance_case = serializers.PrimaryKeyRelatedField(many=False, read_only=True)
+#    context = ContextSerializer(many=False, read_only=True)
+#    system_description = SystemDescriptionSerializer(many=False, read_only=True)
+    property_claims = PropertyClaimSerializer(many=True, read_only=True)
+    class Meta:
+        model = TopLevelNormativeGoal
+        fields = (
+            "id",
+            "name",
+            "short_description",
+            "long_description",
+            "keywords",
+#            "assurance_case",
+            "assurance_case",
+ #           "context",
+ #           "system_description",
+            "property_claims"
+        )
+
+class AssuranceCaseSerializer(serializers.ModelSerializer):
+    goals = TopLevelNormativeGoalSerializer(many=True, read_only=True)
+    class Meta:
+        model = AssuranceCase
+        fields = ("id", "name", "description", "created_date", "goals")

--- a/eap_backend/eap_api/serializers.py
+++ b/eap_backend/eap_api/serializers.py
@@ -13,14 +13,6 @@ from .models import (
 
 class EvidenceSerializer(serializers.ModelSerializer):
     evidential_claim = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
-#
-#    EvidentialClaimSerializer(many=True, read_only=True)
-#    evidential_claim_id = serializers.PrimaryKeyRelatedField(
-#        source="evidential_claim",
-#        queryset=EvidentialClaim.objects.all(),
-#        write_only=True,
-#        many=True
- #   )
     class Meta:
         model = Evidence
         fields = (
@@ -29,20 +21,11 @@ class EvidenceSerializer(serializers.ModelSerializer):
             "short_description",
             "long_description",
             "URL",
-#            "evidential_claim",
             "evidential_claim"
         )
 
 class EvidentialClaimSerializer(serializers.ModelSerializer):
-#    argument = ArgumentSerializer(many=False, read_only=True)
-    argument_id = serializers.PrimaryKeyRelatedField(many=False, read_only=True)
-
- #   serializers.PrimaryKeyRelatedField(
-  #      source="argument",
-   #     queryset=Argument.objects.all(),
-    #    write_only=True,
-     #   many=False
-   # )
+    argument = serializers.PrimaryKeyRelatedField(many=False, read_only=True)
     evidence = EvidenceSerializer(
         many=True, read_only=True
     )
@@ -53,23 +36,14 @@ class EvidentialClaimSerializer(serializers.ModelSerializer):
             "name",
             "short_description",
             "long_description",
-#            "argument",
-            "argument_id",
+            "argument",
             "evidence"
         )
 
 class ArgumentSerializer(serializers.ModelSerializer):
- #   property_claim = PropertyClaimSerializer(many=True, read_only=True)
     property_claim = serializers.PrimaryKeyRelatedField(
         many=True, read_only=True
     )
-
-#    serializers.PrimaryKeyRelatedField(
- #       source="property_claim",
- #       queryset = PropertyClaim.objects.all(),
- #       write_only=True,
- #       many=True
- #   )
     evidential_claims = EvidentialClaimSerializer(
         many=True, read_only=True
     )
@@ -80,18 +54,14 @@ class ArgumentSerializer(serializers.ModelSerializer):
             "name",
             "short_description",
             "long_description",
-#            "property_claim",
             "property_claim",
             "evidential_claims"
         )
 
 
 class PropertyClaimSerializer(serializers.ModelSerializer):
-#    goal = TopLevelNormativeGoalSerializer(many=False, read_only=True)
     goal = serializers.PrimaryKeyRelatedField(
         many=False,
- #       source="goal",
- #       queryset=TopLevelNormativeGoal.objects.all(),
         read_only=True
     )
     arguments = ArgumentSerializer(many=True, read_only=True)
@@ -102,17 +72,13 @@ class PropertyClaimSerializer(serializers.ModelSerializer):
             "name",
             "short_description",
             "long_description",
-#            "goal",
             "goal",
             "arguments"
         )
 
 class SystemDescriptionSerializer(serializers.ModelSerializer):
-#    goal = TopLevelNormativeGoalSerializer(many=False, read_only=True)
-    goal_id = serializers.PrimaryKeyRelatedField(
+    goal = serializers.PrimaryKeyRelatedField(
         many=False,
-#        source="goal",
- #       queryset=TopLevelNormativeGoal.objects.all(),
         read_only=True)
     class Meta:
         model = SystemDescription
@@ -121,16 +87,12 @@ class SystemDescriptionSerializer(serializers.ModelSerializer):
             "name",
             "short_description",
             "long_description",
-         #   "goal",
             "goal"
         )
 
 class ContextSerializer(serializers.ModelSerializer):
- #   goal = TopLevelNormativeGoalSerializer(many=False, read_only=True)
     goal = serializers.PrimaryKeyRelatedField(
         many=False,
-    #    source="goal",
-    #    queryset=TopLevelNormativeGoal.objects.all(),
         read_only=True)
     class Meta:
         model = Context
@@ -140,15 +102,14 @@ class ContextSerializer(serializers.ModelSerializer):
             "short_description",
             "long_description",
             "created_date",
- #           "goal",
             "goal"
         )
 
 
 class TopLevelNormativeGoalSerializer(serializers.ModelSerializer):
     assurance_case = serializers.PrimaryKeyRelatedField(many=False, read_only=True)
-#    context = ContextSerializer(many=False, read_only=True)
-#    system_description = SystemDescriptionSerializer(many=False, read_only=True)
+    context = ContextSerializer(many=True, read_only=True)
+    system_description = SystemDescriptionSerializer(many=True, read_only=True)
     property_claims = PropertyClaimSerializer(many=True, read_only=True)
     class Meta:
         model = TopLevelNormativeGoal
@@ -158,10 +119,9 @@ class TopLevelNormativeGoalSerializer(serializers.ModelSerializer):
             "short_description",
             "long_description",
             "keywords",
-#            "assurance_case",
             "assurance_case",
- #           "context",
- #           "system_description",
+            "context",
+            "system_description",
             "property_claims"
         )
 


### PR DESCRIPTION
Reverse the order of the serializers in `eap_backend/eap_api/serializers.py` such that when we GET a "case" from the DB, the JSON is the full AssuranceCase including all the child relations.
Conversely, when we GET a child object, we have the ID of the parent but not the full JSON object.