### PR TITLE
New endoint for password change

### DIFF
--- a/eap_backend/eap_api/serializers.py
+++ b/eap_backend/eap_api/serializers.py
@@ -47,6 +47,11 @@ class GitHubRepositorySerializer(serializers.ModelSerializer):
         fields = ("id", "name", "url", "description", "created_date", "owner")
 
 
+class PasswordChangeSerializer(serializers.Serializer):
+    password = serializers.CharField(required=True)
+    new_password = serializers.CharField(required=True)
+
+
 class EAPUserSerializer(serializers.ModelSerializer):
     all_groups = serializers.PrimaryKeyRelatedField(
         many=True, read_only=True, required=False

--- a/eap_backend/eap_api/urls.py
+++ b/eap_backend/eap_api/urls.py
@@ -8,6 +8,11 @@ urlpatterns = [
     path("user/", views.self_detail, name="self_detail"),
     path("users/", views.user_list, name="user_list"),
     path("users/<int:pk>/", views.user_detail, name="user_detail"),
+    path(
+        "users/<int:pk>/change-password",
+        views.change_user_password,
+        name="change_user_password",
+    ),
     path("groups/", views.group_list, name="group_list"),
     path("groups/<int:pk>/", views.group_detail, name="group_detail"),
     path("cases/", views.case_list, name="case_list"),

--- a/eap_backend/eap_api/views.py
+++ b/eap_backend/eap_api/views.py
@@ -36,6 +36,7 @@ from .serializers import (
     EvidenceSerializer,
     GitHubRepositorySerializer,
     GithubSocialAuthSerializer,
+    PasswordChangeSerializer,
     PropertyClaimSerializer,
     StrategySerializer,
     TopLevelNormativeGoalSerializer,
@@ -143,9 +144,25 @@ def change_user_password(request: HttpRequest, pk: int) -> HttpResponse:
 
     if request.user != user_to_update:
         return Response(
-            {"error": "You are not authorized to perform this operation"}, status=403
+            {"error": "You are not authorized to perform this operation"},
+            status=status.HTTP_403_FORBIDDEN,
         )
-    return HttpResponse(status=200)
+
+    serializer = PasswordChangeSerializer(data=request.data)
+    if not serializer.is_valid():
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    if not user_to_update.check_password(
+        raw_password=cast(str, serializer.validated_data.get("password"))
+    ):
+        return Response(
+            {"error": "Passwords do not match"}, status=status.HTTP_400_BAD_REQUEST
+        )
+
+    user_to_update.set_password(serializer.validated_data.get("new_password"))
+    user_to_update.save()
+
+    return HttpResponse({"message": "Password updated!"}, status=200)
 
 
 @csrf_exempt

--- a/eap_backend/eap_api/views.py
+++ b/eap_backend/eap_api/views.py
@@ -136,6 +136,19 @@ def user_detail(request, pk=None):
 
 
 @csrf_exempt
+@api_view(["PUT"])
+@permission_classes([IsAuthenticated])
+def change_user_password(request: HttpRequest, pk: int) -> HttpResponse:
+    user_to_update: EAPUser = EAPUser.objects.get(pk=pk)
+
+    if request.user != user_to_update:
+        return Response(
+            {"error": "You are not authorized to perform this operation"}, status=403
+        )
+    return HttpResponse(status=200)
+
+
+@csrf_exempt
 @api_view(["GET", "POST"])
 def group_list(request):
     """


### PR DESCRIPTION
To consume the endpoint, do a `PUT` request to endpoint `users/<user-id>/change-password` with body `{"password": <current-password>, "new_password": <new-password>}` , to set the password of user with ID `<user-id>`to `<new-password>`. The user needs to provide the old password (`<current-password>`) and the authorization token.