### PR TITLE
Including permissions when returning the case list

### DIFF
--- a/eap_backend/eap_api/views.py
+++ b/eap_backend/eap_api/views.py
@@ -52,7 +52,6 @@ from .view_utils import (
     get_allowed_groups,
     get_case_permissions,
     get_json_tree,
-    make_case_summary,
     make_summary,
     save_json_tree,
 )
@@ -233,12 +232,10 @@ def case_list(request):
 
     if request.method == "GET":
 
-        cases = ShareAssuranceCaseUtils.get_user_cases(
+        serialized_cases = ShareAssuranceCaseUtils.get_user_cases(
             request.user, owner=owner, view=view, edit=edit
         )
-        serializer = AssuranceCaseSerializer(cases, many=True)
-        summaries = make_case_summary(serializer.data)
-        return JsonResponse(summaries, safe=False)
+        return JsonResponse(serialized_cases, safe=False)
     elif request.method == "POST":
         data = JSONParser().parse(request)
         data["owner"] = request.user.id

--- a/eap_backend/tests/test_views.py
+++ b/eap_backend/tests/test_views.py
@@ -97,9 +97,13 @@ class CaseViewTest(TestCase):
             HTTP_AUTHORIZATION=f"Token {self.token.key}",
         )
         assert response_get.status_code == 200
-        assert response_get.json() == make_case_summary(
-            self.serializer.data
-        ), f"Expected is {make_case_summary(self.serializer.data)} but was {response_get.json()}"
+        expected_response: list = [
+            make_case_summary(case) | {"permissions": ["owner"]}
+            for case in self.serializer.data
+        ]
+        assert (
+            response_get.json() == expected_response
+        ), f"Expected is {expected_response} but was {response_get.json()}"
 
     def test_case_detail_view_get(self):
         response_get = self.client.get(
@@ -1964,6 +1968,7 @@ class ShareAssuranceCaseViewTest(TestCase):
             len(response_body) == 1
         ), f"Expected one case response but was {response_body}"
         assert response_body[0]["id"] == self.assurance_case.pk
+        assert response_body[0]["permissions"] == ["view"]
 
         response_get = self.client.get(
             f'{reverse("case_list")}?{urlencode({"view": "true", "owner": "false", "edit": "false"})}',
@@ -2000,6 +2005,7 @@ class ShareAssuranceCaseViewTest(TestCase):
             len(response_body) == 1
         ), f"Expected one case response but was {response_body}"
         assert response_body[0]["id"] == self.assurance_case.pk
+        assert response_body[0]["permissions"] == ["edit"]
 
     def test_retrieve_all_user_cases(self):
         view_group: EAPGroup = ShareAssuranceCaseUtils.get_view_group(
@@ -2025,8 +2031,8 @@ class ShareAssuranceCaseViewTest(TestCase):
             len(response_body) == 2
         ), f"Expected two cases response but was {response_body}"
 
-        assurance_cases: list[int] = [
-            assurance_case["id"] for assurance_case in response_body
-        ]
-        assert self.assurance_case.pk in assurance_cases
-        assert owned_case.pk in assurance_cases
+        assert response_body[0]["id"] == self.assurance_case.pk
+        assert response_body[0]["permissions"] == ["view"]
+
+        assert response_body[1]["id"] == owned_case.pk
+        assert response_body[1]["permissions"] == ["owner"]


### PR DESCRIPTION
Changed the response of the `GET cases/` endpoint. It now includes the field `{"permissions": ["view", "edit", "owner"]}`, depending on the permissions a user has for a given case.