### PR TITLE
Trigger identifier update when moving property claims.

### DIFF
--- a/eap_backend/eap_api/models.py
+++ b/eap_backend/eap_api/models.py
@@ -60,7 +60,7 @@ class CaseItem(models.Model):
     table.
     """
 
-    name = models.CharField(max_length=200)
+    name = models.CharField(max_length=200, blank=True)
     short_description = models.CharField(max_length=1000)
     long_description = models.CharField(max_length=3000)
     shape = Shape

--- a/eap_backend/eap_api/view_utils.py
+++ b/eap_backend/eap_api/view_utils.py
@@ -133,7 +133,6 @@ def make_summary(model_data: Union[dict, list, CaseItem]):
 
     def summarize_one(data: Union[dict, CaseItem]):
         if isinstance(data, CaseItem):
-            data.refresh_from_db()
             data = model_to_dict(data)
 
         if not (isinstance(data, dict) and "id" in data and "name" in data):


### PR DESCRIPTION
When moving Property Claims under other property claims, we trigger the property claim logic.