### PR TITLE
don't allow editing of case name or description when not in edit mode…

### DIFF
--- a/frontend/src/components/CaseContainer.js
+++ b/frontend/src/components/CaseContainer.js
@@ -490,9 +490,10 @@ class CaseContainer extends Component {
                 initialValue={this.state.assurance_case.name}
                 textsize="xlarge"
                 style={{
-                  height: 0,
+                  height: 30,
                 }}
                 onSubmit={(value) => this.submitCaseChange("name", value)}
+                editMode={this.inEditMode()}
               />
               <EditableText
                 initialValue={this.state.assurance_case.description}
@@ -503,6 +504,7 @@ class CaseContainer extends Component {
                 onSubmit={(value) =>
                   this.submitCaseChange("description", value)
                 }
+                editMode={this.inEditMode()}
               />
               {this.getEditableControls()}
             </Box>

--- a/frontend/src/components/EditableText.js
+++ b/frontend/src/components/EditableText.js
@@ -16,7 +16,7 @@ class EditableText extends Component {
   }
 
   onChange(event) {
-    this.setState({ value: event.target.value });
+    if (this.props.editMode) this.setState({ value: event.target.value });
   }
 
   onSubmit(event) {


### PR DESCRIPTION
* Add a new prop to EditableText to say whether we are in editMode, and if not, don't do anything in `onChange.
* Set the `height` prop of the case name's EditableText component to 30 to prevent clipping (would eventually be good to check the effect of this on different screens, e.g. mobile....)