### PR TITLE
Alert pop up changes

### DIFF
--- a/next_frontend/components/common/NodeEdit.tsx
+++ b/next_frontend/components/common/NodeEdit.tsx
@@ -282,7 +282,9 @@ const NodeEdit = ({ node, isOpen, setEditOpen }: NodeEditProps) => {
             onClose={() => setDeleteOpen(false)}
             onConfirm={handleDelete}
             loading={loading}
-            confirmButtonText={'Delete'}
+            message={'Deleting this element will also remove all of the connected child elements. This cannot be undone.'}
+            confirmButtonText={'Yes, delete this element!'}
+            cancelButtonText={'No, keep the element'}
           />
 
           <AlertModal
@@ -290,8 +292,9 @@ const NodeEdit = ({ node, isOpen, setEditOpen }: NodeEditProps) => {
             onClose={() => setAlertOpen(false)}
             onConfirm={handleClose}
             loading={loading}
-            message={'There are unresolved changes, continue to discard these changes.'}
-            confirmButtonText={'Discard Changes'}
+            message={'You have changes that have not been updated, would you like to discard these changes?'}
+            confirmButtonText={'Yes, discard changes!'}
+            cancelButtonText={'No, keep editing'}
           />
         </>
       )}

--- a/next_frontend/components/modals/alertModal.tsx
+++ b/next_frontend/components/modals/alertModal.tsx
@@ -12,6 +12,7 @@ interface AlertModalProps {
   loading: boolean;
   message?: string
   confirmButtonText: string
+  cancelButtonText?: string | null
 }
 
 export const AlertModal: React.FC<AlertModalProps> = ({
@@ -20,7 +21,8 @@ export const AlertModal: React.FC<AlertModalProps> = ({
   onConfirm,
   loading,
   message,
-  confirmButtonText
+  confirmButtonText,
+  cancelButtonText
 }) => {
   const [isMounted, setIsMounted] = useState(false);
 
@@ -41,7 +43,7 @@ export const AlertModal: React.FC<AlertModalProps> = ({
     >
       <div className="pt-6 space-x-2 flex items-center justify-end w-full">
         <Button disabled={loading} variant="outline" onClick={onClose}>
-          Cancel
+          {cancelButtonText ? cancelButtonText : 'Cancel'}
         </Button>
         <Button disabled={loading} variant="destructive" onClick={onConfirm}>
           {loading ? 'Deleting' : confirmButtonText}


### PR DESCRIPTION
Modifying the `Alert` component to handle custom description and button text based on where the component is placed. This change is primarily for the following:

- When editing and closing the panel without saving changes
- When deleting an element - letting the user know this will also remove child elements
