### PR TITLE
feat(auth): machine access — scoped API tokens, integration registry, /api/machine surface

### DIFF
--- a/app/api/machine/whoami/route.ts
+++ b/app/api/machine/whoami/route.ts
@@ -1,0 +1,33 @@
+import type { NextRequest } from "next/server";
+import { apiErrorFromUnknown, apiSuccess } from "@/lib/api-response";
+import { requireApiToken } from "@/lib/auth/require-api-token";
+
+/**
+ * Diagnostic identity check for a machine integration.
+ *
+ * @description Returns the identity of the integration whose bearer token
+ * authenticated this request — name, current scopes, and the prefix of the
+ * token used. No scope is required beyond a valid, non-suspended/revoked
+ * token: this is the end-to-end reachability proof for `/api/machine/*`
+ * (a valid token reaches the handler; an invalid one gets the API error
+ * envelope, never a login-page redirect) and a genuinely useful "am I
+ * talking to the platform correctly" check for integration operators.
+ *
+ * @response 200 - { name, scopes, tokenPrefix }
+ * @response 401 - Unauthorised (missing, malformed, unknown, revoked, or expired token; non-ACTIVE integration)
+ * @response 429 - Rate limited (too many failed attempts from this IP)
+ * @auth bearer
+ * @tag Machine
+ */
+export async function GET(request: NextRequest) {
+	try {
+		const principal = await requireApiToken(request);
+		return apiSuccess({
+			name: principal.integrationName,
+			scopes: principal.scopes,
+			tokenPrefix: principal.tokenPrefix,
+		});
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}

--- a/e2e/machine-whoami.spec.ts
+++ b/e2e/machine-whoami.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * e2e smoke coverage for the machine-auth request path (ADR 0002 v2 §2.4,
+ * the R1 closure): a real, DB-issued bearer token reaches
+ * `/api/machine/whoami` end to end through the actual running Next.js
+ * server + middleware, and a request with no token gets the API error
+ * envelope rather than the session-auth redirect that would otherwise
+ * catch every other `/api/*` route (see `middleware.ts`'s `api/machine`
+ * matcher exemption, unit-tested at the regex level in
+ * `src/__tests__/integration/machine-auth.test.ts`).
+ *
+ * This is a plain HTTP smoke test, not a UI journey, so it uses
+ * Playwright's `request` fixture directly and skips the browser. No
+ * session/storageState is needed either — the endpoint under test
+ * authenticates via bearer token, not cookies (mirrors the
+ * `case-studies-index.spec.ts` pattern for auth-agnostic specs).
+ *
+ * Seeding: registers a real `Integration` and issues a real token through
+ * the actual service functions (`registerIntegration` / `issueToken`) —
+ * not a raw DB insert — so this exercises genuine business logic, not a
+ * fixture shortcut. This assumes the same DATABASE_URL (and friends)
+ * `e2e/global-setup.ts` and `prisma/seed/dev-seed.ts` already require to
+ * run this suite at all locally; see the file header note in
+ * `e2e/global-setup.ts` for that precondition.
+ */
+import { expect, test } from "@playwright/test";
+import prisma from "@/lib/prisma";
+import {
+	issueToken,
+	registerIntegration,
+} from "@/lib/services/integration-registry-service";
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe("/api/machine/whoami — e2e smoke (R1)", () => {
+	let ownerId: string | undefined;
+	let integrationId: string | undefined;
+	let secret: string | undefined;
+	let integrationName: string | undefined;
+
+	test.beforeAll(async () => {
+		const unique = `e2e-machine-whoami-${Date.now()}`;
+
+		const owner = await prisma.user.create({
+			data: {
+				email: `${unique}@example.com`,
+				username: unique,
+				passwordHash: "not-a-real-hash",
+				passwordAlgorithm: "argon2id",
+				authProvider: "LOCAL",
+				emailVerified: true,
+			},
+		});
+		ownerId = owner.id;
+
+		const registered = await registerIntegration(
+			{ name: unique, ownerId: owner.id, scopes: ["case:read"] },
+			owner.id
+		);
+		if ("error" in registered) {
+			throw new Error(`Failed to seed test integration: ${registered.error}`);
+		}
+		integrationId = registered.data.integration.id;
+		integrationName = registered.data.integration.name;
+
+		const issued = await issueToken(integrationId, owner.id);
+		if ("error" in issued) {
+			throw new Error(`Failed to seed test token: ${issued.error}`);
+		}
+		secret = issued.data.secret;
+	});
+
+	test.afterAll(async () => {
+		// Deleting the integration cascades its token(s); the owner user
+		// cleans up last so nothing is left orphaned in a shared dev DB.
+		if (integrationId) {
+			await prisma.integration.deleteMany({ where: { id: integrationId } });
+		}
+		if (ownerId) {
+			await prisma.user.deleteMany({ where: { id: ownerId } });
+		}
+	});
+
+	test("a real seeded bearer token authenticates and returns the integration's identity", async ({
+		request,
+	}) => {
+		if (!secret) {
+			throw new Error("beforeAll did not seed a token");
+		}
+
+		const response = await request.get("/api/machine/whoami", {
+			headers: { authorization: `Bearer ${secret}` },
+		});
+
+		expect(response.status()).toBe(200);
+		const body = await response.json();
+		expect(body.name).toBe(integrationName);
+		expect(body.scopes).toEqual(["case:read"]);
+		expect(typeof body.tokenPrefix).toBe("string");
+	});
+
+	test("no token returns the JSON 401 envelope, NOT a redirect to /login", async ({
+		request,
+	}) => {
+		const response = await request.get("/api/machine/whoami", {
+			maxRedirects: 0,
+		});
+
+		// The API error envelope, not next-auth's 307-to-/login redirect —
+		// the whole point of the middleware's `api/machine` exemption (R1).
+		expect(response.status()).not.toBe(307);
+		expect(response.status()).toBe(401);
+		expect(response.headers().location).toBeUndefined();
+
+		const body = await response.json();
+		expect(body.code).toBe("UNAUTHORISED");
+	});
+});

--- a/lib/auth/__tests__/scopes.test.ts
+++ b/lib/auth/__tests__/scopes.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { findUnknownScopes, isValidScope, SCOPES, sameScopes } from "../scopes";
+
+describe("scopes", () => {
+	/**
+	 * Pins the exact v1 machine-access scope vocabulary (ADR 0002 v2 §2.4).
+	 * Breaks loudly if a scope is added, removed, or renamed without this
+	 * test being deliberately updated — the registry is meant to change only
+	 * via an ADR amendment, never silently.
+	 */
+	it("locks the exact v1 scope vocabulary", () => {
+		expect(SCOPES).toEqual([
+			"case:read",
+			"health:evidence:read",
+			"health:evidence:write",
+		]);
+	});
+
+	describe("isValidScope", () => {
+		it("accepts every scope in the registry", () => {
+			for (const scope of SCOPES) {
+				expect(isValidScope(scope)).toBe(true);
+			}
+		});
+
+		it("rejects a scope not in the registry", () => {
+			expect(isValidScope("case:write")).toBe(false);
+			expect(isValidScope("")).toBe(false);
+		});
+	});
+
+	describe("findUnknownScopes", () => {
+		it("returns an empty array when every scope is known", () => {
+			expect(findUnknownScopes(["case:read", "health:evidence:write"])).toEqual(
+				[]
+			);
+		});
+
+		it("returns only the unknown scopes, preserving order", () => {
+			expect(
+				findUnknownScopes(["case:read", "not-a-real-scope", "case:write"])
+			).toEqual(["not-a-real-scope", "case:write"]);
+		});
+
+		it("returns an empty array for an empty input", () => {
+			expect(findUnknownScopes([])).toEqual([]);
+		});
+	});
+
+	/**
+	 * Smoke coverage for the scope-reconciliation logic reused by
+	 * `scripts/seed-darter-integration.ts` (item 10 of the fix round) — the
+	 * script itself is untested end-to-end (it talks to a real database and
+	 * takes CLI args), but the comparison it hinges on is a pure function and
+	 * cheap to pin here.
+	 */
+	describe("sameScopes", () => {
+		it("treats identically-ordered sets as the same", () => {
+			expect(
+				sameScopes(
+					["case:read", "health:evidence:write"],
+					["case:read", "health:evidence:write"]
+				)
+			).toBe(true);
+		});
+
+		it("treats differently-ordered sets as the same (order-independent)", () => {
+			expect(
+				sameScopes(
+					["health:evidence:write", "case:read"],
+					["case:read", "health:evidence:write"]
+				)
+			).toBe(true);
+		});
+
+		it("treats sets of different length as different", () => {
+			expect(
+				sameScopes(["case:read"], ["case:read", "health:evidence:write"])
+			).toBe(false);
+		});
+
+		it("treats same-length sets with different members as different", () => {
+			expect(
+				sameScopes(
+					["case:read", "health:evidence:read"],
+					["case:read", "health:evidence:write"]
+				)
+			).toBe(false);
+		});
+
+		it("treats two empty sets as the same", () => {
+			expect(sameScopes([], [])).toBe(true);
+		});
+	});
+});

--- a/lib/auth/api-token-service.ts
+++ b/lib/auth/api-token-service.ts
@@ -1,0 +1,42 @@
+import { createHash, randomBytes } from "node:crypto";
+
+/**
+ * Pure crypto helpers for machine API tokens (ADR 0002 v2 §2.4). Mirrors
+ * `password-service.ts`'s split: no Prisma here, no business rules — just
+ * secret generation and hashing. The integration registry service owns the
+ * database side.
+ */
+
+/** Prefix on every issued token secret, e.g. `teap_xxxxxxxxxxxxxxxxxxxxxxxx`. */
+export const TOKEN_PREFIX = "teap_";
+
+/** Random bytes of entropy in the token body (256 bits). */
+const TOKEN_BODY_BYTES = 32;
+
+/** Leading characters of the plaintext secret persisted for UI/log identification. */
+const TOKEN_PREFIX_DISPLAY_LENGTH = 12;
+
+/**
+ * Generates a new token secret: `teap_` + a cryptographically random,
+ * URL-safe body. Shown to the caller exactly once — only its SHA-256 hash
+ * is persisted.
+ */
+export function generateApiTokenSecret(): string {
+	const body = randomBytes(TOKEN_BODY_BYTES).toString("base64url");
+	return `${TOKEN_PREFIX}${body}`;
+}
+
+/** SHA-256 hash (hex) of a token secret, for at-rest storage and lookup. */
+export function hashApiTokenSecret(secret: string): string {
+	return createHash("sha256").update(secret, "utf8").digest("hex");
+}
+
+/** Leading characters of a secret, stored alongside the hash for identification. */
+export function tokenDisplayPrefix(secret: string): string {
+	return secret.slice(0, TOKEN_PREFIX_DISPLAY_LENGTH);
+}
+
+/** True if `value` has the shape of a machine API token (cheap pre-filter before hashing). */
+export function looksLikeApiToken(value: string): boolean {
+	return value.startsWith(TOKEN_PREFIX) && value.length > TOKEN_PREFIX.length;
+}

--- a/lib/auth/require-api-token.ts
+++ b/lib/auth/require-api-token.ts
@@ -1,0 +1,71 @@
+import type { NextRequest } from "next/server";
+import type { Scope } from "@/lib/auth/scopes";
+import { AppError, unauthorised } from "@/lib/errors";
+import {
+	type ValidatedApiTokenPrincipal,
+	validateApiToken,
+} from "@/lib/services/integration-registry-service";
+
+/**
+ * Machine-access counterpart to `validate-session.ts`: identifies the
+ * caller of a `/api/machine/*` request. Unlike session auth, a bearer
+ * token cannot be trusted without a database lookup, so this module
+ * delegates that lookup to `integration-registry-service.ts` — it does
+ * NOT import Prisma itself, keeping all Prisma access inside the service
+ * layer per house rule.
+ */
+
+export type ApiTokenPrincipal = ValidatedApiTokenPrincipal;
+
+const BEARER_PREFIX = "Bearer ";
+
+function extractBearerToken(request: NextRequest): string | null {
+	const header = request.headers.get("authorization");
+	if (!header?.startsWith(BEARER_PREFIX)) {
+		return null;
+	}
+	const token = header.slice(BEARER_PREFIX.length).trim();
+	return token.length > 0 ? token : null;
+}
+
+/** Best-effort client IP for throttling — matches the pattern used elsewhere (e.g. forgot-password). */
+function extractIpAddress(request: NextRequest): string {
+	const forwarded = request.headers.get("x-forwarded-for");
+	if (forwarded) {
+		return forwarded.split(",")[0]?.trim() ?? "unknown";
+	}
+	return request.headers.get("x-real-ip") ?? "unknown";
+}
+
+/**
+ * Validates the bearer token on `request` and returns the acting
+ * integration's identity. Pass `scope` to additionally require that scope
+ * be present on the integration; omit it for endpoints (like `whoami`)
+ * that accept any validly authenticated integration regardless of scope.
+ *
+ * Throws `unauthorised()` with the SAME message for every auth-failure
+ * mode (missing header, malformed token, unknown/revoked/expired token,
+ * non-ACTIVE integration, or missing scope) so a caller cannot use the
+ * response to distinguish one failure reason from another. A throttled
+ * caller instead gets a distinct `RATE_LIMITED` (429) error — that is
+ * already a public, expected signal throughout this codebase's other
+ * rate limiters and isn't part of the no-oracle guarantee above. Route
+ * handlers use this exactly like `requireAuth()`: call inside a try/catch
+ * and map to `apiErrorFromUnknown`.
+ */
+export async function requireApiToken(
+	request: NextRequest,
+	scope?: Scope
+): Promise<ApiTokenPrincipal> {
+	const token = extractBearerToken(request);
+	const ipAddress = extractIpAddress(request);
+
+	const result = await validateApiToken({ token, scope, ipAddress });
+	if ("error" in result) {
+		if (result.rateLimited) {
+			throw new AppError({ code: "RATE_LIMITED", message: result.error });
+		}
+		throw unauthorised(result.error);
+	}
+	return result.data;
+}

--- a/lib/auth/scopes.ts
+++ b/lib/auth/scopes.ts
@@ -1,0 +1,55 @@
+/**
+ * The v1 machine-access scope vocabulary (ADR 0002 v2 §2.4).
+ *
+ * Scopes gate verbs, not resources: *which* cases an integration may touch
+ * rides the existing per-case permission model via its system user, not a
+ * parallel machine ACL. Core scopes are unprefixed (`case:read`); scopes
+ * that gate a plugin's own endpoints are plugin-namespaced
+ * (`health:evidence:write`).
+ *
+ * This list is deliberately closed — extend it only via an ADR amendment,
+ * never ad hoc at a call site. `Integration.scopes` is an open `String[]`
+ * at the database level (Prisma has no enum-array constraint), so this
+ * registry is what makes an unknown scope string a loud, rejected error
+ * instead of a silently persisted typo.
+ */
+export const SCOPES = [
+	"case:read",
+	"health:evidence:read",
+	"health:evidence:write",
+] as const;
+
+export type Scope = (typeof SCOPES)[number];
+
+const SCOPE_SET: ReadonlySet<string> = new Set(SCOPES);
+
+/** Type guard: is `value` a member of the current scope vocabulary? */
+export function isValidScope(value: string): value is Scope {
+	return SCOPE_SET.has(value);
+}
+
+/**
+ * Returns the subset of `values` that are NOT in the scope registry.
+ * Empty array means every value is a known scope.
+ */
+export function findUnknownScopes(values: readonly string[]): string[] {
+	return values.filter((value) => !isValidScope(value));
+}
+
+/**
+ * Order-independent equality check for two scope sets. Used wherever a
+ * caller needs to detect scope drift without treating `["a", "b"]` and
+ * `["b", "a"]` as a change — e.g. `scripts/seed-darter-integration.ts`
+ * reconciling a re-run's expected scopes against what's persisted.
+ */
+export function sameScopes(
+	a: readonly string[],
+	b: readonly string[]
+): boolean {
+	if (a.length !== b.length) {
+		return false;
+	}
+	const sortedA = [...a].sort();
+	const sortedB = [...b].sort();
+	return sortedA.every((value, index) => value === sortedB[index]);
+}

--- a/lib/services/integration-registry-service.ts
+++ b/lib/services/integration-registry-service.ts
@@ -1,0 +1,726 @@
+import { logSecurityEvent } from "@/lib/audit/security-log";
+import {
+	generateApiTokenSecret,
+	hashApiTokenSecret,
+	looksLikeApiToken,
+	tokenDisplayPrefix,
+} from "@/lib/auth/api-token-service";
+import { findUnknownScopes, type Scope } from "@/lib/auth/scopes";
+import { addTimingNoise, isTimestampValid } from "@/lib/auth/timing-safe";
+import { prisma } from "@/lib/prisma";
+import {
+	checkRateLimit,
+	RATE_LIMIT_CONFIGS,
+	recordAttempt,
+} from "@/lib/services/rate-limit-service";
+import {
+	type ApiToken,
+	type Integration,
+	Prisma,
+} from "@/src/generated/prisma";
+import type { ServiceResult } from "@/types/service";
+
+/**
+ * Owns the machine-access layer's data: registering/suspending/revoking
+ * `Integration`s, issuing/rotating/revoking their `ApiToken`s, and
+ * validating a presented bearer token on every `/api/machine/*` request
+ * (ADR 0002 v2 §2.4). All Prisma access for this domain lives here — routes
+ * and `lib/auth/require-api-token.ts` never import Prisma directly.
+ *
+ * Authorisation note: this service does not itself enforce WHO may call
+ * register/suspend/revoke/issue/rotate — that authority model belongs to
+ * the management API + settings UI (issue 7, not yet built). `actorUserId`
+ * parameters here are for audit attribution only.
+ */
+
+// ============================================
+// Types
+// ============================================
+
+export interface RegisterIntegrationInput {
+	description?: string;
+	name: string;
+	ownerId: string;
+	scopes: string[];
+}
+
+export interface RegisteredIntegration {
+	integration: Integration;
+	systemUserId: string;
+}
+
+export interface IssuedToken {
+	apiToken: ApiToken;
+	/** Plaintext secret — present ONLY on this return value, never persisted or shown again. */
+	secret: string;
+}
+
+export interface RotatedToken {
+	newToken: IssuedToken;
+	oldTokenId: string;
+	/** When the rotated-out token's brought-forward expiry takes effect. */
+	overlapUntil: Date;
+}
+
+/**
+ * Rotation grace window: the old token keeps authenticating for this long
+ * after `rotateToken()` (its expiry is brought forward to `now + this`,
+ * unless it already expired sooner). Long enough for a batch/cron-driven
+ * integration such as DARTER to pick up the new secret on its own schedule
+ * without a hard-cutover outage; short enough that a token being rotated
+ * away from doesn't linger for days. Chosen: 24 hours — one deploy cycle.
+ */
+export const TOKEN_ROTATION_OVERLAP_MS = 24 * 60 * 60 * 1000;
+
+// ============================================
+// Helpers
+// ============================================
+
+function isUniqueConstraintError(error: unknown): boolean {
+	return (
+		error instanceof Prisma.PrismaClientKnownRequestError &&
+		error.code === "P2002"
+	);
+}
+
+function slugifyIntegrationName(name: string): string {
+	return name
+		.toLowerCase()
+		.trim()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/(^-+|-+$)/g, "");
+}
+
+interface AuditLogInput {
+	eventType: string;
+	ipAddress?: string | null;
+	metadata?: Record<string, unknown>;
+	userAgent?: string | null;
+	userId?: string | null;
+}
+
+/**
+ * Records a security-relevant machine-auth event: `logSecurityEvent` for
+ * dev-console visibility (existing pattern) plus a persisted
+ * `SecurityAuditLog` row (the pattern's call shape has no DB write yet —
+ * this service adds one, scoped to its own events, all Prisma access
+ * staying inside this service per house rule).
+ */
+async function writeAuditLog(input: AuditLogInput): Promise<void> {
+	logSecurityEvent({
+		event: input.eventType,
+		severity: "medium",
+		metadata: {
+			...input.metadata,
+			userId: input.userId,
+			ipAddress: input.ipAddress,
+		},
+	});
+	await prisma.securityAuditLog.create({
+		data: {
+			userId: input.userId ?? null,
+			eventType: input.eventType,
+			ipAddress: input.ipAddress ?? null,
+			userAgent: input.userAgent ?? null,
+			// biome-ignore lint/suspicious/noExplicitAny: Prisma JSON type requires any
+			metadata: (input.metadata ?? null) as any,
+		},
+	});
+}
+
+/**
+ * Loads an `Integration` by id with the given `select`, or the shared
+ * not-found error. Dedupes the "load integration, fail if absent"
+ * boilerplate repeated across the register/suspend/revoke/reassign/
+ * delete/issue call sites below (fallow clone finding, fix round).
+ */
+async function getIntegrationOrError<S extends Prisma.IntegrationSelect>(
+	integrationId: string,
+	select: S
+): ServiceResult<Prisma.IntegrationGetPayload<{ select: S }>> {
+	const integration = await prisma.integration.findUnique({
+		where: { id: integrationId },
+		select,
+	});
+	if (!integration) {
+		return { error: "Integration not found" };
+	}
+	// `lib/prisma.ts` wraps the client in `$extends()`, which rebinds its
+	// InternalArgs — the client-bound result of `findUnique({ select })` and
+	// the standalone `Prisma.IntegrationGetPayload<{ select: S }>` type (which
+	// defaults to `DefaultArgs`) are two structurally-identical but nominally
+	// distinct instantiations of the same generated type. Runtime shape is
+	// identical; this cast just reconciles the two static instantiations.
+	return { data: integration as Prisma.IntegrationGetPayload<{ select: S }> };
+}
+
+function issueTokenRecord(integrationId: string, expiresAt?: Date) {
+	const secret = generateApiTokenSecret();
+	return {
+		secret,
+		data: {
+			integrationId,
+			tokenHash: hashApiTokenSecret(secret),
+			tokenPrefix: tokenDisplayPrefix(secret),
+			expiresAt,
+		},
+	};
+}
+
+// ============================================
+// Registration / lifecycle
+// ============================================
+
+/**
+ * Registers a new integration: creates its dedicated system `User`
+ * (`isSystemUser: true`) and the `Integration` row transactionally.
+ * Rejects any scope not in the current registry (`lib/auth/scopes.ts`) —
+ * loud failure, never a silent partial save.
+ */
+export async function registerIntegration(
+	input: RegisterIntegrationInput,
+	actorUserId: string
+): ServiceResult<RegisteredIntegration> {
+	try {
+		const unknownScopes = findUnknownScopes(input.scopes);
+		if (unknownScopes.length > 0) {
+			return { error: `Unknown scope(s): ${unknownScopes.join(", ")}` };
+		}
+
+		const owner = await prisma.user.findUnique({
+			where: { id: input.ownerId },
+			select: { id: true },
+		});
+		if (!owner) {
+			return { error: "Owner not found" };
+		}
+
+		const slug = slugifyIntegrationName(input.name);
+		const result = await prisma.$transaction(async (tx) => {
+			const systemUser = await tx.user.create({
+				data: {
+					email: `integration+${slug}@tea-platform.internal`,
+					username: `integration-${slug}`,
+					isSystemUser: true,
+					authProvider: "SYSTEM",
+					emailVerified: true,
+				},
+				select: { id: true },
+			});
+
+			const integration = await tx.integration.create({
+				data: {
+					name: input.name,
+					description: input.description,
+					ownerId: input.ownerId,
+					systemUserId: systemUser.id,
+					scopes: input.scopes,
+				},
+			});
+
+			return { integration, systemUserId: systemUser.id };
+		});
+
+		await writeAuditLog({
+			userId: actorUserId,
+			eventType: "integration_registered",
+			metadata: {
+				integrationId: result.integration.id,
+				name: input.name,
+				scopes: input.scopes,
+			},
+		});
+
+		return { data: result };
+	} catch (error) {
+		if (isUniqueConstraintError(error)) {
+			return { error: "An integration with this name already exists" };
+		}
+		return { error: "Failed to register integration" };
+	}
+}
+
+/** Validates and replaces an integration's scope set. Same registry check as registration. */
+export async function updateIntegrationScopes(
+	integrationId: string,
+	scopes: string[],
+	actorUserId: string
+): ServiceResult<Integration> {
+	try {
+		const unknownScopes = findUnknownScopes(scopes);
+		if (unknownScopes.length > 0) {
+			return { error: `Unknown scope(s): ${unknownScopes.join(", ")}` };
+		}
+
+		const existing = await getIntegrationOrError(integrationId, { id: true });
+		if ("error" in existing) {
+			return existing;
+		}
+
+		const integration = await prisma.integration.update({
+			where: { id: integrationId },
+			data: { scopes },
+		});
+
+		await writeAuditLog({
+			userId: actorUserId,
+			eventType: "integration_scopes_updated",
+			metadata: { integrationId, scopes },
+		});
+
+		return { data: integration };
+	} catch {
+		return { error: "Failed to update integration scopes" };
+	}
+}
+
+export async function suspendIntegration(
+	integrationId: string,
+	actorUserId: string
+): ServiceResult<Integration> {
+	try {
+		const existing = await getIntegrationOrError(integrationId, { id: true });
+		if ("error" in existing) {
+			return existing;
+		}
+
+		const integration = await prisma.integration.update({
+			where: { id: integrationId },
+			data: { status: "SUSPENDED" },
+		});
+
+		await writeAuditLog({
+			userId: actorUserId,
+			eventType: "integration_suspended",
+			metadata: { integrationId },
+		});
+
+		return { data: integration };
+	} catch {
+		return { error: "Failed to suspend integration" };
+	}
+}
+
+/**
+ * Revokes an integration permanently and, in the same transaction, revokes
+ * every one of its currently-unrevoked tokens — a revoked integration
+ * should not keep authenticating on a token issued before the revocation.
+ */
+export async function revokeIntegration(
+	integrationId: string,
+	actorUserId: string
+): ServiceResult<Integration> {
+	try {
+		const existing = await getIntegrationOrError(integrationId, { id: true });
+		if ("error" in existing) {
+			return existing;
+		}
+
+		const now = new Date();
+		const [integration] = await prisma.$transaction([
+			prisma.integration.update({
+				where: { id: integrationId },
+				data: { status: "REVOKED" },
+			}),
+			prisma.apiToken.updateMany({
+				where: { integrationId, revokedAt: null },
+				data: { revokedAt: now },
+			}),
+		]);
+
+		await writeAuditLog({
+			userId: actorUserId,
+			eventType: "integration_revoked",
+			metadata: { integrationId },
+		});
+
+		return { data: integration };
+	} catch {
+		return { error: "Failed to revoke integration" };
+	}
+}
+
+// ============================================
+// Owner-deletion flow (ADR 0002 v2 §2.4 — DB RESTRICTs unconditionally;
+// this is the humane path layered on top)
+// ============================================
+
+/** Lists integrations owned by a user — the set that would block their account deletion. */
+export async function getIntegrationsOwnedBy(
+	ownerId: string
+): ServiceResult<Integration[]> {
+	try {
+		const integrations = await prisma.integration.findMany({
+			where: { ownerId },
+			orderBy: { createdAt: "asc" },
+		});
+		return { data: integrations };
+	} catch {
+		return { error: "Failed to list owned integrations" };
+	}
+}
+
+export async function reassignIntegrationOwner(
+	integrationId: string,
+	newOwnerId: string,
+	actorUserId: string
+): ServiceResult<Integration> {
+	try {
+		const [existing, newOwner] = await Promise.all([
+			getIntegrationOrError(integrationId, { id: true }),
+			prisma.user.findUnique({
+				where: { id: newOwnerId },
+				select: { id: true },
+			}),
+		]);
+		if ("error" in existing || !newOwner) {
+			return { error: "Integration not found" };
+		}
+
+		const integration = await prisma.integration.update({
+			where: { id: integrationId },
+			data: { ownerId: newOwnerId },
+		});
+
+		await writeAuditLog({
+			userId: actorUserId,
+			eventType: "integration_owner_reassigned",
+			metadata: { integrationId, newOwnerId },
+		});
+
+		return { data: integration };
+	} catch {
+		return { error: "Failed to reassign integration owner" };
+	}
+}
+
+/**
+ * Hard-deletes an integration's registration (cascades its tokens). Use
+ * when reassignment isn't wanted — deleting the row, not just revoking,
+ * gives up the integration's own accountability trail, so prefer
+ * `revokeIntegration` when that trail matters and this only when a human
+ * owner needs the RESTRICT cleared without a new owner to hand off to.
+ */
+export async function deleteIntegrationRegistration(
+	integrationId: string,
+	actorUserId: string
+): ServiceResult<true> {
+	try {
+		const existing = await getIntegrationOrError(integrationId, {
+			id: true,
+			name: true,
+		});
+		if ("error" in existing) {
+			return existing;
+		}
+
+		await prisma.integration.delete({ where: { id: integrationId } });
+
+		await writeAuditLog({
+			userId: actorUserId,
+			eventType: "integration_deleted",
+			metadata: { integrationId, name: existing.data.name },
+		});
+
+		return { data: true };
+	} catch {
+		return { error: "Failed to delete integration" };
+	}
+}
+
+// ============================================
+// Token issuance / rotation / revocation
+// ============================================
+
+/**
+ * Issues a new token for an ACTIVE integration.
+ *
+ * Deliberately no default lifetime: `options.expiresAt` is optional, and an
+ * omitted value means the token never expires on its own
+ * (`isTimestampValid` treats an absent expiry as always-valid — see
+ * `lib/auth/timing-safe.ts`). This is a considered posture, not an
+ * oversight — revocation (`revokeToken` / `revokeIntegration`), not
+ * expiry, is the primary kill switch for this system: integrations like
+ * DARTER are long-lived batch/cron clients with no natural
+ * re-authentication moment, so forcing an expiry would just mean building
+ * a renewal flow nothing here yet has, whereas revocation is immediate,
+ * always available, and already the mechanism suspension/deletion rely on.
+ * Callers that DO want a bounded-lifetime token (e.g. a short-lived
+ * delegated credential) can still pass `expiresAt` explicitly — nothing
+ * about this default forecloses that.
+ */
+export async function issueToken(
+	integrationId: string,
+	actorUserId: string,
+	options: { expiresAt?: Date } = {}
+): ServiceResult<IssuedToken> {
+	try {
+		const integration = await getIntegrationOrError(integrationId, {
+			id: true,
+			status: true,
+		});
+		if ("error" in integration) {
+			return integration;
+		}
+		if (integration.data.status !== "ACTIVE") {
+			return { error: "Cannot issue a token for a non-active integration" };
+		}
+
+		const { secret, data } = issueTokenRecord(integrationId, options.expiresAt);
+		const apiToken = await prisma.apiToken.create({ data });
+
+		await writeAuditLog({
+			userId: actorUserId,
+			eventType: "token_issued",
+			metadata: {
+				integrationId,
+				tokenId: apiToken.id,
+				tokenPrefix: apiToken.tokenPrefix,
+			},
+		});
+
+		return { data: { apiToken, secret } };
+	} catch {
+		return { error: "Failed to issue token" };
+	}
+}
+
+/**
+ * Issues a replacement token and brings the old token's expiry forward to
+ * `now + TOKEN_ROTATION_OVERLAP_MS` (unless it already expires sooner) —
+ * both tokens authenticate during the overlap. Does NOT set `revokedAt` on
+ * the old token: that field means "dead immediately" and is reserved for
+ * `revokeToken`/`revokeIntegration`; rotation reuses the existing expiry
+ * check instead of inventing grace-period semantics on top of `revokedAt`.
+ */
+export async function rotateToken(
+	tokenId: string,
+	actorUserId: string
+): ServiceResult<RotatedToken> {
+	try {
+		const oldToken = await prisma.apiToken.findUnique({
+			where: { id: tokenId },
+			include: { integration: { select: { id: true, status: true } } },
+		});
+		if (!oldToken) {
+			return { error: "Token not found" };
+		}
+		if (oldToken.revokedAt) {
+			return { error: "Cannot rotate a revoked token" };
+		}
+		if (oldToken.integration.status !== "ACTIVE") {
+			return { error: "Cannot rotate a token for a non-active integration" };
+		}
+
+		const overlapUntil = new Date(Date.now() + TOKEN_ROTATION_OVERLAP_MS);
+		const newExpiresAt =
+			oldToken.expiresAt && oldToken.expiresAt < overlapUntil
+				? oldToken.expiresAt
+				: overlapUntil;
+
+		const { secret, data } = issueTokenRecord(oldToken.integrationId);
+
+		const [, apiToken] = await prisma.$transaction([
+			prisma.apiToken.update({
+				where: { id: tokenId },
+				data: { expiresAt: newExpiresAt },
+			}),
+			prisma.apiToken.create({ data }),
+		]);
+
+		await writeAuditLog({
+			userId: actorUserId,
+			eventType: "token_rotated",
+			metadata: {
+				integrationId: oldToken.integrationId,
+				oldTokenId: tokenId,
+				newTokenId: apiToken.id,
+				overlapUntil: overlapUntil.toISOString(),
+			},
+		});
+
+		return {
+			data: {
+				newToken: { apiToken, secret },
+				oldTokenId: tokenId,
+				overlapUntil: newExpiresAt,
+			},
+		};
+	} catch {
+		return { error: "Failed to rotate token" };
+	}
+}
+
+export async function revokeToken(
+	tokenId: string,
+	actorUserId: string
+): ServiceResult<ApiToken> {
+	try {
+		const existing = await prisma.apiToken.findUnique({
+			where: { id: tokenId },
+			select: { id: true, revokedAt: true, integrationId: true },
+		});
+		if (!existing) {
+			return { error: "Token not found" };
+		}
+		if (existing.revokedAt) {
+			return { error: "Token already revoked" };
+		}
+
+		const apiToken = await prisma.apiToken.update({
+			where: { id: tokenId },
+			data: { revokedAt: new Date() },
+		});
+
+		await writeAuditLog({
+			userId: actorUserId,
+			eventType: "token_revoked",
+			metadata: { integrationId: existing.integrationId, tokenId },
+		});
+
+		return { data: apiToken };
+	} catch {
+		return { error: "Failed to revoke token" };
+	}
+}
+
+// ============================================
+// Auth path — validates a presented bearer token
+// ============================================
+
+export interface ValidateApiTokenParams {
+	ipAddress: string;
+	scope?: Scope;
+	token: string | null;
+}
+
+export interface ValidatedApiTokenPrincipal {
+	integrationId: string;
+	integrationName: string;
+	scopes: string[];
+	systemUserId: string;
+	tokenPrefix: string;
+}
+
+export type ValidateApiTokenResult =
+	| { data: ValidatedApiTokenPrincipal }
+	| { error: string; rateLimited?: true };
+
+/** Single generic message for every auth failure — see module doc: no oracle. */
+const AUTH_FAILURE_MESSAGE = "Invalid or expired token";
+
+/**
+ * Validates a presented bearer token against an optional required scope.
+ * Used by `lib/auth/require-api-token.ts` — all Prisma access for the
+ * machine-auth request path lives here, not in `lib/auth/`.
+ *
+ * Every failure mode (missing header, malformed token, unknown hash,
+ * revoked, expired, non-ACTIVE integration, missing scope) returns the
+ * SAME error message, so a caller cannot use the response to distinguish
+ * "no such token" from "revoked" from "wrong scope" (deliberate — ADR 0002
+ * v2 §2.4 / feasibility review). Failed attempts are throttled by IP
+ * (`RATE_LIMIT_CONFIGS.machineAuth`) and written to `SecurityAuditLog`;
+ * successful requests are not — polling with a valid token never spends
+ * the throttle budget. `addTimingNoise` masks residual latency
+ * differences between the failure branches.
+ */
+export async function validateApiToken(
+	params: ValidateApiTokenParams
+): Promise<ValidateApiTokenResult> {
+	const { token, scope, ipAddress } = params;
+
+	const throttle = await checkRateLimit(RATE_LIMIT_CONFIGS.machineAuth, {
+		ipAddress,
+	});
+	if (!throttle.allowed) {
+		await recordAttempt(RATE_LIMIT_CONFIGS.machineAuth, { ipAddress }, true);
+		await writeAuditLog({
+			eventType: "machine_auth_rate_limited",
+			ipAddress,
+			metadata: { reason: throttle.reason },
+		});
+		return {
+			error: throttle.reason ?? "Too many failed attempts",
+			rateLimited: true,
+		};
+	}
+
+	const fail = async (
+		reason: string,
+		metadata: Record<string, unknown> = {}
+	): Promise<ValidateApiTokenResult> => {
+		await recordAttempt(RATE_LIMIT_CONFIGS.machineAuth, { ipAddress }, false);
+		await writeAuditLog({
+			eventType: "machine_auth_failed",
+			ipAddress,
+			metadata: { reason, ...metadata },
+		});
+		await addTimingNoise();
+		return { error: AUTH_FAILURE_MESSAGE };
+	};
+
+	if (!(token && looksLikeApiToken(token))) {
+		return fail("malformed_or_missing");
+	}
+
+	const tokenHash = hashApiTokenSecret(token);
+	const record = await prisma.apiToken.findUnique({
+		where: { tokenHash },
+		include: {
+			integration: {
+				select: {
+					id: true,
+					name: true,
+					status: true,
+					scopes: true,
+					systemUserId: true,
+				},
+			},
+		},
+	});
+
+	if (!record) {
+		return fail("not_found");
+	}
+	if (record.revokedAt) {
+		return fail("revoked", { tokenId: record.id });
+	}
+	if (!isTimestampValid(record.expiresAt?.getTime())) {
+		return fail("expired", { tokenId: record.id });
+	}
+	if (record.integration.status !== "ACTIVE") {
+		return fail("integration_not_active", {
+			integrationId: record.integrationId,
+		});
+	}
+	if (scope && !record.integration.scopes.includes(scope)) {
+		return fail("scope_missing", {
+			integrationId: record.integrationId,
+			scope,
+		});
+	}
+
+	const now = new Date();
+	await prisma.$transaction([
+		prisma.apiToken.update({
+			where: { id: record.id },
+			data: { lastUsedAt: now },
+		}),
+		prisma.integration.update({
+			where: { id: record.integrationId },
+			data: { lastSeenAt: now },
+		}),
+	]);
+
+	await addTimingNoise();
+
+	return {
+		data: {
+			integrationId: record.integrationId,
+			systemUserId: record.integration.systemUserId,
+			integrationName: record.integration.name,
+			scopes: record.integration.scopes,
+			tokenPrefix: record.tokenPrefix,
+		},
+	};
+}

