### PR TITLE
Feature/95 constrain width

### DIFF
--- a/frontend/src/components/utils.js
+++ b/frontend/src/components/utils.js
@@ -17,15 +17,15 @@ function jsonToMermaid(in_json) {
   }
 
   function makeBox(text, shape) {
-    if (text.length > configData["BOX_WIDTH"]) {
-      text = text.substring(0, configData["BOX_WIDTH"] - 3) + "...";
+    if (text.length > configData["BOX_NCHAR"]) {
+      text = text.substring(0, configData["BOX_NCHAR"] - 3) + "...";
     } else {
       // pad the text with spaces to make it the same width
-      let nSpaces = configData["BOX_WIDTH"] - text.length;
+      let nSpaces = configData["BOX_NCHAR"] - text.length;
       text =
-        "&#160".repeat(Math.floor(nSpaces / 2)) +
+        "&#160".repeat(Math.ceil(nSpaces / 2)) +
         text +
-        "&#160".repeat(Math.ceil(nSpaces / 2));
+        "&#160".repeat(Math.floor(nSpaces / 2));
     }
     if (shape === "square") return "[" + text + "]";
     else if (shape === "diamond") return "{" + text + "}";
@@ -63,6 +63,8 @@ function jsonToMermaid(in_json) {
         ' callback "' +
         thisObj.short_description +
         '"\n';
+      // add style to the node
+      outputmd += "\nclass " + thisNode + " blackBox;\n";
       for (
         let j = 0;
         j < configData.navigation[itemType]["children"].length;
@@ -72,11 +74,13 @@ function jsonToMermaid(in_json) {
         outputmd = addTree(childType, thisObj, thisNode, outputmd);
       }
     }
-    //console.log(outputmd)
+    console.log(outputmd);
     return outputmd;
   }
 
   let outputmd = "graph TB; \n";
+  outputmd +=
+    "classDef blackBox stroke:#333,stroke-width:3px,text-align:center; \n";
   // call the recursive addTree function, starting with the Goal as the top node
   outputmd = addTree("TopLevelNormativeGoal", in_json, null, outputmd);
 

--- a/frontend/src/components/utils.js
+++ b/frontend/src/components/utils.js
@@ -1,4 +1,5 @@
 // Useful functions used in CaseContainer component.
+import { Test } from "grommet-icons";
 import configData from "../config.json";
 
 function sanitizeForMermaid(input_text) {
@@ -16,6 +17,16 @@ function jsonToMermaid(in_json) {
   }
 
   function makeBox(text, shape) {
+    if (text.length > configData["BOX_WIDTH"]) {
+      text = text.substring(0, configData["BOX_WIDTH"] - 3) + "...";
+    } else {
+      // pad the text with spaces to make it the same width
+      let nSpaces = configData["BOX_WIDTH"] - text.length;
+      text =
+        "&#160".repeat(Math.floor(nSpaces / 2)) +
+        text +
+        "&#160".repeat(Math.ceil(nSpaces / 2));
+    }
     if (shape === "square") return "[" + text + "]";
     else if (shape === "diamond") return "{" + text + "}";
     else if (shape === "rounded") return "(" + text + ")";

--- a/frontend/src/config.json
+++ b/frontend/src/config.json
@@ -1,5 +1,6 @@
 {
   "BASE_URL": "http://localhost:8000/api",
+  "BOX_WIDTH": 25,
   "navigation": {
     "TopLevelNormativeGoal": {
       "api_name": "goals",

--- a/frontend/src/config.json
+++ b/frontend/src/config.json
@@ -1,6 +1,6 @@
 {
   "BASE_URL": "http://localhost:8000/api",
-  "BOX_WIDTH": 25,
+  "BOX_NCHAR": 25,
   "navigation": {
     "TopLevelNormativeGoal": {
       "api_name": "goals",


### PR DESCRIPTION
Use a parameter "BOX_NCHAR" in config.json to define a maximum number of characters to display in a box in the mermaid chart, and enforce this in `makeBox` function in `utils.js`.   Also pad text with spaces if it is shorter than this, to make all boxes (roughly) the same size.   See the discussion in the final comment of #95 for why this approach was used instead of html tags or `text-align:center` CSS.