### PR TITLE
remove line to optimise images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,6 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: apt-get install pngquant 
       - run: pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
       - name: Build and Deploy
         working-directory: ./site


### PR DESCRIPTION
Removing line from `ci.yaml` that is causing GH actions error, and is not needed for building site. 