--- a/lib/services/rate-limit-service.ts
+++ b/lib/services/rate-limit-service.ts
@@ -63,6 +63,23 @@ export const RATE_LIMIT_CONFIGS = {
 			},
 		],
 	},
+	/**
+	 * Failed `/api/machine/*` bearer-token auth attempts (ADR 0002 v2 §2.4).
+	 * `identifierType: "ip"` only — the identifier union has no token variant,
+	 * and a garbage/unknown token resolves to no user to key on. Only failed
+	 * attempts consume this budget (see integration-registry-service.ts); a
+	 * validly authenticated integration polling frequently never touches it.
+	 */
+	machineAuth: {
+		endpoint: "machine_auth",
+		limits: [
+			{
+				identifierType: "ip" as const,
+				maxAttempts: 20,
+				windowMs: 15 * 60 * 1000,
+			},
+		],
+	},
 } as const;
 
 // ============================================

--- a/lib/services/user-management-service.ts
+++ b/lib/services/user-management-service.ts
@@ -273,13 +273,24 @@ const SYSTEM_USER_EMAIL = "system@tea-platform.internal";
 const SYSTEM_USER_USERNAME = "system";
 
 /**
- * Gets or creates the system user for ownership transfer.
+ * Gets or creates the generic fallback system user for ownership transfer
+ * (used when a human account is deleted).
+ *
+ * Selects by the stable `SYSTEM_USER_EMAIL` identifier, NOT bare
+ * `isSystemUser: true` — a bare-flag lookup is a privilege-escalation
+ * hazard once integration system users exist (ADR 0002 v2 §2.4, feasibility
+ * review R2): `findFirst({ isSystemUser: true })` returns whichever system
+ * user Postgres happens to return first, which could just as easily be an
+ * integration's machine principal as this fallback account. Deleted users'
+ * case ownership — createdById, i.e. implicit ADMIN — would then be
+ * reassigned to an integration's principal instead of the intended generic
+ * account, handing that integration elevated access it never had.
  */
 async function getOrCreateSystemUser(
 	tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0]
 ): Promise<string> {
 	let systemUser = await tx.user.findFirst({
-		where: { isSystemUser: true },
+		where: { email: SYSTEM_USER_EMAIL, isSystemUser: true },
 		select: { id: true },
 	});
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -71,11 +71,25 @@ export const config = {
 		/*
 		 * Match all request paths except for the ones starting with:
 		 * - api/auth (auth endpoints)
+		 * - api/cron (cron endpoints, own CRON_SECRET bearer auth)
+		 * - api/machine (machine/integration endpoints, own requireApiToken
+		 *   bearer auth — ADR 0002 v2 §2.4. Without this exemption every
+		 *   bearer-token request here 307-redirects to /login instead of
+		 *   reaching the route handler.)
+		 * - api/health (health checks)
 		 * - _next/static (static files)
 		 * - _next/image (image optimization files)
 		 * - favicon.ico (favicon file)
 		 * - public folder
+		 *
+		 * Each of the four `api/*` prefixes above is boundary-anchored
+		 * (`(?:/|$)`) rather than a bare string prefix — otherwise a
+		 * hypothetical future route like `/api/machinery` or
+		 * `/api/healthcheck` would be silently exempted from session auth
+		 * too. Verified against the full route inventory (fix round,
+		 * 2026-07-03): no existing route under any of the four prefixes
+		 * relies on the looser match, so all four were anchored together.
 		 */
-		"/((?!api/auth|api/cron|api/health|api/users/register|_next/static|_next/image|favicon.ico|images|data|.*\\.png$|.*\\.jpg$|.*\\.jpeg$|.*\\.svg$|.*\\.json$|.*\\.html$).*)",
+		"/((?!api/auth(?:/|$)|api/cron(?:/|$)|api/machine(?:/|$)|api/health(?:/|$)|api/users/register|_next/static|_next/image|favicon.ico|images|data|.*\\.png$|.*\\.jpg$|.*\\.jpeg$|.*\\.svg$|.*\\.json$|.*\\.html$).*)",
 	],
 };

