### PR TITLE
feat(plugins): plugin lifecycle core — manifest, enablement, plugin-data services

### DIFF
--- a/lib/plugins/manifest.ts
+++ b/lib/plugins/manifest.ts
@@ -1,0 +1,104 @@
+/**
+ * Static registry of official plugins (ADR 0002 v2 §2.2). An official plugin
+ * is first-party code compiled into the platform — this manifest is what
+ * makes it "known" at all: the enablement service refuses to resolve a
+ * plugin id absent here, and deployment availability (below) can only
+ * withhold a manifest entry, never invent one out of thin air.
+ *
+ * This list is deliberately closed and hand-edited — extend it only when a
+ * new official plugin actually ships (1.1: `tea.techniques`, `tea.gsn-ui`),
+ * never ad hoc at a call site.
+ */
+
+/** The four extension surfaces a plugin may use (ADR 0002 v2 §2.2/§2.3). */
+export type PluginSurface =
+	| "extension-data" // tier-1 PluginData
+	| "plugin-tables" // tier-2 plugin-owned tables
+	| "machine-endpoints" // /api/machine/* routes this plugin exposes
+	| "element-badge"
+	| "element-panel"
+	| "case-panel"
+	| "canvas-decorator"
+	| "settings-section"
+	| "events"; // namespaced SSE event types
+
+export interface PluginManifestEntry {
+	/** Namespace, e.g. "tea.health" — matches `PluginData.pluginId` / `PluginState.pluginId`. */
+	readonly id: string;
+	readonly name: string;
+	readonly surfaces: readonly PluginSurface[];
+	readonly version: string;
+}
+
+/**
+ * 1.0 ships one official plugin: claim/evidence health (ADR 0002 v2 §3).
+ * Its implementation (storage, scoring, machine endpoints) is a later issue —
+ * this entry is metadata only, enough for the lifecycle/enablement/PluginData
+ * plumbing to have a real namespace to prove itself against.
+ */
+export const PLUGIN_MANIFEST: readonly PluginManifestEntry[] = [
+	{
+		id: "tea.health",
+		name: "Claim/Evidence Health",
+		version: "0.1.0",
+		surfaces: [
+			"extension-data",
+			"plugin-tables",
+			"machine-endpoints",
+			"element-badge",
+			"element-panel",
+			"settings-section",
+			"events",
+		],
+	},
+];
+
+const MANIFEST_BY_ID: ReadonlyMap<string, PluginManifestEntry> = new Map(
+	PLUGIN_MANIFEST.map((entry) => [entry.id, entry])
+);
+
+/** Looks up a manifest entry by plugin id. `undefined` means the id is not an official plugin at all. */
+export function getManifestEntry(
+	pluginId: string
+): PluginManifestEntry | undefined {
+	return MANIFEST_BY_ID.get(pluginId);
+}
+
+/** All plugin ids known to this build, in manifest order. */
+export function listManifestPluginIds(): string[] {
+	return PLUGIN_MANIFEST.map((entry) => entry.id);
+}
+
+/**
+ * Deployment availability (ADR 0002 v2 §2.2: "a deployment concern —
+ * config/env: which official plugins this instance offers"). Every manifest
+ * plugin is available by default, so a fresh deployment (or the DARTER
+ * keystone demo) gets the full architecture with zero configuration; an
+ * operator withholds a plugin entirely by listing its id in
+ * `TEA_PLUGINS_DISABLED` (comma-separated). Withholding an id that isn't in
+ * the manifest is a no-op — deployment config can only narrow what's
+ * compiled in, never widen it.
+ *
+ * Read from `process.env` on every call (not cached at module load) so
+ * tests can flip it per-case without a module reset.
+ */
+function disabledPluginIdsFromEnv(): ReadonlySet<string> {
+	const raw = process.env.TEA_PLUGINS_DISABLED;
+	if (!raw) {
+		return new Set();
+	}
+	return new Set(
+		raw
+			.split(",")
+			.map((id) => id.trim())
+			.filter(Boolean)
+	);
+}
+
+/** Is `pluginId` a manifest entry this deployment currently offers at all? */
+export function isPluginAvailableForDeployment(pluginId: string): boolean {
+	if (!getManifestEntry(pluginId)) {
+		return false;
+	}
+	return !disabledPluginIdsFromEnv().has(pluginId);
+}

