### PR TITLE
Silence Firefox leaving prompts

### DIFF
--- a/frontend/src/components/CaseContainer.js
+++ b/frontend/src/components/CaseContainer.js
@@ -155,7 +155,6 @@ class CaseContainer extends Component {
   // Setup the `beforeunload` event listener to detect browser/tab closing
   setupBeforeUnloadListener = () => {
     window.addEventListener("beforeunload", (ev) => {
-      ev.preventDefault();
       return this.cleanup();
     });
   };


### PR DESCRIPTION
The `ev.preventDefault()` was, for some bizarre reason, causing firefox to give me naggy "are you sure you want to leave this page" pop ups every time I e.g. refreshed. Removing it, unless it was there for some particular purpose?