### PR TITLE
Return serialised case items when creating them with POST

### DIFF
--- a/eap_backend/eap_api/serializers.py
+++ b/eap_backend/eap_api/serializers.py
@@ -255,12 +255,14 @@ class StrategySerializer(serializers.ModelSerializer):
         required=False,
     )
 
+    type = serializers.CharField(default="Strategy", read_only=True)
     property_claims = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
 
     class Meta:
         model = Strategy
         fields = (
             "id",
+            "type",
             "name",
             "short_description",
             "long_description",

--- a/eap_backend/eap_api/views.py
+++ b/eap_backend/eap_api/views.py
@@ -358,8 +358,9 @@ def context_list(request):
         if serializer.is_valid():
             model_instance: Context = cast(Context, serializer.save())
             update_identifiers(model_instance=model_instance)
-            summary = make_summary(model_instance)
-            return JsonResponse(summary, status=201)
+
+            serialised_model = ContextSerializer(model_instance)
+            return JsonResponse(serialised_model.data, status=201)
         return JsonResponse(serializer.errors, status=400)
     return None
 

--- a/eap_backend/eap_api/views.py
+++ b/eap_backend/eap_api/views.py
@@ -477,8 +477,9 @@ def evidence_list(request):
         if serializer.is_valid():
             model_instance: Evidence = cast(Evidence, serializer.save())
             update_identifiers(model_instance=model_instance)
-            summary = make_summary(model_instance)
-            return JsonResponse(summary, status=201)
+
+            serialised_model = EvidenceSerializer(model_instance)
+            return JsonResponse(serialised_model.data, status=201)
         return JsonResponse(serializer.errors, status=400)
     return None
 

--- a/eap_backend/eap_api/views.py
+++ b/eap_backend/eap_api/views.py
@@ -297,9 +297,9 @@ def goal_list(request):
                 TopLevelNormativeGoal, serializer.save()
             )
             update_identifiers(model_instance=model_instance)
-            summary = make_summary(model_instance)
 
-            return JsonResponse(summary, status=201)
+            serialised_model = TopLevelNormativeGoalSerializer(model_instance)
+            return JsonResponse(serialised_model.data, status=201)
 
         return JsonResponse(serializer.errors, status=400)
     return None

--- a/eap_backend/eap_api/views.py
+++ b/eap_backend/eap_api/views.py
@@ -414,8 +414,9 @@ def property_claim_list(request):
         if serializer.is_valid():
             model_instance: PropertyClaim = cast(PropertyClaim, serializer.save())
             update_identifiers(model_instance=model_instance)
-            summary = make_summary(model_instance)
-            return JsonResponse(summary, status=201)
+
+            serialised_model = PropertyClaimSerializer(model_instance)
+            return JsonResponse(serialised_model.data, status=201)
         return JsonResponse(serializer.errors, status=400)
     return None
 

--- a/eap_backend/eap_api/views.py
+++ b/eap_backend/eap_api/views.py
@@ -550,8 +550,8 @@ def strategies_list(request):
             model_instance: Strategy = cast(Strategy, serializer.save())
             update_identifiers(model_instance=model_instance)
 
-            summary = make_summary(model_instance)
-            return JsonResponse(summary, status=201)
+            serialised_model = StrategySerializer(model_instance)
+            return JsonResponse(serialised_model.data, status=201)
         return JsonResponse(serializer.errors, status=400)
     return None
 

--- a/eap_backend/tests/constants_tests.py
+++ b/eap_backend/tests/constants_tests.py
@@ -34,6 +34,13 @@ CONTEXT_INFO = {
     "goal_id": 1,
 }
 