--- a/lib/plugins/manifest.ts
+++ b/lib/plugins/manifest.ts
@@ -35,6 +35,9 @@ export interface PluginManifestEntry {
  * Its implementation (storage, scoring, machine endpoints) is a later issue —
  * this entry is metadata only, enough for the lifecycle/enablement/PluginData
  * plumbing to have a real namespace to prove itself against.
+ *
+ * No external callers yet (fallow dead-export finding) — staged for the
+ * settings pane, a later work item. Not dead code; do not remove.
  */
 export const PLUGIN_MANIFEST: readonly PluginManifestEntry[] = [
 	{
@@ -64,7 +67,12 @@ export function getManifestEntry(
 	return MANIFEST_BY_ID.get(pluginId);
 }
 
-/** All plugin ids known to this build, in manifest order. */
+/**
+ * All plugin ids known to this build, in manifest order.
+ *
+ * No external callers yet (fallow dead-export finding) — staged for the
+ * settings pane, a later work item. Not dead code; do not remove.
+ */
 export function listManifestPluginIds(): string[] {
 	return PLUGIN_MANIFEST.map((entry) => entry.id);
 }

--- a/lib/services/plugin-data-service.ts
+++ b/lib/services/plugin-data-service.ts
@@ -1,0 +1,312 @@
+import { canAccessCase } from "@/lib/permissions";
+import { prisma } from "@/lib/prisma";
+import { assertPluginEnabledForUser } from "@/lib/services/plugin-enablement-service";
+import {
+	type PermissionLevel,
+	type PluginData,
+	Prisma,
+} from "@/src/generated/prisma";
+import type { ServiceResult } from "@/types/service";
+
+/**
+ * Namespaced read/write access over the tier-1 `PluginData` model (ADR 0002
+ * v2 §2.1). Two guarantees this service exists to make structural rather
+ * than conventional:
+ *
+ * 1. **Namespace isolation.** A caller acting for plugin X can touch ONLY
+ *    rows with `pluginId` X. Every query below includes `pluginId` in its
+ *    `where` clause and addresses rows via the case/element composite, never
+ *    a bare `PluginData.id` — there is no code path here that could resolve
+ *    to a different plugin's row no matter what a caller passes in.
+ * 2. **elementId <-> caseId integrity.** There is no DB constraint tying
+ *    `PluginData.elementId` to `PluginData.caseId` (element-level rows
+ *    reference both independently), so every element-scoped operation
+ *    verifies the element actually belongs to the given case before
+ *    touching anything — otherwise element-scoped plugin data could ride a
+ *    permission anchor (`caseId`) that has nothing to do with the element it
+ *    claims to describe.
+ *
+ * Disabled plugins (deployment-unavailable or off for this user) refuse
+ * every operation here — read, write, and delete alike (ADR §2.2: off hides
+ * the plugin's surface for that user; existing rows sit inert, never
+ * purged). This is the "plugin routes refuse when the plugin is off for the
+ * caller" behaviour (work item 4) until the health plugin's own machine
+ * endpoints exist to enforce it on their own surface too.
+ */
+
+export interface PluginDataLocation {
+	caseId: string;
+	/** Omit or `null` for case-level data. */
+	elementId?: string | null;
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+	return (
+		error instanceof Prisma.PrismaClientKnownRequestError &&
+		error.code === "P2002"
+	);
+}
+
+/**
+ * Enablement + case-permission guard shared by every operation below.
+ * Returns `null` on success, or the error message to surface otherwise.
+ * Order is deliberate: the enablement check is a cheap, case-independent
+ * lookup and fails closed before any case-specific query runs.
+ */
+async function guardPluginAccess(
+	pluginId: string,
+	userId: string,
+	caseId: string,
+	requiredLevel: PermissionLevel
+): Promise<string | null> {
+	const enablement = await assertPluginEnabledForUser(pluginId, userId);
+	if ("error" in enablement) {
+		return enablement.error;
+	}
+
+	const hasAccess = await canAccessCase({ userId, caseId }, requiredLevel);
+	if (!hasAccess) {
+		// Same message for not-found and no-permission (repo convention) —
+		// prevents resource-enumeration via the plugin surface.
+		return "Case not found";
+	}
+
+	return null;
+}
+
+/**
+ * Verifies `elementId` belongs to `caseId` and is not soft-deleted
+ * (nanaki QA finding 4, 2026-07-03). Returns `null` on success, or a clear
+ * rejection message otherwise — distinct messages for "doesn't exist" vs.
+ * "exists but wrong case" so a caller can tell a typo'd id from a genuine
+ * cross-case mismatch.
+ */
+async function validateElementBelongsToCase(
+	elementId: string,
+	caseId: string
+): Promise<string | null> {
+	const element = await prisma.assuranceElement.findUnique({
+		where: { id: elementId },
+		select: { caseId: true, deletedAt: true },
+	});
+
+	if (!element || element.deletedAt) {
+		return "Element not found";
+	}
+	if (element.caseId !== caseId) {
+		return "Element does not belong to the specified case";
+	}
+	return null;
+}
+
+/**
+ * Upserts an element-level row via the real (fully non-null) compound
+ * unique key — a single atomic Prisma upsert, no race window.
+ */
+function upsertElementLevelPluginData(
+	pluginId: string,
+	caseId: string,
+	elementId: string,
+	data: Prisma.InputJsonValue
+): Promise<PluginData> {
+	return prisma.pluginData.upsert({
+		where: { pluginId_caseId_elementId: { pluginId, caseId, elementId } },
+		create: { pluginId, caseId, elementId, data },
+		update: { data },
+	});
+}
+
+/**
+ * Upserts a case-level row (`elementId` null). Prisma's compound-unique
+ * lookup type requires a non-null `elementId`, so it cannot address
+ * case-level rows directly — this does a manual find-then-create/update
+ * instead. The migration's hand-written partial unique index
+ * (`pluginId, caseId WHERE elementId IS NULL`, see `prisma/schema.prisma`)
+ * backstops the small race window: if a concurrent writer wins, the create
+ * throws P2002 and this falls back to updating the row that now exists.
+ */
+async function upsertCaseLevelPluginData(
+	pluginId: string,
+	caseId: string,
+	data: Prisma.InputJsonValue
+): Promise<PluginData> {
+	const existing = await prisma.pluginData.findFirst({
+		where: { pluginId, caseId, elementId: null },
+	});
+	if (existing) {
+		return prisma.pluginData.update({
+			where: { id: existing.id },
+			data: { data },
+		});
+	}
+
+	try {
+		return await prisma.pluginData.create({
+			data: { pluginId, caseId, elementId: null, data },
+		});
+	} catch (error) {
+		if (!isUniqueConstraintError(error)) {
+			throw error;
+		}
+		const afterRace = await prisma.pluginData.findFirstOrThrow({
+			where: { pluginId, caseId, elementId: null },
+		});
+		return prisma.pluginData.update({
+			where: { id: afterRace.id },
+			data: { data },
+		});
+	}
+}
+
+/** Reads a single case- or element-level row for `pluginId`, or `null` if none exists. Requires VIEW on the case. */
+export async function readPluginData(
+	pluginId: string,
+	userId: string,
+	location: PluginDataLocation
+): ServiceResult<PluginData | null> {
+	const guardError = await guardPluginAccess(
+		pluginId,
+		userId,
+		location.caseId,
+		"VIEW"
+	);
+	if (guardError) {
+		return { error: guardError };
+	}
+
+	if (location.elementId) {
+		const elementError = await validateElementBelongsToCase(
+			location.elementId,
+			location.caseId
+		);
+		if (elementError) {
+			return { error: elementError };
+		}
+	}
+
+	try {
+		const record = await prisma.pluginData.findFirst({
+			where: {
+				pluginId,
+				caseId: location.caseId,
+				elementId: location.elementId ?? null,
+			},
+		});
+		return { data: record };
+	} catch (error) {
+		console.error("Failed to read plugin data:", error);
+		return { error: "Failed to read plugin data" };
+	}
+}
+
+/** Lists every row (case-level and all element-level) `pluginId` holds on `caseId`. Requires VIEW on the case. */
+export async function listPluginDataForCase(
+	pluginId: string,
+	userId: string,
+	caseId: string
+): ServiceResult<PluginData[]> {
+	const guardError = await guardPluginAccess(pluginId, userId, caseId, "VIEW");
+	if (guardError) {
+		return { error: guardError };
+	}
+
+	try {
+		const records = await prisma.pluginData.findMany({
+			where: { pluginId, caseId },
+			orderBy: { createdAt: "asc" },
+		});
+		return { data: records };
+	} catch (error) {
+		console.error("Failed to list plugin data:", error);
+		return { error: "Failed to list plugin data" };
+	}
+}
+
+/** Creates or replaces a case- or element-level row for `pluginId`. Requires EDIT on the case. */
+export async function writePluginData(
+	pluginId: string,
+	userId: string,
+	location: PluginDataLocation,
+	data: Prisma.InputJsonValue
+): ServiceResult<PluginData> {
+	const guardError = await guardPluginAccess(
+		pluginId,
+		userId,
+		location.caseId,
+		"EDIT"
+	);
+	if (guardError) {
+		return { error: guardError };
+	}
+
+	if (location.elementId) {
+		const elementError = await validateElementBelongsToCase(
+			location.elementId,
+			location.caseId
+		);
+		if (elementError) {
+			return { error: elementError };
+		}
+	}
+
+	try {
+		const record = location.elementId
+			? await upsertElementLevelPluginData(
+					pluginId,
+					location.caseId,
+					location.elementId,
+					data
+				)
+			: await upsertCaseLevelPluginData(pluginId, location.caseId, data);
+		return { data: record };
+	} catch (error) {
+		console.error("Failed to write plugin data:", error);
+		return { error: "Failed to write plugin data" };
+	}
+}
+
+/**
+ * Deletes a case- or element-level row for `pluginId` — the "explicit user
+ * action" ADR §2.2 reserves as the only way plugin data is ever removed
+ * (disabling a plugin never purges it). Requires EDIT on the case. A no-op
+ * (success, no error) if no such row exists.
+ */
+export async function deletePluginData(
+	pluginId: string,
+	userId: string,
+	location: PluginDataLocation
+): ServiceResult<true> {
+	const guardError = await guardPluginAccess(
+		pluginId,
+		userId,
+		location.caseId,
+		"EDIT"
+	);
+	if (guardError) {
+		return { error: guardError };
+	}
+
+	if (location.elementId) {
+		const elementError = await validateElementBelongsToCase(
+			location.elementId,
+			location.caseId
+		);
+		if (elementError) {
+			return { error: elementError };
+		}
+	}
+
+	try {
+		await prisma.pluginData.deleteMany({
+			where: {
+				pluginId,
+				caseId: location.caseId,
+				elementId: location.elementId ?? null,
+			},
+		});
+		return { data: true };
+	} catch (error) {
+		console.error("Failed to delete plugin data:", error);
+		return { error: "Failed to delete plugin data" };
+	}
+}

--- a/lib/services/plugin-data-service.ts
+++ b/lib/services/plugin-data-service.ts
@@ -36,7 +36,12 @@ import type { ServiceResult } from "@/types/service";
 
 export interface PluginDataLocation {
 	caseId: string;
-	/** Omit or `null` for case-level data. */
+	/**
+	 * Omit or `null` for case-level data. `""` is rejected outright by
+	 * `resolveDataAccess` rather than silently treated as "omitted" — an
+	 * empty string is never a valid id, and falling through to case-level
+	 * semantics would hide a caller bug.
+	 */
 	elementId?: string | null;
 }
 
@@ -76,10 +81,15 @@ async function guardPluginAccess(
 
 /**
  * Verifies `elementId` belongs to `caseId` and is not soft-deleted
- * (nanaki QA finding 4, 2026-07-03). Returns `null` on success, or a clear
- * rejection message otherwise — distinct messages for "doesn't exist" vs.
- * "exists but wrong case" so a caller can tell a typo'd id from a genuine
- * cross-case mismatch.
+ * (nanaki QA finding 4, 2026-07-03). Returns `null` on success, or the
+ * single generic "Element not found" message otherwise — non-existent,
+ * soft-deleted, and belongs-to-a-different-case all collapse to the SAME
+ * message (repo convention: same error for not-found and no-permission,
+ * `element-service.ts`'s `updateElement` precedent). Distinguishing them
+ * would let any caller with access to ANY case probe arbitrary elementIds
+ * against their own caseId and learn, from the message difference, whether
+ * that element exists anywhere on the platform (vincent review, BLOCKER,
+ * 2026-07-03).
  */
 async function validateElementBelongsToCase(
 	elementId: string,
@@ -90,12 +100,50 @@ async function validateElementBelongsToCase(
 		select: { caseId: true, deletedAt: true },
 	});
 
-	if (!element || element.deletedAt) {
+	if (!element || element.deletedAt || element.caseId !== caseId) {
 		return "Element not found";
 	}
-	if (element.caseId !== caseId) {
-		return "Element does not belong to the specified case";
+	return null;
+}
+
+/**
+ * Combined guard for every location-scoped operation below (read/write/
+ * delete): enablement + case-permission (`guardPluginAccess`), then — if
+ * `location.elementId` is present — element validation. Extracted to remove
+ * the guard+element-validation preamble previously duplicated across
+ * read/write (25 lines) and write/delete (31 lines) — same fallow-clone fix
+ * pattern as `integration-registry-service.ts`'s `getIntegrationOrError`.
+ * Returns `null` on success, or the error message to surface otherwise.
+ */
+async function resolveDataAccess(
+	pluginId: string,
+	userId: string,
+	location: PluginDataLocation,
+	requiredLevel: PermissionLevel
+): Promise<string | null> {
+	const guardError = await guardPluginAccess(
+		pluginId,
+		userId,
+		location.caseId,
+		requiredLevel
+	);
+	if (guardError) {
+		return guardError;
 	}
+
+	if (location.elementId != null) {
+		if (location.elementId === "") {
+			return "elementId must not be empty";
+		}
+		const elementError = await validateElementBelongsToCase(
+			location.elementId,
+			location.caseId
+		);
+		if (elementError) {
+			return elementError;
+		}
+	}
+
 	return null;
 }
 
@@ -164,24 +212,14 @@ export async function readPluginData(
 	userId: string,
 	location: PluginDataLocation
 ): ServiceResult<PluginData | null> {
-	const guardError = await guardPluginAccess(
+	const accessError = await resolveDataAccess(
 		pluginId,
 		userId,
-		location.caseId,
+		location,
 		"VIEW"
 	);
-	if (guardError) {
-		return { error: guardError };
-	}
-
-	if (location.elementId) {
-		const elementError = await validateElementBelongsToCase(
-			location.elementId,
-			location.caseId
-		);
-		if (elementError) {
-			return { error: elementError };
-		}
+	if (accessError) {
+		return { error: accessError };
 	}
 
 	try {
@@ -229,24 +267,14 @@ export async function writePluginData(
 	location: PluginDataLocation,
 	data: Prisma.InputJsonValue
 ): ServiceResult<PluginData> {
-	const guardError = await guardPluginAccess(
+	const accessError = await resolveDataAccess(
 		pluginId,
 		userId,
-		location.caseId,
+		location,
 		"EDIT"
 	);
-	if (guardError) {
-		return { error: guardError };
-	}
-
-	if (location.elementId) {
-		const elementError = await validateElementBelongsToCase(
-			location.elementId,
-			location.caseId
-		);
-		if (elementError) {
-			return { error: elementError };
-		}
+	if (accessError) {
+		return { error: accessError };
 	}
 
 	try {
@@ -276,24 +304,14 @@ export async function deletePluginData(
 	userId: string,
 	location: PluginDataLocation
 ): ServiceResult<true> {
-	const guardError = await guardPluginAccess(
+	const accessError = await resolveDataAccess(
 		pluginId,
 		userId,
-		location.caseId,
+		location,
 		"EDIT"
 	);
-	if (guardError) {
-		return { error: guardError };
-	}
-
-	if (location.elementId) {
-		const elementError = await validateElementBelongsToCase(
-			location.elementId,
-			location.caseId
-		);
-		if (elementError) {
-			return { error: elementError };
-		}
+	if (accessError) {
+		return { error: accessError };
 	}
 
 	try {

--- a/lib/services/plugin-enablement-service.ts
+++ b/lib/services/plugin-enablement-service.ts
@@ -1,0 +1,204 @@
+import {
+	getManifestEntry,
+	isPluginAvailableForDeployment,
+} from "@/lib/plugins/manifest";
+import { prisma } from "@/lib/prisma";
+import type {
+	PluginScopeType,
+	PluginState,
+	Prisma,
+} from "@/src/generated/prisma";
+import type { ServiceResult } from "@/types/service";
+
+/**
+ * Resolves effective plugin enablement per ADR 0002 v2 §2.2: a plugin is ON
+ * for a user iff it is available at the deployment level AND no
+ * `PluginState` row with `enabled: false` exists at any scope at-or-above
+ * the user in the ORGANISATION -> TEAM -> USER chain ("off wins downward").
+ *
+ * 1.0 activates only the USER tier for writes (`setPluginEnabledForUser`
+ * below) — there is no Organisation model yet, and mapping a user to their
+ * team(s) for plugin-scoping purposes is deliberately deferred. But this
+ * resolver walks the FULL chain unconditionally: given an `organisationId`
+ * and/or `teamIds`, it honours rows at those scopes today. Nothing here
+ * needs to change when the organisation model lands and callers start
+ * supplying those ids — only the callers do.
+ */
+
+export interface PluginScopeChain {
+	/** Not derivable in 1.0 (no Organisation model yet) — omit to skip this tier. */
+	organisationId?: string;
+	/** A user may belong to several teams; any one of them being off disables the plugin. */
+	teamIds?: string[];
+	userId: string;
+}
+
+export interface EffectivePluginState {
+	availableAtDeployment: boolean;
+	/**
+	 * The scope that turned this off — "DEPLOYMENT" if withheld before any
+	 * per-scope row is consulted, the topmost `PluginScopeType` whose row was
+	 * `enabled: false`, or `null` if the plugin is on. ADR §2.2's storage
+	 * guarantee ("nothing stored at all") attaches to this value being
+	 * "DEPLOYMENT" or "ORGANISATION" — the topmost OFF.
+	 */
+	disabledAt: "DEPLOYMENT" | PluginScopeType | null;
+	enabled: boolean;
+}
+
+interface ScopeLookup {
+	scopeId: string;
+	scopeType: PluginScopeType;
+}
+
+/**
+ * Builds the ordered (scopeType, scopeId) pairs to consult, in
+ * ORGANISATION -> TEAM -> USER order — array order IS precedence order, so
+ * the first disabling row found while walking it is the topmost OFF.
+ */
+function buildScopeLookups(scopeIds: PluginScopeChain): ScopeLookup[] {
+	const lookups: ScopeLookup[] = [];
+	if (scopeIds.organisationId) {
+		lookups.push({
+			scopeType: "ORGANISATION",
+			scopeId: scopeIds.organisationId,
+		});
+	}
+	for (const teamId of scopeIds.teamIds ?? []) {
+		lookups.push({ scopeType: "TEAM", scopeId: teamId });
+	}
+	lookups.push({ scopeType: "USER", scopeId: scopeIds.userId });
+	return lookups;
+}
+
+export async function resolveEffectivePluginState(
+	pluginId: string,
+	scopeIds: PluginScopeChain
+): ServiceResult<EffectivePluginState> {
+	if (!getManifestEntry(pluginId)) {
+		return { error: `Unknown plugin '${pluginId}'` };
+	}
+
+	if (!isPluginAvailableForDeployment(pluginId)) {
+		return {
+			data: {
+				enabled: false,
+				availableAtDeployment: false,
+				disabledAt: "DEPLOYMENT",
+			},
+		};
+	}
+
+	const lookups = buildScopeLookups(scopeIds);
+
+	try {
+		const rows = await prisma.pluginState.findMany({
+			where: {
+				pluginId,
+				OR: lookups.map(({ scopeType, scopeId }) => ({ scopeType, scopeId })),
+			},
+			select: { scopeType: true, scopeId: true, enabled: true },
+		});
+
+		for (const { scopeType, scopeId } of lookups) {
+			const row = rows.find(
+				(r) => r.scopeType === scopeType && r.scopeId === scopeId
+			);
+			if (row && !row.enabled) {
+				return {
+					data: {
+						enabled: false,
+						availableAtDeployment: true,
+						disabledAt: scopeType,
+					},
+				};
+			}
+		}
+
+		return {
+			data: { enabled: true, availableAtDeployment: true, disabledAt: null },
+		};
+	} catch (error) {
+		console.error("Failed to resolve plugin state:", error);
+		return { error: "Failed to resolve plugin state" };
+	}
+}
+
+/**
+ * Convenience guard for any future plugin route/service (item 4 — disabled
+ * plugins refuse server-side): resolves effective state for `userId` alone
+ * (the only tier 1.0 writes to) and collapses it to a single pass/fail
+ * `ServiceResult`. `lib/services/plugin-data-service.ts` composes this;
+ * the health plugin's machine endpoints (a later issue) call it directly.
+ */
+export async function assertPluginEnabledForUser(
+	pluginId: string,
+	userId: string
+): ServiceResult<true> {
+	const result = await resolveEffectivePluginState(pluginId, { userId });
+	if ("error" in result) {
+		return result;
+	}
+	if (!result.data.enabled) {
+		return { error: `Plugin '${pluginId}' is not enabled` };
+	}
+	return { data: true };
+}
+
+/** Boolean convenience form of `assertPluginEnabledForUser` for non-`ServiceResult` call sites (e.g. UI slot rendering). */
+export async function isPluginEnabledForUser(
+	pluginId: string,
+	userId: string
+): Promise<boolean> {
+	const result = await assertPluginEnabledForUser(pluginId, userId);
+	return "data" in result;
+}
+
+export interface SetUserPluginEnabledInput {
+	enabled: boolean;
+	settings?: Prisma.InputJsonValue;
+}
+
+/**
+ * Sets a plugin's USER-scope enablement row for `userId` — the only scope
+ * tier 1.0 writes to (ADR §2.2: "1.0 implements deployment availability +
+ * the user-level toggle"). ORGANISATION/TEAM rows may exist (read by
+ * `resolveEffectivePluginState` above) but are not writable through this
+ * service until the organisation model lands.
+ */
+export async function setPluginEnabledForUser(
+	pluginId: string,
+	userId: string,
+	input: SetUserPluginEnabledInput
+): ServiceResult<PluginState> {
+	if (!getManifestEntry(pluginId)) {
+		return { error: `Unknown plugin '${pluginId}'` };
+	}
+
+	try {
+		const state = await prisma.pluginState.upsert({
+			where: {
+				pluginId_scopeType_scopeId: {
+					pluginId,
+					scopeType: "USER",
+					scopeId: userId,
+				},
+			},
+			create: {
+				pluginId,
+				scopeType: "USER",
+				scopeId: userId,
+				enabled: input.enabled,
+				settings: input.settings,
+			},
+			update: {
+				enabled: input.enabled,
+				settings: input.settings,
+			},
+		});
+		return { data: state };
+	} catch (error) {
+		console.error("Failed to set plugin enablement:", error);
+		return { error: "Failed to update plugin state" };
+	}
+}

--- a/src/__tests__/integration/plugin-data-service.test.ts
+++ b/src/__tests__/integration/plugin-data-service.test.ts
@@ -25,8 +25,10 @@ const KNOWN_PLUGIN_ID = "tea.health";
 const OTHER_NAMESPACE = "tea.other-namespace"; // deliberately not manifest-registered — seeded directly, never through the service
 const UNKNOWN_PLUGIN_ID = "tea.does-not-exist";
 const NOT_ENABLED_PATTERN = /is not enabled/;
-const NOT_FOUND_PATTERN = /not found/i;
-const MISMATCH_PATTERN = /does not belong to the specified case/;
+// Single generic message for non-existent, soft-deleted, and cross-case
+// mismatch alike (no enumeration oracle — see plugin-data-service.ts's
+// validateElementBelongsToCase).
+const ELEMENT_NOT_FOUND = "Element not found";
 
 async function setup() {
 	const owner = await createTestUser();
@@ -190,7 +192,7 @@ describe("plugin-data-service — element-level data", () => {
 // ============================================
 
 describe("plugin-data-service — elementId/caseId mismatch", () => {
-	it("rejects a write whose elementId belongs to a different case", async () => {
+	it("rejects a write whose elementId belongs to a different case with the generic not-found message (no enumeration oracle)", async () => {
 		const { owner, testCase } = await setup();
 		const otherCase = await createTestCase(owner.id);
 		const elementInOtherCase = await createTestElement(otherCase.id, owner.id);
@@ -201,7 +203,7 @@ describe("plugin-data-service — elementId/caseId mismatch", () => {
 			{ caseId: testCase.id, elementId: elementInOtherCase.id },
 			{ score: 0.1 }
 		);
-		expectError(result, MISMATCH_PATTERN);
+		expectError(result, ELEMENT_NOT_FOUND);
 
 		// Nothing was written under either case for this element.
 		const rows = await prisma.pluginData.findMany({
@@ -210,7 +212,7 @@ describe("plugin-data-service — elementId/caseId mismatch", () => {
 		expect(rows).toHaveLength(0);
 	});
 
-	it("rejects a read whose elementId belongs to a different case", async () => {
+	it("rejects a read whose elementId belongs to a different case with the generic not-found message (no enumeration oracle)", async () => {
 		const { owner, testCase } = await setup();
 		const otherCase = await createTestCase(owner.id);
 		const elementInOtherCase = await createTestElement(otherCase.id, owner.id);
@@ -219,10 +221,10 @@ describe("plugin-data-service — elementId/caseId mismatch", () => {
 			caseId: testCase.id,
 			elementId: elementInOtherCase.id,
 		});
-		expectError(result, MISMATCH_PATTERN);
+		expectError(result, ELEMENT_NOT_FOUND);
 	});
 
-	it("rejects an elementId that does not exist at all", async () => {
+	it("rejects an elementId that does not exist at all with the same generic message", async () => {
 		const { owner, testCase } = await setup();
 		const result = await writePluginData(
 			KNOWN_PLUGIN_ID,
@@ -233,10 +235,19 @@ describe("plugin-data-service — elementId/caseId mismatch", () => {
 			},
 			{ score: 0.1 }
 		);
-		expectError(result, NOT_FOUND_PATTERN);
+		expectError(result, ELEMENT_NOT_FOUND);
+
+		// Nothing was written for the non-existent element.
+		const rows = await prisma.pluginData.findMany({
+			where: {
+				pluginId: KNOWN_PLUGIN_ID,
+				elementId: "00000000-0000-0000-0000-000000000000",
+			},
+		});
+		expect(rows).toHaveLength(0);
 	});
 
-	it("rejects an elementId belonging to a soft-deleted element", async () => {
+	it("rejects an elementId belonging to a soft-deleted element with the same generic message", async () => {
 		const { owner, testCase, element } = await setup();
 		await prisma.assuranceElement.update({
 			where: { id: element.id },
@@ -249,7 +260,92 @@ describe("plugin-data-service — elementId/caseId mismatch", () => {
 			{ caseId: testCase.id, elementId: element.id },
 			{ score: 0.1 }
 		);
-		expectError(result, NOT_FOUND_PATTERN);
+		expectError(result, ELEMENT_NOT_FOUND);
+
+		// Nothing was written for the soft-deleted element.
+		const rows = await prisma.pluginData.findMany({
+			where: { pluginId: KNOWN_PLUGIN_ID, elementId: element.id },
+		});
+		expect(rows).toHaveLength(0);
+	});
+});
+
+// ============================================
+// Empty-string elementId (item 3 — must not silently fall through to
+// case-level semantics)
+// ============================================
+
+describe("plugin-data-service — empty-string elementId", () => {
+	it("rejects an empty-string elementId on write rather than silently treating it as case-level", async () => {
+		const { owner, testCase } = await setup();
+		const result = await writePluginData(
+			KNOWN_PLUGIN_ID,
+			owner.id,
+			{ caseId: testCase.id, elementId: "" },
+			{ score: 0.1 }
+		);
+		expectError(result, "elementId must not be empty");
+
+		const rows = await prisma.pluginData.findMany({
+			where: { pluginId: KNOWN_PLUGIN_ID, caseId: testCase.id },
+		});
+		expect(rows).toHaveLength(0);
+	});
+
+	it("rejects an empty-string elementId on read rather than silently treating it as case-level", async () => {
+		const { owner, testCase } = await setup();
+		// A real case-level row exists — if "" fell through to case-level
+		// semantics, this read would wrongly return it.
+		await writePluginData(
+			KNOWN_PLUGIN_ID,
+			owner.id,
+			{ caseId: testCase.id },
+			{ score: 0.9 }
+		);
+
+		const result = await readPluginData(KNOWN_PLUGIN_ID, owner.id, {
+			caseId: testCase.id,
+			elementId: "",
+		});
+		expectError(result, "elementId must not be empty");
+	});
+});
+
+// ============================================
+// Concurrent case-level upsert race (item 5 — the P2002 catch->fallback
+// path in upsertCaseLevelPluginData is otherwise never exercised)
+// ============================================
+
+describe("plugin-data-service — concurrent case-level upsert", () => {
+	it("survives two concurrent case-level writes with exactly one row surviving, holding one of the two payloads", async () => {
+		const { owner, testCase } = await setup();
+
+		const [resultA, resultB] = await Promise.all([
+			writePluginData(
+				KNOWN_PLUGIN_ID,
+				owner.id,
+				{ caseId: testCase.id },
+				{ writer: "a" }
+			),
+			writePluginData(
+				KNOWN_PLUGIN_ID,
+				owner.id,
+				{ caseId: testCase.id },
+				{ writer: "b" }
+			),
+		]);
+		expectSuccess(resultA);
+		expectSuccess(resultB);
+
+		const rows = await prisma.pluginData.findMany({
+			where: {
+				pluginId: KNOWN_PLUGIN_ID,
+				caseId: testCase.id,
+				elementId: null,
+			},
+		});
+		expect(rows).toHaveLength(1);
+		expect([{ writer: "a" }, { writer: "b" }]).toContainEqual(rows[0]!.data);
 	});
 });
 

--- a/src/__tests__/integration/plugin-data-service.test.ts
+++ b/src/__tests__/integration/plugin-data-service.test.ts
@@ -1,0 +1,538 @@
+import { describe, expect, it } from "vitest";
+import prisma from "@/lib/prisma";
+import {
+	deletePluginData,
+	listPluginDataForCase,
+	readPluginData,
+	writePluginData,
+} from "@/lib/services/plugin-data-service";
+import { setPluginEnabledForUser } from "@/lib/services/plugin-enablement-service";
+import {
+	expectError,
+	expectSameError,
+	expectSuccess,
+} from "../utils/assertion-helpers";
+import {
+	createTestCase,
+	createTestElement,
+	createTestPermission,
+	createTestTeam,
+	createTestTeamPermission,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+const KNOWN_PLUGIN_ID = "tea.health";
+const OTHER_NAMESPACE = "tea.other-namespace"; // deliberately not manifest-registered — seeded directly, never through the service
+const UNKNOWN_PLUGIN_ID = "tea.does-not-exist";
+const NOT_ENABLED_PATTERN = /is not enabled/;
+const NOT_FOUND_PATTERN = /not found/i;
+const MISMATCH_PATTERN = /does not belong to the specified case/;
+
+async function setup() {
+	const owner = await createTestUser();
+	const testCase = await createTestCase(owner.id);
+	const element = await createTestElement(testCase.id, owner.id);
+	return { owner, testCase, element };
+}
+
+// ============================================
+// Case-level read/write round trip
+// ============================================
+
+describe("plugin-data-service — case-level data", () => {
+	it("returns null when no case-level row exists yet", async () => {
+		const { owner, testCase } = await setup();
+		// Not `expectSuccess`: its `data === null` branch is designed for
+		// void-result services (delete/reset) and returns `undefined` rather
+		// than asserting the value — here `null` is the meaningful "no row
+		// yet" payload, so assert on the raw ServiceResult directly.
+		const result = await readPluginData(KNOWN_PLUGIN_ID, owner.id, {
+			caseId: testCase.id,
+		});
+		expect("error" in result).toBe(false);
+		expect("data" in result && result.data).toBeNull();
+	});
+
+	it("writes then reads back case-level data", async () => {
+		const { owner, testCase } = await setup();
+		const written = expectSuccess(
+			await writePluginData(
+				KNOWN_PLUGIN_ID,
+				owner.id,
+				{ caseId: testCase.id },
+				{ score: 0.9 }
+			)
+		);
+		expect(written.elementId).toBeNull();
+		expect(written.data).toEqual({ score: 0.9 });
+
+		const read = expectSuccess(
+			await readPluginData(KNOWN_PLUGIN_ID, owner.id, { caseId: testCase.id })
+		);
+		expect(read?.data).toEqual({ score: 0.9 });
+	});
+
+	it("a second write updates the same row rather than creating a duplicate", async () => {
+		const { owner, testCase } = await setup();
+		const first = expectSuccess(
+			await writePluginData(
+				KNOWN_PLUGIN_ID,
+				owner.id,
+				{ caseId: testCase.id },
+				{ score: 0.5 }
+			)
+		);
+		const second = expectSuccess(
+			await writePluginData(
+				KNOWN_PLUGIN_ID,
+				owner.id,
+				{ caseId: testCase.id },
+				{ score: 0.7 }
+			)
+		);
+		expect(second.id).toBe(first.id);
+
+		const rows = await prisma.pluginData.findMany({
+			where: {
+				pluginId: KNOWN_PLUGIN_ID,
+				caseId: testCase.id,
+				elementId: null,
+			},
+		});
+		expect(rows).toHaveLength(1);
+		expect(rows[0]!.data).toEqual({ score: 0.7 });
+	});
+});
+
+// ============================================
+// Element-level read/write round trip
+// ============================================
+
+describe("plugin-data-service — element-level data", () => {
+	it("writes then reads back element-level data", async () => {
+		const { owner, testCase, element } = await setup();
+		const written = expectSuccess(
+			await writePluginData(
+				KNOWN_PLUGIN_ID,
+				owner.id,
+				{ caseId: testCase.id, elementId: element.id },
+				{ score: 0.4 }
+			)
+		);
+		expect(written.elementId).toBe(element.id);
+
+		const read = expectSuccess(
+			await readPluginData(KNOWN_PLUGIN_ID, owner.id, {
+				caseId: testCase.id,
+				elementId: element.id,
+			})
+		);
+		expect(read?.data).toEqual({ score: 0.4 });
+	});
+
+	it("keeps case-level and element-level rows independent for the same plugin+case", async () => {
+		const { owner, testCase, element } = await setup();
+		await writePluginData(
+			KNOWN_PLUGIN_ID,
+			owner.id,
+			{ caseId: testCase.id },
+			{ scope: "case" }
+		);
+		await writePluginData(
+			KNOWN_PLUGIN_ID,
+			owner.id,
+			{ caseId: testCase.id, elementId: element.id },
+			{ scope: "element" }
+		);
+
+		const list = expectSuccess(
+			await listPluginDataForCase(KNOWN_PLUGIN_ID, owner.id, testCase.id)
+		);
+		expect(list).toHaveLength(2);
+		const caseRow = list.find((r) => r.elementId === null);
+		const elementRow = list.find((r) => r.elementId === element.id);
+		expect(caseRow?.data).toEqual({ scope: "case" });
+		expect(elementRow?.data).toEqual({ scope: "element" });
+	});
+
+	it("deletes a single element-level row without touching the case-level row", async () => {
+		const { owner, testCase, element } = await setup();
+		await writePluginData(
+			KNOWN_PLUGIN_ID,
+			owner.id,
+			{ caseId: testCase.id },
+			{ scope: "case" }
+		);
+		await writePluginData(
+			KNOWN_PLUGIN_ID,
+			owner.id,
+			{ caseId: testCase.id, elementId: element.id },
+			{ scope: "element" }
+		);
+
+		expectSuccess(
+			await deletePluginData(KNOWN_PLUGIN_ID, owner.id, {
+				caseId: testCase.id,
+				elementId: element.id,
+			})
+		);
+
+		const remaining = expectSuccess(
+			await listPluginDataForCase(KNOWN_PLUGIN_ID, owner.id, testCase.id)
+		);
+		expect(remaining).toHaveLength(1);
+		expect(remaining[0]!.elementId).toBeNull();
+	});
+});
+
+// ============================================
+// elementId <-> caseId integrity (nanaki QA finding 4 — CRITICAL)
+// ============================================
+
+describe("plugin-data-service — elementId/caseId mismatch", () => {
+	it("rejects a write whose elementId belongs to a different case", async () => {
+		const { owner, testCase } = await setup();
+		const otherCase = await createTestCase(owner.id);
+		const elementInOtherCase = await createTestElement(otherCase.id, owner.id);
+
+		const result = await writePluginData(
+			KNOWN_PLUGIN_ID,
+			owner.id,
+			{ caseId: testCase.id, elementId: elementInOtherCase.id },
+			{ score: 0.1 }
+		);
+		expectError(result, MISMATCH_PATTERN);
+
+		// Nothing was written under either case for this element.
+		const rows = await prisma.pluginData.findMany({
+			where: { pluginId: KNOWN_PLUGIN_ID, elementId: elementInOtherCase.id },
+		});
+		expect(rows).toHaveLength(0);
+	});
+
+	it("rejects a read whose elementId belongs to a different case", async () => {
+		const { owner, testCase } = await setup();
+		const otherCase = await createTestCase(owner.id);
+		const elementInOtherCase = await createTestElement(otherCase.id, owner.id);
+
+		const result = await readPluginData(KNOWN_PLUGIN_ID, owner.id, {
+			caseId: testCase.id,
+			elementId: elementInOtherCase.id,
+		});
+		expectError(result, MISMATCH_PATTERN);
+	});
+
+	it("rejects an elementId that does not exist at all", async () => {
+		const { owner, testCase } = await setup();
+		const result = await writePluginData(
+			KNOWN_PLUGIN_ID,
+			owner.id,
+			{
+				caseId: testCase.id,
+				elementId: "00000000-0000-0000-0000-000000000000",
+			},
+			{ score: 0.1 }
+		);
+		expectError(result, NOT_FOUND_PATTERN);
+	});
+
+	it("rejects an elementId belonging to a soft-deleted element", async () => {
+		const { owner, testCase, element } = await setup();
+		await prisma.assuranceElement.update({
+			where: { id: element.id },
+			data: { deletedAt: new Date(), deletedById: owner.id },
+		});
+
+		const result = await writePluginData(
+			KNOWN_PLUGIN_ID,
+			owner.id,
+			{ caseId: testCase.id, elementId: element.id },
+			{ score: 0.1 }
+		);
+		expectError(result, NOT_FOUND_PATTERN);
+	});
+});
+
+// ============================================
+// Namespace isolation
+// ============================================
+
+describe("plugin-data-service — namespace isolation", () => {
+	it("does not return another plugin's row for the same case/element", async () => {
+		const { owner, testCase, element } = await setup();
+		await prisma.pluginData.create({
+			data: {
+				pluginId: OTHER_NAMESPACE,
+				caseId: testCase.id,
+				elementId: element.id,
+				data: { belongsTo: OTHER_NAMESPACE },
+			},
+		});
+
+		const read = await readPluginData(KNOWN_PLUGIN_ID, owner.id, {
+			caseId: testCase.id,
+			elementId: element.id,
+		});
+		expect("error" in read).toBe(false);
+		expect("data" in read && read.data).toBeNull();
+	});
+
+	it("does not include another plugin's rows in listPluginDataForCase", async () => {
+		const { owner, testCase } = await setup();
+		await prisma.pluginData.create({
+			data: {
+				pluginId: OTHER_NAMESPACE,
+				caseId: testCase.id,
+				elementId: null,
+				data: { belongsTo: OTHER_NAMESPACE },
+			},
+		});
+		await writePluginData(
+			KNOWN_PLUGIN_ID,
+			owner.id,
+			{ caseId: testCase.id },
+			{ belongsTo: KNOWN_PLUGIN_ID }
+		);
+
+		const list = expectSuccess(
+			await listPluginDataForCase(KNOWN_PLUGIN_ID, owner.id, testCase.id)
+		);
+		expect(list).toHaveLength(1);
+		expect(list[0]!.pluginId).toBe(KNOWN_PLUGIN_ID);
+	});
+
+	it("writing under one pluginId creates a separate row rather than overwriting another plugin's existing row", async () => {
+		const { owner, testCase } = await setup();
+		const otherRow = await prisma.pluginData.create({
+			data: {
+				pluginId: OTHER_NAMESPACE,
+				caseId: testCase.id,
+				elementId: null,
+				data: { belongsTo: OTHER_NAMESPACE },
+			},
+		});
+
+		await writePluginData(
+			KNOWN_PLUGIN_ID,
+			owner.id,
+			{ caseId: testCase.id },
+			{ belongsTo: KNOWN_PLUGIN_ID }
+		);
+
+		const untouchedOtherRow = await prisma.pluginData.findUniqueOrThrow({
+			where: { id: otherRow.id },
+		});
+		expect(untouchedOtherRow.data).toEqual({ belongsTo: OTHER_NAMESPACE });
+
+		const rows = await prisma.pluginData.findMany({
+			where: { caseId: testCase.id, elementId: null },
+		});
+		expect(rows).toHaveLength(2);
+	});
+
+	it("deleting under one pluginId does not delete another plugin's row at the same location", async () => {
+		const { owner, testCase } = await setup();
+		const otherRow = await prisma.pluginData.create({
+			data: {
+				pluginId: OTHER_NAMESPACE,
+				caseId: testCase.id,
+				elementId: null,
+				data: { belongsTo: OTHER_NAMESPACE },
+			},
+		});
+		await writePluginData(
+			KNOWN_PLUGIN_ID,
+			owner.id,
+			{ caseId: testCase.id },
+			{ belongsTo: KNOWN_PLUGIN_ID }
+		);
+
+		expectSuccess(
+			await deletePluginData(KNOWN_PLUGIN_ID, owner.id, { caseId: testCase.id })
+		);
+
+		const stillThere = await prisma.pluginData.findUnique({
+			where: { id: otherRow.id },
+		});
+		expect(stillThere).not.toBeNull();
+	});
+});
+
+// ============================================
+// Permission matrix (repo convention: owner; EDIT/VIEW via direct share and
+// via team; no permission; non-existent case)
+// ============================================
+
+describe("plugin-data-service — permission matrix", () => {
+	it("allows the case owner to read and write", async () => {
+		const { owner, testCase } = await setup();
+		expectSuccess(
+			await writePluginData(
+				KNOWN_PLUGIN_ID,
+				owner.id,
+				{ caseId: testCase.id },
+				{ ok: true }
+			)
+		);
+	});
+
+	it("allows a direct EDIT share to write", async () => {
+		const { owner, testCase } = await setup();
+		const editor = await createTestUser();
+		await createTestPermission(testCase.id, editor.id, owner.id, "EDIT");
+
+		expectSuccess(
+			await writePluginData(
+				KNOWN_PLUGIN_ID,
+				editor.id,
+				{ caseId: testCase.id },
+				{ ok: true }
+			)
+		);
+	});
+
+	it("allows a direct VIEW share to read but refuses it to write", async () => {
+		const { owner, testCase } = await setup();
+		const viewer = await createTestUser();
+		await createTestPermission(testCase.id, viewer.id, owner.id, "VIEW");
+		await writePluginData(
+			KNOWN_PLUGIN_ID,
+			owner.id,
+			{ caseId: testCase.id },
+			{ ok: true }
+		);
+
+		expectSuccess(
+			await readPluginData(KNOWN_PLUGIN_ID, viewer.id, { caseId: testCase.id })
+		);
+		expectError(
+			await writePluginData(
+				KNOWN_PLUGIN_ID,
+				viewer.id,
+				{ caseId: testCase.id },
+				{ ok: false }
+			)
+		);
+	});
+
+	it("allows a team EDIT share to write", async () => {
+		const { owner, testCase } = await setup();
+		const teamMember = await createTestUser();
+		const team = await createTestTeam(teamMember.id);
+		await createTestTeamPermission(testCase.id, team.id, owner.id, "EDIT");
+
+		expectSuccess(
+			await writePluginData(
+				KNOWN_PLUGIN_ID,
+				teamMember.id,
+				{ caseId: testCase.id },
+				{ ok: true }
+			)
+		);
+	});
+
+	it("refuses a user with no permission on the case", async () => {
+		const { testCase } = await setup();
+		const stranger = await createTestUser();
+
+		expectError(
+			await readPluginData(KNOWN_PLUGIN_ID, stranger.id, {
+				caseId: testCase.id,
+			})
+		);
+	});
+
+	it("returns the same error for a non-existent case and for no permission (no enumeration oracle)", async () => {
+		const { owner } = await setup();
+		const stranger = await createTestUser();
+		const otherCase = await createTestCase(owner.id);
+
+		const notFoundResult = await readPluginData(KNOWN_PLUGIN_ID, owner.id, {
+			caseId: "00000000-0000-0000-0000-000000000000",
+		});
+		const noAccessResult = await readPluginData(KNOWN_PLUGIN_ID, stranger.id, {
+			caseId: otherCase.id,
+		});
+		expectSameError(notFoundResult, noAccessResult);
+	});
+});
+
+// ============================================
+// Disabled-plugin behaviour (work item 4) — refused, not purged
+// ============================================
+
+describe("plugin-data-service — disabled plugin", () => {
+	it("refuses reads and writes when the plugin is off for the caller", async () => {
+		const { owner, testCase } = await setup();
+		await setPluginEnabledForUser(KNOWN_PLUGIN_ID, owner.id, {
+			enabled: false,
+		});
+
+		expectError(
+			await readPluginData(KNOWN_PLUGIN_ID, owner.id, { caseId: testCase.id }),
+			NOT_ENABLED_PATTERN
+		);
+		expectError(
+			await writePluginData(
+				KNOWN_PLUGIN_ID,
+				owner.id,
+				{ caseId: testCase.id },
+				{ ok: true }
+			),
+			NOT_ENABLED_PATTERN
+		);
+	});
+
+	it("does not delete existing rows when the plugin is subsequently disabled — they sit inert", async () => {
+		const { owner, testCase } = await setup();
+		const written = expectSuccess(
+			await writePluginData(
+				KNOWN_PLUGIN_ID,
+				owner.id,
+				{ caseId: testCase.id },
+				{ score: 0.9 }
+			)
+		);
+
+		await setPluginEnabledForUser(KNOWN_PLUGIN_ID, owner.id, {
+			enabled: false,
+		});
+
+		// The service refuses to serve it back to this (now-disabled-for)
+		// caller, but the row itself is untouched in the database.
+		expectError(
+			await readPluginData(KNOWN_PLUGIN_ID, owner.id, { caseId: testCase.id }),
+			NOT_ENABLED_PATTERN
+		);
+		const stillThere = await prisma.pluginData.findUniqueOrThrow({
+			where: { id: written.id },
+		});
+		expect(stillThere.data).toEqual({ score: 0.9 });
+	});
+
+	it("re-enabling makes previously-written data visible again, unchanged", async () => {
+		const { owner, testCase } = await setup();
+		await writePluginData(
+			KNOWN_PLUGIN_ID,
+			owner.id,
+			{ caseId: testCase.id },
+			{ score: 0.6 }
+		);
+		await setPluginEnabledForUser(KNOWN_PLUGIN_ID, owner.id, {
+			enabled: false,
+		});
+		await setPluginEnabledForUser(KNOWN_PLUGIN_ID, owner.id, { enabled: true });
+
+		const read = expectSuccess(
+			await readPluginData(KNOWN_PLUGIN_ID, owner.id, { caseId: testCase.id })
+		);
+		expect(read?.data).toEqual({ score: 0.6 });
+	});
+
+	it("refuses an unregistered plugin id even with full case permission", async () => {
+		const { owner, testCase } = await setup();
+		expectError(
+			await readPluginData(UNKNOWN_PLUGIN_ID, owner.id, { caseId: testCase.id })
+		);
+	});
+});

--- a/src/__tests__/integration/plugin-enablement-service.test.ts
+++ b/src/__tests__/integration/plugin-enablement-service.test.ts
@@ -1,0 +1,390 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import {
+	assertPluginEnabledForUser,
+	isPluginEnabledForUser,
+	resolveEffectivePluginState,
+	setPluginEnabledForUser,
+} from "@/lib/services/plugin-enablement-service";
+import { expectError, expectSuccess } from "../utils/assertion-helpers";
+import {
+	createTestPluginState,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+const KNOWN_PLUGIN_ID = "tea.health";
+const UNKNOWN_PLUGIN_ID = "tea.does-not-exist";
+const NOT_ENABLED_PATTERN = /is not enabled/;
+const UNKNOWN_PLUGIN_PATTERN = /Unknown plugin/;
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+// ============================================
+// Unknown plugin id — refuses before touching the DB at all
+// ============================================
+
+describe("resolveEffectivePluginState — unknown plugin id", () => {
+	it("rejects a plugin id absent from the manifest", async () => {
+		const user = await createTestUser();
+		expectError(
+			await resolveEffectivePluginState(UNKNOWN_PLUGIN_ID, { userId: user.id }),
+			UNKNOWN_PLUGIN_PATTERN
+		);
+	});
+});
+
+// ============================================
+// Deployment availability
+// ============================================
+
+describe("resolveEffectivePluginState — deployment availability", () => {
+	it("is enabled by default with no TEA_PLUGINS_DISABLED configured", async () => {
+		const user = await createTestUser();
+		const state = expectSuccess(
+			await resolveEffectivePluginState(KNOWN_PLUGIN_ID, { userId: user.id })
+		);
+		expect(state.enabled).toBe(true);
+		expect(state.availableAtDeployment).toBe(true);
+		expect(state.disabledAt).toBeNull();
+	});
+
+	it("is disabled when withheld via TEA_PLUGINS_DISABLED, regardless of any user-level row", async () => {
+		const user = await createTestUser();
+		await createTestPluginState(user.id, {
+			pluginId: KNOWN_PLUGIN_ID,
+			scopeType: "USER",
+			enabled: true,
+		});
+		vi.stubEnv("TEA_PLUGINS_DISABLED", KNOWN_PLUGIN_ID);
+
+		const state = expectSuccess(
+			await resolveEffectivePluginState(KNOWN_PLUGIN_ID, { userId: user.id })
+		);
+		expect(state.enabled).toBe(false);
+		expect(state.availableAtDeployment).toBe(false);
+		expect(state.disabledAt).toBe("DEPLOYMENT");
+	});
+
+	it("ignores an unrelated plugin id in TEA_PLUGINS_DISABLED", async () => {
+		const user = await createTestUser();
+		vi.stubEnv("TEA_PLUGINS_DISABLED", "tea.techniques, tea.gsn-ui");
+
+		const state = expectSuccess(
+			await resolveEffectivePluginState(KNOWN_PLUGIN_ID, { userId: user.id })
+		);
+		expect(state.enabled).toBe(true);
+	});
+});
+
+// ============================================
+// Effective-state matrix — user tier
+// ============================================
+
+describe("resolveEffectivePluginState — user tier", () => {
+	it("is ON with no PluginState row at all (available + no rows = enabled)", async () => {
+		const user = await createTestUser();
+		const state = expectSuccess(
+			await resolveEffectivePluginState(KNOWN_PLUGIN_ID, { userId: user.id })
+		);
+		expect(state.enabled).toBe(true);
+	});
+
+	it("is OFF when the user has an explicit disabling row", async () => {
+		const user = await createTestUser();
+		await createTestPluginState(user.id, {
+			pluginId: KNOWN_PLUGIN_ID,
+			scopeType: "USER",
+			enabled: false,
+		});
+
+		const state = expectSuccess(
+			await resolveEffectivePluginState(KNOWN_PLUGIN_ID, { userId: user.id })
+		);
+		expect(state.enabled).toBe(false);
+		expect(state.disabledAt).toBe("USER");
+	});
+
+	it("is ON when the user has an explicit enabling row", async () => {
+		const user = await createTestUser();
+		await createTestPluginState(user.id, {
+			pluginId: KNOWN_PLUGIN_ID,
+			scopeType: "USER",
+			enabled: true,
+		});
+
+		const state = expectSuccess(
+			await resolveEffectivePluginState(KNOWN_PLUGIN_ID, { userId: user.id })
+		);
+		expect(state.enabled).toBe(true);
+	});
+
+	it("does not let one user's disabling row affect another user", async () => {
+		const disabledUser = await createTestUser();
+		const otherUser = await createTestUser();
+		await createTestPluginState(disabledUser.id, {
+			pluginId: KNOWN_PLUGIN_ID,
+			scopeType: "USER",
+			enabled: false,
+		});
+
+		const state = expectSuccess(
+			await resolveEffectivePluginState(KNOWN_PLUGIN_ID, {
+				userId: otherUser.id,
+			})
+		);
+		expect(state.enabled).toBe(true);
+	});
+
+	it("does not let a different plugin's disabling row affect this plugin", async () => {
+		const user = await createTestUser();
+		await createTestPluginState(user.id, {
+			pluginId: "tea.other-namespace",
+			scopeType: "USER",
+			enabled: false,
+		});
+
+		const state = expectSuccess(
+			await resolveEffectivePluginState(KNOWN_PLUGIN_ID, { userId: user.id })
+		);
+		expect(state.enabled).toBe(true);
+	});
+});
+
+// ============================================
+// Full chain — future tiers, proven ready even though 1.0 never supplies
+// them from a real caller (no organisation model; team derivation deferred)
+// ============================================
+
+describe("resolveEffectivePluginState — full ORGANISATION -> TEAM -> USER chain", () => {
+	it("is OFF when the organisation tier is off, even though the user tier is explicitly ON (off wins downward)", async () => {
+		const user = await createTestUser();
+		const organisationId = "00000000-0000-4000-8000-0000000000f1";
+		await createTestPluginState(organisationId, {
+			pluginId: KNOWN_PLUGIN_ID,
+			scopeType: "ORGANISATION",
+			enabled: false,
+		});
+		await createTestPluginState(user.id, {
+			pluginId: KNOWN_PLUGIN_ID,
+			scopeType: "USER",
+			enabled: true,
+		});
+
+		const state = expectSuccess(
+			await resolveEffectivePluginState(KNOWN_PLUGIN_ID, {
+				organisationId,
+				userId: user.id,
+			})
+		);
+		expect(state.enabled).toBe(false);
+		expect(state.disabledAt).toBe("ORGANISATION");
+	});
+
+	it("is OFF when any one of several team ids is off, even with the user tier ON", async () => {
+		const user = await createTestUser();
+		const teamIdOn = "00000000-0000-4000-8000-0000000000f2";
+		const teamIdOff = "00000000-0000-4000-8000-0000000000f3";
+		await createTestPluginState(teamIdOn, {
+			pluginId: KNOWN_PLUGIN_ID,
+			scopeType: "TEAM",
+			enabled: true,
+		});
+		await createTestPluginState(teamIdOff, {
+			pluginId: KNOWN_PLUGIN_ID,
+			scopeType: "TEAM",
+			enabled: false,
+		});
+		await createTestPluginState(user.id, {
+			pluginId: KNOWN_PLUGIN_ID,
+			scopeType: "USER",
+			enabled: true,
+		});
+
+		const state = expectSuccess(
+			await resolveEffectivePluginState(KNOWN_PLUGIN_ID, {
+				teamIds: [teamIdOn, teamIdOff],
+				userId: user.id,
+			})
+		);
+		expect(state.enabled).toBe(false);
+		expect(state.disabledAt).toBe("TEAM");
+	});
+
+	it("lets the user turn a plugin off for themselves even where the organisation/team have it on (never the reverse)", async () => {
+		const user = await createTestUser();
+		const organisationId = "00000000-0000-4000-8000-0000000000f4";
+		const teamId = "00000000-0000-4000-8000-0000000000f5";
+		await createTestPluginState(organisationId, {
+			pluginId: KNOWN_PLUGIN_ID,
+			scopeType: "ORGANISATION",
+			enabled: true,
+		});
+		await createTestPluginState(teamId, {
+			pluginId: KNOWN_PLUGIN_ID,
+			scopeType: "TEAM",
+			enabled: true,
+		});
+		await createTestPluginState(user.id, {
+			pluginId: KNOWN_PLUGIN_ID,
+			scopeType: "USER",
+			enabled: false,
+		});
+
+		const state = expectSuccess(
+			await resolveEffectivePluginState(KNOWN_PLUGIN_ID, {
+				organisationId,
+				teamIds: [teamId],
+				userId: user.id,
+			})
+		);
+		expect(state.enabled).toBe(false);
+		expect(state.disabledAt).toBe("USER");
+	});
+
+	it("future-tier rows sit present-but-inactive when a 1.0 caller omits organisationId/teamIds", async () => {
+		const user = await createTestUser();
+		// A row exists at ORGANISATION scope for an id that would, in a
+		// future organisation-aware caller, apply to this user — but no
+		// 1.0 call site can derive an organisationId yet, so a caller that
+		// (correctly, for 1.0) omits it never has this row applied.
+		const organisationId = "00000000-0000-4000-8000-0000000000f6";
+		await createTestPluginState(organisationId, {
+			pluginId: KNOWN_PLUGIN_ID,
+			scopeType: "ORGANISATION",
+			enabled: false,
+		});
+
+		const state = expectSuccess(
+			await resolveEffectivePluginState(KNOWN_PLUGIN_ID, { userId: user.id })
+		);
+		expect(state.enabled).toBe(true);
+		expect(state.disabledAt).toBeNull();
+	});
+});
+
+// ============================================
+// assertPluginEnabledForUser / isPluginEnabledForUser — the guard future
+// plugin routes call directly (work item 4)
+// ============================================
+
+describe("assertPluginEnabledForUser", () => {
+	it("succeeds when the plugin is enabled", async () => {
+		const user = await createTestUser();
+		expectSuccess(await assertPluginEnabledForUser(KNOWN_PLUGIN_ID, user.id));
+	});
+
+	it("fails with a clear message when the plugin is off for the user", async () => {
+		const user = await createTestUser();
+		await createTestPluginState(user.id, {
+			pluginId: KNOWN_PLUGIN_ID,
+			scopeType: "USER",
+			enabled: false,
+		});
+
+		expectError(
+			await assertPluginEnabledForUser(KNOWN_PLUGIN_ID, user.id),
+			NOT_ENABLED_PATTERN
+		);
+	});
+
+	it("passes through the unknown-plugin error unchanged", async () => {
+		const user = await createTestUser();
+		expectError(
+			await assertPluginEnabledForUser(UNKNOWN_PLUGIN_ID, user.id),
+			UNKNOWN_PLUGIN_PATTERN
+		);
+	});
+});
+
+describe("isPluginEnabledForUser", () => {
+	it("returns true when enabled, false when disabled — no throw either way", async () => {
+		const user = await createTestUser();
+		expect(await isPluginEnabledForUser(KNOWN_PLUGIN_ID, user.id)).toBe(true);
+
+		await createTestPluginState(user.id, {
+			pluginId: KNOWN_PLUGIN_ID,
+			scopeType: "USER",
+			enabled: false,
+		});
+		expect(await isPluginEnabledForUser(KNOWN_PLUGIN_ID, user.id)).toBe(false);
+	});
+
+	it("returns false for an unknown plugin id rather than throwing", async () => {
+		const user = await createTestUser();
+		expect(await isPluginEnabledForUser(UNKNOWN_PLUGIN_ID, user.id)).toBe(
+			false
+		);
+	});
+});
+
+// ============================================
+// setPluginEnabledForUser — the only writable tier in 1.0
+// ============================================
+
+describe("setPluginEnabledForUser", () => {
+	it("creates a USER-scope row on first call", async () => {
+		const user = await createTestUser();
+		const state = expectSuccess(
+			await setPluginEnabledForUser(KNOWN_PLUGIN_ID, user.id, {
+				enabled: false,
+			})
+		);
+		expect(state.scopeType).toBe("USER");
+		expect(state.scopeId).toBe(user.id);
+		expect(state.enabled).toBe(false);
+	});
+
+	it("upserts (toggling) rather than creating a duplicate row", async () => {
+		const user = await createTestUser();
+		await setPluginEnabledForUser(KNOWN_PLUGIN_ID, user.id, { enabled: false });
+		await setPluginEnabledForUser(KNOWN_PLUGIN_ID, user.id, { enabled: true });
+
+		const rows = await prisma.pluginState.findMany({
+			where: { pluginId: KNOWN_PLUGIN_ID, scopeType: "USER", scopeId: user.id },
+		});
+		expect(rows).toHaveLength(1);
+		expect(rows[0]!.enabled).toBe(true);
+	});
+
+	it("persists settings JSON alongside the toggle", async () => {
+		const user = await createTestUser();
+		const state = expectSuccess(
+			await setPluginEnabledForUser(KNOWN_PLUGIN_ID, user.id, {
+				enabled: true,
+				settings: { threshold: 0.8 },
+			})
+		);
+		expect(state.settings).toEqual({ threshold: 0.8 });
+	});
+
+	it("rejects an unknown plugin id — nothing persisted", async () => {
+		const user = await createTestUser();
+		expectError(
+			await setPluginEnabledForUser(UNKNOWN_PLUGIN_ID, user.id, {
+				enabled: false,
+			}),
+			UNKNOWN_PLUGIN_PATTERN
+		);
+
+		const rows = await prisma.pluginState.findMany({
+			where: { pluginId: UNKNOWN_PLUGIN_ID },
+		});
+		expect(rows).toHaveLength(0);
+	});
+
+	it("takes effect immediately through resolveEffectivePluginState", async () => {
+		const user = await createTestUser();
+		expectSuccess(
+			await setPluginEnabledForUser(KNOWN_PLUGIN_ID, user.id, {
+				enabled: false,
+			})
+		);
+
+		const state = expectSuccess(
+			await resolveEffectivePluginState(KNOWN_PLUGIN_ID, { userId: user.id })
+		);
+		expect(state.enabled).toBe(false);
+	});
+});

--- a/src/__tests__/integration/plugin-enablement-service.test.ts
+++ b/src/__tests__/integration/plugin-enablement-service.test.ts
@@ -262,6 +262,30 @@ describe("resolveEffectivePluginState — full ORGANISATION -> TEAM -> USER chai
 		expect(state.enabled).toBe(true);
 		expect(state.disabledAt).toBeNull();
 	});
+
+	it("a disabling TEAM row for a team outside the caller's teamIds sits present-but-inactive (ORGANISATION twin above)", async () => {
+		const user = await createTestUser();
+		// The caller belongs to `memberTeamId` only — `otherTeamId`'s
+		// disabling row is for a team this caller isn't in, so it must have
+		// no effect on the resolved state (mirrors the ORGANISATION
+		// present-but-inactive test above at the TEAM tier).
+		const memberTeamId = "00000000-0000-4000-8000-0000000000f7";
+		const otherTeamId = "00000000-0000-4000-8000-0000000000f8";
+		await createTestPluginState(otherTeamId, {
+			pluginId: KNOWN_PLUGIN_ID,
+			scopeType: "TEAM",
+			enabled: false,
+		});
+
+		const state = expectSuccess(
+			await resolveEffectivePluginState(KNOWN_PLUGIN_ID, {
+				teamIds: [memberTeamId],
+				userId: user.id,
+			})
+		);
+		expect(state.enabled).toBe(true);
+		expect(state.disabledAt).toBeNull();
+	});
 });
 
 // ============================================
@@ -356,6 +380,22 @@ describe("setPluginEnabledForUser", () => {
 				settings: { threshold: 0.8 },
 			})
 		);
+		expect(state.settings).toEqual({ threshold: 0.8 });
+	});
+
+	it("does not wipe settings when a later call only toggles enabled (guards against a future `?? null` regression)", async () => {
+		const user = await createTestUser();
+		await setPluginEnabledForUser(KNOWN_PLUGIN_ID, user.id, {
+			enabled: true,
+			settings: { threshold: 0.8 },
+		});
+
+		const state = expectSuccess(
+			await setPluginEnabledForUser(KNOWN_PLUGIN_ID, user.id, {
+				enabled: false,
+			})
+		);
+		expect(state.enabled).toBe(false);
 		expect(state.settings).toEqual({ threshold: 0.8 });
 	});
 


### PR DESCRIPTION
Implements work item 3 of ADR 0002 v2 (plugin architecture: extensible core, official plugins first) — the plugin lifecycle layer.

## What this adds

- **Static plugin manifest** (`lib/plugins/manifest.ts`): in-code registry of official plugins (first entry: `tea.health`, metadata only) with deployment-level availability via `TEA_PLUGINS_DISABLED`.
- **Enablement service** (`lib/services/plugin-enablement-service.ts`): effective-state resolution across the ORGANISATION → TEAM → USER scope chain, off-wins-downward. 1.0 writes only the USER tier; resolution walks the full chain so future tiers activate with no logic change.
- **PluginData access service** (`lib/services/plugin-data-service.ts`): namespaced read/write over the tier-1 `PluginData` table. Namespace isolation enforced in the service; permissions ride `canAccessCase` on the anchoring case (VIEW read / EDIT mutate); every element-level operation validates the element belongs to the claimed case (no DB constraint ties them).
- **47 integration tests** covering the effective-state matrix, namespace isolation, permission matrix, element/case integrity, and disabled-plugin inertness (rows sit untouched, never deleted).

## Review chain

- QA (test adequacy): PASS-WITH-FINDINGS — all findings addressed in the fix commit (concurrent-upsert race test, settings-survival test, TEAM-tier inactive test) or tracked on the board.
- Code review: REQUEST-CHANGES → addressed. Blocker fixed in `97f19e12`: element-existence enumeration oracle — the element/case mismatch check previously returned distinguishable errors ("not found" vs "wrong case"), letting any authenticated user probe whether arbitrary element ids exist platform-wide; now collapsed to one generic message, matching `element-service` precedent. Also: guard-preamble dedup into `resolveDataAccess`, empty-string `elementId` rejected loudly, staged manifest exports documented.
- Structural audit (fallow): complexity clean (avg cyclomatic 1.6); two dead-export findings are the documented staged-for-settings-pane exports; in-file duplication consolidated in the fix commit, one cross-file clone tracked on the board.
- Post-review delta (`9daac4f5` → `97f19e12`) read in full by the lead: confined to prescribed fixes.

## Gate evidence

Lint clean (623 files) · typecheck clean · integration suite 523/523 across 4 sequential shards · unit 885/885 (pre-fix baseline; fix commit touches integration-tested paths only).

## Notes for reviewers

- The settings pane (UI half of this work item) follows as a separate PR consuming the enablement service.
- Trust boundary for future routes: these services trust `userId` as given — any route wiring them MUST derive `userId` from the session (`requireAuth()`), never from the request body.