### PR TITLE
chore(deps): slow dependabot version updates to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     target-branch: "staging"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -20,7 +20,7 @@ updates:
     directory: "/"
     target-branch: "staging"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"


### PR DESCRIPTION
Weekly grouped dependency PRs went unmerged for 5+ weeks during the 1.0 push (#813, #815, #824 closed stale today). Monthly cadence bounds drift at one review sitting per month. Security alerts and CVE-driven fix PRs are unaffected by this schedule and stay on.