+STRATEGY_INFO = {
+    "name": "S1",
+    "short_description": "A strategy for The Goal",
+    "long_description": "A longer description of the strategy",
+    "goal_id": 1,
+}
+
 PROPERTYCLAIM1_INFO = {
     "name": "PropertyClaim 1",
     "short_description": "Goal 1 should be x",

--- a/eap_backend/tests/test_views.py
+++ b/eap_backend/tests/test_views.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from typing import Any
 
 from django.http import HttpResponse
@@ -290,6 +291,32 @@ class ContextViewTest(TestCase):
         self.data = Context.objects.all()
         # convert it to JSON
         self.serializer = ContextSerializer(self.data, many=True)
+
+    def test_create_context_with_post(self):
+        response_post: HttpResponse = self.client.post(
+            reverse("context_list"),
+            data=json.dumps(CONTEXT_INFO),
+            content_type="application/json",
+        )
+
+        assert response_post.status_code == 201
+
+        context_name: str = "C2"
+        context_created: Context = Context.objects.get(name=context_name)
+        json_response = response_post.json()
+
+        assert json_response["id"] == context_created.pk
+        assert json_response["type"] == "Context"
+        assert json_response["name"] == context_name
+        assert json_response["short_description"] == CONTEXT_INFO["short_description"]
+        assert json_response["long_description"] == CONTEXT_INFO["long_description"]
+        assert (
+            datetime.fromisoformat(
+                json_response["created_date"],
+            )
+            == context_created.created_date
+        )
+        assert json_response["goal_id"] == CONTEXT_INFO["goal_id"]
 
     def test_context_list_view_get(self):
         response_get = self.client.get(reverse("context_list"))

--- a/eap_backend/tests/test_views.py
+++ b/eap_backend/tests/test_views.py
@@ -311,9 +311,7 @@ class ContextViewTest(TestCase):
         assert json_response["short_description"] == CONTEXT_INFO["short_description"]
         assert json_response["long_description"] == CONTEXT_INFO["long_description"]
         assert (
-            datetime.fromisoformat(
-                json_response["created_date"],
-            )
+            datetime.strptime(json_response["created_date"], "%Y-%m-%dT%H:%M:%S.%f%z")
             == context_created.created_date
         )
         assert json_response["goal_id"] == CONTEXT_INFO["goal_id"]

--- a/eap_backend/tests/test_views.py
+++ b/eap_backend/tests/test_views.py
@@ -369,6 +369,43 @@ class PropertyClaimViewTest(TestCase):
             response_put.json()["short_description"] == self.update["short_description"]
         )
 
+    def test_create_property_claim_with_post(self):
+
+        response_post: HttpResponse = self.client.post(
+            reverse("property_claim_list"),
+            data=json.dumps(PROPERTYCLAIM1_INFO),
+            content_type="application/json",
+        )
+
+        property_claim_name: str = "P3"
+        property_claim_created: list[PropertyClaim] = list(
+            PropertyClaim.objects.filter(name=property_claim_name)
+        )
+
+        assert len(property_claim_created) == 1
+        current_property_claim: PropertyClaim = property_claim_created[0]
+
+        json_response = response_post.json()
+
+        assert json_response["id"] == current_property_claim.pk
+        assert json_response["type"] == "PropertyClaim"
+        assert json_response["name"] == property_claim_name
+        assert (
+            json_response["short_description"]
+            == PROPERTYCLAIM1_INFO["short_description"]
+        )
+        assert (
+            json_response["long_description"] == PROPERTYCLAIM1_INFO["long_description"]
+        )
+
+        assert json_response["goal_id"] == PROPERTYCLAIM1_INFO["goal_id"]
+        assert json_response["property_claim_id"] is None
+        assert json_response["level"] == 1
+        assert json_response["claim_type"] == "Project claim"
+        assert json_response["property_claims"] == []
+        assert json_response["evidence"] == []
+        assert json_response["strategy_id"] is None
+
     def test_identifier_update_on_move(self):
         self.pclaim1.name = "P1"
         self.pclaim1.save()

--- a/eap_backend/tests/test_views.py
+++ b/eap_backend/tests/test_views.py
@@ -117,6 +117,36 @@ class GoalViewTest(TestCase):
         # convert it to JSON
         self.serializer = TopLevelNormativeGoalSerializer(self.data, many=True)
 
+    def test_create_goal_with_post(self):
+
+        self.goal.delete()
+
+        response_post: HttpResponse = self.client.post(
+            reverse("goal_list"),
+            data=json.dumps(GOAL_INFO),
+            content_type="application/json",
+        )
+
+        goals_created: list[TopLevelNormativeGoal] = list(
+            TopLevelNormativeGoal.objects.all()
+        )
+        assert len(goals_created) == 1
+        current_goal: TopLevelNormativeGoal = goals_created[0]
+
+        json_response: dict = response_post.json()
+
+        assert current_goal.pk == json_response["id"]
+        assert json_response["type"] == "TopLevelNormativeGoal"
+        assert current_goal.name == json_response["name"]
+        assert current_goal.short_description == json_response["short_description"]
+        assert current_goal.long_description == json_response["long_description"]
+        assert current_goal.keywords == json_response["keywords"]
+        assert current_goal.assurance_case.pk == json_response["assurance_case_id"]
+
+        assert [] == json_response["context"]
+        assert [] == json_response["property_claims"]
+        assert [] == json_response["strategies"]
+
     def test_goal_list_view_post_with_id_update(self):
 
         self.goal.delete()

