### PR TITLE
Expanding evidence for property claims in sandbox

### DIFF
--- a/eap_backend/eap_api/view_utils.py
+++ b/eap_backend/eap_api/view_utils.py
@@ -272,6 +272,10 @@ class SandboxUtils:
                 property_claim["property_claims"], "property_claims"
             )
 
+            property_claim["evidence"] = get_json_tree(
+                property_claim["evidence"], "evidence"
+            )
+
         for strategy in serialized_sandbox["strategies"]:
             strategy["property_claims"] = get_json_tree(
                 strategy["property_claims"], "property_claims"


### PR DESCRIPTION
Evidence was not expanding when serialising a case sandbox. This PR fixes that.