--- a/scripts/seed-darter-integration.ts
+++ b/scripts/seed-darter-integration.ts
@@ -1,0 +1,199 @@
+/**
+ * Registers the DARTER pipeline as a machine integration (ADR 0002 v2 §2.4)
+ * and grants it case-level access so it can call `/api/machine/*` end to
+ * end. Idempotent — safe to re-run:
+ *   - reuses the existing `darter-pipeline` integration/system user if one
+ *     already exists, reconciling its scopes to the current expected set
+ *   - upserts the case permission grant
+ *   - only issues a new token if the integration has no currently-active
+ *     one (a plaintext secret is shown exactly once at issuance and never
+ *     again, so a re-run cannot reprint an old one — it also never
+ *     silently issues a surplus token on every run)
+ *
+ * Usage:
+ *   npx tsx scripts/seed-darter-integration.ts <caseId> --owner-email=<email> [--permission=EDIT]
+ *
+ * `--owner-email` must be an existing human user — the ADR requires a real
+ * accountable owner, so this script never invents one.
+ */
+
+import { sameScopes } from "../lib/auth/scopes";
+import { prisma } from "../lib/prisma";
+import {
+	issueToken,
+	registerIntegration,
+	updateIntegrationScopes,
+} from "../lib/services/integration-registry-service";
+import type { PermissionLevel } from "../src/generated/prisma";
+
+const INTEGRATION_NAME = "darter-pipeline";
+const EXPECTED_SCOPES = ["case:read", "health:evidence:write"] as const;
+const VALID_PERMISSIONS: PermissionLevel[] = [
+	"VIEW",
+	"COMMENT",
+	"EDIT",
+	"ADMIN",
+];
+
+interface Args {
+	caseId: string;
+	ownerEmail: string;
+	permission: PermissionLevel;
+}
+
+function parseArgs(): Args {
+	const [caseId, ...flags] = process.argv.slice(2);
+	if (!caseId) {
+		usageError("Missing required <caseId> argument.");
+	}
+
+	let ownerEmail: string | undefined;
+	let permission: PermissionLevel = "EDIT";
+
+	for (const flag of flags) {
+		if (flag.startsWith("--owner-email=")) {
+			ownerEmail = flag.slice("--owner-email=".length);
+		} else if (flag.startsWith("--permission=")) {
+			const value = flag.slice("--permission=".length).toUpperCase();
+			if (!VALID_PERMISSIONS.includes(value as PermissionLevel)) {
+				usageError(
+					`Invalid --permission="${value}". Must be one of ${VALID_PERMISSIONS.join(", ")}.`
+				);
+			}
+			permission = value as PermissionLevel;
+		}
+	}
+
+	if (!ownerEmail) {
+		usageError("Missing required --owner-email=<email> flag.");
+	}
+
+	return { caseId, ownerEmail, permission };
+}
+
+function usageError(message: string): never {
+	console.error(`Error: ${message}`);
+	console.error(
+		"Usage: npx tsx scripts/seed-darter-integration.ts <caseId> --owner-email=<email> [--permission=EDIT]"
+	);
+	process.exit(1);
+}
+
+async function main() {
+	const { caseId, ownerEmail, permission } = parseArgs();
+
+	const owner = await prisma.user.findUnique({ where: { email: ownerEmail } });
+	if (!owner) {
+		usageError(`No user found with email "${ownerEmail}".`);
+		return;
+	}
+
+	const targetCase = await prisma.assuranceCase.findUnique({
+		where: { id: caseId },
+		select: { id: true, name: true },
+	});
+	if (!targetCase) {
+		usageError(`No assurance case found with id "${caseId}".`);
+		return;
+	}
+
+	let integrationId: string;
+	let systemUserId: string;
+
+	const existing = await prisma.integration.findUnique({
+		where: { name: INTEGRATION_NAME },
+	});
+
+	if (existing) {
+		integrationId = existing.id;
+		systemUserId = existing.systemUserId;
+		console.log(
+			`Integration "${INTEGRATION_NAME}" already registered (${existing.id}).`
+		);
+
+		if (!sameScopes(existing.scopes, EXPECTED_SCOPES)) {
+			const result = await updateIntegrationScopes(
+				existing.id,
+				[...EXPECTED_SCOPES],
+				owner.id
+			);
+			if ("error" in result) {
+				console.error(`Failed to reconcile scopes: ${result.error}`);
+				process.exit(1);
+			}
+			console.log(`Reconciled scopes to: ${EXPECTED_SCOPES.join(", ")}`);
+		}
+	} else {
+		const result = await registerIntegration(
+			{
+				name: INTEGRATION_NAME,
+				description:
+					"DARTER evidence pipeline — machine client for the health plugin",
+				ownerId: owner.id,
+				scopes: [...EXPECTED_SCOPES],
+			},
+			owner.id
+		);
+		if ("error" in result) {
+			console.error(`Failed to register integration: ${result.error}`);
+			process.exit(1);
+			return;
+		}
+		integrationId = result.data.integration.id;
+		systemUserId = result.data.systemUserId;
+		console.log(
+			`Registered integration "${INTEGRATION_NAME}" (${integrationId}).`
+		);
+	}
+
+	await prisma.casePermission.upsert({
+		where: { caseId_userId: { caseId, userId: systemUserId } },
+		create: { caseId, userId: systemUserId, permission, grantedById: owner.id },
+		update: { permission, grantedById: owner.id },
+	});
+	console.log(
+		`Granted ${permission} on case "${targetCase.name}" (${caseId}) to the DARTER system user.`
+	);
+
+	const now = new Date();
+	const activeTokens = await prisma.apiToken.findMany({
+		where: {
+			integrationId,
+			revokedAt: null,
+			OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
+		},
+		select: { tokenPrefix: true },
+	});
+
+	if (activeTokens.length > 0) {
+		console.log(
+			`Integration already has ${activeTokens.length} active token(s): ${activeTokens
+				.map((t) => t.tokenPrefix)
+				.join(
+					", "
+				)}. Not issuing a new one — rotate explicitly if a fresh secret is needed.`
+		);
+		return;
+	}
+
+	const issued = await issueToken(integrationId, owner.id);
+	if ("error" in issued) {
+		console.error(`Failed to issue token: ${issued.error}`);
+		process.exit(1);
+		return;
+	}
+
+	console.log("");
+	console.log("Token issued — shown once, will not be retrievable again:");
+	console.log(`  ${issued.data.secret}`);
+	console.log("");
+	console.log(`  Token ID:     ${issued.data.apiToken.id}`);
+	console.log(`  Token prefix: ${issued.data.apiToken.tokenPrefix}`);
+}
+
+main()
+	.catch((error) => {
+		console.error(error);
+		process.exitCode = 1;
+	})
+	.finally(() => prisma.$disconnect());

