### PR TITLE
The "Update Identifier" logic is now aware of claim parents

### DIFF
--- a/eap_backend/eap_api/view_utils.py
+++ b/eap_backend/eap_api/view_utils.py
@@ -426,7 +426,10 @@ class UpdateIdentifierUtils:
         elif one_claim.strategy is not None and another_claim.strategy is None:
             result = ONE_CLAIM_RIGHT
         elif one_claim.strategy is not None and another_claim.strategy is not None:
-            result = one_claim.strategy.pk - another_claim.strategy.pk
+            if one_claim.strategy != another_claim.strategy:
+                result = one_claim.strategy.pk - another_claim.strategy.pk
+            else:
+                result = one_claim.pk - another_claim.pk
 
         return result
 

--- a/eap_backend/eap_api/view_utils.py
+++ b/eap_backend/eap_api/view_utils.py
@@ -304,6 +304,156 @@ class SandboxUtils:
             case_item.save()
 
 
+class UpdateIdentifierUtils:
+    @staticmethod
+    def update_identifiers(
+        case_id: Optional[int] = None, model_instance: Optional[CaseItem] = None
+    ):
+        """Traverses the case and ensures the identifiers follow a sequence
+
+        Args:
+            case_id: Identifier of the case where we perform the update.
+            model_instance: The case element that triggered this method.
+        """
+
+        error_message: str = "Assurance Case ID not provided."
+        if case_id is None and model_instance is not None:
+            case_id = get_case_id(model_instance)
+
+        if case_id is None:
+            raise ValueError(error_message)
+
+        if TopLevelNormativeGoal.objects.filter(assurance_case_id=case_id).exists():
+
+            current_case_goal: TopLevelNormativeGoal = (
+                TopLevelNormativeGoal.objects.get(assurance_case_id=case_id)
+            )
+            goal_id: int = current_case_goal.pk
+
+            UpdateIdentifierUtils._update_sequential_identifiers(
+                TopLevelNormativeGoal.objects.filter(id=goal_id).order_by("id"),
+                "G",
+            )
+
+            UpdateIdentifierUtils._update_sequential_identifiers(
+                Context.objects.filter(goal_id=goal_id).order_by("id"), "C"
+            )
+
+            current_case_strategies: QuerySet = Strategy.objects.filter(
+                goal_id=goal_id
+            ).order_by("id")
+            UpdateIdentifierUtils._update_sequential_identifiers(
+                current_case_strategies, "S"
+            )
+
+            (
+                top_level_claim_ids,
+                child_claim_ids,
+            ) = UpdateIdentifierUtils._get_case_property_claims(
+                current_case_goal, current_case_strategies
+            )
+
+            UpdateIdentifierUtils._update_sequential_identifiers(
+                Evidence.objects.filter(
+                    property_claim__id__in=top_level_claim_ids + child_claim_ids
+                ).order_by("id"),
+                "E",
+            )
+
+            parent_property_claims: QuerySet = PropertyClaim.objects.filter(
+                pk__in=top_level_claim_ids
+            ).order_by("id")
+
+            UpdateIdentifierUtils._update_sequential_identifiers(
+                parent_property_claims, "P"
+            )
+
+            for _, property_claim in enumerate(parent_property_claims):
+                UpdateIdentifierUtils._traverse_child_property_claims(
+                    lambda index, child, parent: UpdateIdentifierUtils._update_item_name(
+                        child, f"{parent.name}.", index + 1
+                    ),
+                    property_claim.pk,
+                )
+
+            if model_instance is not None:
+                model_instance.refresh_from_db()
+
+    @staticmethod
+    def _traverse_child_property_claims(
+        on_child_claim: Callable[[int, PropertyClaim, PropertyClaim], None],
+        parent_claim_id: int,
+    ):
+        """Applies a function to all the children of a Property Claim.
+
+        Args:
+            on_child_claim: The function to call on each child claim.
+            parent_claim_id: The id of the claim we will traverse.
+        """
+        child_property_claims = PropertyClaim.objects.filter(
+            property_claim_id=parent_claim_id
+        ).order_by("id")
+
+        if len(child_property_claims) == 0:
+            return
+        else:
+            for index, child_property_claim in enumerate(child_property_claims):
+                on_child_claim(
+                    index,
+                    child_property_claim,
+                    PropertyClaim.objects.get(pk=parent_claim_id),
+                )
+                UpdateIdentifierUtils._traverse_child_property_claims(
+                    on_child_claim, child_property_claim.pk
+                )
+
+    @staticmethod
+    def _get_case_property_claims(
+        goal: TopLevelNormativeGoal, strategies: QuerySet
+    ) -> tuple:
+        """Retrieves all the property claims associated to a goal and a list of strategies.
+
+        Args:
+            goal: Goal whose property claims we will extract.
+            strategies: Strategies whose property claims we will extract.
+
+        Returns:
+            A tuple containing parent property claims and child property claims, all sorted
+            by primary key.
+        """
+        strategy_ids: list[int] = [strategy.pk for strategy in strategies]
+
+        top_level_claim_ids: list[int] = [
+            claim.pk
+            for claim in PropertyClaim.objects.filter(
+                Q(goal_id=goal.pk) | Q(strategy__id__in=strategy_ids)
+            ).order_by("id")
+        ]
+
+        child_claim_ids: list[int] = []
+        for parent_claim_id in top_level_claim_ids:
+            UpdateIdentifierUtils._traverse_child_property_claims(
+                lambda _, child, parent: child_claim_ids.append(  # noqa: ARG005
+                    child.pk
+                ),
+                parent_claim_id,
+            )
+
+        return top_level_claim_ids, sorted(child_claim_ids)
+
+    @staticmethod
+    def _update_item_name(case_item: CaseItem, prefix: str, number: int) -> None:
+        """Updates the name of a case item, given a prefix and a sequence number."""
+        case_item.name = f"{prefix}{number}"
+        case_item.save()
+
+    @staticmethod
+    def _update_sequential_identifiers(query_set: QuerySet, prefix: str):
+        """For a list of case items, it updates their name according to its order."""
+        for model_index, model in enumerate(query_set):
+            UpdateIdentifierUtils._update_item_name(model, prefix, model_index + 1)
+
+
 def get_case_id(item) -> Optional[int]:
     """Return the id of the case in which this item is. Works for all item types."""
     # In some cases, when there's a ManyToManyField, instead of the parent item, we get
