### PR TITLE
Feature/94 order items

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
   - id: end-of-file-fixer
   - id: trailing-whitespace
 - repo: https://github.com/psf/black
-  rev: 22.1.0
+  rev: 22.3.0
   hooks:
   - id: black
     language: python

--- a/eap_backend/eap_api/views.py
+++ b/eap_backend/eap_api/views.py
@@ -139,7 +139,7 @@ def get_json_tree(id_list, obj_type):
         obj_serializer = TYPE_DICT[obj_type]["serializer"](obj)
         obj_data = obj_serializer.data
         for child_type in TYPE_DICT[obj_type]["children"]:
-            child_list = obj_data[child_type]
+            child_list = sorted(obj_data[child_type])
             obj_data[child_type] = get_json_tree(child_list, child_type)
         objs.append(obj_data)
     return objs

--- a/frontend/src/components/CaseContainer.js
+++ b/frontend/src/components/CaseContainer.js
@@ -98,7 +98,7 @@ class CaseContainer extends Component {
     const id = this.props.params.caseSlug;
     this.setState({ id: id });
     this.fetchData(id);
-    this.timer = setInterval(() => this.fetchData(id), 2000);
+    this.timer = setInterval(() => this.fetchData(id), 5000);
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Sort the order of ids of children when returning the JSON from the case details view.
This may or may not help with #94 , in determining the order in which items are drawn in mermaid.

Also set the polling rate for CaseContainer to 5s rather than 2s.