--- a/eap_backend/tests/test_views.py
+++ b/eap_backend/tests/test_views.py
@@ -460,6 +460,36 @@ class EvidenceViewTest(TestCase):
         # convert it to JSON
         self.serializer = EvidenceSerializer(self.data, many=True)
 
+    def test_create_evidence_with_post(self):
+        response_post: HttpResponse = self.client.post(
+            reverse("evidence_list"),
+            data=json.dumps(
+                EVIDENCE1_INFO_NO_ID | {"property_claim_id": [self.pclaim.pk]}
+            ),
+            content_type="application/json",
+        )
+
+        assert response_post.status_code == 201
+
+        evidence_name: str = "E3"
+        evidence_created: Evidence = Evidence.objects.get(name=evidence_name)
+        json_response = response_post.json()
+
+        assert json_response["id"] == evidence_created.pk
+        assert json_response["type"] == "Evidence"
+        assert json_response["name"] == evidence_name
+        assert (
+            json_response["short_description"]
+            == EVIDENCE1_INFO_NO_ID["short_description"]
+        )
+        assert (
+            json_response["long_description"]
+            == EVIDENCE1_INFO_NO_ID["long_description"]
+        )
+
+        assert json_response["URL"] == EVIDENCE1_INFO_NO_ID["URL"]
+        assert json_response["property_claim_id"] == [self.pclaim.pk]
+
     def test_evidence_list_view_get(self):
         response_get = self.client.get(reverse("evidence_list"))
         assert response_get.status_code == 200

--- a/eap_backend/tests/test_views.py
+++ b/eap_backend/tests/test_views.py
@@ -206,7 +206,32 @@ class StrategyViewTest(TestCase):
             **GOAL_INFO
         )
 
-    def test_strategy_serialisation(self):
+    def test_create_strategy_with_post(self):
+
+        response_post: HttpResponse = self.client.post(
+            reverse("strategies_list"),
+            data=json.dumps(STRATEGY_INFO),
+            content_type="application/json",
+        )
+
+        assert response_post.status_code == 201
+
+        strategies_created: list[Strategy] = list(Strategy.objects.all())
+        assert len(strategies_created) == 1
+
+        current_strategy: Strategy = strategies_created[0]
+        json_response: dict = response_post.json()
+
+        assert json_response["id"] == current_strategy.pk
+        assert json_response["type"] == "Strategy"
+
+        assert json_response["name"] == STRATEGY_INFO["name"]
+        assert json_response["short_description"] == STRATEGY_INFO["short_description"]
+        assert json_response["long_description"] == STRATEGY_INFO["long_description"]
+        assert json_response["goal_id"] == self.goal.pk
+        assert json_response["property_claims"] == []
+
+    def test_retrieve_strategy_with_get(self):
 
         strategy: Strategy = Strategy.objects.create(**STRATEGY_INFO)
 

--- a/eap_backend/tests/test_views.py
+++ b/eap_backend/tests/test_views.py
@@ -36,6 +36,7 @@ from .constants_tests import (
     GROUP1_INFO,
     PROPERTYCLAIM1_INFO,
     PROPERTYCLAIM2_INFO,
+    STRATEGY_INFO,
     USER1_INFO,
 )
 
@@ -174,6 +175,25 @@ class StrategyViewTest(TestCase):
         self.goal: TopLevelNormativeGoal = TopLevelNormativeGoal.objects.create(
             **GOAL_INFO
         )
+
+    def test_strategy_serialisation(self):
+
+        strategy: Strategy = Strategy.objects.create(**STRATEGY_INFO)
+
+        response_get: HttpResponse = self.client.get(
+            reverse("strategy_detail", kwargs={"pk": strategy.pk})
+        )
+        assert response_get.status_code == 200
+        response_data = response_get.json()
+
+        assert response_data["id"] == strategy.pk
+        assert response_data["type"] == "Strategy"
+
+        assert response_data["name"] == STRATEGY_INFO["name"]
+        assert response_data["short_description"] == STRATEGY_INFO["short_description"]
+        assert response_data["long_description"] == STRATEGY_INFO["long_description"]
+        assert response_data["goal_id"] == self.goal.pk
+        assert response_data["property_claims"] == []
 
     def test_identifier_update_follows_order(self):
         number_of_strategies: int = 3


### PR DESCRIPTION
Before this PR, case item creation with POST only returned `id` and `name`. Now, we return a complete serialised case item. We also addressed the missing `type` value for strategies when retrieving cases.