--- a/src/__tests__/integration/machine-auth.test.ts
+++ b/src/__tests__/integration/machine-auth.test.ts
@@ -1,0 +1,877 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+import { GET as whoamiGET } from "@/app/api/machine/whoami/route";
+import {
+	generateApiTokenSecret,
+	hashApiTokenSecret,
+	TOKEN_PREFIX,
+	tokenDisplayPrefix,
+} from "@/lib/auth/api-token-service";
+import prisma from "@/lib/prisma";
+import {
+	deleteIntegrationRegistration,
+	getIntegrationsOwnedBy,
+	issueToken,
+	reassignIntegrationOwner,
+	registerIntegration,
+	revokeIntegration,
+	revokeToken,
+	rotateToken,
+	suspendIntegration,
+	TOKEN_ROTATION_OVERLAP_MS,
+	updateIntegrationScopes,
+	validateApiToken,
+} from "@/lib/services/integration-registry-service";
+import { RATE_LIMIT_CONFIGS } from "@/lib/services/rate-limit-service";
+import { expectError, expectSuccess } from "../utils/assertion-helpers";
+import { createTestUser } from "../utils/prisma-factories";
+
+const AUTH_FAILURE_MESSAGE = "Invalid or expired token";
+const UNKNOWN_SCOPE_PATTERN = /Unknown scope/;
+const ALREADY_EXISTS_PATTERN = /already exists/;
+const NON_ACTIVE_PATTERN = /non-active/;
+const ALREADY_REVOKED_PATTERN = /revoked/;
+const NOT_FOUND_PATTERN = /not found/i;
+const NOT_FOUND_ID = "00000000-0000-0000-0000-000000000000";
+
+/** Creates a raw ApiToken row with a known plaintext secret (for edge cases the service's own issueToken doesn't cover, e.g. a past expiresAt). */
+async function createRawToken(
+	integrationId: string,
+	overrides: Partial<{ expiresAt: Date; revokedAt: Date }> = {}
+) {
+	const secret = generateApiTokenSecret();
+	const apiToken = await prisma.apiToken.create({
+		data: {
+			integrationId,
+			tokenHash: hashApiTokenSecret(secret),
+			tokenPrefix: tokenDisplayPrefix(secret),
+			...overrides,
+		},
+	});
+	return { secret, apiToken };
+}
+
+async function registerTestIntegration(
+	scopes: string[] = ["case:read", "health:evidence:write"]
+) {
+	const owner = await createTestUser();
+	const result = expectSuccess(
+		await registerIntegration(
+			{ name: `test-integration-${owner.id}`, ownerId: owner.id, scopes },
+			owner.id
+		)
+	);
+	return { owner, ...result };
+}
+
+/** Builds a `whoami` request with the given headers (omit `authorization` to simulate a missing token). */
+function whoamiRequest(headers: Record<string, string> = {}): NextRequest {
+	return new NextRequest("http://localhost:3000/api/machine/whoami", {
+		headers,
+	});
+}
+
+describe("integration-registry-service — registration & lifecycle", () => {
+	it("registers an integration with its own system user", async () => {
+		const { integration, systemUserId } = await registerTestIntegration();
+
+		expect(integration.status).toBe("ACTIVE");
+		const systemUser = await prisma.user.findUniqueOrThrow({
+			where: { id: systemUserId },
+		});
+		expect(systemUser.isSystemUser).toBe(true);
+	});
+
+	it("rejects registration with an unknown scope (loud failure, nothing persisted)", async () => {
+		const owner = await createTestUser();
+		const result = await registerIntegration(
+			{
+				name: "bad-scope-integration",
+				ownerId: owner.id,
+				scopes: ["case:read", "not-a-real-scope"],
+			},
+			owner.id
+		);
+		expectError(result, UNKNOWN_SCOPE_PATTERN);
+
+		const persisted = await prisma.integration.findUnique({
+			where: { name: "bad-scope-integration" },
+		});
+		expect(persisted).toBeNull();
+	});
+
+	it("rejects updateIntegrationScopes with an unknown scope", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const result = await updateIntegrationScopes(
+			integration.id,
+			["case:read", "evil:scope"],
+			owner.id
+		);
+		expectError(result, UNKNOWN_SCOPE_PATTERN);
+
+		const unchanged = await prisma.integration.findUniqueOrThrow({
+			where: { id: integration.id },
+		});
+		expect(unchanged.scopes).toEqual(integration.scopes);
+	});
+
+	it("rejects a duplicate integration name", async () => {
+		const owner = await createTestUser();
+		expectSuccess(
+			await registerIntegration(
+				{ name: "dup-name", ownerId: owner.id, scopes: ["case:read"] },
+				owner.id
+			)
+		);
+		const second = await registerIntegration(
+			{ name: "dup-name", ownerId: owner.id, scopes: ["case:read"] },
+			owner.id
+		);
+		expectError(second, ALREADY_EXISTS_PATTERN);
+	});
+
+	it("suspends an integration", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const suspended = expectSuccess(
+			await suspendIntegration(integration.id, owner.id)
+		);
+		expect(suspended.status).toBe("SUSPENDED");
+	});
+
+	it("revokes an integration and revokes all its unrevoked tokens", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const { apiToken } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+
+		const revoked = expectSuccess(
+			await revokeIntegration(integration.id, owner.id)
+		);
+		expect(revoked.status).toBe("REVOKED");
+
+		const token = await prisma.apiToken.findUniqueOrThrow({
+			where: { id: apiToken.id },
+		});
+		expect(token.revokedAt).not.toBeNull();
+	});
+
+	it("writes an audit log entry for registration, suspension, and revocation", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		await suspendIntegration(integration.id, owner.id);
+		await revokeIntegration(integration.id, owner.id);
+
+		const events = await prisma.securityAuditLog.findMany({
+			where: { userId: owner.id },
+			orderBy: { createdAt: "asc" },
+		});
+		const eventTypes = events.map((e) => e.eventType);
+		expect(eventTypes).toEqual(
+			expect.arrayContaining([
+				"integration_registered",
+				"integration_suspended",
+				"integration_revoked",
+			])
+		);
+	});
+});
+
+describe("integration-registry-service — owner-deletion flow", () => {
+	it("lists integrations owned by a user", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const owned = expectSuccess(await getIntegrationsOwnedBy(owner.id));
+		expect(owned.map((i) => i.id)).toContain(integration.id);
+	});
+
+	it("reassigns an integration's owner", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const newOwner = await createTestUser();
+
+		const updated = expectSuccess(
+			await reassignIntegrationOwner(integration.id, newOwner.id, owner.id)
+		);
+		expect(updated.ownerId).toBe(newOwner.id);
+	});
+
+	it("hard-deletes an integration registration, cascading its tokens", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const { apiToken } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+
+		expectSuccess(
+			await deleteIntegrationRegistration(integration.id, owner.id)
+		);
+
+		const gone = await prisma.integration.findUnique({
+			where: { id: integration.id },
+		});
+		expect(gone).toBeNull();
+		const tokenGone = await prisma.apiToken.findUnique({
+			where: { id: apiToken.id },
+		});
+		expect(tokenGone).toBeNull();
+	});
+
+	it("clears the way for owner deletion once integrations are reassigned or deleted (DB RESTRICT no longer blocks)", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const newOwner = await createTestUser();
+
+		expectSuccess(
+			await reassignIntegrationOwner(integration.id, newOwner.id, owner.id)
+		);
+
+		// The original owner no longer owns any integration, so the DB's
+		// unconditional ON DELETE RESTRICT on Integration.ownerId no longer applies.
+		await expect(
+			prisma.user.delete({ where: { id: owner.id } })
+		).resolves.toBeDefined();
+	});
+});
+
+describe("integration-registry-service — token lifecycle", () => {
+	it("issues a token whose plaintext authenticates and whose secret is never persisted", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const { secret, apiToken } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+
+		expect(secret.startsWith(TOKEN_PREFIX)).toBe(true);
+		expect(apiToken.tokenHash).not.toBe(secret);
+
+		const result = await validateApiToken({
+			token: secret,
+			ipAddress: "203.0.113.10",
+		});
+		expectSuccess(result);
+	});
+
+	it("refuses to issue a token for a non-ACTIVE integration", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		await suspendIntegration(integration.id, owner.id);
+
+		const result = await issueToken(integration.id, owner.id);
+		expectError(result, NON_ACTIVE_PATTERN);
+	});
+
+	it("rotates a token: both old and new authenticate during the overlap window", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const { secret: oldSecret, apiToken: oldApiToken } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+
+		const rotated = expectSuccess(await rotateToken(oldApiToken.id, owner.id));
+		expect(rotated.newToken.secret.startsWith(TOKEN_PREFIX)).toBe(true);
+
+		const oldResult = await validateApiToken({
+			token: oldSecret,
+			ipAddress: "203.0.113.11",
+		});
+		expectSuccess(oldResult);
+
+		const newResult = await validateApiToken({
+			token: rotated.newToken.secret,
+			ipAddress: "203.0.113.11",
+		});
+		expectSuccess(newResult);
+
+		const oldRow = await prisma.apiToken.findUniqueOrThrow({
+			where: { id: oldApiToken.id },
+		});
+		expect(oldRow.revokedAt).toBeNull(); // rotation schedules expiry, doesn't hard-revoke
+		expect(oldRow.expiresAt).not.toBeNull();
+		const untilMs = oldRow.expiresAt!.getTime() - Date.now();
+		expect(untilMs).toBeGreaterThan(0);
+		expect(untilMs).toBeLessThanOrEqual(TOKEN_ROTATION_OVERLAP_MS + 1000);
+	});
+
+	it("stops the old token working once the rotation overlap has elapsed", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const { secret: oldSecret, apiToken: oldApiToken } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+		await rotateToken(oldApiToken.id, owner.id);
+
+		// Simulate the overlap window having elapsed.
+		await prisma.apiToken.update({
+			where: { id: oldApiToken.id },
+			data: { expiresAt: new Date(Date.now() - 1000) },
+		});
+
+		const result = await validateApiToken({
+			token: oldSecret,
+			ipAddress: "203.0.113.12",
+		});
+		expectError(result, AUTH_FAILURE_MESSAGE);
+	});
+
+	it("refuses to rotate an already-revoked token", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const { apiToken } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+		expectSuccess(await revokeToken(apiToken.id, owner.id));
+
+		const result = await rotateToken(apiToken.id, owner.id);
+		expectError(result, ALREADY_REVOKED_PATTERN);
+	});
+
+	it("revokes a token immediately — no grace period", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const { secret, apiToken } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+
+		expectSuccess(await revokeToken(apiToken.id, owner.id));
+
+		const result = await validateApiToken({
+			token: secret,
+			ipAddress: "203.0.113.13",
+		});
+		expectError(result, AUTH_FAILURE_MESSAGE);
+	});
+
+	it("rejects an expired token with the same generic message", async () => {
+		const { integration } = await registerTestIntegration();
+		const { secret } = await createRawToken(integration.id, {
+			expiresAt: new Date(Date.now() - 1000),
+		});
+
+		const result = await validateApiToken({
+			token: secret,
+			ipAddress: "203.0.113.14",
+		});
+		expectError(result, AUTH_FAILURE_MESSAGE);
+	});
+});
+
+describe("integration-registry-service — scope enforcement", () => {
+	it("authenticates when the required scope is present", async () => {
+		const { integration, owner } = await registerTestIntegration(["case:read"]);
+		const { secret } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+
+		const result = await validateApiToken({
+			token: secret,
+			scope: "case:read",
+			ipAddress: "203.0.113.20",
+		});
+		expectSuccess(result);
+	});
+
+	it("rejects when the required scope is absent — same generic message as any other failure", async () => {
+		const { integration, owner } = await registerTestIntegration(["case:read"]);
+		const { secret } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+
+		const result = await validateApiToken({
+			token: secret,
+			scope: "health:evidence:write",
+			ipAddress: "203.0.113.21",
+		});
+		expectError(result, AUTH_FAILURE_MESSAGE);
+	});
+
+	it("authenticates regardless of scopes when no scope is required (whoami's use case)", async () => {
+		const { integration, owner } = await registerTestIntegration(["case:read"]);
+		const { secret } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+
+		const result = await validateApiToken({
+			token: secret,
+			ipAddress: "203.0.113.22",
+		});
+		expectSuccess(result);
+	});
+});
+
+describe("integration-registry-service — revoked/suspended integration paths", () => {
+	it("rejects a token belonging to a SUSPENDED integration", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const { secret } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+		expectSuccess(await suspendIntegration(integration.id, owner.id));
+
+		const result = await validateApiToken({
+			token: secret,
+			ipAddress: "203.0.113.30",
+		});
+		expectError(result, AUTH_FAILURE_MESSAGE);
+	});
+
+	it("rejects a token belonging to a REVOKED integration", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const { secret } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+		expectSuccess(await revokeIntegration(integration.id, owner.id));
+
+		const result = await validateApiToken({
+			token: secret,
+			ipAddress: "203.0.113.31",
+		});
+		expectError(result, AUTH_FAILURE_MESSAGE);
+	});
+});
+
+describe("integration-registry-service — same error for every failure mode (no oracle)", () => {
+	it("returns an identical message for missing, malformed, unknown, revoked, expired, and wrong-scope tokens", async () => {
+		const { integration, owner } = await registerTestIntegration(["case:read"]);
+		const { secret: revokedSecret, apiToken: revokedApiToken } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+		expectSuccess(await revokeToken(revokedApiToken.id, owner.id));
+		const { secret: expiredSecret } = await createRawToken(integration.id, {
+			expiresAt: new Date(Date.now() - 1000),
+		});
+		const { secret: scopedSecret } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+
+		const cases: Parameters<typeof validateApiToken>[0][] = [
+			{ token: null, ipAddress: "203.0.113.40" },
+			{ token: "not-even-shaped-right", ipAddress: "203.0.113.41" },
+			{ token: "teap_totally-unknown-hash", ipAddress: "203.0.113.42" },
+			{ token: revokedSecret, ipAddress: "203.0.113.43" },
+			{ token: expiredSecret, ipAddress: "203.0.113.44" },
+			{
+				token: scopedSecret,
+				scope: "health:evidence:write",
+				ipAddress: "203.0.113.45",
+			},
+		];
+
+		for (const params of cases) {
+			const result = await validateApiToken(params);
+			expectError(result, AUTH_FAILURE_MESSAGE);
+		}
+	});
+});
+
+describe("integration-registry-service — throttle behaviour", () => {
+	it("throttles failed attempts by IP and stops before the DB lookup once over the limit", async () => {
+		const ipAddress = "203.0.113.99";
+		const maxAttempts = RATE_LIMIT_CONFIGS.machineAuth.limits[0].maxAttempts;
+
+		for (let i = 0; i < maxAttempts; i++) {
+			const result = await validateApiToken({ token: null, ipAddress });
+			expect("error" in result).toBe(true);
+			expect((result as { rateLimited?: true }).rateLimited).toBeUndefined();
+		}
+
+		const blocked = await validateApiToken({ token: null, ipAddress });
+		expect("error" in blocked).toBe(true);
+		expect((blocked as { rateLimited?: true }).rateLimited).toBe(true);
+
+		const attempts = await prisma.rateLimitAttempt.count({
+			where: { endpoint: "machine_auth", identifier: ipAddress },
+		});
+		expect(attempts).toBe(maxAttempts + 1);
+	});
+
+	it("does not consume the throttle budget on successful authentication", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const { secret } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+		const ipAddress = "203.0.113.98";
+
+		for (let i = 0; i < 5; i++) {
+			expectSuccess(await validateApiToken({ token: secret, ipAddress }));
+		}
+
+		const attempts = await prisma.rateLimitAttempt.count({
+			where: { endpoint: "machine_auth", identifier: ipAddress },
+		});
+		expect(attempts).toBe(0);
+	});
+
+	it("writes a SecurityAuditLog row for a failed attempt", async () => {
+		const ipAddress = "203.0.113.97";
+		await validateApiToken({ token: "teap_nope", ipAddress });
+
+		const events = await prisma.securityAuditLog.findMany({
+			where: { eventType: "machine_auth_failed", ipAddress },
+		});
+		expect(events.length).toBeGreaterThan(0);
+	});
+});
+
+describe("/api/machine/whoami — reachability", () => {
+	it("reaches the handler and returns the integration's identity for a valid token", async () => {
+		const { integration, owner } = await registerTestIntegration(["case:read"]);
+		const { secret } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+
+		const req = new NextRequest("http://localhost:3000/api/machine/whoami", {
+			headers: { authorization: `Bearer ${secret}` },
+		});
+		const response = await whoamiGET(req);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.name).toBe(integration.name);
+		expect(body.scopes).toEqual(["case:read"]);
+		expect(typeof body.tokenPrefix).toBe("string");
+	});
+
+	it("returns the API error envelope — not a redirect — for a missing token", async () => {
+		const req = new NextRequest("http://localhost:3000/api/machine/whoami");
+		const response = await whoamiGET(req);
+
+		expect(response.status).toBe(401);
+		expect(response.headers.get("location")).toBeNull();
+		const body = await response.json();
+		expect(body.code).toBe("UNAUTHORISED");
+	});
+
+	it("returns the API error envelope — not a redirect — for an invalid token", async () => {
+		const req = new NextRequest("http://localhost:3000/api/machine/whoami", {
+			headers: { authorization: "Bearer teap_garbage-not-a-real-token" },
+		});
+		const response = await whoamiGET(req);
+
+		expect(response.status).toBe(401);
+		expect(response.headers.get("location")).toBeNull();
+		const body = await response.json();
+		expect(body.code).toBe("UNAUTHORISED");
+	});
+
+	it("stamps lastUsedAt / lastSeenAt on a successful request", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const { secret, apiToken } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+
+		const req = new NextRequest("http://localhost:3000/api/machine/whoami", {
+			headers: { authorization: `Bearer ${secret}` },
+		});
+		await whoamiGET(req);
+
+		const [updatedToken, updatedIntegration] = await Promise.all([
+			prisma.apiToken.findUniqueOrThrow({ where: { id: apiToken.id } }),
+			prisma.integration.findUniqueOrThrow({ where: { id: integration.id } }),
+		]);
+		expect(updatedToken.lastUsedAt).not.toBeNull();
+		expect(updatedIntegration.lastSeenAt).not.toBeNull();
+	});
+});
+
+describe("requireApiToken — header shapes", () => {
+	it("rejects a non-Bearer scheme (Basic) the same as a missing token", async () => {
+		const response = await whoamiGET(
+			whoamiRequest({ authorization: "Basic dXNlcjpwYXNz" })
+		);
+
+		expect(response.status).toBe(401);
+		const body = await response.json();
+		expect(body.error).toBe(AUTH_FAILURE_MESSAGE);
+	});
+
+	it("rejects a bare 'Bearer' scheme with no token", async () => {
+		const response = await whoamiGET(
+			whoamiRequest({ authorization: "Bearer" })
+		);
+
+		expect(response.status).toBe(401);
+		const body = await response.json();
+		expect(body.error).toBe(AUTH_FAILURE_MESSAGE);
+	});
+
+	it("rejects 'Bearer ' followed only by whitespace where the token should be", async () => {
+		const response = await whoamiGET(
+			whoamiRequest({ authorization: "Bearer    " })
+		);
+
+		expect(response.status).toBe(401);
+		const body = await response.json();
+		expect(body.error).toBe(AUTH_FAILURE_MESSAGE);
+	});
+
+	it("rejects a lower-cased 'bearer' scheme even with an otherwise-valid token (case-sensitive parsing)", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const { secret } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+
+		const response = await whoamiGET(
+			whoamiRequest({ authorization: `bearer ${secret}` })
+		);
+
+		expect(response.status).toBe(401);
+		const body = await response.json();
+		expect(body.error).toBe(AUTH_FAILURE_MESSAGE);
+	});
+});
+
+describe("requireApiToken — extractIpAddress, via whoami's failed-attempt audit trail", () => {
+	/** A failed whoami call always audit-logs the IP `extractIpAddress` resolved — the cheapest observable proxy for a private helper. */
+	async function failedWhoamiIpAddress(
+		headers: Record<string, string>
+	): Promise<void> {
+		const response = await whoamiGET(
+			whoamiRequest({
+				authorization: `Bearer ${TOKEN_PREFIX}does-not-exist`,
+				...headers,
+			})
+		);
+		// biome-ignore lint/suspicious/noMisplacedAssertion: Called from within test blocks
+		expect(response.status).toBe(401);
+	}
+
+	it("uses a single x-forwarded-for value as the client IP", async () => {
+		await failedWhoamiIpAddress({ "x-forwarded-for": "203.0.113.60" });
+
+		const event = await prisma.securityAuditLog.findFirst({
+			where: { eventType: "machine_auth_failed", ipAddress: "203.0.113.60" },
+		});
+		expect(event).not.toBeNull();
+	});
+
+	it("takes the first entry of a comma-separated x-forwarded-for chain", async () => {
+		await failedWhoamiIpAddress({
+			"x-forwarded-for": "203.0.113.61, 70.41.3.18, 150.172.238.178",
+		});
+
+		const event = await prisma.securityAuditLog.findFirst({
+			where: { eventType: "machine_auth_failed", ipAddress: "203.0.113.61" },
+		});
+		expect(event).not.toBeNull();
+	});
+
+	it("falls back to x-real-ip when x-forwarded-for is absent", async () => {
+		await failedWhoamiIpAddress({ "x-real-ip": "203.0.113.62" });
+
+		const event = await prisma.securityAuditLog.findFirst({
+			where: { eventType: "machine_auth_failed", ipAddress: "203.0.113.62" },
+		});
+		expect(event).not.toBeNull();
+	});
+
+	it("records 'unknown' when neither IP header is present", async () => {
+		await failedWhoamiIpAddress({});
+
+		const event = await prisma.securityAuditLog.findFirst({
+			where: { eventType: "machine_auth_failed", ipAddress: "unknown" },
+		});
+		expect(event).not.toBeNull();
+	});
+});
+
+describe("HTTP 429 through whoami/requireApiToken", () => {
+	it("returns 429 + a RATE_LIMITED envelope once the machineAuth throttle is exhausted via whoami — not validateApiToken directly", async () => {
+		const ipAddress = "203.0.113.70";
+		const maxAttempts = RATE_LIMIT_CONFIGS.machineAuth.limits[0].maxAttempts;
+
+		for (let i = 0; i < maxAttempts; i++) {
+			const response = await whoamiGET(
+				whoamiRequest({ "x-forwarded-for": ipAddress })
+			);
+			expect(response.status).toBe(401);
+		}
+
+		const blocked = await whoamiGET(
+			whoamiRequest({ "x-forwarded-for": ipAddress })
+		);
+
+		expect(blocked.status).toBe(429);
+		const body = await blocked.json();
+		expect(body.code).toBe("RATE_LIMITED");
+		expect(typeof body.error).toBe("string");
+	});
+});
+
+describe("issueToken({ expiresAt }) — both directions through the normal issue path", () => {
+	it("authenticates when expiresAt is in the future", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const future = new Date(Date.now() + 60_000);
+
+		const { secret } = expectSuccess(
+			await issueToken(integration.id, owner.id, { expiresAt: future })
+		);
+
+		const result = await validateApiToken({
+			token: secret,
+			ipAddress: "203.0.113.71",
+		});
+		expectSuccess(result);
+	});
+
+	it("fails closed when expiresAt has already elapsed", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const elapsed = new Date(Date.now() - 60_000);
+
+		const { secret } = expectSuccess(
+			await issueToken(integration.id, owner.id, { expiresAt: elapsed })
+		);
+
+		const result = await validateApiToken({
+			token: secret,
+			ipAddress: "203.0.113.72",
+		});
+		expectError(result, AUTH_FAILURE_MESSAGE);
+	});
+});
+
+describe("envelope no-oracle — whoami's body.error is textually identical across failure modes", () => {
+	it("returns the exact same body.error for missing, malformed, unknown, revoked, expired, and suspended-integration tokens", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const { secret: revokedSecret, apiToken: revokedApiToken } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+		expectSuccess(await revokeToken(revokedApiToken.id, owner.id));
+
+		const { secret: expiredSecret } = await createRawToken(integration.id, {
+			expiresAt: new Date(Date.now() - 1000),
+		});
+
+		const { integration: suspended, owner: suspendedOwner } =
+			await registerTestIntegration();
+		const { secret: suspendedSecret } = expectSuccess(
+			await issueToken(suspended.id, suspendedOwner.id)
+		);
+		expectSuccess(await suspendIntegration(suspended.id, suspendedOwner.id));
+
+		const headerSets: Record<string, string>[] = [
+			{},
+			{ authorization: "Bearer not-even-shaped-right" },
+			{ authorization: `Bearer ${TOKEN_PREFIX}totally-unknown-hash` },
+			{ authorization: `Bearer ${revokedSecret}` },
+			{ authorization: `Bearer ${expiredSecret}` },
+			{ authorization: `Bearer ${suspendedSecret}` },
+		];
+
+		for (const headers of headerSets) {
+			const response = await whoamiGET(whoamiRequest(headers));
+			expect(response.status).toBe(401);
+			const body = await response.json();
+			expect(body.error).toBe(AUTH_FAILURE_MESSAGE);
+		}
+	});
+});
+
+describe("service CRUD guards — not-found / non-active / already-revoked batch", () => {
+	it("returns the not-found error from updateIntegrationScopes for an unknown integration id", async () => {
+		const owner = await createTestUser();
+		expectError(
+			await updateIntegrationScopes(NOT_FOUND_ID, ["case:read"], owner.id),
+			NOT_FOUND_PATTERN
+		);
+	});
+
+	it("returns the not-found error from suspendIntegration for an unknown integration id", async () => {
+		const owner = await createTestUser();
+		expectError(
+			await suspendIntegration(NOT_FOUND_ID, owner.id),
+			NOT_FOUND_PATTERN
+		);
+	});
+
+	it("returns the not-found error from revokeIntegration for an unknown integration id", async () => {
+		const owner = await createTestUser();
+		expectError(
+			await revokeIntegration(NOT_FOUND_ID, owner.id),
+			NOT_FOUND_PATTERN
+		);
+	});
+
+	it("returns the not-found error from reassignIntegrationOwner for an unknown integration id", async () => {
+		const owner = await createTestUser();
+		const newOwner = await createTestUser();
+		expectError(
+			await reassignIntegrationOwner(NOT_FOUND_ID, newOwner.id, owner.id),
+			NOT_FOUND_PATTERN
+		);
+	});
+
+	it("returns the not-found error from reassignIntegrationOwner for an unknown new-owner id", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		expectError(
+			await reassignIntegrationOwner(integration.id, NOT_FOUND_ID, owner.id),
+			NOT_FOUND_PATTERN
+		);
+	});
+
+	it("returns the not-found error from deleteIntegrationRegistration for an unknown integration id", async () => {
+		const owner = await createTestUser();
+		expectError(
+			await deleteIntegrationRegistration(NOT_FOUND_ID, owner.id),
+			NOT_FOUND_PATTERN
+		);
+	});
+
+	it("returns the not-found error from issueToken for an unknown integration id", async () => {
+		const owner = await createTestUser();
+		expectError(await issueToken(NOT_FOUND_ID, owner.id), NOT_FOUND_PATTERN);
+	});
+
+	it("returns the not-found error from rotateToken for an unknown token id", async () => {
+		const owner = await createTestUser();
+		expectError(await rotateToken(NOT_FOUND_ID, owner.id), NOT_FOUND_PATTERN);
+	});
+
+	it("returns the not-found error from revokeToken for an unknown token id", async () => {
+		const owner = await createTestUser();
+		expectError(await revokeToken(NOT_FOUND_ID, owner.id), NOT_FOUND_PATTERN);
+	});
+
+	it("refuses to rotate a token belonging to a non-ACTIVE (suspended) integration", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const { apiToken } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+		expectSuccess(await suspendIntegration(integration.id, owner.id));
+
+		expectError(await rotateToken(apiToken.id, owner.id), NON_ACTIVE_PATTERN);
+	});
+
+	it("refuses a second revocation of an already-revoked token", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const { apiToken } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+		expectSuccess(await revokeToken(apiToken.id, owner.id));
+
+		expectError(
+			await revokeToken(apiToken.id, owner.id),
+			ALREADY_REVOKED_PATTERN
+		);
+	});
+});
+
+/**
+ * Next.js compiles `config.matcher` entries via path-to-regexp, which
+ * anchors the pattern to the full pathname (`^...$`) — an unanchored
+ * `new RegExp(pattern).test(path)` can find a spurious match starting
+ * from a later `/` in the path (e.g. re-trying from "/machine/whoami"
+ * once "/api/machine/whoami" fails the lookahead at index 0), which
+ * would falsely report the exemption as not working. Anchoring here
+ * reproduces the real matching behaviour.
+ */
+function compileMatcher(pattern: string): RegExp {
+	return new RegExp(`^${pattern}$`);
+}
+
+describe("middleware — /api/machine exemption (R1)", () => {
+	it("excludes every /api/machine/* path from the auth-redirect matcher", async () => {
+		const { config } = await import("@/middleware");
+		const matcherRegex = compileMatcher(config.matcher[0] as string);
+
+		expect(matcherRegex.test("/api/machine/whoami")).toBe(false);
+		expect(matcherRegex.test("/api/machine/health/elements/123/evidence")).toBe(
+			false
+		);
+	});
+
+	it("still matches ordinary protected app/API routes", async () => {
+		const { config } = await import("@/middleware");
+		const matcherRegex = compileMatcher(config.matcher[0] as string);
+
+		expect(matcherRegex.test("/dashboard")).toBe(true);
+		expect(matcherRegex.test("/api/cases/123")).toBe(true);
+	});
+});

