### PR TITLE
feat(schema): extension foundations — plugin data, plugin state, integrations, API tokens

### DIFF
--- a/docs/database/schema.dbml
+++ b/docs/database/schema.dbml
@@ -50,6 +50,8 @@ Table users {
   caseStudies case_studies [not null]
   markedReadyCases assurance_cases [not null]
   deletedCases assurance_cases [not null]
+  ownedIntegrations integrations [not null]
+  integrationPrincipal integrations
 
   Note: 'Platform user account. Supports local (email/password) and GitHub OAuth authentication.'
 }
@@ -152,6 +154,7 @@ Table assurance_cases {
   comments comments [not null]
   caseImage case_images
   caseTypes case_type_assignments [not null]
+  pluginData plugin_data [not null]
   sourceReleases releases [not null]
   publishedReleases releases [not null]
   publishedVersions published_assurance_cases [not null]
@@ -250,6 +253,7 @@ Table assurance_elements {
   evidenceLinksTo evidence_links [not null]
   comments comments [not null]
   releaseComments release_comments [not null]
+  pluginData plugin_data [not null]
 
   Note: 'Node in the assurance case hierarchy: GOAL, STRATEGY, PROPERTY_CLAIM, EVIDENCE, CONTEXT, MODULE, etc.'
 }
@@ -552,6 +556,86 @@ Table published_assurance_cases {
   Note: 'Snapshot of an assurance case for case study integration. Content stored as JSON.'
 }
 
+Table plugin_data {
+  id String [pk]
+  pluginId String [not null, note: 'Namespace, e.g. "tea.health"']
+  caseId String [not null, note: 'Permission anchor — access rides on canAccessCase']
+  elementId String [note: 'Null = case-level data']
+  data Json [not null]
+  createdAt DateTime [default: `now()`, not null]
+  updatedAt DateTime [not null]
+  case assurance_cases [not null]
+  element assurance_elements
+
+  indexes {
+    (pluginId, caseId, elementId) [unique]
+  }
+
+  Note: 'Tier-1 namespaced plugin storage, scoped to a case or element. Access
+rides on the case\'s existing canAccessCase permission machinery — no
+parallel ACL. A disabled or uninstalled plugin leaves its rows inert:
+never rendered, never deleted without an explicit user action.'
+}
+
+Table plugin_state {
+  id String [pk]
+  pluginId String [not null]
+  scopeType PluginScopeType [not null]
+  scopeId String [not null]
+  enabled Boolean [not null]
+  settings Json
+  createdAt DateTime [default: `now()`, not null]
+  updatedAt DateTime [not null]
+
+  indexes {
+    (pluginId, scopeType, scopeId) [unique]
+  }
+
+  Note: 'Hierarchical plugin enablement (organisation → team → user; off wins
+downward). 1.0 activates only the USER tier; the schema carries all three
+from day one so organisation/team activate later with no migration. No FK
+on scopeId — scope is polymorphic across account tiers, and the
+ORGANISATION tier\'s referent does not exist yet (deliberate).'
+}
+
+Table integrations {
+  id String [pk]
+  name String [unique, not null, note: 'e.g. "darter-evidence-pipeline"']
+  description String
+  ownerId String [not null, note: 'The human accountable for this integration']
+  systemUserId String [unique, not null, note: 'The machine principal (User with isSystemUser)']
+  scopes String[] [not null]
+  status IntegrationStatus [not null, default: 'ACTIVE']
+  createdAt DateTime [default: `now()`, not null]
+  updatedAt DateTime [not null]
+  lastSeenAt DateTime [note: 'Updated on authenticated use']
+  owner users [not null]
+  systemUser users [not null]
+  tokens api_tokens [not null]
+
+  Note: 'External machine client holding scoped API tokens (renamed from
+PluginRegistration in ADR 0002 v1 — these are integrations, not in-app
+plugins). Owned by a human (accountability) and acts through a dedicated
+system User (principal). No cascade on either User relation: owner
+deletion is blocked while ACTIVE integrations exist, enforced at the
+service layer when the registry service lands.'
+}
+
+Table api_tokens {
+  id String [pk]
+  integrationId String [not null]
+  tokenHash String [unique, not null, note: 'SHA-256 of the secret']
+  tokenPrefix String [not null, note: 'Leading chars of the secret, for identification in UI/logs']
+  expiresAt DateTime
+  lastUsedAt DateTime
+  revokedAt DateTime
+  createdAt DateTime [default: `now()`, not null]
+  integration integrations [not null]
+
+  Note: 'Bearer tokens issued to an integration, never free-floating. Hashed at
+rest; plaintext shown once at issuance.'
+}
+
 Enum AuthProvider {
   LOCAL
   GITHUB
@@ -628,6 +712,18 @@ Enum CaseTypeCategory {
   DOMAIN
   TECHNIQUE
   STANDARD
+}
+
+Enum PluginScopeType {
+  ORGANISATION
+  TEAM
+  USER
+}
+
+Enum IntegrationStatus {
+  ACTIVE
+  SUSPENDED
+  REVOKED
 }
 
 Ref: teams.createdById > users.id
@@ -725,3 +821,13 @@ Ref: case_study_published_cases.publishedAssuranceCaseId > published_assurance_c
 Ref: case_study_images.caseStudyId - case_studies.id [delete: No Action]
 
 Ref: published_assurance_cases.assuranceCaseId > assurance_cases.id
+
+Ref: plugin_data.caseId > assurance_cases.id [delete: Cascade]
+
+Ref: plugin_data.elementId > assurance_elements.id [delete: Cascade]
+
+Ref: integrations.ownerId > users.id
+
+Ref: integrations.systemUserId > users.id
+
+Ref: api_tokens.integrationId > integrations.id [delete: Cascade]

--- a/prisma/migrations/20260703000000_extension_foundations/migration.sql
+++ b/prisma/migrations/20260703000000_extension_foundations/migration.sql
@@ -1,0 +1,109 @@
+-- Extension foundations (ADR 0002 v2 §2.1, §2.2, §2.4): PluginData (tier-1
+-- namespaced plugin storage), PluginState (hierarchical enablement),
+-- Integration + ApiToken (machine-access pillar, renamed from
+-- PluginRegistration in ADR 0002 v1). Schema and one migration only — no
+-- plugin-owned (tier-2) tables here; those ship with their own plugin's
+-- work item.
+
+-- CreateEnum
+CREATE TYPE "PluginScopeType" AS ENUM ('ORGANISATION', 'TEAM', 'USER');
+
+-- CreateEnum
+CREATE TYPE "IntegrationStatus" AS ENUM ('ACTIVE', 'SUSPENDED', 'REVOKED');
+
+-- CreateTable
+CREATE TABLE "plugin_data" (
+    "id" TEXT NOT NULL,
+    "plugin_id" TEXT NOT NULL,
+    "case_id" TEXT NOT NULL,
+    "element_id" TEXT,
+    "data" JSONB NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "plugin_data_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "plugin_state" (
+    "id" TEXT NOT NULL,
+    "plugin_id" TEXT NOT NULL,
+    "scope_type" "PluginScopeType" NOT NULL,
+    "scope_id" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL,
+    "settings" JSONB,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "plugin_state_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "integrations" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "owner_id" TEXT NOT NULL,
+    "system_user_id" TEXT NOT NULL,
+    "scopes" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "status" "IntegrationStatus" NOT NULL DEFAULT 'ACTIVE',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "last_seen_at" TIMESTAMP(3),
+
+    CONSTRAINT "integrations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "api_tokens" (
+    "id" TEXT NOT NULL,
+    "integration_id" TEXT NOT NULL,
+    "token_hash" TEXT NOT NULL,
+    "token_prefix" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3),
+    "last_used_at" TIMESTAMP(3),
+    "revoked_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "api_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "plugin_data_plugin_id_case_id_element_id_key" ON "plugin_data"("plugin_id", "case_id", "element_id");
+
+-- CreateIndex
+CREATE INDEX "plugin_data_case_id_plugin_id_idx" ON "plugin_data"("case_id", "plugin_id");
+
+-- Partial unique index: Postgres treats NULL <> NULL, so the @@unique above
+-- (pluginId, caseId, elementId) does not constrain case-level rows
+-- (elementId IS NULL) — this closes that gap by keying case-level rows on
+-- (pluginId, caseId) alone. Cannot be expressed in Prisma's schema DSL (see
+-- the comment on the PluginData model), hence raw SQL here.
+CREATE UNIQUE INDEX "plugin_data_plugin_id_case_id_case_level_key" ON "plugin_data"("plugin_id", "case_id") WHERE "element_id" IS NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "plugin_state_plugin_id_scope_type_scope_id_key" ON "plugin_state"("plugin_id", "scope_type", "scope_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "integrations_name_key" ON "integrations"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "integrations_system_user_id_key" ON "integrations"("system_user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "api_tokens_token_hash_key" ON "api_tokens"("token_hash");
+
+-- AddForeignKey
+ALTER TABLE "plugin_data" ADD CONSTRAINT "plugin_data_case_id_fkey" FOREIGN KEY ("case_id") REFERENCES "assurance_cases"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "plugin_data" ADD CONSTRAINT "plugin_data_element_id_fkey" FOREIGN KEY ("element_id") REFERENCES "assurance_elements"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "integrations" ADD CONSTRAINT "integrations_owner_id_fkey" FOREIGN KEY ("owner_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "integrations" ADD CONSTRAINT "integrations_system_user_id_fkey" FOREIGN KEY ("system_user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "api_tokens" ADD CONSTRAINT "api_tokens_integration_id_fkey" FOREIGN KEY ("integration_id") REFERENCES "integrations"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,6 +87,8 @@ model User {
   caseStudies          CaseStudy[]
   markedReadyCases     AssuranceCase[]    @relation("CaseMarkedReady")
   deletedCases         AssuranceCase[]    @relation("CaseDeleter")
+  ownedIntegrations    Integration[]      @relation("IntegrationOwner")
+  integrationPrincipal Integration?       @relation("IntegrationPrincipal")
 
   @@map("users")
 }
@@ -268,6 +270,7 @@ model AssuranceCase {
   comments        Comment[]
   caseImage       CaseImage?
   caseTypes       CaseTypeAssignment[]
+  pluginData      PluginData[]
 
   // Release relations
   sourceReleases    Release[] @relation("SourceCase")
@@ -426,6 +429,7 @@ model AssuranceElement {
 
   comments            Comment[]
   releaseComments     ReleaseComment[]
+  pluginData          PluginData[]
 
   @@index([caseId])
   @@index([caseId, elementType])
@@ -910,4 +914,117 @@ model PublishedAssuranceCase {
 
   @@index([assuranceCaseId], map: "published_assurance_cases_assurance_case_id_idx")
   @@map("published_assurance_cases")
+}
+
+// ============================================
+// EXTENSION FOUNDATIONS (plugins & integrations)
+// ============================================
+// ADR 0002 v2 §2.1, §2.2, §2.4. One-way dependency rule: nothing below may
+// reference a plugin-owned (tier-2) table — plugin tables belong to plugin
+// work items, foundations stay plugin-free.
+
+/// Tier-1 namespaced plugin storage, scoped to a case or element. Access
+/// rides on the case's existing canAccessCase permission machinery — no
+/// parallel ACL. A disabled or uninstalled plugin leaves its rows inert:
+/// never rendered, never deleted without an explicit user action.
+model PluginData {
+  id        String  @id @default(uuid())
+  pluginId  String  @map("plugin_id") /// Namespace, e.g. "tea.health"
+  caseId    String  @map("case_id") /// Permission anchor — access rides on canAccessCase
+  elementId String? @map("element_id") /// Null = case-level data
+  data      Json
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  // Relations
+  case    AssuranceCase     @relation(fields: [caseId], references: [id], onDelete: Cascade)
+  element AssuranceElement? @relation(fields: [elementId], references: [id], onDelete: Cascade)
+
+  // @@unique below covers element-level rows, but Postgres treats NULL <>
+  // NULL, so it does NOT constrain case-level rows (elementId IS NULL) to one
+  // per (pluginId, caseId) — two such rows are both accepted. That gap is
+  // closed by a partial unique index (pluginId, caseId) WHERE elementId IS
+  // NULL, hand-written in this migration's SQL because Prisma's schema DSL
+  // cannot express partial indexes. Keep both in sync if this model changes.
+  @@unique([pluginId, caseId, elementId])
+  @@index([caseId, pluginId])
+  @@map("plugin_data")
+}
+
+/// Hierarchical plugin enablement (organisation → team → user; off wins
+/// downward). 1.0 activates only the USER tier; the schema carries all three
+/// from day one so organisation/team activate later with no migration. No FK
+/// on scopeId — scope is polymorphic across account tiers, and the
+/// ORGANISATION tier's referent does not exist yet (deliberate).
+model PluginState {
+  id        String          @id @default(uuid())
+  pluginId  String          @map("plugin_id")
+  scopeType PluginScopeType @map("scope_type")
+  scopeId   String          @map("scope_id")
+  enabled   Boolean
+  settings  Json?
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@unique([pluginId, scopeType, scopeId])
+  @@map("plugin_state")
+}
+
+enum PluginScopeType {
+  ORGANISATION
+  TEAM
+  USER
+}
+
+/// External machine client holding scoped API tokens (renamed from
+/// PluginRegistration in ADR 0002 v1 — these are integrations, not in-app
+/// plugins). Owned by a human (accountability) and acts through a dedicated
+/// system User (principal). No cascade on either User relation: owner
+/// deletion is blocked while ACTIVE integrations exist, enforced at the
+/// service layer when the registry service lands.
+model Integration {
+  id           String            @id @default(uuid())
+  name         String            @unique /// e.g. "darter-evidence-pipeline"
+  description  String?
+  ownerId      String            @map("owner_id") /// The human accountable for this integration
+  systemUserId String            @unique @map("system_user_id") /// The machine principal (User with isSystemUser)
+  scopes       String[]          @default([])
+  status       IntegrationStatus @default(ACTIVE)
+
+  createdAt  DateTime  @default(now()) @map("created_at")
+  updatedAt  DateTime  @updatedAt @map("updated_at")
+  lastSeenAt DateTime? @map("last_seen_at") /// Updated on authenticated use
+
+  // Relations
+  owner      User       @relation("IntegrationOwner", fields: [ownerId], references: [id])
+  systemUser User       @relation("IntegrationPrincipal", fields: [systemUserId], references: [id])
+  tokens     ApiToken[]
+
+  @@map("integrations")
+}
+
+enum IntegrationStatus {
+  ACTIVE
+  SUSPENDED
+  REVOKED
+}
+
+/// Bearer tokens issued to an integration, never free-floating. Hashed at
+/// rest; plaintext shown once at issuance.
+model ApiToken {
+  id            String    @id @default(uuid())
+  integrationId String    @map("integration_id")
+  tokenHash     String    @unique @map("token_hash") /// SHA-256 of the secret
+  tokenPrefix   String    @map("token_prefix") /// Leading chars of the secret, for identification in UI/logs
+  expiresAt     DateTime? @map("expires_at")
+  lastUsedAt    DateTime? @map("last_used_at")
+  revokedAt     DateTime? @map("revoked_at")
+  createdAt     DateTime  @default(now()) @map("created_at")
+
+  // Relations
+  integration Integration @relation(fields: [integrationId], references: [id], onDelete: Cascade)
+
+  @@map("api_tokens")
 }

--- a/src/__tests__/integration/extension-foundations.test.ts
+++ b/src/__tests__/integration/extension-foundations.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, it } from "vitest";
+import prisma from "@/lib/prisma";
+import { Prisma } from "@/src/generated/prisma";
+import {
+	createTestApiToken,
+	createTestCase,
+	createTestElement,
+	createTestIntegration,
+	createTestIntegrationWithSystemUser,
+	createTestPluginData,
+	createTestPluginState,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+/**
+ * Asserts that a promise rejects with a Prisma constraint violation carrying
+ * the given error code (P2002 = unique constraint, P2003 = foreign key
+ * constraint). This is the repo's first raw-constraint test suite — copy
+ * this helper's call pattern for future constraint tests rather than a bare
+ * `.rejects.toThrow()`, which also passes for unrelated errors.
+ */
+async function expectPrismaErrorCode(
+	promise: Promise<unknown>,
+	code: "P2002" | "P2003"
+): Promise<void> {
+	const error = await promise.catch((caught: unknown) => caught);
+	// biome-ignore lint/suspicious/noMisplacedAssertion: helper called from within it() blocks
+	expect(error).toBeInstanceOf(Prisma.PrismaClientKnownRequestError);
+	// biome-ignore lint/suspicious/noMisplacedAssertion: helper called from within it() blocks
+	expect((error as Prisma.PrismaClientKnownRequestError).code).toBe(code);
+}
+
+// ============================================
+// PluginData
+// ============================================
+
+describe("PluginData", () => {
+	it("creates case-level plugin data (elementId null)", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+
+		const record = await createTestPluginData(testCase.id, {
+			pluginId: "tea.health",
+			data: { score: 0.9 },
+		});
+
+		expect(record.caseId).toBe(testCase.id);
+		expect(record.elementId).toBeNull();
+		expect(record.data).toEqual({ score: 0.9 });
+	});
+
+	it("creates element-level plugin data", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+		const element = await createTestElement(testCase.id, user.id);
+
+		const record = await createTestPluginData(testCase.id, {
+			pluginId: "tea.health",
+			elementId: element.id,
+		});
+
+		expect(record.elementId).toBe(element.id);
+	});
+
+	it("rejects a duplicate (pluginId, caseId, elementId) combination", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+		const element = await createTestElement(testCase.id, user.id);
+
+		await createTestPluginData(testCase.id, {
+			pluginId: "tea.health",
+			elementId: element.id,
+		});
+
+		await expectPrismaErrorCode(
+			createTestPluginData(testCase.id, {
+				pluginId: "tea.health",
+				elementId: element.id,
+			}),
+			"P2002"
+		);
+	});
+
+	it("allows different pluginIds on the same case/element", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+		const element = await createTestElement(testCase.id, user.id);
+
+		await createTestPluginData(testCase.id, {
+			pluginId: "tea.health",
+			elementId: element.id,
+		});
+
+		await expect(
+			createTestPluginData(testCase.id, {
+				pluginId: "tea.techniques",
+				elementId: element.id,
+			})
+		).resolves.toBeDefined();
+	});
+
+	it("rejects a duplicate case-level (pluginId, caseId) row with elementId null", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+
+		await createTestPluginData(testCase.id, {
+			pluginId: "tea.health",
+		});
+
+		await expectPrismaErrorCode(
+			createTestPluginData(testCase.id, {
+				pluginId: "tea.health",
+			}),
+			"P2002"
+		);
+	});
+
+	it("allows one case-level row alongside element-level rows for the same (pluginId, caseId)", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+		const elementA = await createTestElement(testCase.id, user.id);
+		const elementB = await createTestElement(testCase.id, user.id);
+
+		const caseLevel = await createTestPluginData(testCase.id, {
+			pluginId: "tea.health",
+		});
+		const elementLevelA = await createTestPluginData(testCase.id, {
+			pluginId: "tea.health",
+			elementId: elementA.id,
+		});
+		const elementLevelB = await createTestPluginData(testCase.id, {
+			pluginId: "tea.health",
+			elementId: elementB.id,
+		});
+
+		expect(caseLevel.elementId).toBeNull();
+		expect(elementLevelA.elementId).toBe(elementA.id);
+		expect(elementLevelB.elementId).toBe(elementB.id);
+	});
+
+	it("cascades delete when the parent case is deleted", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+		const record = await createTestPluginData(testCase.id, {
+			pluginId: "tea.health",
+		});
+
+		await prisma.assuranceCase.delete({ where: { id: testCase.id } });
+
+		const found = await prisma.pluginData.findUnique({
+			where: { id: record.id },
+		});
+		expect(found).toBeNull();
+	});
+
+	it("cascades delete when the parent element is deleted", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+		const element = await createTestElement(testCase.id, user.id);
+		const record = await createTestPluginData(testCase.id, {
+			pluginId: "tea.health",
+			elementId: element.id,
+		});
+
+		await prisma.assuranceElement.delete({ where: { id: element.id } });
+
+		const found = await prisma.pluginData.findUnique({
+			where: { id: record.id },
+		});
+		expect(found).toBeNull();
+	});
+});
+
+// ============================================
+// PluginState
+// ============================================
+
+describe("PluginState", () => {
+	it("creates a user-scoped enablement row", async () => {
+		const user = await createTestUser();
+
+		const state = await createTestPluginState(user.id, {
+			pluginId: "tea.health",
+			scopeType: "USER",
+			enabled: false,
+		});
+
+		expect(state.scopeType).toBe("USER");
+		expect(state.scopeId).toBe(user.id);
+		expect(state.enabled).toBe(false);
+		expect(state.settings).toBeNull();
+	});
+
+	it("rejects a duplicate (pluginId, scopeType, scopeId) combination", async () => {
+		const user = await createTestUser();
+
+		await createTestPluginState(user.id, { pluginId: "tea.health" });
+
+		await expectPrismaErrorCode(
+			createTestPluginState(user.id, { pluginId: "tea.health" }),
+			"P2002"
+		);
+	});
+
+	it("allows the same pluginId across different scope tiers for the same id", async () => {
+		const user = await createTestUser();
+
+		await createTestPluginState(user.id, {
+			pluginId: "tea.health",
+			scopeType: "USER",
+		});
+
+		await expect(
+			createTestPluginState(user.id, {
+				pluginId: "tea.health",
+				scopeType: "TEAM",
+			})
+		).resolves.toBeDefined();
+	});
+
+	it("has no foreign key on scopeId — an arbitrary id is accepted", async () => {
+		await expect(
+			createTestPluginState("00000000-0000-4000-8000-000000000099", {
+				pluginId: "tea.health",
+				scopeType: "ORGANISATION",
+			})
+		).resolves.toBeDefined();
+	});
+});
+
+// ============================================
+// Integration
+// ============================================
+
+describe("Integration", () => {
+	it("creates an integration owned by a human and acting through a system user", async () => {
+		const owner = await createTestUser();
+
+		const { integration, systemUser } =
+			await createTestIntegrationWithSystemUser(owner.id, {
+				name: "darter-evidence-pipeline",
+				scopes: ["case:read", "evidence:write"],
+			});
+
+		expect(integration.ownerId).toBe(owner.id);
+		expect(integration.systemUserId).toBe(systemUser.id);
+		expect(integration.status).toBe("ACTIVE");
+		expect(systemUser.isSystemUser).toBe(true);
+	});
+
+	it("creates an integration with a non-ACTIVE status", async () => {
+		const owner = await createTestUser();
+		const systemUser = await createTestUser();
+
+		const integration = await createTestIntegration(owner.id, systemUser.id, {
+			status: "SUSPENDED",
+		});
+
+		expect(integration.status).toBe("SUSPENDED");
+	});
+
+	it("defaults scopes to an empty array when omitted", async () => {
+		const owner = await createTestUser();
+		const systemUser = await createTestUser();
+
+		// Bypasses createTestIntegration: the factory always supplies a
+		// `scopes` default (`overrides.scopes ?? ["case:read"]`), which would
+		// mask the DB-level `@default([])` this test exists to verify.
+		const integration = await prisma.integration.create({
+			data: {
+				name: "scopes-default-integration",
+				ownerId: owner.id,
+				systemUserId: systemUser.id,
+			},
+		});
+
+		expect(integration.scopes).toEqual([]);
+	});
+
+	it("rejects a duplicate integration name", async () => {
+		const owner = await createTestUser();
+		const systemUserA = await createTestUser();
+		const systemUserB = await createTestUser();
+
+		await createTestIntegration(owner.id, systemUserA.id, {
+			name: "duplicate-name",
+		});
+
+		await expectPrismaErrorCode(
+			createTestIntegration(owner.id, systemUserB.id, {
+				name: "duplicate-name",
+			}),
+			"P2002"
+		);
+	});
+
+	it("rejects reusing a systemUserId across two integrations", async () => {
+		const owner = await createTestUser();
+		const systemUser = await createTestUser();
+
+		await createTestIntegration(owner.id, systemUser.id, {
+			name: "integration-one",
+		});
+
+		await expectPrismaErrorCode(
+			createTestIntegration(owner.id, systemUser.id, {
+				name: "integration-two",
+			}),
+			"P2002"
+		);
+	});
+
+	it("does not cascade when the owner User is deleted (no cascade by design)", async () => {
+		const owner = await createTestUser();
+		const systemUser = await createTestUser();
+		await createTestIntegration(owner.id, systemUser.id);
+
+		await expectPrismaErrorCode(
+			prisma.user.delete({ where: { id: owner.id } }),
+			"P2003"
+		);
+	});
+
+	it("does not cascade when the system user is deleted (no cascade by design)", async () => {
+		const owner = await createTestUser();
+		const systemUser = await createTestUser();
+		await createTestIntegration(owner.id, systemUser.id);
+
+		await expectPrismaErrorCode(
+			prisma.user.delete({ where: { id: systemUser.id } }),
+			"P2003"
+		);
+	});
+});
+
+// ============================================
+// ApiToken
+// ============================================
+
+describe("ApiToken", () => {
+	it("creates a token for an integration", async () => {
+		const owner = await createTestUser();
+		const systemUser = await createTestUser();
+		const integration = await createTestIntegration(owner.id, systemUser.id);
+
+		const token = await createTestApiToken(integration.id, {
+			tokenPrefix: "teap_abcd",
+		});
+
+		expect(token.integrationId).toBe(integration.id);
+		expect(token.tokenPrefix).toBe("teap_abcd");
+		expect(token.revokedAt).toBeNull();
+	});
+
+	it("rejects a duplicate tokenHash", async () => {
+		const owner = await createTestUser();
+		const systemUser = await createTestUser();
+		const integration = await createTestIntegration(owner.id, systemUser.id);
+
+		await createTestApiToken(integration.id, {
+			tokenHash: "duplicate-hash",
+		});
+
+		await expectPrismaErrorCode(
+			createTestApiToken(integration.id, { tokenHash: "duplicate-hash" }),
+			"P2002"
+		);
+	});
+
+	it("cascades delete when the parent integration is deleted", async () => {
+		const owner = await createTestUser();
+		const systemUser = await createTestUser();
+		const integration = await createTestIntegration(owner.id, systemUser.id);
+		const token = await createTestApiToken(integration.id);
+
+		await prisma.integration.delete({ where: { id: integration.id } });
+
+		const found = await prisma.apiToken.findUnique({
+			where: { id: token.id },
+		});
+		expect(found).toBeNull();
+	});
+});

