### PR TITLE
Search for elements within collapsed  case elements

### DIFF
--- a/next_frontend/components/Header.tsx
+++ b/next_frontend/components/Header.tsx
@@ -1,22 +1,45 @@
-import React, { useState, useRef, useEffect, Dispatch, SetStateAction } from 'react';
-import { Button } from './ui/button';
-import { ArrowLeft, Check, ChevronsUpDown, Copy, MessageSquareMore, Search, SearchIcon, X } from 'lucide-react';
-import { ModeToggle } from './ui/theme-toggle';
-import { useRouter } from 'next/navigation';
-import { useLoginToken } from '@/hooks/useAuth';
-import useStore from '@/data/store';
-import { CaseNavigation } from './cases/CaseNavigation';
-import Link from 'next/link';
-import { useReactFlow } from 'reactflow';
-import SearchNodes from './common/SearchNodes';
+import React, {
+  useState,
+  useRef,
+  useEffect,
+  Dispatch,
+  SetStateAction,
+} from "react";
+import { Button } from "./ui/button";
+import {
+  ArrowLeft,
+  Check,
+  ChevronsUpDown,
+  Copy,
+  MessageSquareMore,
+  Search,
+  SearchIcon,
+  X,
+} from "lucide-react";
+import { ModeToggle } from "./ui/theme-toggle";
+import { useRouter } from "next/navigation";
+import { useLoginToken } from "@/hooks/useAuth";
+import useStore from "@/data/store";
+import { CaseNavigation } from "./cases/CaseNavigation";
+import Link from "next/link";
+import {
+  useReactFlow,
+  useUpdateNodeInternals,
+  getNodesBounds,
+} from "reactflow";
+import SearchNodes from "./common/SearchNodes";
+
+import { toggleHiddenForParent } from "@/lib/case-helper";
 
 interface HeaderProps {
-  setOpen: Dispatch<SetStateAction<boolean>>
+  setOpen: Dispatch<SetStateAction<boolean>>;
 }
 
 const Header = ({ setOpen }: HeaderProps) => {
   const { nodes, assuranceCase, setAssuranceCase } = useStore();
   const router = useRouter();
+  const updateNodeInternals = useUpdateNodeInternals();
+
   const [editName, setEditName] = useState<boolean>(false);
   const [newCaseName, setNewCaseName] = useState<string>(assuranceCase.name);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -36,40 +59,57 @@ const Header = ({ setOpen }: HeaderProps) => {
   const updateAssuranceCaseName = async () => {
     try {
       const newData = {
-        name: newCaseName
-      }
-      const url = `${process.env.NEXT_PUBLIC_API_URL}/api/cases/${assuranceCase.id}/`
+        name: newCaseName,
+      };
+      const url = `${process.env.NEXT_PUBLIC_API_URL}/api/cases/${assuranceCase.id}/`;
       const requestOptions: RequestInit = {
-          method: "PUT",
-          headers: {
-              Authorization: `Token ${token}`,
-              "Content-Type": "application/json",
-          },
-          body: JSON.stringify(newData)
+        method: "PUT",
+        headers: {
+          Authorization: `Token ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(newData),
       };
 
       const response = await fetch(url, requestOptions);
-      if(!response.ok) {
-        console.log('Render a new error')
+      if (!response.ok) {
+        console.log("Render a new error");
       }
-      setEditName(false)
-      setAssuranceCase({ ...assuranceCase, name: newCaseName })
+      setEditName(false);
+      setAssuranceCase({ ...assuranceCase, name: newCaseName });
     } catch (error) {
-      console.log(error)
+      console.log(error);
     }
-  }
+  };
+
+  const unhideParents = (nodeId: string) => {
+    const currentNode = nodes.find((node) => node.id == nodeId);
+
+    const updatedAssuranceCase = toggleHiddenForParent(
+      currentNode,
+      assuranceCase
+    );
+
+    setAssuranceCase(updatedAssuranceCase);
+  };
 
   const focusNode = (value: string) => {
-    console.log('Focus Node');
-    let nodeId: any = nodes.filter(n => n.id === value)[0].id
+    console.log("Focus Node");
+    let nodeId: any = nodes.filter((n) => n.id === value)[0].id;
+
+    unhideParents(nodeId);
 
     // nodes.map(n => {
     //   (n.data.name === 'P2') ? nodeId = n.id : null
     // })
 
     if (nodeId) {
-      const node = nodes.find(n => n.id === nodeId);
-      console.log(node);
+      // const { nodes } = useStore();
+      const node = nodes.find((n) => n.id === nodeId);
+
+      // TODO(cgavidia): Remove later
+      console.log("Node for Zoom", node);
+
       if (node) {
         const zoomLevel = 1.5; // Adjust the zoom level as needed
 
@@ -81,21 +121,26 @@ const Header = ({ setOpen }: HeaderProps) => {
         const centerX = node.position.x + nodeWidth / 2;
         const centerY = node.position.y + nodeHeight / 2;
 
-        setCenter(centerX, centerY)
+        setCenter(centerX, centerY);
       } else {
-        console.error('Node is null');
+        console.error("Node is null");
       }
     } else {
-      console.error('Node ID is undefined');
+      console.error("Node ID is undefined");
     }
-  }
+  };
 
   return (
-    <div className='fixed top-0 left-0 bg-indigo-600 dark:bg-slate-900 text-white w-full z-50'>
-      <div className='container py-3 flex justify-between items-center'>
-        <div className='flex justify-start items-center gap-2'>
-          <Button variant={'ghost'} size={'icon'} onClick={() => router.push('/dashboard')} className='hover:bg-indigo-900/20 hover:dark:bg-gray-100/10 hover:text-white'>
-            <ArrowLeft className='w-4 h-4' />
+    <div className="fixed top-0 left-0 bg-indigo-600 dark:bg-slate-900 text-white w-full z-50">
+      <div className="container py-3 flex justify-between items-center">
+        <div className="flex justify-start items-center gap-2">
+          <Button
+            variant={"ghost"}
+            size={"icon"}
+            onClick={() => router.push("/dashboard")}
+            className="hover:bg-indigo-900/20 hover:dark:bg-gray-100/10 hover:text-white"
+          >
+            <ArrowLeft className="w-4 h-4" />
           </Button>
           {/* {editName ? (
             <div className='flex justify-start items-center gap-4'>
@@ -117,21 +162,28 @@ const Header = ({ setOpen }: HeaderProps) => {
               {assuranceCase.name}
             </p>
           )} */}
-          <p onClick={() => setOpen(true)} className='font-semibold hover:cursor-pointer'>{assuranceCase.name}</p>
+          <p
+            onClick={() => setOpen(true)}
+            className="font-semibold hover:cursor-pointer"
+          >
+            {assuranceCase.name}
+          </p>
         </div>
 
-        <div className='flex justify-start items-center gap-4'>
+        <div className="flex justify-start items-center gap-4">
           <SearchNodes nodes={nodes} focusNode={focusNode} />
           <CaseNavigation />
           <Link
-            href={'https://alan-turing-institute.github.io/AssurancePlatform/community/community-support/'}
-            target='_blank'
-            className='flex justify-center items-center gap-2 bg-indigo-600 text-white py-2 px-3 rounded-md'
+            href={
+              "https://alan-turing-institute.github.io/AssurancePlatform/community/community-support/"
+            }
+            target="_blank"
+            className="flex justify-center items-center gap-2 bg-indigo-600 text-white py-2 px-3 rounded-md"
           >
-            <MessageSquareMore className='w-4 h-4' />
+            <MessageSquareMore className="w-4 h-4" />
             <span className="font-medium text-sm">Feedback</span>
           </Link>
-          <ModeToggle className='bg-indigo-500 dark:bg-slate-900 hover:bg-indigo-900/20 hover:dark:bg-gray-100/10 hover:text-white border-none' />
+          <ModeToggle className="bg-indigo-500 dark:bg-slate-900 hover:bg-indigo-900/20 hover:dark:bg-gray-100/10 hover:text-white border-none" />
         </div>
       </div>
     </div>

--- a/next_frontend/components/Header.tsx
+++ b/next_frontend/components/Header.tsx
@@ -107,9 +107,6 @@ const Header = ({ setOpen }: HeaderProps) => {
       // const { nodes } = useStore();
       const node = nodes.find((n) => n.id === nodeId);
 
-      // TODO(cgavidia): Remove later
-      console.log("Node for Zoom", node);
-
       if (node) {
         const zoomLevel = 1.5; // Adjust the zoom level as needed
 

--- a/next_frontend/data/store.ts
+++ b/next_frontend/data/store.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { create } from 'zustand';
 import {
   Connection,
@@ -43,41 +41,21 @@ export type NodeData = {
 // Define a function to layout nodes vertically using Dagre
 const layoutNodesVertically = (nodes: Node[], edges: Edge[]) => {
   const g = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
-
-  // g.setGraph({ rankdir: 'TB' });
-
-  // edges.forEach((edge: Edge) => g.setEdge(edge.source, edge.target));
-  // nodes.forEach((node: Node | any) => g.setNode(node.id, node));
-
-  // Dagre.layout(g);
-
-  // return {
-  //   nodes: nodes.map((node: any, index: any) => {
-  //     const { x, y } = g.node(node.id);
-  //     return { ...node, position: { x, y } };
-  //   }),
-  //   edges,
-  // };
-
   g.setGraph({ rankdir: 'TB' });
 
-  // Filter out hidden nodes and edges
-  const visibleNodes = nodes.filter((node: any) => !node.hidden);
-  const visibleEdges = edges.filter((edge: any) => !edge.hidden);
+  // Set all nodes in the graph, including hidden ones
+  nodes.forEach((node: any) => g.setNode(node.id, node));
 
+  // Set edges for visible nodes only
+  const visibleEdges = edges.filter((edge: any) => !edge.hidden);
   visibleEdges.forEach((edge: any) => g.setEdge(edge.source, edge.target));
-  visibleNodes.forEach((node: any) => g.setNode(node.id, node));
 
   Dagre.layout(g);
 
   return {
     nodes: nodes.map((node: any) => {
-      // Only update position for visible nodes
-      if (!node.hidden) {
-        const { x, y } = g.node(node.id);
-        return { ...node, position: { x, y } };
-      }
-      return node;
+      const { x, y } = g.node(node.id);
+      return { ...node, position: { x, y } };
     }),
     edges,
   };
@@ -86,16 +64,7 @@ const layoutNodesVertically = (nodes: Node[], edges: Edge[]) => {
 // this is our useStore hook that we can use in our components to get parts of the store and call actions
 const useStore = create<Store>((set, get) => ({
   assuranceCase: null,
-  orphanedElements: [
-    // { id: crypto.randomUUID(), name: 'P1', description: 'Lorem ipsum blah blah woof woof', type:'claims' },
-    // { id: crypto.randomUUID(), name: 'P3', description: 'Lorem ipsum blah blah woof woof', type:'claims' },
-    // { id: crypto.randomUUID(), name: 'P4.5', description: 'Lorem ipsum blah blah woof woof', type:'claims' },
-    // { id: crypto.randomUUID(), name: 'P2', description: 'Lorem ipsum blah blah woof woof', type:'claims' },
-    // { id: crypto.randomUUID(), name: 'S8', description: 'Lorem ipsum blah blah woof woof', type:'strategy' },
-    // { id: crypto.randomUUID(), name: 'S1', description: 'Lorem ipsum blah blah woof woof', type:'strategy' },
-    // { id: crypto.randomUUID(), name: 'P3.2', description: 'Lorem ipsum blah blah woof woof', type:'claims' },
-    // { id: crypto.randomUUID(), name: 'E99', description: 'Lorem ipsum blah blah woof woof', type:'evidence' },
-  ],
+  orphanedElements: [],
   nodes: initNodes,
   edges: initEdges,
   nodeTypes: nodeTypes,
@@ -115,31 +84,38 @@ const useStore = create<Store>((set, get) => ({
     });
   },
   setAssuranceCase: (assuranceCase: any) => {
-    set({ assuranceCase })
+    // Update the assurance case in the state
+    set({ assuranceCase });
+
+    // Get the current nodes and edges from the state
+    const { nodes, edges } = get();
+
+    // Layout the nodes and edges
+    get().layoutNodes(nodes, edges);
   },
   setOrphanedElements: (orphanedElements: any) => {
     console.log('orphanedElements_Sandbox', orphanedElements)
     let newArray: any[] = []
 
-    if(orphanedElements.contexts && orphanedElements.contexts.length > 0) {
+    if (orphanedElements.contexts && orphanedElements.contexts.length > 0) {
       orphanedElements.contexts.map((context: any) => {
         newArray.push(context)
       })
     }
 
-    if(orphanedElements.property_claims && orphanedElements.property_claims.length > 0) {
+    if (orphanedElements.property_claims && orphanedElements.property_claims.length > 0) {
       orphanedElements.property_claims.map((claim: any) => {
         newArray.push(claim)
       })
     }
 
-    if(orphanedElements.strategies && orphanedElements.strategies.length > 0) {
+    if (orphanedElements.strategies && orphanedElements.strategies.length > 0) {
       orphanedElements.strategies.map((strategy: any) => {
         newArray.push(strategy)
       })
     }
 
-    if(orphanedElements.evidence && orphanedElements.evidence.length > 0) {
+    if (orphanedElements.evidence && orphanedElements.evidence.length > 0) {
       orphanedElements.evidence.map((evidence: any) => {
         newArray.push(evidence)
       })
@@ -148,7 +124,6 @@ const useStore = create<Store>((set, get) => ({
     set({ orphanedElements: newArray })
   },
   setNodes: (nodes: Node[]) => {
-    // const { nodes: layoutedNodes } = layoutNodesVertically(nodes, []);
     set({ nodes });
   },
   setEdges: (edges: Edge[]) => {

--- a/next_frontend/lib/case-helper.ts
+++ b/next_frontend/lib/case-helper.ts
@@ -1,1056 +1,1393 @@
 import { AssuranceCase } from "@/types";
 
 interface Map {
-    [key: string]: string | undefined
+  [key: string]: string | undefined;
+}
+
+interface CaseNode {
+  hidden: boolean;
+  id: number;
+  type: string;
+  [key: string]: any;
 }
 
 const DESCRIPTION_FROM_TYPE: Map = {
-    goal: "Goal",
-    context: "Context",
-    strategy: "Strategy",
-    property: "Property Claim",
-    evidence: "Evidence"
+  goal: "Goal",
+  context: "Context",
+  strategy: "Strategy",
+  property: "Property Claim",
+  evidence: "Evidence",
 };
 
-export const caseItemDescription = (caseItemName: string) => DESCRIPTION_FROM_TYPE[caseItemName] || caseItemName;
+export const caseItemDescription = (caseItemName: string) =>
+  DESCRIPTION_FROM_TYPE[caseItemName] || caseItemName;
 
-export const addPropertyClaimToNested = (propertyClaims: any, parentId: any, newPropertyClaim: any) => {
-    // Iterate through the property claims array
-    for (let i = 0; i < propertyClaims.length; i++) {
-        const propertyClaim = propertyClaims[i];
+export const addPropertyClaimToNested = (
+  propertyClaims: any,
+  parentId: any,
+  newPropertyClaim: any
+) => {
+  // Iterate through the property claims array
+  for (let i = 0; i < propertyClaims.length; i++) {
+    const propertyClaim = propertyClaims[i];
 
-        // Check if this property claim matches the parent ID
-        if (propertyClaim.id === parentId) {
-            // Check if the property claim already has property claims array
-            if (!propertyClaim.property_claims) {
-                propertyClaim.property_claims = [];
-            }
+    // Check if this property claim matches the parent ID
+    if (propertyClaim.id === parentId) {
+      // Check if the property claim already has property claims array
+      if (!propertyClaim.property_claims) {
+        propertyClaim.property_claims = [];
+      }
 
-            // Add the new property claim to the property claim's property claims
-            propertyClaim.property_claims.push(newPropertyClaim);
+      // Add the new property claim to the property claim's property claims
+      propertyClaim.property_claims.push(newPropertyClaim);
 
-            return true; // Indicates the property claim was found and updated
-        }
-
-        // If this property claim has nested property claims, recursively search within them
-        if (propertyClaim.property_claims && propertyClaim.property_claims.length > 0) {
-            const found = addPropertyClaimToNested(propertyClaim.property_claims, parentId, newPropertyClaim);
-            if (found) {
-                return true; // Indicates the property claim was found and updated within nested property claims
-            }
-        }
-
-        // If this property claim has strategies, recursively search within them
-        if (propertyClaim.strategies && propertyClaim.strategies.length > 0) {
-            for (const strategy of propertyClaim.strategies) {
-                if (strategy.property_claims && strategy.property_claims.length > 0) {
-                    const found = addPropertyClaimToNested(strategy.property_claims, parentId, newPropertyClaim);
-                    if (found) {
-                        return true; // Indicates the property claim was found and updated within nested property claims of strategy
-                    }
-                }
-            }
-        }
+      return true; // Indicates the property claim was found and updated
     }
 
-    return false; // Indicates the parent property claim was not found
-}
+    // If this property claim has nested property claims, recursively search within them
+    if (
+      propertyClaim.property_claims &&
+      propertyClaim.property_claims.length > 0
+    ) {
+      const found = addPropertyClaimToNested(
+        propertyClaim.property_claims,
+        parentId,
+        newPropertyClaim
+      );
+      if (found) {
+        return true; // Indicates the property claim was found and updated within nested property claims
+      }
+    }
+
+    // If this property claim has strategies, recursively search within them
+    if (propertyClaim.strategies && propertyClaim.strategies.length > 0) {
+      for (const strategy of propertyClaim.strategies) {
+        if (strategy.property_claims && strategy.property_claims.length > 0) {
+          const found = addPropertyClaimToNested(
+            strategy.property_claims,
+            parentId,
+            newPropertyClaim
+          );
+          if (found) {
+            return true; // Indicates the property claim was found and updated within nested property claims of strategy
+          }
+        }
+      }
+    }
+  }
+
+  return false; // Indicates the parent property claim was not found
+};
 
 // UPDATE PROPERTY CLAIMS
 // TODO: Evidence and Property Claims are doing a similar actions when moving this can be refactored.
 
-export const updatePropertyClaimNested = (array: any, id: any, newPropertyClaim: any) => {
-    // Iterate through the property claims array
-    for (let i = 0; i < array.length; i++) {
-        let propertyClaim = array[i];
+export const updatePropertyClaimNested = (
+  array: any,
+  id: any,
+  newPropertyClaim: any
+) => {
+  // Iterate through the property claims array
+  for (let i = 0; i < array.length; i++) {
+    let propertyClaim = array[i];
 
-        // Check if this property claim matches the parent ID
-        if (propertyClaim.id === id && propertyClaim.type === 'PropertyClaim') {
-            array[i] = { ...propertyClaim, ...newPropertyClaim };
+    // Check if this property claim matches the parent ID
+    if (propertyClaim.id === id && propertyClaim.type === "PropertyClaim") {
+      array[i] = { ...propertyClaim, ...newPropertyClaim };
 
-            return array; // Return the updated array
-        }
-
-        // If this property claim has nested property claims, recursively search within them
-        if (propertyClaim.property_claims && propertyClaim.property_claims.length > 0) {
-            const updatedNestedArray = updatePropertyClaimNested(propertyClaim.property_claims, id, newPropertyClaim);
-            if (updatedNestedArray) {
-                return array; // Return the updated array
-            }
-        }
-
-        // If this property claim has strategies, recursively search within them
-        if (propertyClaim.strategies && propertyClaim.strategies.length > 0) {
-            for (const strategy of propertyClaim.strategies) {
-                if (strategy.property_claims && strategy.property_claims.length > 0) {
-                    const updatedNestedArray = updatePropertyClaimNested(strategy.property_claims, id, newPropertyClaim);
-                    if (updatedNestedArray) {
-                        return array; // Return the updated array
-                    }
-                }
-            }
-        }
+      return array; // Return the updated array
     }
 
-    return null; // Indicates the parent property claim was not found
-}
+    // If this property claim has nested property claims, recursively search within them
+    if (
+      propertyClaim.property_claims &&
+      propertyClaim.property_claims.length > 0
+    ) {
+      const updatedNestedArray = updatePropertyClaimNested(
+        propertyClaim.property_claims,
+        id,
+        newPropertyClaim
+      );
+      if (updatedNestedArray) {
+        return array; // Return the updated array
+      }
+    }
+
+    // If this property claim has strategies, recursively search within them
+    if (propertyClaim.strategies && propertyClaim.strategies.length > 0) {
+      for (const strategy of propertyClaim.strategies) {
+        if (strategy.property_claims && strategy.property_claims.length > 0) {
+          const updatedNestedArray = updatePropertyClaimNested(
+            strategy.property_claims,
+            id,
+            newPropertyClaim
+          );
+          if (updatedNestedArray) {
+            return array; // Return the updated array
+          }
+        }
+      }
+    }
+  }
+
+  return null; // Indicates the parent property claim was not found
+};
 
 const removePropertyClaimFromOldLocation = (array: any, id: any) => {
-    return array.map((item: any) => {
-        if (item.property_claims) {
-            // Filter out the claim with the given id
-            item.property_claims = item.property_claims.filter((claim: any) => claim.id !== id);
-            // Recursively remove the claim from nested property_claims
-            item.property_claims = removePropertyClaimFromOldLocation(item.property_claims, id);
-        }
+  return array.map((item: any) => {
+    if (item.property_claims) {
+      // Filter out the claim with the given id
+      item.property_claims = item.property_claims.filter(
+        (claim: any) => claim.id !== id
+      );
+      // Recursively remove the claim from nested property_claims
+      item.property_claims = removePropertyClaimFromOldLocation(
+        item.property_claims,
+        id
+      );
+    }
 
-        if (item.strategies) {
-            // Recursively process each strategy
-            item.strategies = item.strategies.map((strategy: any) => {
-                if (strategy.property_claims) {
-                    // Filter out the claim with the given id from the strategy's property_claims
-                    strategy.property_claims = strategy.property_claims.filter((claim: any) => claim.id !== id);
-                    // Recursively remove the claim from the strategy's nested property_claims
-                    strategy.property_claims = removePropertyClaimFromOldLocation(strategy.property_claims, id);
-                }
-                return strategy;
-            });
+    if (item.strategies) {
+      // Recursively process each strategy
+      item.strategies = item.strategies.map((strategy: any) => {
+        if (strategy.property_claims) {
+          // Filter out the claim with the given id from the strategy's property_claims
+          strategy.property_claims = strategy.property_claims.filter(
+            (claim: any) => claim.id !== id
+          );
+          // Recursively remove the claim from the strategy's nested property_claims
+          strategy.property_claims = removePropertyClaimFromOldLocation(
+            strategy.property_claims,
+            id
+          );
         }
+        return strategy;
+      });
+    }
 
-        return item;
-    });
+    return item;
+  });
 };
 
-const addPropertyClaimToLocation = (array: any, property_claim: any, newParentId: any) => {
-    return array.map((item: any) => {
-        if (item.id === newParentId) {
-            if (!item.property_claims) {
-                item.property_claims = [];
-            }
-            item.property_claims.push(property_claim);
+const addPropertyClaimToLocation = (
+  array: any,
+  property_claim: any,
+  newParentId: any
+) => {
+  return array.map((item: any) => {
+    if (item.id === newParentId) {
+      if (!item.property_claims) {
+        item.property_claims = [];
+      }
+      item.property_claims.push(property_claim);
+    }
+
+    if (item.property_claims) {
+      item.property_claims = addPropertyClaimToLocation(
+        item.property_claims,
+        property_claim,
+        newParentId
+      );
+    }
+
+    if (item.strategies) {
+      item.strategies = item.strategies.map((strategy: any) => {
+        if (strategy.id === newParentId) {
+          if (!strategy.property_claims) {
+            strategy.property_claims = [];
+          }
+          strategy.property_claims.push(property_claim);
         }
 
-        if (item.property_claims) {
-            item.property_claims = addPropertyClaimToLocation(item.property_claims, property_claim, newParentId);
+        if (strategy.property_claims) {
+          strategy.property_claims = addPropertyClaimToLocation(
+            strategy.property_claims,
+            property_claim,
+            newParentId
+          );
         }
+        return strategy;
+      });
+    }
 
-        if (item.strategies) {
-            item.strategies = item.strategies.map((strategy: any) => {
-                if (strategy.id === newParentId) {
-                    if (!strategy.property_claims) {
-                        strategy.property_claims = [];
-                    }
-                    strategy.property_claims.push(property_claim);
-                }
-
-                if (strategy.property_claims) {
-                    strategy.property_claims = addPropertyClaimToLocation(strategy.property_claims, property_claim, newParentId);
-                }
-                return strategy;
-            });
-        }
-
-        return item;
-    });
+    return item;
+  });
 };
 
-export const updatePropertyClaimNestedMove = (array: any, id: any, newPropertyClaim: any) => {
-    // Find the existing property claim item
-    let existingPropertyClaim = null;
-    const findExstingPropertyClaim = (arr: any) => {
-        for (let i = 0; i < arr.length; i++) {
-            let item = arr[i];
+export const updatePropertyClaimNestedMove = (
+  array: any,
+  id: any,
+  newPropertyClaim: any
+) => {
+  // Find the existing property claim item
+  let existingPropertyClaim = null;
+  const findExstingPropertyClaim = (arr: any) => {
+    for (let i = 0; i < arr.length; i++) {
+      let item = arr[i];
 
-            if (item.id === id && item.type === 'PropertyClaim') {
-                existingPropertyClaim = item;
-                return;
-            }
+      if (item.id === id && item.type === "PropertyClaim") {
+        existingPropertyClaim = item;
+        return;
+      }
 
-            if (item.property_claims) {
-                findExstingPropertyClaim(item.property_claims);
-            }
-            if (item.strategies) {
-                for (const strategy of item.strategies) {
-                    if (strategy.property_claims) {
-                        findExstingPropertyClaim(strategy.property_claims);
-                    }
-                }
-            }
+      if (item.property_claims) {
+        findExstingPropertyClaim(item.property_claims);
+      }
+      if (item.strategies) {
+        for (const strategy of item.strategies) {
+          if (strategy.property_claims) {
+            findExstingPropertyClaim(strategy.property_claims);
+          }
         }
-    };
-    findExstingPropertyClaim(array);
-
-    // Remove evidence from its old location
-    console.log('Remove Element')
-    const arrayWithoutOldPropertyClaim = removePropertyClaimFromOldLocation(array, id)
-    console.log('arrayWithoutOldPropertyClaim', arrayWithoutOldPropertyClaim)
-
-    // Merge existing evidence properties with updated ones
-    const updatedPropertyClaim = { ...existingPropertyClaim as any, ...newPropertyClaim };
-
-    // Add evidence to the new location
-    // const newClaimId = newPropertyClaim.property_claim_id[0];
-
-    let newParentId = null
-    let newParentType = null
-
-    if(updatedPropertyClaim.goal_id !== null) {
-        newParentId = updatedPropertyClaim.goal_id
+      }
     }
-    if(updatedPropertyClaim.strategy_id !== null) {
-        newParentId = updatedPropertyClaim.strategy_id
-    }
-    if(updatedPropertyClaim.property_claim_id !== null) {
-        newParentId = updatedPropertyClaim.property_claim_id
-    }
+  };
+  findExstingPropertyClaim(array);
 
-    console.log('New Parent Id', newParentId)
+  // Remove evidence from its old location
+  console.log("Remove Element");
+  const arrayWithoutOldPropertyClaim = removePropertyClaimFromOldLocation(
+    array,
+    id
+  );
+  console.log("arrayWithoutOldPropertyClaim", arrayWithoutOldPropertyClaim);
 
-    const updatedArray = addPropertyClaimToLocation(arrayWithoutOldPropertyClaim, updatedPropertyClaim, newParentId);
+  // Merge existing evidence properties with updated ones
+  const updatedPropertyClaim = {
+    ...(existingPropertyClaim as any),
+    ...newPropertyClaim,
+  };
 
-    return updatedArray;
+  // Add evidence to the new location
+  // const newClaimId = newPropertyClaim.property_claim_id[0];
+
+  let newParentId = null;
+  let newParentType = null;
+
+  if (updatedPropertyClaim.goal_id !== null) {
+    newParentId = updatedPropertyClaim.goal_id;
+  }
+  if (updatedPropertyClaim.strategy_id !== null) {
+    newParentId = updatedPropertyClaim.strategy_id;
+  }
+  if (updatedPropertyClaim.property_claim_id !== null) {
+    newParentId = updatedPropertyClaim.property_claim_id;
+  }
+
+  console.log("New Parent Id", newParentId);
+
+  const updatedArray = addPropertyClaimToLocation(
+    arrayWithoutOldPropertyClaim,
+    updatedPropertyClaim,
+    newParentId
+  );
+
+  return updatedArray;
 };
 
-export const listPropertyClaims = (array: any, currentClaimName: string, claims: any[] = []) => {
-    // Iterate through the property claims array
-    for (let i = 0; i < array.length; i++) {
-        const item = array[i];
+export const listPropertyClaims = (
+  array: any,
+  currentClaimName: string,
+  claims: any[] = []
+) => {
+  // Iterate through the property claims array
+  for (let i = 0; i < array.length; i++) {
+    const item = array[i];
 
-        if (item.type === 'PropertyClaim' && item.name !== currentClaimName) {
-            claims.push(item);
-        }
-
-        // If this item has nested property claims, recursively search within them
-        if (item.property_claims && item.property_claims.length > 0) {
-            listPropertyClaims(item.property_claims, currentClaimName, claims);
-        }
-
-        // If this property claim has strategies, recursively search within them
-        if (item.strategies && item.strategies.length > 0) {
-            for (const strategy of item.strategies) {
-                if (strategy.property_claims && strategy.property_claims.length > 0) {
-                    listPropertyClaims(strategy.property_claims, currentClaimName, claims);
-                }
-            }
-        }
+    if (item.type === "PropertyClaim" && item.name !== currentClaimName) {
+      claims.push(item);
     }
 
-    return claims;
+    // If this item has nested property claims, recursively search within them
+    if (item.property_claims && item.property_claims.length > 0) {
+      listPropertyClaims(item.property_claims, currentClaimName, claims);
+    }
+
+    // If this property claim has strategies, recursively search within them
+    if (item.strategies && item.strategies.length > 0) {
+      for (const strategy of item.strategies) {
+        if (strategy.property_claims && strategy.property_claims.length > 0) {
+          listPropertyClaims(
+            strategy.property_claims,
+            currentClaimName,
+            claims
+          );
+        }
+      }
+    }
+  }
+
+  return claims;
 };
 
-export const addEvidenceToClaim = (array: any, parentId: any, newEvidence: any) => {
-    // Iterate through the property claims array
-    for (let i = 0; i < array.length; i++) {
-        const propertyClaim = array[i];
+export const addEvidenceToClaim = (
+  array: any,
+  parentId: any,
+  newEvidence: any
+) => {
+  // Iterate through the property claims array
+  for (let i = 0; i < array.length; i++) {
+    const propertyClaim = array[i];
 
-        // Check if this property claim matches the parent ID
-        if (propertyClaim.id === parentId) {
-            console.log(propertyClaim)
-            // Check if the property claim already has evidence array
-            if (!propertyClaim.evidence) {
-                propertyClaim.evidence = [];
-            }
+    // Check if this property claim matches the parent ID
+    if (propertyClaim.id === parentId) {
+      console.log(propertyClaim);
+      // Check if the property claim already has evidence array
+      if (!propertyClaim.evidence) {
+        propertyClaim.evidence = [];
+      }
 
-            // Add the new property claim to the property claim's property claims
-            propertyClaim.evidence.push(newEvidence);
+      // Add the new property claim to the property claim's property claims
+      propertyClaim.evidence.push(newEvidence);
 
-            return true; // Indicates the property claim was found and updated
-        }
-
-        // If this property claim has nested property claims, recursively search within them
-        if (propertyClaim.property_claims && propertyClaim.property_claims.length > 0) {
-            const found = addEvidenceToClaim(propertyClaim.property_claims, parentId, newEvidence);
-            if (found) {
-                return true; // Indicates the property claim was found and updated within nested property claims
-            }
-        }
-
-        // If this property claim has strategies, recursively search within them
-        if (propertyClaim.strategies && propertyClaim.strategies.length > 0) {
-            for (const strategy of propertyClaim.strategies) {
-                if (strategy.property_claims && strategy.property_claims.length > 0) {
-                    const found = addEvidenceToClaim(strategy.property_claims, parentId, newEvidence);
-                    if (found) {
-                        return true; // Indicates the property claim was found and updated within nested property claims of strategy
-                    }
-                }
-            }
-        }
+      return true; // Indicates the property claim was found and updated
     }
 
-    return false; // Indicates the parent property claim was not found
-}
+    // If this property claim has nested property claims, recursively search within them
+    if (
+      propertyClaim.property_claims &&
+      propertyClaim.property_claims.length > 0
+    ) {
+      const found = addEvidenceToClaim(
+        propertyClaim.property_claims,
+        parentId,
+        newEvidence
+      );
+      if (found) {
+        return true; // Indicates the property claim was found and updated within nested property claims
+      }
+    }
+
+    // If this property claim has strategies, recursively search within them
+    if (propertyClaim.strategies && propertyClaim.strategies.length > 0) {
+      for (const strategy of propertyClaim.strategies) {
+        if (strategy.property_claims && strategy.property_claims.length > 0) {
+          const found = addEvidenceToClaim(
+            strategy.property_claims,
+            parentId,
+            newEvidence
+          );
+          if (found) {
+            return true; // Indicates the property claim was found and updated within nested property claims of strategy
+          }
+        }
+      }
+    }
+  }
+
+  return false; // Indicates the parent property claim was not found
+};
 
 // UPDATE EVIDENCE
 // TODO: Evidence and Property Claims are doing a similar actions when moving this can be refactored.
 
 export const updateEvidenceNested = (array: any, id: any, newEvidence: any) => {
-    // Iterate through the array
-    for (let i = 0; i < array.length; i++) {
-        let item = array[i];
+  // Iterate through the array
+  for (let i = 0; i < array.length; i++) {
+    let item = array[i];
 
-        // Check if this evidence matches the parent ID
-        if (item.id === id) {
-            array[i] = { ...item, ...newEvidence };
-            return array; // Return the updated array
-        }
-
-        if (item.evidence && item.evidence.length > 0) {
-            const updatedNestedArray = updateEvidenceNested(item.evidence, id, newEvidence)
-            if (updatedNestedArray) {
-                return array
-            }
-        }
-
-        if (item.property_claims && item.property_claims.length > 0) {
-            const updatedNestedArray = updateEvidenceNested(item.property_claims, id, newEvidence)
-            if (updatedNestedArray) {
-                return array
-            }
-        }
-
-        if (item.strategies && item.strategies.length > 0) {
-            for (const strategy of item.strategies) {
-                if (strategy.property_claims && strategy.property_claims.length > 0) {
-                    const updatedNestedArray = updateEvidenceNested(strategy.property_claims, id, newEvidence)
-                    if (updatedNestedArray) {
-                        return array
-                    }
-                }
-            }
-        }
+    // Check if this evidence matches the parent ID
+    if (item.id === id) {
+      array[i] = { ...item, ...newEvidence };
+      return array; // Return the updated array
     }
 
-    // If evidence with the given ID is not found, return null
-    return null;
+    if (item.evidence && item.evidence.length > 0) {
+      const updatedNestedArray = updateEvidenceNested(
+        item.evidence,
+        id,
+        newEvidence
+      );
+      if (updatedNestedArray) {
+        return array;
+      }
+    }
+
+    if (item.property_claims && item.property_claims.length > 0) {
+      const updatedNestedArray = updateEvidenceNested(
+        item.property_claims,
+        id,
+        newEvidence
+      );
+      if (updatedNestedArray) {
+        return array;
+      }
+    }
+
+    if (item.strategies && item.strategies.length > 0) {
+      for (const strategy of item.strategies) {
+        if (strategy.property_claims && strategy.property_claims.length > 0) {
+          const updatedNestedArray = updateEvidenceNested(
+            strategy.property_claims,
+            id,
+            newEvidence
+          );
+          if (updatedNestedArray) {
+            return array;
+          }
+        }
+      }
+    }
+  }
+
+  // If evidence with the given ID is not found, return null
+  return null;
 };
 
 const removeEvidenceFromOldLocation = (array: any, id: any) => {
-    return array.map((item: any) => {
-        if (item.evidence) {
-            item.evidence = item.evidence.filter((evidence: any) => evidence.id !== id);
-        }
+  return array.map((item: any) => {
+    if (item.evidence) {
+      item.evidence = item.evidence.filter(
+        (evidence: any) => evidence.id !== id
+      );
+    }
 
-        if (item.property_claims) {
-            item.property_claims = removeEvidenceFromOldLocation(item.property_claims, id);
-        }
+    if (item.property_claims) {
+      item.property_claims = removeEvidenceFromOldLocation(
+        item.property_claims,
+        id
+      );
+    }
 
-        if (item.strategies) {
-            item.strategies = item.strategies.map((strategy: any) => {
-                if (strategy.property_claims) {
-                    strategy.property_claims = removeEvidenceFromOldLocation(strategy.property_claims, id);
-                }
-                return strategy;
-            });
+    if (item.strategies) {
+      item.strategies = item.strategies.map((strategy: any) => {
+        if (strategy.property_claims) {
+          strategy.property_claims = removeEvidenceFromOldLocation(
+            strategy.property_claims,
+            id
+          );
         }
+        return strategy;
+      });
+    }
 
-        return item;
-    });
+    return item;
+  });
 };
 
-const addEvidenceToNewLocation = (array: any, evidence: any, newClaimId: any) => {
-    return array.map((item: any) => {
-        if (item.id === newClaimId) {
-            if (!item.evidence) {
-                item.evidence = [];
-            }
-            item.evidence.push(evidence);
-        }
+const addEvidenceToNewLocation = (
+  array: any,
+  evidence: any,
+  newClaimId: any
+) => {
+  return array.map((item: any) => {
+    if (item.id === newClaimId) {
+      if (!item.evidence) {
+        item.evidence = [];
+      }
+      item.evidence.push(evidence);
+    }
 
-        if (item.property_claims) {
-            item.property_claims = addEvidenceToNewLocation(item.property_claims, evidence, newClaimId);
-        }
+    if (item.property_claims) {
+      item.property_claims = addEvidenceToNewLocation(
+        item.property_claims,
+        evidence,
+        newClaimId
+      );
+    }
 
-        if (item.strategies) {
-            item.strategies = item.strategies.map((strategy:any) => {
-                if (strategy.property_claims) {
-                    strategy.property_claims = addEvidenceToNewLocation(strategy.property_claims, evidence, newClaimId);
-                }
-                return strategy;
-            });
+    if (item.strategies) {
+      item.strategies = item.strategies.map((strategy: any) => {
+        if (strategy.property_claims) {
+          strategy.property_claims = addEvidenceToNewLocation(
+            strategy.property_claims,
+            evidence,
+            newClaimId
+          );
         }
+        return strategy;
+      });
+    }
 
-        return item;
-    });
+    return item;
+  });
 };
 
-export const updateEvidenceNestedMove = (array: any, id: any, newEvidence: any) => {
-    console.log('updateEvidenceNested called with array:', array, 'id:', id, 'newEvidence:', newEvidence);
+export const updateEvidenceNestedMove = (
+  array: any,
+  id: any,
+  newEvidence: any
+) => {
+  console.log(
+    "updateEvidenceNested called with array:",
+    array,
+    "id:",
+    id,
+    "newEvidence:",
+    newEvidence
+  );
 
-    // Find the existing evidence item
-    let existingEvidence = null;
-    const findExistingEvidence = (arr: any) => {
-        for (let i = 0; i < arr.length; i++) {
-            let item = arr[i];
-            if (item.evidence) {
-                for (let j = 0; j < item.evidence.length; j++) {
-                    if (item.evidence[j].id === id) {
-                        existingEvidence = item.evidence[j];
-                        return;
-                    }
-                }
-            }
-            if (item.property_claims) {
-                findExistingEvidence(item.property_claims);
-            }
-            if (item.strategies) {
-                for (const strategy of item.strategies) {
-                    if (strategy.property_claims) {
-                        findExistingEvidence(strategy.property_claims);
-                    }
-                }
-            }
+  // Find the existing evidence item
+  let existingEvidence = null;
+  const findExistingEvidence = (arr: any) => {
+    for (let i = 0; i < arr.length; i++) {
+      let item = arr[i];
+      if (item.evidence) {
+        for (let j = 0; j < item.evidence.length; j++) {
+          if (item.evidence[j].id === id) {
+            existingEvidence = item.evidence[j];
+            return;
+          }
         }
+      }
+      if (item.property_claims) {
+        findExistingEvidence(item.property_claims);
+      }
+      if (item.strategies) {
+        for (const strategy of item.strategies) {
+          if (strategy.property_claims) {
+            findExistingEvidence(strategy.property_claims);
+          }
+        }
+      }
+    }
+  };
+  findExistingEvidence(array);
+
+  // Remove evidence from its old location
+  const arrayWithoutOldEvidence = removeEvidenceFromOldLocation(array, id);
+
+  // Merge existing evidence properties with updated ones
+  const updatedEvidence = { ...(existingEvidence as any), ...newEvidence };
+
+  // Add evidence to the new location
+  const newClaimId = newEvidence.property_claim_id[0];
+  const updatedArray = addEvidenceToNewLocation(
+    arrayWithoutOldEvidence,
+    updatedEvidence,
+    newClaimId
+  );
+
+  return updatedArray;
+};
+
+export const createAssuranceCaseNode = async (
+  entity: string,
+  newItem: any,
+  token: string | null
+) => {
+  if (!token) return console.log("No token");
+
+  try {
+    let url = `${process.env.NEXT_PUBLIC_API_URL}/api/${entity}/`;
+
+    const requestOptions: RequestInit = {
+      method: "POST",
+      headers: {
+        Authorization: `Token ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(newItem),
     };
-    findExistingEvidence(array);
+    const response = await fetch(url, requestOptions);
 
-    // Remove evidence from its old location
-    const arrayWithoutOldEvidence = removeEvidenceFromOldLocation(array, id)
+    if (!response.ok) {
+      return { error: `Something went wrong ${response.status}` };
+    }
 
-    // Merge existing evidence properties with updated ones
-    const updatedEvidence = { ...existingEvidence as any, ...newEvidence };
+    const result = await response.json();
+    console.log("Node Create Result", result);
 
-    // Add evidence to the new location
-    const newClaimId = newEvidence.property_claim_id[0];
-    const updatedArray = addEvidenceToNewLocation(arrayWithoutOldEvidence, updatedEvidence, newClaimId);
+    const data = {
+      ...newItem,
+      id: result.id,
+    };
 
-    return updatedArray;
+    return { data };
+  } catch (error) {
+    console.log("Error", error);
+    return { error };
+  }
 };
 
-export const createAssuranceCaseNode = async (entity: string, newItem: any, token: string | null) => {
-    if (!token) return console.log('No token')
+export const deleteAssuranceCaseNode = async (
+  type: string,
+  id: any,
+  token: string | null
+) => {
+  if (!token) return console.log("No token");
 
-    try {
-        let url = `${process.env.NEXT_PUBLIC_API_URL}/api/${entity}/`
+  let entity = null;
+  switch (type.toLowerCase()) {
+    case "context":
+      entity = "contexts";
+      break;
+    case "strategy":
+      entity = "strategies";
+      break;
+    case "property":
+      entity = "propertyclaims";
+      break;
+    case "evidence":
+      entity = "evidence";
+      break;
+    default:
+      entity = "goals";
+      break;
+  }
 
-        const requestOptions: RequestInit = {
-            method: "POST",
-            headers: {
-                Authorization: `Token ${token}`,
-                "Content-Type": "application/json",
-            },
-            body: JSON.stringify(newItem),
-        };
-        const response = await fetch(url, requestOptions);
+  try {
+    let url = `${process.env.NEXT_PUBLIC_API_URL}/api/${entity}/${id}/`;
 
-        if (!response.ok) {
-            return { error: `Something went wrong ${response.status}` }
-        }
+    const requestOptions: RequestInit = {
+      method: "DELETE",
+      headers: {
+        Authorization: `Token ${token}`,
+        "Content-Type": "application/json",
+      },
+    };
+    const response = await fetch(url, requestOptions);
 
-        const result = await response.json()
-        console.log('Node Create Result', result)
-
-        const data = {
-            ...newItem,
-            id: result.id
-        }
-
-        return { data }
-    } catch (error) {
-        console.log('Error', error)
-        return { error }
+    if (response.ok) {
+      return true;
     }
-}
+  } catch (error) {
+    console.log("Error", error);
+    return false;
+  }
+};
 
-export const deleteAssuranceCaseNode = async (type: string, id: any, token: string | null) => {
-    if (!token) return console.log('No token')
+export const updateAssuranceCaseNode = async (
+  type: string,
+  id: any,
+  token: string | null,
+  updateItem: any
+) => {
+  if (!token) return console.log("No token");
 
-    let entity = null
-    switch (type.toLowerCase()) {
-        case 'context':
-            entity = 'contexts'
-            break;
-        case 'strategy':
-            entity = 'strategies'
-            break;
-        case 'property':
-            entity = 'propertyclaims'
-            break;
-        case 'evidence':
-            entity = 'evidence'
-            break;
-        default:
-            entity = 'goals'
-            break;
+  let entity = null;
+  switch (type) {
+    case "context":
+      entity = "contexts";
+      break;
+    case "strategy":
+      entity = "strategies";
+      break;
+    case "property":
+      entity = "propertyclaims";
+      break;
+    case "evidence":
+      entity = "evidence";
+      break;
+    default:
+      entity = "goals";
+      break;
+  }
+
+  try {
+    let url = `${process.env.NEXT_PUBLIC_API_URL}/api/${entity}/${id}/`;
+
+    const requestOptions: RequestInit = {
+      method: "PUT",
+      headers: {
+        Authorization: `Token ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(updateItem),
+    };
+    const response = await fetch(url, requestOptions);
+
+    if (response.ok) {
+      return true;
     }
-
-    try {
-        let url = `${process.env.NEXT_PUBLIC_API_URL}/api/${entity}/${id}/`
-
-        const requestOptions: RequestInit = {
-            method: "DELETE",
-            headers: {
-                Authorization: `Token ${token}`,
-                "Content-Type": "application/json",
-            }
-        };
-        const response = await fetch(url, requestOptions);
-
-        if (response.ok) {
-            return true
-        }
-    } catch (error) {
-        console.log('Error', error)
-        return false
-    }
-}
-
-export const updateAssuranceCaseNode = async (type: string, id: any, token: string | null, updateItem: any) => {
-    if (!token) return console.log('No token')
-
-    let entity = null
-    switch (type) {
-        case 'context':
-            entity = 'contexts'
-            break;
-        case 'strategy':
-            entity = 'strategies'
-            break;
-        case 'property':
-            entity = 'propertyclaims'
-            break;
-        case 'evidence':
-            entity = 'evidence'
-            break;
-        default:
-            entity = 'goals'
-            break;
-    }
-
-    try {
-        let url = `${process.env.NEXT_PUBLIC_API_URL}/api/${entity}/${id}/`
-
-        const requestOptions: RequestInit = {
-            method: "PUT",
-            headers: {
-                Authorization: `Token ${token}`,
-                "Content-Type": "application/json",
-            },
-            body: JSON.stringify(updateItem)
-        };
-        const response = await fetch(url, requestOptions);
-
-        if (response.ok) {
-            return true
-        }
-    } catch (error) {
-        console.log('Error', error)
-        return false
-    }
-}
+  } catch (error) {
+    console.log("Error", error);
+    return false;
+  }
+};
 
 export const findItemById = async (item: any, id: any) => {
-    if (item.id === id) {
-        // updateFn(item); // Update the item
-        return item
-    }
-    if (item.context) {
-        item.context.forEach((contextItem: any) => findItemById(contextItem, id));
-    }
-    if (item.property_claims) {
-        item.property_claims.forEach((propertyClaim: any) => {
-            findItemById(propertyClaim, id);
-            if (propertyClaim.property_claims) {
-                propertyClaim.property_claims.forEach((childPropertyClaim: any) => findItemById(childPropertyClaim, id));
-            }
-        });
-    }
-    if (item.evidence) {
-        item.evidence.forEach((evidenceItem: any) => findItemById(evidenceItem, id));
-    }
-    if (item.strategies) {
-        item.strategies.forEach((strategyItem: any) => {
-            findItemById(strategyItem, id);
-            if (strategyItem.property_claims) {
-                strategyItem.property_claims.forEach((childPropertyClaim: any) => findItemById(childPropertyClaim, id));
-            }
-        });
-    }
+  if (item.id === id) {
+    // updateFn(item); // Update the item
+    return item;
+  }
+  if (item.context) {
+    item.context.forEach((contextItem: any) => findItemById(contextItem, id));
+  }
+  if (item.property_claims) {
+    item.property_claims.forEach((propertyClaim: any) => {
+      findItemById(propertyClaim, id);
+      if (propertyClaim.property_claims) {
+        propertyClaim.property_claims.forEach((childPropertyClaim: any) =>
+          findItemById(childPropertyClaim, id)
+        );
+      }
+    });
+  }
+  if (item.evidence) {
+    item.evidence.forEach((evidenceItem: any) =>
+      findItemById(evidenceItem, id)
+    );
+  }
+  if (item.strategies) {
+    item.strategies.forEach((strategyItem: any) => {
+      findItemById(strategyItem, id);
+      if (strategyItem.property_claims) {
+        strategyItem.property_claims.forEach((childPropertyClaim: any) =>
+          findItemById(childPropertyClaim, id)
+        );
+      }
+    });
+  }
 
-    return null
-}
-
-export const updateAssuranceCase = async (type: string, assuranceCase: any, updatedItem: any, id: any, node: any, move: boolean = false) => {
-    let updatedAssuranceCase: any
-    let updatedGoals: any
-
-    switch (type) {
-        case 'context':
-            const newContext = assuranceCase.goals[0].context.map((context: any) => {
-                if (context.id === id && context.type === 'Context') {
-                    return {
-                        ...context,
-                        ...updatedItem
-                    }
-                }
-                return { ...context }
-            })
-
-            updatedAssuranceCase = {
-                ...assuranceCase,
-                goals: [{ ...assuranceCase.goals[0], context: newContext }]
-            }
-            return updatedAssuranceCase
-        case 'strategy':
-            // Create a new strategy array by adding the new context item
-            const newStrategy = assuranceCase.goals[0].strategies.map((strategy: any) => {
-                if (strategy.id === id && strategy.type === 'Strategy') {
-                    return {
-                        ...strategy,
-                        ...updatedItem
-                    }
-                }
-                return { ...strategy }
-            })
-
-            // Create a new assuranceCase object with the updated strategy array
-            updatedAssuranceCase = {
-                ...assuranceCase,
-                goals: [
-                    {
-                        ...assuranceCase.goals[0],
-                        strategies: newStrategy
-                    }
-                ]
-            }
-            return updatedAssuranceCase
-        case 'property':
-            // updatedGoals = updatePropertyClaimNested(assuranceCase.goals, id, updatedItem);
-            if(move) {
-                updatedGoals = updatePropertyClaimNestedMove(assuranceCase.goals, id, updatedItem);
-            } else {
-                updatedGoals = updatePropertyClaimNested(assuranceCase.goals, id, updatedItem);
-            }
-            updatedAssuranceCase = {
-                ...assuranceCase,
-                goals: updatedGoals
-            }
-            return updatedAssuranceCase
-        case 'evidence':
-            // updatedGoals = updateEvidenceNested(assuranceCase.goals, id, updatedItem);
-            if(move) {
-                updatedGoals = updateEvidenceNestedMove(assuranceCase.goals, id, updatedItem);
-            } else {
-                updatedGoals = updateEvidenceNested(assuranceCase.goals, id, updatedItem);
-            }
-            console.log(updatedGoals)
-            updatedAssuranceCase = {
-                ...assuranceCase,
-                goals: updatedGoals
-            }
-            return updatedAssuranceCase
-        default:
-            updatedAssuranceCase = {
-                ...assuranceCase,
-                goals: [{
-                    ...assuranceCase.goals[0],
-                    ...updatedItem
-                }]
-            }
-            return updatedAssuranceCase
-    }
-}
-
-export const setNodeIdentifier = (parentNode: any, newNodeType: string) => {
-    let identifier: number = 0
-    let newArray: any[] = []
-    let parentPrefix: number | null = null
-
-    switch (newNodeType.toLowerCase()) {
-        case 'context':
-            newArray = [...parentNode.data.context]
-            break;
-        case 'strategy':
-            newArray = [...parentNode.data.strategies]
-            break;
-        case 'property':
-            parentPrefix = parseFloat(parentNode.data.name.substring(1))
-            newArray = [...parentNode.data.property_claims]
-            break;
-        case 'evidence':
-            newArray = [...parentNode.data.evidence]
-            break;
-        default:
-            break;
-    }
-
-    if (newArray.length > 0) {
-        const lastItem = newArray.pop()
-
-        if (newNodeType === 'property' && parentNode.type === 'property') {
-            const lastIdentifier = parseFloat(lastItem.name.substring(1)).toString()
-            const subIdentifier = lastIdentifier.split('.')[1]
-            identifier = parseInt(subIdentifier) + 1;
-        }
-        else {
-            const lastIdentifier = parseFloat(lastItem.name.substring(1))
-            identifier = lastIdentifier + 1
-        }
-    } else {
-        identifier = 1
-    }
-
-    if (parentNode && parentNode.type === 'property' && parentPrefix !== null) {
-        return `${parentPrefix}.${identifier}`;
-    }
-
-    return identifier.toString()
-}
-
-// Removing elements from Assurance Case
-const removeItemFromNestedStructure = (array: any[], id: any, type: string): any[] => {
-    return array.map((item: any) => {
-        // Remove from property_claims
-        if (item.property_claims) {
-            item.property_claims = item.property_claims.filter((claim: any) => !(claim.id === id && claim.type === type));
-            item.property_claims = removeItemFromNestedStructure(item.property_claims, id, type);
-        }
-
-        // Remove from strategies
-        if (item.strategies) {
-            item.strategies = item.strategies.map((strategy: any) => {
-                if (strategy.property_claims) {
-                    strategy.property_claims = strategy.property_claims.filter((claim: any) => !(claim.id === id && claim.type === type));
-                    strategy.property_claims = removeItemFromNestedStructure(strategy.property_claims, id, type);
-                }
-                return strategy;
-            }).filter((strategy: any) => !(strategy.id === id && strategy.type === type));
-        }
-
-        // Remove from contexts
-        if (item.context) {
-            item.context = item.context.filter((context: any) => !(context.id === id && context.type === type));
-            item.context = removeItemFromNestedStructure(item.context, id, type);
-        }
-
-        // Remove from evidence
-        if (item.evidence) {
-            item.evidence = item.evidence.filter((evidence: any) => !(evidence.id === id && evidence.type === type));
-            item.evidence = removeItemFromNestedStructure(item.evidence, id, type);
-        }
-
-        return item;
-    }).filter((item: any) => !(item.id === id && item.type === type));
+  return null;
 };
 
+export const updateAssuranceCase = async (
+  type: string,
+  assuranceCase: any,
+  updatedItem: any,
+  id: any,
+  node: any,
+  move: boolean = false
+) => {
+  let updatedAssuranceCase: any;
+  let updatedGoals: any;
 
-export const removeAssuranceCaseNode = (assuranceCase: any, id: any, type: string) => {
-    console.log(`Remove id: ${id} type: ${type}`)
-    const updatedGoals = removeItemFromNestedStructure(assuranceCase.goals, id, type);
-    console.log('updatedGoals', updatedGoals)
-    return {
+  switch (type) {
+    case "context":
+      const newContext = assuranceCase.goals[0].context.map((context: any) => {
+        if (context.id === id && context.type === "Context") {
+          return {
+            ...context,
+            ...updatedItem,
+          };
+        }
+        return { ...context };
+      });
+
+      updatedAssuranceCase = {
         ...assuranceCase,
-        goals: updatedGoals
-    };
-}
+        goals: [{ ...assuranceCase.goals[0], context: newContext }],
+      };
+      return updatedAssuranceCase;
+    case "strategy":
+      // Create a new strategy array by adding the new context item
+      const newStrategy = assuranceCase.goals[0].strategies.map(
+        (strategy: any) => {
+          if (strategy.id === id && strategy.type === "Strategy") {
+            return {
+              ...strategy,
+              ...updatedItem,
+            };
+          }
+          return { ...strategy };
+        }
+      );
+
+      // Create a new assuranceCase object with the updated strategy array
+      updatedAssuranceCase = {
+        ...assuranceCase,
+        goals: [
+          {
+            ...assuranceCase.goals[0],
+            strategies: newStrategy,
+          },
+        ],
+      };
+      return updatedAssuranceCase;
+    case "property":
+      // updatedGoals = updatePropertyClaimNested(assuranceCase.goals, id, updatedItem);
+      if (move) {
+        updatedGoals = updatePropertyClaimNestedMove(
+          assuranceCase.goals,
+          id,
+          updatedItem
+        );
+      } else {
+        updatedGoals = updatePropertyClaimNested(
+          assuranceCase.goals,
+          id,
+          updatedItem
+        );
+      }
+      updatedAssuranceCase = {
+        ...assuranceCase,
+        goals: updatedGoals,
+      };
+      return updatedAssuranceCase;
+    case "evidence":
+      // updatedGoals = updateEvidenceNested(assuranceCase.goals, id, updatedItem);
+      if (move) {
+        updatedGoals = updateEvidenceNestedMove(
+          assuranceCase.goals,
+          id,
+          updatedItem
+        );
+      } else {
+        updatedGoals = updateEvidenceNested(
+          assuranceCase.goals,
+          id,
+          updatedItem
+        );
+      }
+      console.log(updatedGoals);
+      updatedAssuranceCase = {
+        ...assuranceCase,
+        goals: updatedGoals,
+      };
+      return updatedAssuranceCase;
+    default:
+      updatedAssuranceCase = {
+        ...assuranceCase,
+        goals: [
+          {
+            ...assuranceCase.goals[0],
+            ...updatedItem,
+          },
+        ],
+      };
+      return updatedAssuranceCase;
+  }
+};
+
+export const setNodeIdentifier = (parentNode: any, newNodeType: string) => {
+  let identifier: number = 0;
+  let newArray: any[] = [];
+  let parentPrefix: number | null = null;
+
+  switch (newNodeType.toLowerCase()) {
+    case "context":
+      newArray = [...parentNode.data.context];
+      break;
+    case "strategy":
+      newArray = [...parentNode.data.strategies];
+      break;
+    case "property":
+      parentPrefix = parseFloat(parentNode.data.name.substring(1));
+      newArray = [...parentNode.data.property_claims];
+      break;
+    case "evidence":
+      newArray = [...parentNode.data.evidence];
+      break;
+    default:
+      break;
+  }
+
+  if (newArray.length > 0) {
+    const lastItem = newArray.pop();
+
+    if (newNodeType === "property" && parentNode.type === "property") {
+      const lastIdentifier = parseFloat(lastItem.name.substring(1)).toString();
+      const subIdentifier = lastIdentifier.split(".")[1];
+      identifier = parseInt(subIdentifier) + 1;
+    } else {
+      const lastIdentifier = parseFloat(lastItem.name.substring(1));
+      identifier = lastIdentifier + 1;
+    }
+  } else {
+    identifier = 1;
+  }
+
+  if (parentNode && parentNode.type === "property" && parentPrefix !== null) {
+    return `${parentPrefix}.${identifier}`;
+  }
+
+  return identifier.toString();
+};
+
+// Removing elements from Assurance Case
+const removeItemFromNestedStructure = (
+  array: any[],
+  id: any,
+  type: string
+): any[] => {
+  return array
+    .map((item: any) => {
+      // Remove from property_claims
+      if (item.property_claims) {
+        item.property_claims = item.property_claims.filter(
+          (claim: any) => !(claim.id === id && claim.type === type)
+        );
+        item.property_claims = removeItemFromNestedStructure(
+          item.property_claims,
+          id,
+          type
+        );
+      }
+
+      // Remove from strategies
+      if (item.strategies) {
+        item.strategies = item.strategies
+          .map((strategy: any) => {
+            if (strategy.property_claims) {
+              strategy.property_claims = strategy.property_claims.filter(
+                (claim: any) => !(claim.id === id && claim.type === type)
+              );
+              strategy.property_claims = removeItemFromNestedStructure(
+                strategy.property_claims,
+                id,
+                type
+              );
+            }
+            return strategy;
+          })
+          .filter(
+            (strategy: any) => !(strategy.id === id && strategy.type === type)
+          );
+      }
+
+      // Remove from contexts
+      if (item.context) {
+        item.context = item.context.filter(
+          (context: any) => !(context.id === id && context.type === type)
+        );
+        item.context = removeItemFromNestedStructure(item.context, id, type);
+      }
+
+      // Remove from evidence
+      if (item.evidence) {
+        item.evidence = item.evidence.filter(
+          (evidence: any) => !(evidence.id === id && evidence.type === type)
+        );
+        item.evidence = removeItemFromNestedStructure(item.evidence, id, type);
+      }
+
+      return item;
+    })
+    .filter((item: any) => !(item.id === id && item.type === type));
+};
+
+export const removeAssuranceCaseNode = (
+  assuranceCase: any,
+  id: any,
+  type: string
+) => {
+  console.log(`Remove id: ${id} type: ${type}`);
+  const updatedGoals = removeItemFromNestedStructure(
+    assuranceCase.goals,
+    id,
+    type
+  );
+  console.log("updatedGoals", updatedGoals);
+  return {
+    ...assuranceCase,
+    goals: updatedGoals,
+  };
+};
 
 export const extractGoalsClaimsStrategies = (array: any) => {
-    const result = {
-        goal: null,
-        claims: <any[]>[],
-        strategies: <any[]>[]
-    };
+  const result = {
+    goal: null,
+    claims: <any[]>[],
+    strategies: <any[]>[],
+  };
 
-    const traverse = (items: any) => {
-        items.forEach((item: any) => {
-            // Collect goals
-            if (item.type === "TopLevelNormativeGoal") {
-                result.goal = item;
-            }
+  const traverse = (items: any) => {
+    items.forEach((item: any) => {
+      // Collect goals
+      if (item.type === "TopLevelNormativeGoal") {
+        result.goal = item;
+      }
 
-            // Collect property claims
-            if (item.type === "PropertyClaim") {
-                result.claims.push(item);
-            }
+      // Collect property claims
+      if (item.type === "PropertyClaim") {
+        result.claims.push(item);
+      }
 
-            // Collect strategies
-            if (item.type !== "Evidence" && item.type !== "Context") {
-                result.strategies.push(item);
-            }
+      // Collect strategies
+      if (item.type !== "Evidence" && item.type !== "Context") {
+        result.strategies.push(item);
+      }
 
-            // Traverse nested structures
-            if (item.property_claims) {
-                traverse(item.property_claims);
-            }
-            if (item.strategies) {
-                traverse(item.strategies);
-            }
-            if (item.context) {
-                traverse(item.context);
-            }
-            if (item.evidence) {
-                traverse(item.evidence);
-            }
-        });
-    };
+      // Traverse nested structures
+      if (item.property_claims) {
+        traverse(item.property_claims);
+      }
+      if (item.strategies) {
+        traverse(item.strategies);
+      }
+      if (item.context) {
+        traverse(item.context);
+      }
+      if (item.evidence) {
+        traverse(item.evidence);
+      }
+    });
+  };
 
-    traverse(array);
-    return result;
+  traverse(array);
+  return result;
 };
 
 export const addHiddenProp = async (assuranceCase: any) => {
-    if (Array.isArray(assuranceCase)) {
-        assuranceCase.forEach(addHiddenProp);
-    } else if (typeof assuranceCase === 'object' && assuranceCase !== null) {
-        assuranceCase.hidden = false;
+  if (Array.isArray(assuranceCase)) {
+    assuranceCase.forEach(addHiddenProp);
+  } else if (typeof assuranceCase === "object" && assuranceCase !== null) {
+    assuranceCase.hidden = false;
 
-        Object.keys(assuranceCase).forEach(key => {
-            addHiddenProp(assuranceCase[key]);
-        });
+    Object.keys(assuranceCase).forEach((key) => {
+      addHiddenProp(assuranceCase[key]);
+    });
+  }
+  return assuranceCase;
+};
+
+const getAdjacent = (caseNode: CaseNode): Array<CaseNode> => {
+  if (caseNode.type == "AssuranceCase") {
+    return caseNode["goals"];
+  } else if (caseNode.type == "TopLevelNormativeGoal") {
+    return caseNode["context"].concat(
+      caseNode["property_claims"],
+      caseNode["strategies"],
+      caseNode["context"]
+    );
+  } else if (caseNode.type == "Strategy") {
+    return caseNode["property_claims"];
+  } else if (caseNode.type == "PropertyClaim") {
+    return caseNode["property_claims"].concat(caseNode["evidence"]);
+  }
+
+  return [];
+};
+
+export function searchWithDeepFirst(
+  targetNode: CaseNode,
+  assuranceCase: CaseNode
+): Array<any> {
+  const visitedNodes: Array<CaseNode> = [];
+  const parentMap: any = {};
+  let nodesToProcess: Array<CaseNode> = [assuranceCase];
+  let nodeFound: CaseNode | null = null;
+
+  while (nodesToProcess.length > 0) {
+    let currentNode: CaseNode | undefined = nodesToProcess.shift();
+    if (currentNode === undefined) {
+      return [];
     }
-    return assuranceCase
+
+    if (currentNode.id == targetNode.id) {
+      visitedNodes.push(currentNode);
+      nodeFound = currentNode;
+      break;
+    } else {
+      visitedNodes.push(currentNode);
+      let adjacentNodes = getAdjacent(currentNode);
+
+      adjacentNodes.forEach((node) => (parentMap[node.id] = currentNode));
+
+      nodesToProcess = nodesToProcess.concat(adjacentNodes);
+    }
+  }
+
+  return [nodeFound, parentMap];
 }
 
-export function toggleHiddenForChildren(assuranceCase: AssuranceCase, parentId: number): AssuranceCase {
-    function toggleChildren(obj: any, parentId: number, parentFound: boolean, hide: boolean): void {
-        if (Array.isArray(obj)) {
-            obj.forEach(item => toggleChildren(item, parentId, parentFound, hide));
-        } else if (typeof obj === 'object' && obj !== null) {
-            // Check if current object is the parent or one of its descendants
-            const isParentOrDescendant = parentFound || obj.id === parentId;
+export function toggleHiddenForParent(
+  node: any,
+  assuranceCase: AssuranceCase
+): AssuranceCase {
+  const newAssuranceCase = JSON.parse(JSON.stringify(assuranceCase));
+  const [nodeFound, parentMap] = searchWithDeepFirst(
+    node.data,
+    newAssuranceCase
+  );
 
-            // Reset childrenHidden if it's a descendant and not the direct parent
-            if (isParentOrDescendant && obj.id !== parentId) {
-                obj.childrenHidden = false;
-            }
+  let currentNode: CaseNode = nodeFound;
+  const nodesToShow: Array<CaseNode> = [];
+  while (currentNode != null) {
+    nodesToShow.push(currentNode);
+    currentNode = parentMap[currentNode.id];
+  }
 
-            if (obj.id === parentId) {
-                parentFound = true;
-                hide = !obj.childrenHidden; // Toggle childrenHidden for the parent
-                obj.childrenHidden = hide;  // Track the state of children visibility
-            }
+  nodesToShow.forEach((node) => (node.hidden = false));
 
-            if (parentFound && obj.id !== parentId) {
-                if (hide) {
-                    if (obj.originalHidden === undefined) {
-                        obj.originalHidden = !!obj.hidden; // Record the original hidden state
-                    }
-                    obj.hidden = true; // Force hidden
-                } else {
-                    if (obj.originalHidden !== undefined) {
-                        obj.hidden = obj.originalHidden; // Reset to original hidden state
-                        delete obj.originalHidden; // Clean up originalHidden property
-                    } else {
-                        obj.hidden = false; // If no original hidden state, set to visible
-                    }
-                }
-            }
+  return newAssuranceCase;
+}
 
-            Object.keys(obj).forEach(key => toggleChildren(obj[key], parentId, parentFound, hide));
+export function toggleHiddenForChildren(
+  assuranceCase: AssuranceCase,
+  parentId: number
+): AssuranceCase {
+  function toggleChildren(
+    obj: any,
+    parentId: number,
+    parentFound: boolean,
+    hide: boolean
+  ): void {
+    if (Array.isArray(obj)) {
+      obj.forEach((item) => toggleChildren(item, parentId, parentFound, hide));
+    } else if (typeof obj === "object" && obj !== null) {
+      // Check if current object is the parent or one of its descendants
+      const isParentOrDescendant = parentFound || obj.id === parentId;
+
+      // Reset childrenHidden if it's a descendant and not the direct parent
+      if (isParentOrDescendant && obj.id !== parentId) {
+        obj.childrenHidden = false;
+      }
+
+      if (obj.id === parentId) {
+        parentFound = true;
+        hide = !obj.childrenHidden; // Toggle childrenHidden for the parent
+        obj.childrenHidden = hide; // Track the state of children visibility
+      }
+
+      if (parentFound && obj.id !== parentId) {
+        if (hide) {
+          if (obj.originalHidden === undefined) {
+            obj.originalHidden = !!obj.hidden; // Record the original hidden state
+          }
+          obj.hidden = true; // Force hidden
+        } else {
+          if (obj.originalHidden !== undefined) {
+            obj.hidden = obj.originalHidden; // Reset to original hidden state
+            delete obj.originalHidden; // Clean up originalHidden property
+          } else {
+            obj.hidden = false; // If no original hidden state, set to visible
+          }
         }
+      }
+
+      Object.keys(obj).forEach((key) =>
+        toggleChildren(obj[key], parentId, parentFound, hide)
+      );
     }
+  }
 
-    // Create a deep copy of the assuranceCase to ensure immutability
-    const newAssuranceCase = JSON.parse(JSON.stringify(assuranceCase));
+  // Create a deep copy of the assuranceCase to ensure immutability
+  const newAssuranceCase = JSON.parse(JSON.stringify(assuranceCase));
 
-    // Toggle hidden property for the children
-    toggleChildren(newAssuranceCase, parentId, false, false);
+  // Toggle hidden property for the children
+  toggleChildren(newAssuranceCase, parentId, false, false);
 
-    return newAssuranceCase;
+  return newAssuranceCase;
 }
 
 export function findElementById(assuranceCase: AssuranceCase, id: number): any {
-    // Recursive function to search for the element with the given ID
-    function searchElement(element: any, id: number): any {
-        if (element.id === id) {
-            return element;
-        }
-        let childrenKeys = ['goals', 'context', 'property_claims', 'strategies', 'evidence', 'comments'];
-        for (let key of childrenKeys) {
-            if (element[key]) {
-                for (let child of element[key]) {
-                    let result = searchElement(child, id);
-                    if (result) {
-                        return result;
-                    }
-                }
-            }
-        }
-        return null;
+  // Recursive function to search for the element with the given ID
+  function searchElement(element: any, id: number): any {
+    if (element.id === id) {
+      return element;
     }
+    let childrenKeys = [
+      "goals",
+      "context",
+      "property_claims",
+      "strategies",
+      "evidence",
+      "comments",
+    ];
+    for (let key of childrenKeys) {
+      if (element[key]) {
+        for (let child of element[key]) {
+          let result = searchElement(child, id);
+          if (result) {
+            return result;
+          }
+        }
+      }
+    }
+    return null;
+  }
 
-    return searchElement(assuranceCase, id);
+  return searchElement(assuranceCase, id);
 }
 
 export function getChildrenHiddenStatus(element: any): boolean[] {
-    let hiddenStatus: boolean[] = [];
-    let childrenKeys = ['context', 'property_claims', 'strategies', 'evidence', 'comments'];
-    for (let key of childrenKeys) {
-        if (element[key]) {
-            for (let child of element[key]) {
-                hiddenStatus.push(child.hidden);
-                // Recursively check nested property claims and strategies
-                if (key === 'property_claims' || key === 'strategies') {
-                    hiddenStatus = hiddenStatus.concat(getChildrenHiddenStatus(child));
-                }
-            }
+  let hiddenStatus: boolean[] = [];
+  let childrenKeys = [
+    "context",
+    "property_claims",
+    "strategies",
+    "evidence",
+    "comments",
+  ];
+  for (let key of childrenKeys) {
+    if (element[key]) {
+      for (let child of element[key]) {
+        hiddenStatus.push(child.hidden);
+        // Recursively check nested property claims and strategies
+        if (key === "property_claims" || key === "strategies") {
+          hiddenStatus = hiddenStatus.concat(getChildrenHiddenStatus(child));
         }
+      }
     }
-    return hiddenStatus;
+  }
+  return hiddenStatus;
 }
 
-export const findSiblingHiddenState = (assuranceCase: AssuranceCase, parentId: number) => {
-    const element = findElementById(assuranceCase, parentId);
-    if (element) {
-        const hiddenStatus = getChildrenHiddenStatus(element);
+export const findSiblingHiddenState = (
+  assuranceCase: AssuranceCase,
+  parentId: number
+) => {
+  const element = findElementById(assuranceCase, parentId);
+  if (element) {
+    const hiddenStatus = getChildrenHiddenStatus(element);
 
-        if(hiddenStatus.length === 0) {
-            // then get parents hidden value
-            return element.hidden
-        } else {
-            return hiddenStatus[0]
-        }
-
+    if (hiddenStatus.length === 0) {
+      // then get parents hidden value
+      return element.hidden;
     } else {
-        console.log(`Element with ID ${parentId} not found.`);
+      return hiddenStatus[0];
     }
-}
+  } else {
+    console.log(`Element with ID ${parentId} not found.`);
+  }
+};
 
 export const findParentNode = (nodes: any, node: any) => {
-    let parent = null
+  let parent = null;
 
-    if(node.data.goal_id) {
-        // search for goal
-        return parent = nodes.filter((n: any) => n.data.id === node.data.goal_id)[0]
+  if (node.data.goal_id) {
+    // search for goal
+    return (parent = nodes.filter(
+      (n: any) => n.data.id === node.data.goal_id
+    )[0]);
+  }
+  if (node.data.property_claim_id) {
+    if (node.type === "evidence") {
+      return (parent = nodes.filter(
+        (n: any) => n.data.id === node.data.property_claim_id[0]
+      )[0]);
     }
-    if(node.data.property_claim_id) {
-        if(node.type === 'evidence') {
-            return parent = nodes.filter((n: any) => n.data.id === node.data.property_claim_id[0])[0]
-        }
-        // search for property claim
-        return parent = nodes.filter((n: any) => n.data.id === node.data.property_claim_id)[0]
-    }
-    if(node.data.strategy_id) {
-        // search for strategy
-        return parent = nodes.filter((n: any) => n.data.id === node.data.strategy_id)[0]
-    }
-    return parent
-}
+    // search for property claim
+    return (parent = nodes.filter(
+      (n: any) => n.data.id === node.data.property_claim_id
+    )[0]);
+  }
+  if (node.data.strategy_id) {
+    // search for strategy
+    return (parent = nodes.filter(
+      (n: any) => n.data.id === node.data.strategy_id
+    )[0]);
+  }
+  return parent;
+};
 
-export const detachCaseElement = async (node: any, type: string, id: any, token: string | null): Promise<any>  => {
-    if (!token) return { error: 'No token' }
+export const detachCaseElement = async (
+  node: any,
+  type: string,
+  id: any,
+  token: string | null
+): Promise<any> => {
+  if (!token) return { error: "No token" };
 
-    console.log('Detaching Node', node)
+  console.log("Detaching Node", node);
 
-    const payload: any = {
-        goal_id: null,
-        strategy_id: null,
-        property_claim_id: null
-    }
+  const payload: any = {
+    goal_id: null,
+    strategy_id: null,
+    property_claim_id: null,
+  };
 
-    let entity = null
-    switch (type) {
-        case 'context':
-            entity = 'contexts'
-            break;
-        case 'strategy':
-            entity = 'strategies'
-            break;
-        case 'property':
-            entity = 'propertyclaims'
-            if(node.data.goal_id !== null) {
-                payload.goal_id = node.data.goal_id
-            }
-            if(node.data.strategy_id !== null) {
-                payload.strategy_id = node.data.strategy_id
-            }
-            if(node.data.property_claim_id !== null) {
-                payload.property_claim_id = node.data.property_claim_id
-            }
-            break;
-        case 'evidence':
-            entity = 'evidence'
-            payload.property_claim_id = node.data.property_claim_id[0]
-            break;
-    }
+  let entity = null;
+  switch (type) {
+    case "context":
+      entity = "contexts";
+      break;
+    case "strategy":
+      entity = "strategies";
+      break;
+    case "property":
+      entity = "propertyclaims";
+      if (node.data.goal_id !== null) {
+        payload.goal_id = node.data.goal_id;
+      }
+      if (node.data.strategy_id !== null) {
+        payload.strategy_id = node.data.strategy_id;
+      }
+      if (node.data.property_claim_id !== null) {
+        payload.property_claim_id = node.data.property_claim_id;
+      }
+      break;
+    case "evidence":
+      entity = "evidence";
+      payload.property_claim_id = node.data.property_claim_id[0];
+      break;
+  }
 
-    try {
-        let url = `${process.env.NEXT_PUBLIC_API_URL}/api/${entity}/${id}/detach`
+  try {
+    let url = `${process.env.NEXT_PUBLIC_API_URL}/api/${entity}/${id}/detach`;
 
-        const requestOptions: RequestInit = {
-            method: "POST",
-            headers: {
-                Authorization: `Token ${token}`,
-                "Content-Type": "application/json",
-            },
-            body: JSON.stringify(payload)
-        };
+    const requestOptions: RequestInit = {
+      method: "POST",
+      headers: {
+        Authorization: `Token ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    };
 
-        const response = await fetch(url, requestOptions);
+    const response = await fetch(url, requestOptions);
 
-        if (!response.ok) {
-            return { error: `Something went wrong ${response.status}` }
-        }
-
-        return { detached: true }
-    } catch (error) {
-        console.log('Error', error)
-        return { error }
-    }
-}
-
-export const attachCaseElement = async (orphan: any, id: any, token: string | null, parent: any): Promise<any>  => {
-    if (!token) return { error: 'No token' }
-
-    console.log('Parent', parent)
-
-    const payload: any = {
-        goal_id: null,
-        strategy_id: null,
-        property_claim_id: null
+    if (!response.ok) {
+      return { error: `Something went wrong ${response.status}` };
     }
 
-    let entity = null
-    switch (orphan.type.toLowerCase()) {
-        case 'context':
-            entity = 'contexts'
-            payload.goal_id = parent.data.id
-            break;
-        case 'strategy':
-            entity = 'strategies'
-            payload.goal_id = parent.data.id
-            break;
-        case 'propertyclaim':
-            entity = 'propertyclaims'
+    return { detached: true };
+  } catch (error) {
+    console.log("Error", error);
+    return { error };
+  }
+};
 
-            if(parent.type === 'property') {
-                payload.property_claim_id = parent.data.id
-            }
-            if(parent.type === 'strategy') {
-                payload.strategy_id = parent.data.id
-            }
-            if(parent.type === 'goal') {
-                payload.goal_id = parent.data.id
-            }
-            break;
-        case 'evidence':
-            entity = 'evidence'
-            payload.property_claim_id = parent.data.id
-            break;
+export const attachCaseElement = async (
+  orphan: any,
+  id: any,
+  token: string | null,
+  parent: any
+): Promise<any> => {
+  if (!token) return { error: "No token" };
+
+  console.log("Parent", parent);
+
+  const payload: any = {
+    goal_id: null,
+    strategy_id: null,
+    property_claim_id: null,
+  };
+
+  let entity = null;
+  switch (orphan.type.toLowerCase()) {
+    case "context":
+      entity = "contexts";
+      payload.goal_id = parent.data.id;
+      break;
+    case "strategy":
+      entity = "strategies";
+      payload.goal_id = parent.data.id;
+      break;
+    case "propertyclaim":
+      entity = "propertyclaims";
+
+      if (parent.type === "property") {
+        payload.property_claim_id = parent.data.id;
+      }
+      if (parent.type === "strategy") {
+        payload.strategy_id = parent.data.id;
+      }
+      if (parent.type === "goal") {
+        payload.goal_id = parent.data.id;
+      }
+      break;
+    case "evidence":
+      entity = "evidence";
+      payload.property_claim_id = parent.data.id;
+      break;
+  }
+
+  console.log("Payload", payload);
+
+  try {
+    let url = `${process.env.NEXT_PUBLIC_API_URL}/api/${entity}/${id}/attach`;
+
+    const requestOptions: RequestInit = {
+      method: "POST",
+      headers: {
+        Authorization: `Token ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    };
+    const response = await fetch(url, requestOptions);
+
+    if (!response.ok) {
+      return { error: `Something went wrong ${response.status}` };
     }
 
-    console.log('Payload', payload)
-
-    try {
-        let url = `${process.env.NEXT_PUBLIC_API_URL}/api/${entity}/${id}/attach`
-
-        const requestOptions: RequestInit = {
-            method: "POST",
-            headers: {
-                Authorization: `Token ${token}`,
-                "Content-Type": "application/json",
-            },
-            body: JSON.stringify(payload),
-        };
-        const response = await fetch(url, requestOptions);
-
-        if (!response.ok) {
-            return { error: `Something went wrong ${response.status}` }
-        }
-
-        return { attached: true }
-    } catch (error) {
-        console.log('Error', error)
-        return { error }
-    }
-}
+    return { attached: true };
+  } catch (error) {
+    console.log("Error", error);
+    return { error };
+  }
+};


### PR DESCRIPTION
For implemented this feature:

1. In `Header.tsx`, I added the `unhideParents` function, which is called as part of the `focusNode` method invoked when selecting a case element from the case results.
2. In `unhideParents`, we call `toggleHiddenForParent` (from `case-helper.ts`) for obtaining a new case representation, where the relevant nodes have `node.hidden == false`. This new case representation is placed in the store via `setAssuranceCase`.
3. The `toggleHiddenForParent` method uses [deep-first search](https://en.wikipedia.org/wiki/Depth-first_search) (implement in `searchWithDeepFirst`) to find the case elements to unhide.
4. @RichGriff made some updates to `store.ts`, to fix some issues when zooming to the selected case element.