### PR TITLE
Return unique name after case element creation

### DIFF
--- a/eap_backend/eap_api/model_utils.py
+++ b/eap_backend/eap_api/model_utils.py
@@ -5,13 +5,35 @@ from django.db.models.query import QuerySet
 
 from .models import (
     PropertyClaim,
+    Strategy,
     TopLevelNormativeGoal,
 )
 
 
+def get_property_claims_by_case_id(case_id: int | None) -> tuple[list[int], list[int]]:
+    if case_id is None:
+        error_message: str = "Please provide an assurance case id."
+        raise ValueError(error_message)
+
+    current_case_goal: TopLevelNormativeGoal = TopLevelNormativeGoal.objects.get(
+        assurance_case_id=case_id
+    )
+
+    current_case_strategies: QuerySet = Strategy.objects.filter(
+        goal_id=current_case_goal.pk
+    )
+
+    (
+        top_level_claim_ids,
+        child_claim_ids,
+    ) = get_case_property_claims(current_case_goal, current_case_strategies)
+
+    return top_level_claim_ids, child_claim_ids
+
+
 def get_case_property_claims(
     goal: TopLevelNormativeGoal, strategies: QuerySet
-) -> tuple:
+) -> tuple[list[int], list[int]]:
     """Retrieves all the property claims associated to a goal and a list of strategies.
 
     Args:

--- a/eap_backend/eap_api/model_utils.py
+++ b/eap_backend/eap_api/model_utils.py
@@ -1,0 +1,65 @@
+from typing import Callable
+
+from django.db.models import Q
+from django.db.models.query import QuerySet
+
+from .models import (
+    PropertyClaim,
+    TopLevelNormativeGoal,
+)
+
+
+def get_case_property_claims(
+    goal: TopLevelNormativeGoal, strategies: QuerySet
+) -> tuple:
+    """Retrieves all the property claims associated to a goal and a list of strategies.
+
+    Args:
+        goal: Goal whose property claims we will extract.
+        strategies: Strategies whose property claims we will extract.
+
+    Returns:
+        A tuple containing parent property claims and child property claims, all sorted
+        by primary key.
+    """
+    strategy_ids: list[int] = [strategy.pk for strategy in strategies]
+    top_level_claims: QuerySet = PropertyClaim.objects.filter(
+        Q(goal_id=goal.pk) | Q(strategy__id__in=strategy_ids)
+    )
+
+    top_level_claim_ids: list[int] = [claim.pk for claim in top_level_claims]
+
+    child_claim_ids: list[int] = []
+    for parent_claim_id in top_level_claim_ids:
+        traverse_child_property_claims(
+            lambda _, child, parent: child_claim_ids.append(child.pk),  # noqa: ARG005
+            parent_claim_id,
+        )
+
+    return top_level_claim_ids, sorted(child_claim_ids)
+
+
+def traverse_child_property_claims(
+    on_child_claim: Callable[[int, PropertyClaim, PropertyClaim], None],
+    parent_claim_id: int,
+):
+    """Applies a function to all the children of a Property Claim.
+
+    Args:
+        on_child_claim: The function to call on each child claim.
+        parent_claim_id: The id of the claim we will traverse.
+    """
+    child_property_claims = PropertyClaim.objects.filter(
+        property_claim_id=parent_claim_id
+    ).order_by("id")
+
+    if len(child_property_claims) == 0:
+        return
+    else:
+        for index, child_property_claim in enumerate(child_property_claims):
+            on_child_claim(
+                index,
+                child_property_claim,
+                PropertyClaim.objects.get(pk=parent_claim_id),
+            )
+            traverse_child_property_claims(on_child_claim, child_property_claim.pk)

--- a/eap_backend/eap_api/serializers.py
+++ b/eap_backend/eap_api/serializers.py
@@ -339,6 +339,14 @@ class StrategySerializer(serializers.ModelSerializer):
 
         extra_kwargs = {"name": {"allow_null": True, "required": False}}
 
+    def create(self, validated_data: dict) -> Strategy:
+        candidate_index: int = (
+            Strategy.objects.filter(goal_id=validated_data["goal"].pk).count() + 1
+        )
+
+        validated_data["name"] = get_unique_name(candidate_index, "S", Strategy)
+        return super().create(validated_data)
+
 
 def get_unique_name(
     candidate_index: int, name_prefix: str, model_class: type[CaseItem]

--- a/eap_backend/eap_api/serializers.py
+++ b/eap_backend/eap_api/serializers.py
@@ -192,7 +192,6 @@ class TopLevelNormativeGoalSerializer(serializers.ModelSerializer):
         extra_kwargs = {"name": {"allow_null": True, "required": False}}
 
     def create(self, validated_data: dict) -> TopLevelNormativeGoal:
-        goal: TopLevelNormativeGoal = TopLevelNormativeGoal(**validated_data)
 
         assurance_case_id: int = validated_data["assurance_case"].pk
         candidate_index: int = (
@@ -202,10 +201,11 @@ class TopLevelNormativeGoalSerializer(serializers.ModelSerializer):
             + 1
         )
 
-        goal.name = get_unique_name(candidate_index, "G", TopLevelNormativeGoal)
-        goal.save()
+        validated_data["name"] = get_unique_name(
+            candidate_index, "G", TopLevelNormativeGoal
+        )
 
-        return goal
+        return super().create(validated_data)
 
 
 class ContextSerializer(serializers.ModelSerializer):
@@ -228,6 +228,14 @@ class ContextSerializer(serializers.ModelSerializer):
         )
 
         extra_kwargs = {"name": {"allow_null": True, "required": False}}
+
+    def create(self, validated_data: dict):
+        candidate_index: int = (
+            Context.objects.filter(goal_id=validated_data["goal"].pk).count() + 1
+        )
+        validated_data["name"] = get_unique_name(candidate_index, "C", Context)
+
+        return super().create(validated_data)
 
 
 class PropertyClaimSerializer(serializers.ModelSerializer):

--- a/eap_backend/eap_api/views.py
+++ b/eap_backend/eap_api/views.py
@@ -279,7 +279,8 @@ def goal_list(request: HttpRequest) -> HttpResponse:
         serializer = TopLevelNormativeGoalSerializer(data=data)
         if serializer.is_valid():
             model_instance: TopLevelNormativeGoal = cast(
-                TopLevelNormativeGoal, serializer.save()
+                TopLevelNormativeGoal,
+                serializer.save(),
             )
 
             serialised_model = TopLevelNormativeGoalSerializer(model_instance)

--- a/eap_backend/eap_api/views.py
+++ b/eap_backend/eap_api/views.py
@@ -23,6 +23,7 @@ from .models import (
     TopLevelNormativeGoal,
 )
 from .serializers import (
+    TYPE_DICT,
     AssuranceCaseSerializer,
     CommentSerializer,
     ContextSerializer,
@@ -36,7 +37,6 @@ from .serializers import (
     TopLevelNormativeGoalSerializer,
 )
 from .view_utils import (
-    TYPE_DICT,
     SandboxUtils,
     UpdateIdentifierUtils,
     can_view_group,

--- a/eap_backend/tests/test_views.py
+++ b/eap_backend/tests/test_views.py
@@ -530,9 +530,12 @@ class StrategyViewTest(TestCase):
 
     def test_create_strategy_with_post(self):
 
+        strategy_information: dict[str, Any] = dict(STRATEGY_INFO)
+        strategy_information["name"] = "Wrong name"
+
         response_post: HttpResponse = self.client.post(
             reverse("strategies_list"),
-            data=json.dumps(STRATEGY_INFO),
+            data=json.dumps(strategy_information),
             content_type="application/json",
         )
 
@@ -542,14 +545,23 @@ class StrategyViewTest(TestCase):
         assert len(strategies_created) == 1
 
         current_strategy: Strategy = strategies_created[0]
+        assert current_strategy.name == "S1"
+
         json_response: dict = response_post.json()
 
         assert json_response["id"] == current_strategy.pk
+        assert json_response["name"] == current_strategy.name
+
         assert json_response["type"] == "Strategy"
 
-        assert json_response["name"] == STRATEGY_INFO["name"]
-        assert json_response["short_description"] == STRATEGY_INFO["short_description"]
-        assert json_response["long_description"] == STRATEGY_INFO["long_description"]
+        assert (
+            json_response["short_description"]
+            == strategy_information["short_description"]
+        )
+        assert (
+            json_response["long_description"]
+            == strategy_information["long_description"]
+        )
         assert json_response["goal_id"] == self.goal.pk
         assert json_response["property_claims"] == []
 

--- a/eap_backend/tests/test_views.py
+++ b/eap_backend/tests/test_views.py
@@ -459,9 +459,12 @@ class GoalViewTest(TestCase):
 
         self.goal.delete()
 
+        goal_information: dict[str, Any] = dict(GOAL_INFO)
+        goal_information["name"] = "Wrong Name"
+
         response_post: HttpResponse = self.client.post(
             reverse("goal_list"),
-            data=json.dumps(GOAL_INFO),
+            data=json.dumps(goal_information),
             content_type="application/json",
         )
 
@@ -473,9 +476,11 @@ class GoalViewTest(TestCase):
 
         json_response: dict = response_post.json()
 
+        assert json_response["name"] == "G1"
+        assert current_goal.name == json_response["name"]
+
         assert current_goal.pk == json_response["id"]
         assert json_response["type"] == "TopLevelNormativeGoal"
-        assert current_goal.name == json_response["name"]
         assert current_goal.short_description == json_response["short_description"]
         assert current_goal.long_description == json_response["long_description"]
         assert current_goal.keywords == json_response["keywords"]
@@ -687,6 +692,7 @@ class ContextViewTest(TestCase):
         assert response_post.status_code == 201
 
         context_created: Context = Context.objects.get(name=CONTEXT_INFO["name"])
+
         json_response = response_post.json()
 
         assert json_response["id"] == context_created.pk

--- a/eap_backend/tests/test_views.py
+++ b/eap_backend/tests/test_views.py
@@ -985,35 +985,36 @@ class EvidenceViewTest(TestCase):
     def test_create_evidence_with_post(self):
 
         self.evidence1.delete()
+        evidence_information: dict[str, Any] = dict(EVIDENCE1_INFO_NO_ID)
+        evidence_information["name"] = "Wrong name"
 
         response_post: HttpResponse = self.client.post(
             reverse("evidence_list"),
             data=json.dumps(
-                EVIDENCE1_INFO_NO_ID | {"property_claim_id": [self.pclaim.pk]}
+                evidence_information | {"property_claim_id": [self.pclaim.pk]}
             ),
             content_type="application/json",
         )
 
         assert response_post.status_code == 201
 
-        evidence_created: Evidence = Evidence.objects.get(
-            name=EVIDENCE1_INFO_NO_ID["name"]
-        )
+        evidence_created: Evidence = Evidence.objects.get(name="E2")
         json_response = response_post.json()
 
         assert json_response["id"] == evidence_created.pk
+        assert json_response["name"] == evidence_created.name
+
         assert json_response["type"] == "Evidence"
-        assert json_response["name"] == EVIDENCE1_INFO_NO_ID["name"]
         assert (
             json_response["short_description"]
-            == EVIDENCE1_INFO_NO_ID["short_description"]
+            == evidence_information["short_description"]
         )
         assert (
             json_response["long_description"]
-            == EVIDENCE1_INFO_NO_ID["long_description"]
+            == evidence_information["long_description"]
         )
 
-        assert json_response["URL"] == EVIDENCE1_INFO_NO_ID["URL"]
+        assert json_response["URL"] == evidence_information["URL"]
         assert json_response["property_claim_id"] == [self.pclaim.pk]
 
     def test_evidence_list_view_get(self):

--- a/eap_backend/tests/test_views.py
+++ b/eap_backend/tests/test_views.py
@@ -683,28 +683,36 @@ class ContextViewTest(TestCase):
     def test_create_context_with_post(self):
         self.context.delete()
 
+        context_information: dict[str, Any] = dict(CONTEXT_INFO)
+        context_information["name"] = "Wrong name"
+
         response_post: HttpResponse = self.client.post(
             reverse("context_list"),
-            data=json.dumps(CONTEXT_INFO),
+            data=json.dumps(context_information),
             content_type="application/json",
         )
 
         assert response_post.status_code == 201
 
-        context_created: Context = Context.objects.get(name=CONTEXT_INFO["name"])
+        context_created: Context = Context.objects.get(name="C1")
 
         json_response = response_post.json()
 
         assert json_response["id"] == context_created.pk
+        assert json_response["name"] == context_created.name
         assert json_response["type"] == "Context"
-        assert json_response["name"] == CONTEXT_INFO["name"]
-        assert json_response["short_description"] == CONTEXT_INFO["short_description"]
-        assert json_response["long_description"] == CONTEXT_INFO["long_description"]
+        assert (
+            json_response["short_description"]
+            == context_information["short_description"]
+        )
+        assert (
+            json_response["long_description"] == context_information["long_description"]
+        )
         assert (
             datetime.strptime(json_response["created_date"], "%Y-%m-%dT%H:%M:%S.%f%z")
             == context_created.created_date
         )
-        assert json_response["goal_id"] == CONTEXT_INFO["goal_id"]
+        assert json_response["goal_id"] == context_information["goal_id"]
 
     def test_context_list_view_get(self):
         response_get = self.client.get(reverse("context_list"))


### PR DESCRIPTION
After a POST request to create a case element (Goal, Context, Strategy, Evidence) the JSON document returned will include a name that's unique within then assurance case.