### PR TITLE
ci: bump release workflow to Node 22 for semantic-release v25

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "pnpm"
 
       - name: Install dependencies


### PR DESCRIPTION
## Bump release workflow to Node 22

`release.yaml` pins `node-version: "20"`, but `semantic-release` is `^25.0.3` and v25 requires Node `^22.14.0 || >= 24.10.0`. The **Semantic Release** job therefore aborts immediately:

```
[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.20.2.
##[error]Process completed with exit code 1.
```

### Effect (pre-existing, not new)
The job has failed silently on the last three releases — #796 (2026-03-17), #799 (2026-03-20), and today's #825. No version tag, changelog entry, or GitHub Release is cut; the latest tag is stuck at `v0.4.1` (2026-03-12). The deployed app is unaffected — *Deploy to Azure* runs inside the **Build** workflow, so production always carries the merged code. Only the versioning bookkeeping is broken.

### Change
One line: `node-version: "20"` → `"22"` in `.github/workflows/release.yaml`. setup-node `"22"` resolves to the latest 22.x, satisfying the `>= 22.14` floor.

### Verification after merge
Once this reaches `main`, the next Build→Release run should complete semantic-release cleanly and cut the first tag past `v0.4.1`.

Tracked in vault issue *TEA — Release workflow Node version blocks semantic-release* (epic: TEA — Performance & Tech-Debt).