@@ -581,140 +731,3 @@ def get_allowed_groups(user, level="member"):
     """
     all_groups = EAPGroup.objects.all()
     return [group for group in all_groups if can_view_group(group, user, level)]
-
-
-def update_identifiers(
-    case_id: Optional[int] = None, model_instance: Optional[CaseItem] = None
-):
-    """Traverses the case and ensures the identifiers follow a sequence
-
-    Args:
-        case_id: Identifier of the case where we perform the update.
-        model_instance: The case element that triggered this method.
-    """
-
-    error_message: str = "Assurance Case ID not provided."
-    if case_id is None and model_instance is not None:
-        case_id = get_case_id(model_instance)
-
-    if case_id is None:
-        raise ValueError(error_message)
-
-    if TopLevelNormativeGoal.objects.filter(assurance_case_id=case_id).exists():
-
-        current_case_goal: TopLevelNormativeGoal = TopLevelNormativeGoal.objects.get(
-            assurance_case_id=case_id
-        )
-        goal_id: int = current_case_goal.pk
-
-        _update_sequential_identifiers(
-            TopLevelNormativeGoal.objects.filter(id=goal_id).order_by("id"),
-            "G",
-        )
-
-        _update_sequential_identifiers(
-            Context.objects.filter(goal_id=goal_id).order_by("id"), "C"
-        )
-
-        current_case_strategies: QuerySet = Strategy.objects.filter(
-            goal_id=goal_id
-        ).order_by("id")
-        _update_sequential_identifiers(current_case_strategies, "S")
-
-        top_level_claim_ids, child_claim_ids = _get_case_property_claims(
-            current_case_goal, current_case_strategies
-        )
-
-        _update_sequential_identifiers(
-            Evidence.objects.filter(
-                property_claim__id__in=top_level_claim_ids + child_claim_ids
-            ).order_by("id"),
-            "E",
-        )
-
-        parent_property_claims: QuerySet = PropertyClaim.objects.filter(
-            pk__in=top_level_claim_ids
-        ).order_by("id")
-
-        _update_sequential_identifiers(parent_property_claims, "P")
-
-        for _, property_claim in enumerate(parent_property_claims):
-            _traverse_child_property_claims(
-                lambda index, child, parent: _update_item_name(
-                    child, f"{parent.name}.", index + 1
-                ),
-                property_claim.pk,
-            )
-
-        if model_instance is not None:
-            model_instance.refresh_from_db()
-
-
-def _traverse_child_property_claims(
-    on_child_claim: Callable[[int, PropertyClaim, PropertyClaim], None],
-    parent_claim_id: int,
-):
-    """Applies a function to all the children of a Property Claim.
-
-    Args:
-        on_child_claim: The function to call on each child claim.
-        parent_claim_id: The id of the claim we will traverse.
-    """
-    child_property_claims = PropertyClaim.objects.filter(
-        property_claim_id=parent_claim_id
-    ).order_by("id")
-
-    if len(child_property_claims) == 0:
-        return
-    else:
-        for index, child_property_claim in enumerate(child_property_claims):
-            on_child_claim(
-                index,
-                child_property_claim,
-                PropertyClaim.objects.get(pk=parent_claim_id),
-            )
-            _traverse_child_property_claims(on_child_claim, child_property_claim.pk)
-
-
-def _get_case_property_claims(
-    goal: TopLevelNormativeGoal, strategies: QuerySet
-) -> tuple:
-    """Retrieves all the property claims associated to a goal and a list of strategies.
-
-    Args:
-        goal: Goal whose property claims we will extract.
-        strategies: Strategies whose property claims we will extract.
-
-    Returns:
-        A tuple containing parent property claims and child property claims, all sorted
-        by primary key.
-    """
-    strategy_ids: list[int] = [strategy.pk for strategy in strategies]
-
-    top_level_claim_ids: list[int] = [
-        claim.pk
-        for claim in PropertyClaim.objects.filter(
-            Q(goal_id=goal.pk) | Q(strategy__id__in=strategy_ids)
-        ).order_by("id")
-    ]
-
-    child_claim_ids: list[int] = []
-    for parent_claim_id in top_level_claim_ids:
-        _traverse_child_property_claims(
-            lambda _, child, parent: child_claim_ids.append(child.pk),  # noqa: ARG005
-            parent_claim_id,
-        )
-
-    return top_level_claim_ids, sorted(child_claim_ids)
-
-
-def _update_item_name(case_item: CaseItem, prefix: str, number: int) -> None:
-    """Updates the name of a case item, given a prefix and a sequence number."""
-    case_item.name = f"{prefix}{number}"
-    case_item.save()
-
-
-def _update_sequential_identifiers(query_set: QuerySet, prefix: str):
-    """For a list of case items, it updates their name according to its order."""
-    for model_index, model in enumerate(query_set):
-        _update_item_name(model, prefix, model_index + 1)

--- a/eap_backend/eap_api/views.py
+++ b/eap_backend/eap_api/views.py
@@ -38,6 +38,7 @@ from .serializers import (
 from .view_utils import (
     TYPE_DICT,
     SandboxUtils,
+    UpdateIdentifierUtils,
     can_view_group,
     filter_by_case_id,
     get_allowed_cases,
@@ -47,7 +48,6 @@ from .view_utils import (
     make_case_summary,
     make_summary,
     save_json_tree,
-    update_identifiers,
 )
 
 
@@ -252,7 +252,7 @@ def case_sandbox(_: HttpRequest, pk: int) -> HttpResponse:
 def case_update_identifiers(_, pk: int):
     try:
         assurance_case: AssuranceCase = AssuranceCase.objects.get(pk=pk)
-        update_identifiers(case_id=assurance_case.pk)
+        UpdateIdentifierUtils.update_identifiers(case_id=assurance_case.pk)
 
     except AssuranceCase.DoesNotExist:
         return HttpResponse(status=404)


### PR DESCRIPTION
The algorithm now has the following considerations, regarding top-level property claims (i.e. children of the goal of a strategy):

- Property claim under goals, always have a lower identifier than property claims under strategies: In the current version of the TEA platform, property claims are always placed to the left of strategies. When issue https://github.com/alan-turing-institute/AssurancePlatform/issues/539 is delivered, we'll need to change this logic.
- Property claims from different strategies have their identifiers reflecting their parents (i.e. property claims under `S1`, will have identifiers inferior to the claims under `S2`.
- The rest of the logic remains the same, where we sort by order of insertion.