### PR TITLE
[Backend] Updating identifiers when the diagram is modified

### DIFF
--- a/eap_backend/eap_api/urls.py
+++ b/eap_backend/eap_api/urls.py
@@ -46,13 +46,9 @@ urlpatterns = [
         views.parents,
         name="parents",
     ),
-    path(
-        "api-auth/", include("rest_framework.urls", namespace="rest_framework")
-    ),
+    path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
     path("strategies/", views.strategies_list, name="strategies_list"),
-    path(
-        "strategies/<int:pk>/", views.strategy_detail, name="strategy_detail"
-    ),
+    path("strategies/<int:pk>/", views.strategy_detail, name="strategy_detail"),
     path("auth/github/", views.GithubSocialAuthView.as_view()),
     path(
         "users/<int:pk>/github_repositories/",

--- a/eap_backend/eap_api/urls.py
+++ b/eap_backend/eap_api/urls.py
@@ -16,8 +16,16 @@ urlpatterns = [
     path("goals/<int:pk>/", views.goal_detail, name="goal_detail"),
     path("contexts/", views.context_list, name="context_list"),
     path("contexts/<int:pk>/", views.context_detail, name="context_detail"),
-    path("propertyclaims/", views.property_claim_list, name="property_claim_list"),
-    path("comments/<int:assurance_case_id>/", views.comment_list, name="comment_list"),
+    path(
+        "propertyclaims/",
+        views.property_claim_list,
+        name="property_claim_list",
+    ),
+    path(
+        "comments/<int:assurance_case_id>/",
+        views.comment_list,
+        name="comment_list",
+    ),
     path(
         "comments/<int:comment_id>/reply/",
         views.reply_to_comment,
@@ -38,9 +46,13 @@ urlpatterns = [
         views.parents,
         name="parents",
     ),
-    path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
+    path(
+        "api-auth/", include("rest_framework.urls", namespace="rest_framework")
+    ),
     path("strategies/", views.strategies_list, name="strategies_list"),
-    path("strategies/<int:pk>/", views.strategy_detail, name="strategy_detail"),
+    path(
+        "strategies/<int:pk>/", views.strategy_detail, name="strategy_detail"
+    ),
     path("auth/github/", views.GithubSocialAuthView.as_view()),
     path(
         "users/<int:pk>/github_repositories/",

--- a/eap_backend/eap_api/views.py
+++ b/eap_backend/eap_api/views.py
@@ -661,3 +661,20 @@ def update_identifiers(item: CaseItem):
     for property_claim_index, property_claim in enumerate(current_case_claims):
         property_claim.name = f"P{property_claim_index + 1}"
         property_claim.save()
+        update_property_claim_identifiers(property_claim)
+
+
+def update_property_claim_identifiers(parent_property_claim: PropertyClaim):
+    child_property_claims = PropertyClaim.objects.filter(
+        property_claim_id=parent_property_claim.pk
+    )
+
+    if len(child_property_claims) == 0:
+        return
+    else:
+        for index, child_property_claim in enumerate(child_property_claims):
+            child_property_claim.name = (
+                f"{parent_property_claim.name}.{index + 1}"
+            )
+            child_property_claim.save()
+            update_property_claim_identifiers(child_property_claim)

--- a/eap_backend/eap_backend/settings.py
+++ b/eap_backend/eap_backend/settings.py
@@ -21,8 +21,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
+# TODO(cgavidia): Move DEBUG and SECRET_KEY to environment variables.
+
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-)@nls8m9den@jbfjkee2h343^=a8#jzq+@^nweds$s#%_1ia_g"
+SECRET_KEY = (
+    "django-insecure-)@nls8m9den@jbfjkee2h343^=a8#jzq+@^nweds$s#%_1ia_g"
+)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -32,7 +36,7 @@ GITHUB_CLIENT_ID = os.environ.get("GITHUB_CLIENT_ID")
 GITHUB_CLIENT_SECRET = os.environ.get("GITHUB_CLIENT_SECRET")
 REDIRECT_URI = "http://localhost:3000/login"
 
-
+# TODO(cgavidia): This should also come from environment variables.
 ALLOWED_HOSTS = ["*"]
 
 
@@ -40,11 +44,11 @@ ALLOWED_HOSTS = ["*"]
 
 INSTALLED_APPS = [
     "eap_api.apps.ApiConfig",
-    "django.contrib.admin",
+    "django.contrib.admin",  # TODO(cgavidia):  Apparently, we don't need this.
     "django.contrib.auth",
     "django.contrib.contenttypes",
-    "django.contrib.sessions",
-    "django.contrib.messages",
+    "django.contrib.sessions",  # TODO(cgavidia): Apparently, we don't need this.
+    "django.contrib.messages",  # TODO(cgavidia): Apparently, we don't need this.
     "django.contrib.staticfiles",
     "rest_framework",
     "rest_framework.authtoken",
@@ -61,13 +65,13 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
-    "django.middleware.common.CommonMiddleware",
+    "django.middleware.common.CommonMiddleware",  # TODO(cgavidia): This line is duplicated.
     "django.middleware.security.SecurityMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware", # TODO(cgavidia): Apparently, we don't need this.
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware", # TODO(cgavidia): Apparently, we don't need this.
+    "django.contrib.messages.middleware.MessageMiddleware", # TODO(cgavidia): Apparently, we don't need this.
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "corsheaders.middleware.CorsMiddleware",
 ]
@@ -104,6 +108,7 @@ TEMPLATES = [
 REST_FRAMEWORK = {
     # Use Django's standard `django.contrib.auth` permissions,
     # or allow read-only access for unauthenticated users.
+    # TODO(cgavidia): Can we use IsAuthenticated instead?
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.AllowAny"],
     # "DEFAULT_PERMISSION_CLASSES": [
     #    "rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly"

--- a/eap_backend/eap_backend/settings.py
+++ b/eap_backend/eap_backend/settings.py
@@ -24,9 +24,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # TODO(cgavidia): Move DEBUG and SECRET_KEY to environment variables.
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = (
-    "django-insecure-)@nls8m9den@jbfjkee2h343^=a8#jzq+@^nweds$s#%_1ia_g"
-)
+SECRET_KEY = "django-insecure-)@nls8m9den@jbfjkee2h343^=a8#jzq+@^nweds$s#%_1ia_g"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -67,11 +65,11 @@ MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",  # TODO(cgavidia): This line is duplicated.
     "django.middleware.security.SecurityMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware", # TODO(cgavidia): Apparently, we don't need this.
+    "django.contrib.sessions.middleware.SessionMiddleware",  # TODO(cgavidia): Apparently, we don't need this.
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware", # TODO(cgavidia): Apparently, we don't need this.
-    "django.contrib.messages.middleware.MessageMiddleware", # TODO(cgavidia): Apparently, we don't need this.
+    "django.contrib.auth.middleware.AuthenticationMiddleware",  # TODO(cgavidia): Apparently, we don't need this.
+    "django.contrib.messages.middleware.MessageMiddleware",  # TODO(cgavidia): Apparently, we don't need this.
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "corsheaders.middleware.CorsMiddleware",
 ]
@@ -108,7 +106,7 @@ TEMPLATES = [
 REST_FRAMEWORK = {
     # Use Django's standard `django.contrib.auth` permissions,
     # or allow read-only access for unauthenticated users.
-    # TODO(cgavidia): Can we use IsAuthenticated instead?
+    # TODO(cgavidia): Can we use IsAuthenticated instead?
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.AllowAny"],
     # "DEFAULT_PERMISSION_CLASSES": [
     #    "rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly"


### PR DESCRIPTION
The following events trigger a re-calculation of the item identifiers:

- Adding/Deleting Context.
- Adding/Deleting Strategies.
- Adding/Deleting Property Claims.

The new identifiers are written on the database. If the frontend re-renders the diagram, the ids should be reflected.

DO NOT MERGE UNLESS EXTENSIVE TESTING IS PERFORMED!

**This is an emergency PR for unblocking @RichGriff for next workshop features:** I've manually verified the changes work using the legacy front-end, but further testing is required, specially with the new frontend and corner-cases.


Automated tests are still pending. I will deliver them once the HackWeek is over.