--- a/src/__tests__/setup.integration.tsx
+++ b/src/__tests__/setup.integration.tsx
@@ -30,6 +30,7 @@ afterEach(async () => {
         case_invites,
         case_team_permissions,
         case_permissions,
+        plugin_data,
         assurance_elements,
         assurance_cases,
         pattern_permissions,
@@ -42,6 +43,9 @@ afterEach(async () => {
         rate_limit_attempts,
         security_audit_logs,
         password_reset_attempts,
+        api_tokens,
+        integrations,
+        plugin_state,
         users
       CASCADE
     `);

--- a/src/__tests__/utils/prisma-factories.ts
+++ b/src/__tests__/utils/prisma-factories.ts
@@ -1,11 +1,15 @@
 import prisma from "@/lib/prisma";
 import type {
+	ApiToken,
 	AssuranceCase,
 	AssuranceElement,
 	CasePermission,
 	CaseStudy,
 	CaseTeamPermission,
 	Comment,
+	Integration,
+	PluginData,
+	PluginState,
 	Team,
 	TeamMember,
 	User,
@@ -247,6 +251,119 @@ export function createTestComment(
 }
 
 // ============================================
+// PLUGIN DATA (tier-1 namespaced plugin storage)
+// ============================================
+
+type PluginDataOverrides = Partial<{
+	pluginId: string;
+	elementId: string;
+	data: Record<string, unknown>;
+}>;
+
+export function createTestPluginData(
+	caseId: string,
+	overrides: PluginDataOverrides = {}
+): Promise<PluginData> {
+	const n = nextId();
+	return prisma.pluginData.create({
+		data: {
+			pluginId: overrides.pluginId ?? `test.plugin-${n}`,
+			caseId,
+			elementId: overrides.elementId,
+			data: overrides.data ?? { test: true },
+		},
+	});
+}
+
+// ============================================
+// PLUGIN STATE (hierarchical enablement)
+// ============================================
+
+type PluginStateOverrides = Partial<{
+	pluginId: string;
+	scopeType: "ORGANISATION" | "TEAM" | "USER";
+	enabled: boolean;
+	settings: Record<string, unknown>;
+}>;
+
+/** scopeId is polymorphic (no FK) — pass whichever tier's ID matches scopeType. */
+export function createTestPluginState(
+	scopeId: string,
+	overrides: PluginStateOverrides = {}
+): Promise<PluginState> {
+	const n = nextId();
+	return prisma.pluginState.create({
+		data: {
+			pluginId: overrides.pluginId ?? `test.plugin-${n}`,
+			scopeType: overrides.scopeType ?? "USER",
+			scopeId,
+			enabled: overrides.enabled ?? true,
+			settings: overrides.settings,
+		},
+	});
+}
+
+// ============================================
+// INTEGRATION (external machine clients)
+// ============================================
+
+type IntegrationOverrides = Partial<{
+	name: string;
+	description: string;
+	scopes: string[];
+	status: "ACTIVE" | "SUSPENDED" | "REVOKED";
+	lastSeenAt: Date;
+}>;
+
+export function createTestIntegration(
+	ownerId: string,
+	systemUserId: string,
+	overrides: IntegrationOverrides = {}
+): Promise<Integration> {
+	const n = nextId();
+	return prisma.integration.create({
+		data: {
+			name: overrides.name ?? `test-integration-${n}`,
+			description: overrides.description,
+			ownerId,
+			systemUserId,
+			scopes: overrides.scopes ?? ["case:read"],
+			status: overrides.status ?? "ACTIVE",
+			lastSeenAt: overrides.lastSeenAt,
+		},
+	});
+}
+
+// ============================================
+// API TOKEN
+// ============================================
+
+type ApiTokenOverrides = Partial<{
+	tokenHash: string;
+	tokenPrefix: string;
+	expiresAt: Date;
+	lastUsedAt: Date;
+	revokedAt: Date;
+}>;
+
+export function createTestApiToken(
+	integrationId: string,
+	overrides: ApiTokenOverrides = {}
+): Promise<ApiToken> {
+	const n = nextId();
+	return prisma.apiToken.create({
+		data: {
+			integrationId,
+			tokenHash: overrides.tokenHash ?? `test-token-hash-${n}`,
+			tokenPrefix: overrides.tokenPrefix ?? `teap_test${n}`,
+			expiresAt: overrides.expiresAt,
+			lastUsedAt: overrides.lastUsedAt,
+			revokedAt: overrides.revokedAt,
+		},
+	});
+}
+
+// ============================================
 // COMPOSITE FACTORIES
 // ============================================
 
@@ -286,6 +403,31 @@ export async function createTestTeamWithAdmin(
 		},
 	});
 	return team.id;
+}
+
+/**
+ * Creates a system user (isSystemUser: true) and an Integration owned by
+ * the given user acting through it. Returns both records.
+ */
+export async function createTestIntegrationWithSystemUser(
+	ownerId: string,
+	overrides: IntegrationOverrides = {}
+): Promise<{ integration: Integration; systemUser: User }> {
+	const n = nextId();
+	const createdUser = await createTestUser({
+		email: `system-user-${n}@example.com`,
+		username: `system-user-${n}`,
+	});
+	const systemUser = await prisma.user.update({
+		where: { id: createdUser.id },
+		data: { isSystemUser: true },
+	});
+	const integration = await createTestIntegration(
+		ownerId,
+		systemUser.id,
+		overrides
+	);
+	return { integration, systemUser };
 }
 
 /**


### PR DESCRIPTION
## What

Work item 1 of ADR 0002 v2 (PR #830): the complete extension-foundations data model, one hand-written migration. Schema, factories, and integration tests only — no services, routes, or UI.

- **`plugin_data`** — tier-1 namespaced plugin storage (pluginId + case anchor + optional element + JSONB), composite unique **plus a partial unique index** closing the Postgres NULL≠NULL gap on case-level rows (raw SQL — Prisma's DSL can't express partial indexes; documented on the model)
- **`plugin_state`** — hierarchically scoped enablement (ORGANISATION | TEAM | USER from day one; 1.0 activates USER)
- **`integrations`** — external machine clients: human owner, dedicated system user, open scopes array, status; **unconditional ON DELETE RESTRICT on both User FKs** (revoked integrations keep their accountability trail)
- **`api_tokens`** — hashed credentials (unique hash, display prefix, expiry/revocation timestamps), cascade from integration

## Review chain (all 2026-07-03)

- **QA (test coverage):** PASS-WITH-NOTES — every constraint the migration creates now has a test proving it bites (22 integration tests vs real Postgres, incl. both plugin_data uniqueness indexes and both RESTRICT paths); constraint tests assert specific Prisma error codes (P2002/P2003)
- **Code review:** APPROVE-WITH-NOTES — migration verified identical to `prisma migrate diff` output (± the documented partial index); dbml regeneration byte-for-byte; **fallow: 6 files, 0 in-scope issues**
- Findings that outlive this PR are tracked on the vault board (scope validation → machine-auth issue; elementId↔caseId consistency → lifecycle service; pre-existing suite flake → own issue)

## Verification

- `prisma migrate deploy` — full 23-migration history applies cleanly on fresh databases
- 22/22 integration tests; `pnpm lint` + `pnpm typecheck` clean

Merge order vs #830: independent branches, either order.