### PR TITLE
Fixing URL in link form

### DIFF
--- a/next_frontend/components/common/NewLinkForm.tsx
+++ b/next_frontend/components/common/NewLinkForm.tsx
@@ -251,7 +251,7 @@ const NewLinkForm: React.FC<NewLinkFormProps> = ({
       name: `E${identifier}`,
       short_description: description,
       long_description: description,
-      URL: 'ww.some-evidence.com',
+      URL: 'www.some-evidence.com',
       property_claim_id
     };
 


### PR DESCRIPTION
In today's workshop I saw that the URL only had two `ww` in the standard text. This PR fixes it.