### PR TITLE
Add footer to Routes, and remove from CaseContainer

### DIFF
--- a/frontend/src/components/App.css
+++ b/frontend/src/components/App.css
@@ -28,6 +28,17 @@
   color: #61dafb;
 }
 
+.App-footer {
+  position: absolute;
+  width: 100%;
+  bottom: 0px;
+  color: #ffffff;
+  background-color: #888888;
+  padding-left: 20px;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  height: 80px;
+}
 @keyframes App-logo-spin {
   from {
     transform: rotate(0deg);

--- a/frontend/src/components/CaseContainer.js
+++ b/frontend/src/components/CaseContainer.js
@@ -496,10 +496,6 @@ class CaseContainer extends Component {
                 )}
               </TransformWrapper>
             </Box>
-
-            <Box gridArea="footer" background="light-5" pad="small">
-              &copy; credits
-            </Box>
           </Grid>
         </Box>
       );

--- a/frontend/src/components/Routes.js
+++ b/frontend/src/components/Routes.js
@@ -1,4 +1,5 @@
 import React from "react";
+import "./App.css";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import Navigation from "./Navigation.js";
 import Home from "./Home.js";
@@ -16,6 +17,9 @@ const AllRoutes = () => (
         <Route path=":caseSlug" element={<CaseContainer />} />
       </Route>
     </Routes>
+    <div class="App-footer">
+      <p>&copy; The Alan Turing Institute</p>
+    </div>
   </Router>
 );
 


### PR DESCRIPTION
Remove copyright bar from grid display in CaseContainer, and instead have as a div with class "App-footer" (and include styling via `App.css`) in `Routes.js`.   This will ensure it is always at the bottom of the screen.