### PR TITLE
Fix fallow config schema + release workflow Prisma/hook gate

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -44,5 +44,5 @@
     "axe-core",
     "conventional-changelog-conventionalcommits"
   ],
-  "ignoreDependencyOverrides": ["@isaacs/brace-expansion"]
+  "ignoreDependencyOverrides": [{ "package": "@isaacs/brace-expansion" }]
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,26 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Cache Prisma Client
+        uses: actions/cache@v5
+        id: prisma-cache-release
+        with:
+          path: src/generated/prisma
+          key: prisma-${{ runner.os }}-${{ hashFiles('prisma/schema.prisma', 'pnpm-lock.yaml') }}
+
+      - name: Generate Prisma client
+        if: steps.prisma-cache-release.outputs.cache-hit != 'true'
+        run: npx prisma generate --schema=prisma/schema.prisma
+        env:
+          DATABASE_URL: postgresql://build:build@localhost:5432/build
+
+      - name: Disarm local pre-push hook for CI
+        # `pnpm install` arms core.hooksPath=.githooks (see the `prepare` script),
+        # which re-runs lint+typecheck on `@semantic-release/git`'s push to main.
+        # That hook is a developer fast-fail; CI is authoritative for the
+        # automated release path, so point hooksPath away from it here.
+        run: git config core.hooksPath /dev/null
+
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
Two 1.0-blocking fixes, one commit each:

**`.fallowrc.json`** — `ignoreDependencyOverrides` carried a bare string where fallow's schema (≥2.104.0) requires an `IgnoreDependencyOverrideRule` object, aborting every fallow analysis on this repo. Corrected to `{"package": "@isaacs/brace-expansion"}`; intent unchanged (suppresses the known unused-dependency-override false positive). Verified: `bunx fallow audit` now runs to completion (previously aborted at config parse).

**`.github/workflows/release.yaml`** — no release tag has been cut since v0.4.1 (2026-03-12). Root cause: the Release job never generates the Prisma client, so the pre-push hook (armed by `pnpm install`'s `prepare` script) fails `tsc --noEmit` on the runner before `@semantic-release/git` can push the tag. This adds the cache+generate step pair mirroring `build.yaml` (identical cache key — reuses the client Build just cached on the same ref) and disarms the client-side developer hook for the automated release path, where Build's validate job has already passed lint+typecheck on the same commit.

Validated with actionlint + action-validator (clean); fallow audit on changed files clean.

Known follow-up (deliberately not included): the Release checkout has no `ref:` pin to `workflow_run.head_sha`, so it releases tip-of-main — pre-existing race, tracked separately because a naive ref pin risks breaking semantic-release's branch detection in detached HEAD.

Refs: vault issues "TEA — fallowrc parse error blocks fallow audits", "TEA — Release workflow Node version blocks semantic-release" (Layer 2).