### PR TITLE
Additional options for case retrieval

### DIFF
--- a/eap_backend/eap_api/view_utils.py
+++ b/eap_backend/eap_api/view_utils.py
@@ -404,6 +404,29 @@ class ShareAssuranceCaseUtils:
         }
 
     @staticmethod
+    def get_user_cases(user: EAPUser, shared: bool = False) -> list[AssuranceCase]:
+        case_catalog: dict[int, AssuranceCase] = {}
+
+        group_ids: list[int] = [group.pk for group in user.all_groups.all()]
+        view_cases: QuerySet[AssuranceCase] = AssuranceCase.objects.filter(
+            view_groups__in=group_ids
+        )
+        edit_cases: QuerySet[AssuranceCase] = AssuranceCase.objects.filter(
+            edit_groups__in=group_ids
+        )
+
+        case_catalog = {case.pk: case for case in list(view_cases) + list(edit_cases)}
+
+        if not shared:
+            cases_owned: dict[int, AssuranceCase] = {
+                case.pk: case for case in user.cases.all()
+            }
+
+            case_catalog = case_catalog | cases_owned
+
+        return list(case_catalog.values())
+
+    @staticmethod
     def _get_users_from_group_list(group_manager: QuerySet) -> list[dict[str, Any]]:
         user_dictionary: dict[int, dict[str, Any]] = {}
         for current_group in group_manager.all():

--- a/eap_backend/eap_api/views.py
+++ b/eap_backend/eap_api/views.py
@@ -48,7 +48,6 @@ from .view_utils import (
     UpdateIdentifierUtils,
     can_view_group,
     filter_by_case_id,
-    get_allowed_cases,
     get_allowed_groups,
     get_case_permissions,
     get_json_tree,
@@ -229,7 +228,10 @@ def case_list(request):
 
     if request.method == "GET":
 
-        cases = get_allowed_cases(request.user)
+        cases = ShareAssuranceCaseUtils.get_user_cases(
+            request.user,
+            shared=(request.query_params.get("shared", "false").lower() == "true"),
+        )
         serializer = AssuranceCaseSerializer(cases, many=True)
         summaries = make_case_summary(serializer.data)
         return JsonResponse(summaries, safe=False)

--- a/eap_backend/eap_api/views.py
+++ b/eap_backend/eap_api/views.py
@@ -226,11 +226,14 @@ def case_list(request):
     List all cases, or make a new case
     """
 
+    owner: bool = request.query_params.get("owner", "true").lower() == "true"
+    view: bool = request.query_params.get("view", "true").lower() == "true"
+    edit: bool = request.query_params.get("edit", "true").lower() == "true"
+
     if request.method == "GET":
 
         cases = ShareAssuranceCaseUtils.get_user_cases(
-            request.user,
-            shared=(request.query_params.get("shared", "false").lower() == "true"),
+            request.user, owner=owner, view=view, edit=edit
         )
         serializer = AssuranceCaseSerializer(cases, many=True)
         summaries = make_case_summary(serializer.data)

--- a/eap_backend/tests/test_permissions.py
+++ b/eap_backend/tests/test_permissions.py
@@ -79,7 +79,9 @@ class CasePermissionsTest(TestCase):
         # user1 and user3 should now be able to see it via case_list, user2 should not.
         get_list1 = self.client1.get(reverse("case_list"))
         assert get_list1.status_code == 200
-        assert len(get_list1.json()) == 1
+        assert (
+            len(get_list1.json()) == 1
+        ), f"Expected 1 entry but was {get_list1.json()}"
         get_list2 = self.client2.get(reverse("case_list"))
         assert get_list2.status_code == 200
         assert len(get_list2.json()) == 0

--- a/eap_backend/tests/test_views.py
+++ b/eap_backend/tests/test_views.py
@@ -1947,7 +1947,7 @@ class ShareAssuranceCaseViewTest(TestCase):
         view_group.member.add(self.tea_user)
 
         response_get: HttpResponse = self.client.get(
-            f'{reverse("case_list")}?{urlencode({"shared": True})}',
+            f'{reverse("case_list")}?{urlencode({"view": "true", "owner": "false", "edit": "false"})}',
             HTTP_AUTHORIZATION=f"Token {self.tea_user_token.key}",
         )
 
@@ -1962,7 +1962,7 @@ class ShareAssuranceCaseViewTest(TestCase):
         assert response_body[0]["id"] == self.assurance_case.pk
 
         response_get = self.client.get(
-            f'{reverse("case_list")}?{urlencode({"shared": True})}',
+            f'{reverse("case_list")}?{urlencode({"view": "true", "owner": "false", "edit": "false"})}',
             HTTP_AUTHORIZATION=f"Token {self.case_owner_token.key}",
         )
 
@@ -1983,7 +1983,7 @@ class ShareAssuranceCaseViewTest(TestCase):
         edit_group.member.add(self.tea_user)
 
         response_get: HttpResponse = self.client.get(
-            f'{reverse("case_list")}?{urlencode({"shared": True})}',
+            f'{reverse("case_list")}?{urlencode({"edit": "true", "view": "false", "owner": "false"})}',
             HTTP_AUTHORIZATION=f"Token {self.tea_user_token.key}",
         )
 
@@ -2008,7 +2008,7 @@ class ShareAssuranceCaseViewTest(TestCase):
         )
 
         response_get: HttpResponse = self.client.get(
-            f'{reverse("case_list")}?{urlencode({"shared": "false"})}',
+            f'{reverse("case_list")}?{urlencode({"owner": "true", "view": "true", "edit": "true"})}',
             HTTP_AUTHORIZATION=f"Token {self.tea_user_token.key}",
         )
 

--- a/next_frontend/components/cases/NoCasesFound.tsx
+++ b/next_frontend/components/cases/NoCasesFound.tsx
@@ -39,7 +39,7 @@ export default function NoCasesFound({ message, shared = false } : NoCasesFoundP
         ) : (
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" className="mx-auto h-12 w-12 text-foreground">
             <path strokeWidth={1} strokeLinecap="round" strokeLinejoin="round" d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 0 0-1.883 2.542l.857 6a2.25 2.25 0 0 0 2.227 1.932H19.05a2.25 2.25 0 0 0 2.227-1.932l.857-6a2.25 2.25 0 0 0-1.883-2.542m-16.5 0V6A2.25 2.25 0 0 1 6 3.75h3.879a1.5 1.5 0 0 1 1.06.44l2.122 2.12a1.5 1.5 0 0 0 1.06.44H18A2.25 2.25 0 0 1 20.25 9v.776" />
-          </svg>        
+          </svg>
         )}
         <h3 className="mt-2 text-lg font-semibold text-foreground">No Cases Found</h3>
         <p className="mt-1 text-sm text-foreground/80">{message}</p>
@@ -73,7 +73,7 @@ export default function NoCasesFound({ message, shared = false } : NoCasesFoundP
               Back to my cases
             </button>
           )}
-          
+
         </div>
       </div>
     </div>


### PR DESCRIPTION
The `cases` endpoint has three additional query parameters: `owner`, `view`, and `edit`, that can be used to filter the cases per user:

1. `GET cases/` still behaves as usual, returning **all** the cases a user has permissions. It is equivalent to `GET cases?owner=true&view=true&edit=true` 
2. `GET cases?owner=false&view=true&edit=true` can be used to retrieve the cases a user has view/edit permissions, but it's not the owner. This can be used to populate the "Shared with me" page.