### PR TITLE
Add templates

### DIFF
--- a/frontend/src/caseTemplates/empty.json
+++ b/frontend/src/caseTemplates/empty.json
@@ -1,5 +1,5 @@
 {
-    "name": "Empty",
-    "description": "N/A",
-    "goals": []
+  "name": "Empty",
+  "description": "N/A",
+  "goals": []
 }

--- a/frontend/src/caseTemplates/empty.json
+++ b/frontend/src/caseTemplates/empty.json
@@ -1,0 +1,5 @@
+{
+    "name": "Empty",
+    "description": "N/A",
+    "goals": []
+}

--- a/frontend/src/caseTemplates/minimal.json
+++ b/frontend/src/caseTemplates/minimal.json
@@ -1,41 +1,55 @@
 {
-    "name":"Minimal",
-    "description":"N/A",
-    "goals":[{
-        "name":"Goal",
-        "short_description":"Short description",
-        "long_description":"Long description",
-        "keywords":"Keywords (comma-separated)",
-        "context":[{
-            "name":"Context",
-            "short_description":"Short description",
-            "long_description":"Long description"
-        }],
-        "system_description":[{
-            "name":"System description",
-            "short_description":"Short description",
-            "long_description":"Long description"
-        }],
-        "property_claims":[{
-            "name":"Property claim",
-            "short_description":"Short description",
-            "long_description":"Long description",
-            "arguments":[{
-                "name":"Argument",
-                "short_description":"Short description",
-                "long_description":"Long description",
-                "evidential_claims":[{
-                    "name":"Evidential claim",
-                    "short_description":"Short description",
-                    "long_description":"Long description",
-                    "evidence":[{
-                        "name":"Evidence",
-                        "short_description":"Short description",
-                        "long_description":"Long description",
-                        "URL":"www.some-evidence.com"
-                    }]
-                }]
-            }]
-        }]
-    }]
+  "name": "Minimal",
+  "description": "N/A",
+  "goals": [
+    {
+      "name": "Goal",
+      "short_description": "Short description",
+      "long_description": "Long description",
+      "keywords": "Keywords (comma-separated)",
+      "context": [
+        {
+          "name": "Context",
+          "short_description": "Short description",
+          "long_description": "Long description"
+        }
+      ],
+      "system_description": [
+        {
+          "name": "System description",
+          "short_description": "Short description",
+          "long_description": "Long description"
+        }
+      ],
+      "property_claims": [
+        {
+          "name": "Property claim",
+          "short_description": "Short description",
+          "long_description": "Long description",
+          "arguments": [
+            {
+              "name": "Argument",
+              "short_description": "Short description",
+              "long_description": "Long description",
+              "evidential_claims": [
+                {
+                  "name": "Evidential claim",
+                  "short_description": "Short description",
+                  "long_description": "Long description",
+                  "evidence": [
+                    {
+                      "name": "Evidence",
+                      "short_description": "Short description",
+                      "long_description": "Long description",
+                      "URL": "www.some-evidence.com"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/frontend/src/caseTemplates/minimal.json
+++ b/frontend/src/caseTemplates/minimal.json
@@ -1,0 +1,41 @@
+{
+    "name":"Minimal",
+    "description":"N/A",
+    "goals":[{
+        "name":"Goal",
+        "short_description":"Short description",
+        "long_description":"Long description",
+        "keywords":"Keywords (comma-separated)",
+        "context":[{
+            "name":"Context",
+            "short_description":"Short description",
+            "long_description":"Long description"
+        }],
+        "system_description":[{
+            "name":"System description",
+            "short_description":"Short description",
+            "long_description":"Long description"
+        }],
+        "property_claims":[{
+            "name":"Property claim",
+            "short_description":"Short description",
+            "long_description":"Long description",
+            "arguments":[{
+                "name":"Argument",
+                "short_description":"Short description",
+                "long_description":"Long description",
+                "evidential_claims":[{
+                    "name":"Evidential claim",
+                    "short_description":"Short description",
+                    "long_description":"Long description",
+                    "evidence":[{
+                        "name":"Evidence",
+                        "short_description":"Short description",
+                        "long_description":"Long description",
+                        "URL":"www.some-evidence.com"
+                    }]
+                }]
+            }]
+        }]
+    }]
+}

--- a/frontend/src/components/CaseContainer.js
+++ b/frontend/src/components/CaseContainer.js
@@ -1,19 +1,8 @@
 import React, { Component } from "react";
 import { useParams } from "react-router-dom";
-import {
-  Grid,
-  Box,
-  DropButton,
-  Heading,
-  TextInput,
-  Layer,
-  Button,
-} from "grommet";
-import { grommet } from "grommet/themes";
-import { FormSearch, FormClose, ZoomIn, ZoomOut } from "grommet-icons";
-import { deepMerge } from "grommet/utils";
+import { Grid, Box, DropButton, Heading, Layer, Button } from "grommet";
+import { FormClose, ZoomIn, ZoomOut } from "grommet-icons";
 
-import RoundLayer from "./Layer.js";
 import MermaidChart from "./Mermaid";
 import configData from "../config.json";
 
@@ -66,7 +55,7 @@ class CaseContainer extends Component {
   componentDidUpdate(prevProps) {
     const id = this.props.params.caseSlug;
     const oldId = prevProps.params.caseSlug;
-    if (id != oldId) {
+    if (id !== oldId) {
       this.setState({ id: id }, this.updateView);
     }
   }

--- a/frontend/src/components/CaseCreator.js
+++ b/frontend/src/components/CaseCreator.js
@@ -1,14 +1,16 @@
 import { Box, Button, Form, FormField, Heading, TextInput } from "grommet";
 import React, { useState } from "react";
+import TemplateSelector from "./TemplateSelector.js";
 import { useNavigate } from "react-router-dom";
 
 import configData from "../config.json";
 
 function CaseCreator() {
   const [name, setName] = useState("Name");
+  const [template, setTemplate] = useState("Template");
   const [description, setDescription] = useState("Description");
 
-  let url = `${configData.BASE_URL}/cases/`;
+  let baseURL = `${configData.BASE_URL}`;
 
   let navigate = useNavigate();
 
@@ -22,38 +24,45 @@ function CaseCreator() {
 
   function handleSubmit(event) {
     event.preventDefault();
-    let state = { name: name, description: description };
+    // Make a copy of the template.
+    const case_json = JSON.parse(JSON.stringify(template));
+    case_json["name"] = name;
+    case_json["short_description"] = description;
+
     const requestOptions = {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(state),
+      body: JSON.stringify(case_json),
     };
 
-    console.log("submit button pressed with state ", JSON.stringify(state));
-    fetch(url, requestOptions)
+    fetch(baseURL + "/cases/", requestOptions)
       .then((response) => response.json())
       .then((json) => {
-        navigate("/cases/" + json.id);
+        navigate("/case/" + json.id);
       });
   }
 
   return (
+    // TODO The visual layout here is a bit ugly, could improve it.
     <Box>
       <Heading level={4}>Create a new assurance case</Heading>
       <Form onSubmit={handleSubmit}>
-        <Box direction="row">
-          <FormField margin="xsmall">
-            <TextInput placeholder={name} name="name" onChange={onChange} />
-          </FormField>
-          <FormField margin="xsmall">
-            <TextInput
-              placeholder={description}
-              name="description"
-              onChange={onChange}
-            />
-          </FormField>
+        <Box direction="column" width="medium">
+          <Box direction="row">
+            <FormField margin="xsmall">
+              <TextInput placeholder={name} name="name" onChange={onChange} />
+            </FormField>
+            <FormField margin="xsmall">
+              <TextInput
+                placeholder={description}
+                name="description"
+                onChange={onChange}
+              />
+            </FormField>
+          </Box>
+          <TemplateSelector value={template} setValue={setTemplate} />
+          <Button type="submit" primary label="Submit" margin="xsmall" />
         </Box>
-        <Button type="submit" primary label="Submit" margin="xsmall" />
       </Form>
     </Box>
   );

--- a/frontend/src/components/CaseCreator.js
+++ b/frontend/src/components/CaseCreator.js
@@ -13,7 +13,7 @@ function CaseCreator() {
   let navigate = useNavigate();
 
   function onChange(event) {
-    if (event.target.name == "name") {
+    if (event.target.name === "name") {
       setName(event.target.value);
     } else {
       setDescription(event.target.value);

--- a/frontend/src/components/ItemCreator.js
+++ b/frontend/src/components/ItemCreator.js
@@ -1,24 +1,16 @@
 /* General function that can create any type of object apart from the top-level Case */
 
 import { Box, Button, Form, FormField, Heading, TextInput } from "grommet";
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import configData from "../config.json";
 
 function ItemCreator(props) {
-  const [loading, setLoading] = useState(true);
-  const [items, setItems] = useState([{ label: "Loading ...", value: "" }]);
-  let parent_type = configData["navigation"][props.type]["parent_name"];
   const [parentId, setParentId] = useState(1);
   const [name, setName] = useState("Name");
   const [sdesc, setShortDesc] = useState("Short description");
   const [ldesc, setLongDesc] = useState("Long description");
   const [keywords, setKeywords] = useState("Keywords (comma-separated)");
   const [url, setURL] = useState("www.some-evidence.com");
-
-  function handleChange(event) {
-    let parent = event.currentTarget.value;
-    setParentId(parent);
-  }
 
   function handleSubmit(event) {
     event.preventDefault();

--- a/frontend/src/components/ItemViewer.js
+++ b/frontend/src/components/ItemViewer.js
@@ -27,7 +27,7 @@ function ItemViewer(props) {
     return () => {
       unmounted = true;
     };
-  }, []);
+  });
 
   return (
     <Box>

--- a/frontend/src/components/TemplateSelector.js
+++ b/frontend/src/components/TemplateSelector.js
@@ -1,0 +1,25 @@
+import { Select } from "grommet";
+import React from "react";
+
+function TemplateSelector(props) {
+  // Import all *.json files from caseTemplates, make a list of the contents.
+  const templates = [];
+  const rc = require.context("../caseTemplates", false, /.json$/);
+  rc.keys().forEach((key) => templates.push(rc(key)));
+
+  function onChange(event) {
+    props.setValue(event.value);
+  }
+
+  return (
+    <Select
+      placeholder="Choose template"
+      onChange={onChange}
+      value={props.value}
+      options={templates}
+      labelKey="name"
+    />
+  );
+}
+
+export default TemplateSelector;


### PR DESCRIPTION
Adds to the `case_list` POST end point the capacity to receive cases with content, and uses that to implement templates. Templates are all JSON files in `frontend/src/caseTemplates`.

Also includes a few unrelated style changes, that remove unused code and such. These were things that a linter was complaining about.

Partially addresses https://github.com/alan-turing-institute/AssurancePlatform/issues/44, though no thumbnails yet, just a dropdown menu on the case creation page.