--- a/src/__tests__/integration/user-management-service.test.ts
+++ b/src/__tests__/integration/user-management-service.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import prisma from "@/lib/prisma";
+import { deleteAccount } from "@/lib/services/user-management-service";
+import { expectSuccess } from "../utils/assertion-helpers";
+import { createTestCase, createTestUser } from "../utils/prisma-factories";
+
+/**
+ * Regression test for feasibility review R2 (ADR 0002 v2 §2.4):
+ * `getOrCreateSystemUser` used to select the fallback account via bare
+ * `findFirst({ isSystemUser: true })`, which — once integration system
+ * users exist alongside the generic fallback — could resolve to WHICHEVER
+ * system user Postgres returned first. That would hand a deleted user's
+ * case ownership (createdById, i.e. implicit ADMIN) to an integration's
+ * machine principal instead of the intended generic fallback account: a
+ * privilege escalation. The fix selects by the stable
+ * `system@tea-platform.internal` email identifier instead.
+ */
+const SYSTEM_USER_EMAIL = "system@tea-platform.internal";
+
+describe("getOrCreateSystemUser (via deleteAccount) — R2 regression", () => {
+	it("reassigns a deleted user's case to the generic fallback account, not an unrelated system user created first", async () => {
+		// Simulates an integration's machine principal: isSystemUser: true,
+		// but NOT the generic fallback — and it exists in the DB before the
+		// generic fallback account is ever created.
+		const decoySystemUser = await createTestUser({
+			email: "integration+decoy@tea-platform.internal",
+			username: "integration-decoy",
+		});
+		await prisma.user.update({
+			where: { id: decoySystemUser.id },
+			data: { isSystemUser: true },
+		});
+
+		// OAuth user — deleteAccount skips password verification for non-LOCAL auth.
+		const owner = await createTestUser({ authProvider: "GITHUB" });
+		const ownedCase = await createTestCase(owner.id, { name: "Owner's case" });
+
+		expectSuccess(await deleteAccount(owner.id));
+
+		const updatedCase = await prisma.assuranceCase.findUniqueOrThrow({
+			where: { id: ownedCase.id },
+		});
+
+		// Must NOT have been reassigned to the decoy system user.
+		expect(updatedCase.createdById).not.toBe(decoySystemUser.id);
+
+		const fallbackUser = await prisma.user.findUnique({
+			where: { email: SYSTEM_USER_EMAIL },
+		});
+		expect(fallbackUser).not.toBeNull();
+		expect(fallbackUser?.isSystemUser).toBe(true);
+		expect(updatedCase.createdById).toBe(fallbackUser?.id);
+	});
+
+	it("reuses the same fallback account across multiple deletions rather than creating duplicates", async () => {
+		const ownerA = await createTestUser({ authProvider: "GITHUB" });
+		const ownerB = await createTestUser({ authProvider: "GITHUB" });
+		const caseA = await createTestCase(ownerA.id, { name: "Case A" });
+		const caseB = await createTestCase(ownerB.id, { name: "Case B" });
+
+		expectSuccess(await deleteAccount(ownerA.id));
+		expectSuccess(await deleteAccount(ownerB.id));
+
+		const fallbackUsers = await prisma.user.findMany({
+			where: { email: SYSTEM_USER_EMAIL },
+		});
+		expect(fallbackUsers).toHaveLength(1);
+
+		const [updatedCaseA, updatedCaseB] = await Promise.all([
+			prisma.assuranceCase.findUniqueOrThrow({ where: { id: caseA.id } }),
+			prisma.assuranceCase.findUniqueOrThrow({ where: { id: caseB.id } }),
+		]);
+		expect(updatedCaseA.createdById).toBe(fallbackUsers[0]?.id);
+		expect(updatedCaseB.createdById).toBe(fallbackUsers[0]?.id);
+	});
+});


