### PR TITLE
Release: fix semantic-release Node version (Node 22)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "pnpm"
 
       - name: Install dependencies


### PR DESCRIPTION
## Release: fix semantic-release Node version

Fast-tracked single-change release to get the Node-22 bump onto `main`, restoring the **Semantic Release** job (broken since semantic-release was bumped to ^25, which requires Node `>= 22.14`).

### Delta (1 file)
- `ci: bump release workflow to Node 22 for semantic-release v25` — `.github/workflows/release.yaml`, `node-version: "20"` → `"22"`

### Why now
The job has aborted on the last three releases (#796, #799, #825), so no tag/changelog/GitHub Release has been cut and the latest tag is stuck at `v0.4.1`. The deployed app was never affected (deploy runs in Build). This release carries the fix to `main` so the Release workflow can run on Node 22.

Tracked in vault issue *TEA — Release workflow Node version blocks semantic-release*.
