### PR TITLE
Make case name and description editable, and cases deletable

### DIFF
--- a/frontend/src/components/CaseContainer.js
+++ b/frontend/src/components/CaseContainer.js
@@ -1,12 +1,13 @@
 import React, { Component } from "react";
 import { useParams } from "react-router-dom";
-import { Grid, Box, DropButton, Heading, Layer, Button } from "grommet";
+import { Grid, Box, DropButton, Layer, Button } from "grommet";
 import { FormClose, ZoomIn, ZoomOut } from "grommet-icons";
 
 import MermaidChart from "./Mermaid";
 import configData from "../config.json";
 
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
+import EditableText from "./EditableText.js";
 import ItemViewer from "./ItemViewer.js";
 import ItemEditor from "./ItemEditor.js";
 import ItemCreator from "./ItemCreator.js";
@@ -257,6 +258,21 @@ class CaseContainer extends Component {
     );
   }
 
+  submitCaseChange(field, value) {
+    // Send to the backend a PUT request, changing the `field` of the current case to be
+    // `value`.
+    const id = this.state.assurance_case.id;
+    const backendURL = `${configData.BASE_URL}/cases/${id}/`;
+    const changeObj = {};
+    changeObj[field] = value;
+    const requestOptions = {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(changeObj),
+    };
+    fetch(backendURL, requestOptions);
+  }
+
   createLayer() {
     return (
       <Box>
@@ -324,13 +340,33 @@ class CaseContainer extends Component {
 
             <Box
               gridArea="header"
+              direction="column"
               pad={{
                 horizontal: "small",
                 top: "small",
                 bottom: "none",
               }}
             >
-              <Heading level={2}>{this.state.assurance_case.name}</Heading>
+              <EditableText
+                initialValue={this.state.assurance_case.name}
+                textsize="xlarge"
+                style={{
+                  height: 0,
+                  "margin-top": "0.4em",
+                }}
+                onSubmit={(value) => this.submitCaseChange("name", value)}
+              />
+              <EditableText
+                initialValue={this.state.assurance_case.description}
+                size="small"
+                style={{
+                  height: 0,
+                  "margin-top": "0.4em",
+                }}
+                onSubmit={(value) =>
+                  this.submitCaseChange("description", value)
+                }
+              />
             </Box>
 
             <Box

--- a/frontend/src/components/EditableText.js
+++ b/frontend/src/components/EditableText.js
@@ -1,0 +1,48 @@
+import { Form, TextInput } from "grommet";
+import React, { Component } from "react";
+import { useParams } from "react-router-dom";
+
+class EditableText extends Component {
+  // A text input box component that renders as an ordinary looking text box, but is
+  // editable. An onSubmit function can be provided as a prop, and it will be called with
+  // the value of the text box when the user hits enter or the text box loses focus.
+
+  constructor(props) {
+    super(props);
+    this.textInputRef = React.createRef();
+    this.state = {
+      value: props.initialValue,
+    };
+  }
+
+  onChange(event) {
+    this.setState({ value: event.target.value });
+  }
+
+  onSubmit(event) {
+    // Make the TextInput component lose focus, if it has focus.
+    this.textInputRef.current.blur();
+    this.props.onSubmit(this.state.value);
+  }
+
+  render() {
+    return (
+      <Form
+        onSubmit={this.onSubmit.bind(this)}
+        // Any time the form loses focus, we should submit, to avoid losing edits.
+        onBlur={this.onSubmit.bind(this)}
+      >
+        <TextInput
+          style={this.props.style}
+          ref={this.textInputRef}
+          plain={true}
+          size={this.props.textsize}
+          onChange={this.onChange.bind(this)}
+          value={this.state.value}
+        />
+      </Form>
+    );
+  }
+}
+
+export default (props) => <EditableText {...props} params={useParams()} />;

--- a/frontend/src/components/tests/CaseContainer.test.js
+++ b/frontend/src/components/tests/CaseContainer.test.js
@@ -4,6 +4,12 @@ import React from "react";
 import "@testing-library/jest-dom";
 import CaseContainer from "../CaseContainer.js";
 
+const mockedUsedNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedUsedNavigate,
+}));
+
 global.fetch = jest.fn(() =>
   Promise.resolve({
     json: () =>
@@ -20,6 +26,6 @@ test("renders loading screen", () => {
 test("renders case view", async () => {
   render(<CaseContainer id="1" />);
   await waitFor(() =>
-    expect(screen.getByText("Test case")).toBeInTheDocument()
+    expect(screen.getByDisplayValue("Test case")).toBeInTheDocument()
   );
 });


### PR DESCRIPTION
Front end elements for editing and deleting cases.

The text boxes for name and description are editable. Edits are submitted to the backend whenever the text box loses focus (e.g. user clicks somewhere else or navigates away) or there's a submit event, such as hitting enter.

Draft while I figure out the test failure.

Closes https://github.com/alan-turing-institute/AssurancePlatform/issues/54