### PR DESCRIPTION
## What

Work item 2 of ADR 0002 v2 (the machine-access pillar): everything an external machine client needs to authenticate to the platform, and everything the platform needs to manage those clients.

- **`requireApiToken(scope)`** — bearer-token auth mirroring the human session check: SHA-256 hash lookup, status/expiry/scope verification, uniform timing noise, one indistinguishable 401 across all failure modes (429 for throttling is the sole, deliberate exception)
- **`/api/machine` middleware exemption** — boundary-anchored (`api/machine(?:/|$)`), with the three pre-existing sibling entries anchored likewise after a 58-route inventory confirmed nothing relies on the loose prefix
- **Integration registry service** — register/suspend/revoke integrations; issue/rotate/revoke tokens (rotation = 24h brought-forward expiry on the old token, revocation stays immediate); scope validation against a closed v1 vocabulary; security-audit persistence for all lifecycle events
- **`getOrCreateSystemUser` fix** — the account-cleanup helper now selects the fallback account by stable identifier rather than the bare system-user flag, closing a privilege-escalation path that would open once integrations have their own system users (regression test reconstructs the exact pre-fix failure)
- **`GET /api/machine/whoami`** — diagnostic identity endpoint; the end-to-end reachability proof
- **Idempotent DARTER seed script** (requires explicit `--owner-email`; prints the token exactly once)

## Review chain (2026-07-03)

Security review: **APPROVE-WITH-NOTES, no blockers** — 256-bit token entropy, plaintext never persisted (traced), oracle resistance verified by table-driven test. QA: **PASS-WITH-NOTES, 35/35 verified independently** — followed by a batched fix round closing every adjudicated finding (56 integration + 11 unit tests final). Post-review delta read in full by the lead before this PR (reviewed `b2c8b0c2` → final `b7ea456b`, confined to prescribed findings).

Routed beyond this PR: X-Forwarded-For first-hop trust (systemic, 5 call sites — tracked), shared security-log module's console-only behaviour (pre-existing — tracked), service-layer authorisation for the management routes (next issue's contract).

## Verification

- Integration suite: 26 files / 471 tests green (full run). Unit: 41 files / 885 green. Lint + typecheck clean.
- New e2e smoke spec (`e2e/machine-whoami.spec.ts`): token reaches the handler through the real server; tokenless request gets the JSON 401, not a login redirect. Written and typecheck-clean; first execution happens in this PR's CI (local e2e env unavailable in the build tree — pre-existing gap).