### PR TITLE
test(integration): per-worker test databases — parallel suite, deadlock-proof cleanup

### DIFF
--- a/src/__tests__/integration/smoke.test.ts
+++ b/src/__tests__/integration/smoke.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from "vitest";
 import prisma from "@/lib/prisma";
+import { INTEGRATION_TEST_WORKER_DATABASE_PATTERN } from "../scripts/test-db-config";
 import { createTestUser } from "../utils/prisma-factories";
 
 describe("Integration test infrastructure", () => {
-	it("connects to tea_test database", async () => {
+	it("connects to its own worker-scoped test database", async () => {
 		const result = await prisma.$queryRaw<
 			Array<{ current_database: string }>
 		>`SELECT current_database()`;
-		expect(result).toEqual([{ current_database: "tea_test" }]);
+		expect(result).toHaveLength(1);
+		expect(result[0]?.current_database).toMatch(
+			INTEGRATION_TEST_WORKER_DATABASE_PATTERN
+		);
 	});
 
 	it("creates and retrieves a user via factory", async () => {

--- a/src/__tests__/scripts/setup-test-db.ts
+++ b/src/__tests__/scripts/setup-test-db.ts
@@ -60,8 +60,16 @@ async function forceDropDatabase(
 	);
 }
 
-/** Drops every database matching the worker-database naming scheme, whatever N was last run with. */
-async function dropAllWorkerDatabases(adminPool: Pool): Promise<void> {
+/**
+ * Drops every database matching the worker-database naming scheme, whatever N
+ * was last run with. `logPrefix` only distinguishes the two call sites in the
+ * console (the startup sweep clears crash strays; the teardown sweep is
+ * routine end-of-run cleanup) — same statement either way.
+ */
+async function dropAllWorkerDatabases(
+	adminPool: Pool,
+	logPrefix: string
+): Promise<void> {
 	const result = await adminPool.query<{ datname: string }>(
 		"SELECT datname FROM pg_database WHERE datname ~ '^tea_test_w[0-9]+$'"
 	);
@@ -70,7 +78,7 @@ async function dropAllWorkerDatabases(adminPool: Pool): Promise<void> {
 			// Defence in depth: the SQL regex above should already guarantee this.
 			continue;
 		}
-		console.log(`Force-dropping stray database ${row.datname}`);
+		console.log(`${logPrefix} ${row.datname}`);
 		await forceDropDatabase(adminPool, row.datname);
 	}
 }
@@ -121,7 +129,7 @@ export async function setup() {
 	});
 
 	try {
-		await dropAllWorkerDatabases(adminPool);
+		await dropAllWorkerDatabases(adminPool, "Force-dropping stray database");
 		await ensureTemplateDatabase(adminPool);
 		await createWorkerDatabases(adminPool);
 	} catch (error) {
@@ -131,7 +139,7 @@ export async function setup() {
 
 	return async function teardown() {
 		try {
-			await dropAllWorkerDatabases(adminPool);
+			await dropAllWorkerDatabases(adminPool, "Dropping worker database");
 		} finally {
 			await adminPool.end();
 		}

--- a/src/__tests__/scripts/setup-test-db.ts
+++ b/src/__tests__/scripts/setup-test-db.ts
@@ -1,42 +1,139 @@
-// globalSetup for integration tests
-// Creates tea_test database and runs migrations
+// globalSetup for integration tests.
+//
+// Gives each vitest fork-pool worker its own throwaway Postgres database
+// cloned from a migrated template, instead of every worker sharing one
+// `tea_test` database (see the design note linked from the issue for the
+// full rationale). Sequence, every run:
+//
+//   1. Force-drop any stray `tea_test_w*` databases left by a prior run
+//      (a crashed run leaves open connections; FORCE terminates them, which
+//      is what eliminates the deadlock-on-shared-TRUNCATE failure mode).
+//   2. Create the `tea_test_template` database if it doesn't exist yet, and
+//      apply migrations to it (idempotent — safe to run every time).
+//   3. Clone `tea_test_w1..wN` from the template, SEQUENTIALLY (Postgres
+//      does not allow concurrent `CREATE DATABASE … TEMPLATE` against the
+//      same source database).
+//
+// Teardown drops the worker databases (the template is left in place so the
+// next run doesn't pay for a fresh clone slot / re-migrate from scratch).
 import { execSync } from "node:child_process";
 import path from "node:path";
 import { Pool } from "pg";
+import {
+	INTEGRATION_TEST_ADMIN_DATABASE_URL,
+	INTEGRATION_TEST_TEMPLATE_DATABASE,
+	INTEGRATION_TEST_WORKER_COUNT,
+	INTEGRATION_TEST_WORKER_DATABASE_PATTERN,
+	workerDatabaseName,
+} from "./test-db-config";
 
 // Resolve project root from this file's location (src/__tests__/scripts/)
 const PROJECT_ROOT = path.resolve(import.meta.dirname, "../../..");
 
-export async function setup() {
-	// Connect to tea_dev (guaranteed to exist) to create tea_test
-	const adminPool = new Pool({
-		connectionString:
-			"postgresql://tea_user:tea_password@localhost:5432/tea_dev",
-	});
+function databaseUrlFor(databaseName: string): string {
+	const url = new URL(INTEGRATION_TEST_ADMIN_DATABASE_URL);
+	url.pathname = `/${databaseName}`;
+	return url.toString();
+}
 
-	try {
-		// Check if tea_test exists
-		const result = await adminPool.query(
-			"SELECT 1 FROM pg_database WHERE datname = 'tea_test'"
-		);
+async function databaseExists(
+	adminPool: Pool,
+	databaseName: string
+): Promise<boolean> {
+	const result = await adminPool.query(
+		"SELECT 1 FROM pg_database WHERE datname = $1",
+		[databaseName]
+	);
+	return (result.rowCount ?? 0) > 0;
+}
 
-		if (result.rowCount === 0) {
-			await adminPool.query("CREATE DATABASE tea_test");
-			console.log("Created tea_test database");
+/** Force-terminates connections and drops the database. Requires Postgres 13+ (FORCE). */
+async function forceDropDatabase(
+	adminPool: Pool,
+	databaseName: string
+): Promise<void> {
+	// Identifiers can't be parameterised; only ever called with names that have
+	// already been matched against INTEGRATION_TEST_WORKER_DATABASE_PATTERN or
+	// the fixed template constant, so this is not building DDL from user input.
+	await adminPool.query(
+		`DROP DATABASE IF EXISTS "${databaseName}" WITH (FORCE)`
+	);
+}
+
+/** Drops every database matching the worker-database naming scheme, whatever N was last run with. */
+async function dropAllWorkerDatabases(adminPool: Pool): Promise<void> {
+	const result = await adminPool.query<{ datname: string }>(
+		"SELECT datname FROM pg_database WHERE datname ~ '^tea_test_w[0-9]+$'"
+	);
+	for (const row of result.rows) {
+		if (!INTEGRATION_TEST_WORKER_DATABASE_PATTERN.test(row.datname)) {
+			// Defence in depth: the SQL regex above should already guarantee this.
+			continue;
 		}
-	} finally {
-		await adminPool.end();
+		console.log(`Force-dropping stray database ${row.datname}`);
+		await forceDropDatabase(adminPool, row.datname);
+	}
+}
+
+async function ensureTemplateDatabase(adminPool: Pool): Promise<void> {
+	const exists = await databaseExists(
+		adminPool,
+		INTEGRATION_TEST_TEMPLATE_DATABASE
+	);
+	if (!exists) {
+		await adminPool.query(
+			`CREATE DATABASE "${INTEGRATION_TEST_TEMPLATE_DATABASE}"`
+		);
+		console.log(`Created ${INTEGRATION_TEST_TEMPLATE_DATABASE} database`);
 	}
 
-	// Run migrations against tea_test
+	// Idempotent — re-applying already-applied migrations is a no-op, so this
+	// also self-heals a template that's missing migrations added since it was
+	// first created.
 	execSync("npx prisma migrate deploy --schema=prisma/schema.prisma", {
 		env: {
 			...process.env,
-			DATABASE_URL:
-				"postgresql://tea_user:tea_password@localhost:5432/tea_test",
+			DATABASE_URL: databaseUrlFor(INTEGRATION_TEST_TEMPLATE_DATABASE),
 		},
 		stdio: "pipe",
 		cwd: PROJECT_ROOT,
 	});
-	console.log("Migrations applied to tea_test");
+	console.log(`Migrations applied to ${INTEGRATION_TEST_TEMPLATE_DATABASE}`);
+}
+
+async function createWorkerDatabases(adminPool: Pool): Promise<void> {
+	// Sequential on purpose: Postgres refuses concurrent `CREATE DATABASE …
+	// TEMPLATE` calls against the same source ("source database is being
+	// accessed by other users"), so cloning must happen one at a time here in
+	// global setup rather than letting workers self-clone.
+	for (let poolId = 1; poolId <= INTEGRATION_TEST_WORKER_COUNT; poolId++) {
+		const name = workerDatabaseName(poolId);
+		await adminPool.query(
+			`CREATE DATABASE "${name}" TEMPLATE "${INTEGRATION_TEST_TEMPLATE_DATABASE}"`
+		);
+		console.log(`Created ${name} database from template`);
+	}
+}
+
+export async function setup() {
+	const adminPool = new Pool({
+		connectionString: INTEGRATION_TEST_ADMIN_DATABASE_URL,
+	});
+
+	try {
+		await dropAllWorkerDatabases(adminPool);
+		await ensureTemplateDatabase(adminPool);
+		await createWorkerDatabases(adminPool);
+	} catch (error) {
+		await adminPool.end();
+		throw error;
+	}
+
+	return async function teardown() {
+		try {
+			await dropAllWorkerDatabases(adminPool);
+		} finally {
+			await adminPool.end();
+		}
+	};
 }

--- a/src/__tests__/scripts/setup-test-db.ts
+++ b/src/__tests__/scripts/setup-test-db.ts
@@ -71,7 +71,8 @@ async function dropAllWorkerDatabases(
 	logPrefix: string
 ): Promise<void> {
 	const result = await adminPool.query<{ datname: string }>(
-		"SELECT datname FROM pg_database WHERE datname ~ '^tea_test_w[0-9]+$'"
+		"SELECT datname FROM pg_database WHERE datname ~ $1",
+		[INTEGRATION_TEST_WORKER_DATABASE_PATTERN.source]
 	);
 	for (const row of result.rows) {
 		if (!INTEGRATION_TEST_WORKER_DATABASE_PATTERN.test(row.datname)) {

--- a/src/__tests__/scripts/test-db-config.ts
+++ b/src/__tests__/scripts/test-db-config.ts
@@ -21,11 +21,23 @@ export const INTEGRATION_TEST_ADMIN_DATABASE_URL =
 export const INTEGRATION_TEST_TEMPLATE_DATABASE = "tea_test_template";
 
 /** Prefix for per-worker throwaway databases: `tea_test_w1`, `tea_test_w2`, … */
-export const INTEGRATION_TEST_WORKER_DATABASE_PREFIX = "tea_test_w";
+const INTEGRATION_TEST_WORKER_DATABASE_PREFIX = "tea_test_w";
 
 /** Matches exactly the worker databases this scheme owns — used for force-drop and assertions. */
 export const INTEGRATION_TEST_WORKER_DATABASE_PATTERN = /^tea_test_w[0-9]+$/;
 
+/**
+ * Validates and formats a vitest worker/pool id into its worker database
+ * name. Rejects anything outside `1..INTEGRATION_TEST_WORKER_COUNT` so a bad
+ * or unset `VITEST_POOL_ID` fails loudly here, naming the bad value, instead
+ * of surfacing later as an opaque "database does not exist" from pg.
+ */
 export function workerDatabaseName(poolId: string | number): string {
-	return `${INTEGRATION_TEST_WORKER_DATABASE_PREFIX}${poolId}`;
+	const id = typeof poolId === "number" ? poolId : Number.parseInt(poolId, 10);
+	if (!Number.isInteger(id) || id < 1 || id > INTEGRATION_TEST_WORKER_COUNT) {
+		throw new Error(
+			`Invalid vitest worker id ${JSON.stringify(poolId)}: expected an integer between 1 and ${INTEGRATION_TEST_WORKER_COUNT} (INTEGRATION_TEST_WORKER_COUNT), got ${id}`
+		);
+	}
+	return `${INTEGRATION_TEST_WORKER_DATABASE_PREFIX}${id}`;
 }

--- a/src/__tests__/scripts/test-db-config.ts
+++ b/src/__tests__/scripts/test-db-config.ts
@@ -1,0 +1,31 @@
+// Shared constants for the per-worker integration test database scheme.
+// Single source of truth so the worker cap can't drift between the vitest
+// workspace config (which sets the fork pool size) and the global setup
+// script (which must create exactly that many worker databases).
+
+/**
+ * Number of parallel vitest forks the integration project is allowed to run.
+ * Also the number of `tea_test_w*` worker databases created in globalSetup.
+ * Connection budget: each worker opens its own Prisma pool (default 10) plus
+ * a 1-connection cleanup pool, so N=4 costs ~44 connections against a default
+ * `max_connections` of 100. Tune only with measurement, and keep this the
+ * single place both files read from.
+ */
+export const INTEGRATION_TEST_WORKER_COUNT = 4;
+
+/** Admin connection — guaranteed to exist, used only to issue DDL (CREATE/DROP DATABASE). */
+export const INTEGRATION_TEST_ADMIN_DATABASE_URL =
+	"postgresql://tea_user:tea_password@localhost:5432/tea_dev";
+
+/** Migrated template that every worker database is cloned from. */
+export const INTEGRATION_TEST_TEMPLATE_DATABASE = "tea_test_template";
+
+/** Prefix for per-worker throwaway databases: `tea_test_w1`, `tea_test_w2`, … */
+export const INTEGRATION_TEST_WORKER_DATABASE_PREFIX = "tea_test_w";
+
+/** Matches exactly the worker databases this scheme owns — used for force-drop and assertions. */
+export const INTEGRATION_TEST_WORKER_DATABASE_PATTERN = /^tea_test_w[0-9]+$/;
+
+export function workerDatabaseName(poolId: string | number): string {
+	return `${INTEGRATION_TEST_WORKER_DATABASE_PREFIX}${poolId}`;
+}

--- a/src/__tests__/setup.integration.tsx
+++ b/src/__tests__/setup.integration.tsx
@@ -1,5 +1,25 @@
 import { Pool } from "pg";
 import { afterAll, afterEach } from "vitest";
+import { workerDatabaseName } from "./scripts/test-db-config";
+
+// Redirect this worker onto its own throwaway database, cloned from the
+// migrated template by globalSetup (setup-test-db.ts). This MUST happen
+// before anything in this process imports lib/prisma.ts: that module reads
+// DATABASE_URL at import time to build its connection pool, and setup files
+// load before test files in each vitest fork — so this override always lands
+// first. `VITEST_POOL_ID` is vitest's 1-indexed fork id; it's stable for the
+// lifetime of the worker process, so every test file the worker picks up
+// shares the same worker-scoped database.
+const workerId = process.env.VITEST_POOL_ID ?? "1";
+const baseDatabaseUrl = process.env.DATABASE_URL;
+if (!baseDatabaseUrl) {
+	throw new Error(
+		"DATABASE_URL must be set (see the integration project's env in vitest.workspace.ts) before integration setup runs"
+	);
+}
+const workerDatabaseUrl = new URL(baseDatabaseUrl);
+workerDatabaseUrl.pathname = `/${workerDatabaseName(workerId)}`;
+process.env.DATABASE_URL = workerDatabaseUrl.toString();
 
 // Create a dedicated pool for cleanup (NOT through Prisma)
 const cleanupPool = new Pool({

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
+import { INTEGRATION_TEST_WORKER_COUNT } from "./src/__tests__/scripts/test-db-config";
 
 /**
  * Vitest workspace configuration with two projects:
@@ -55,8 +56,13 @@ export default defineConfig({
 					testTimeout: 30_000,
 					hookTimeout: 15_000,
 					pool: "forks",
-					fileParallelism: false,
+					// vitest 4 replaced poolOptions.forks.maxForks with a single
+					// maxWorkers option shared across pool types.
+					maxWorkers: INTEGRATION_TEST_WORKER_COUNT,
 					env: {
+						// Fallback/admin connection only — each worker's setup file
+						// (setup.integration.tsx) overrides DATABASE_URL to point at its
+						// own throwaway `tea_test_w*` database before any test runs.
 						DATABASE_URL:
 							"postgresql://tea_user:tea_password@localhost:5432/tea_test",
 						SKIP_ELEMENT_VALIDATION: "false",


### PR DESCRIPTION
## Summary

Gives each vitest integration worker its own throwaway Postgres database cloned from a migrated template (`tea_test_template` → `tea_test_w1..w4`), replacing the single shared `tea_test` database and serial file execution.

- **Suite speed:** 571.57s → ~250s (523 tests, 4 workers, file-level parallelism enabled).
- **Deadlock elimination:** interrupted runs used to leave connections holding locks on the shared database, deadlocking the next run's cleanup (`40P01` on the global `TRUNCATE … CASCADE`). Worker databases are now swept at startup with a forced drop that terminates lingering connections, so stale state from a crashed run cannot poison the next one.

## Changes

- `src/__tests__/scripts/test-db-config.ts` (new) — single source of truth for the worker count, database naming, and match pattern; strict validation of the vitest worker id (fails loudly with a named value instead of an opaque driver error).
- `src/__tests__/scripts/setup-test-db.ts` — global setup rewritten: force-drop stray worker databases, create/migrate the template (idempotent), clone worker databases sequentially, tear them down at suite end.
- `src/__tests__/setup.integration.tsx` — per-worker `DATABASE_URL` override derived from `VITEST_POOL_ID`; the per-test TRUNCATE cleanup is unchanged, now scoped to the worker's own database.
- `vitest.workspace.ts` — `fileParallelism` restriction removed; `maxWorkers: 4` (connection budget: ~44 of 100 default `max_connections`).
- `src/__tests__/integration/smoke.test.ts` — asserts the connection lands on a worker-scoped database (anchored pattern) instead of the hardcoded shared name.

Test infrastructure only — no product code, no changes to what any test asserts.

## Verification

- Integration suite green across repeated runs (523/523), including the cold path (template rebuilt from scratch) and the crash-recovery path (stale worker database with a **live held connection** is terminated by the startup sweep; the following run passes clean).
- Unit suite unaffected (885/885). Lint, typecheck, and fallow audit clean (`No issues in 5 changed files`).
- Reviewed for security (identifier construction in the setup SQL; the stray sweep provably cannot match `tea_dev`, `tea_test`, or the template) and for quality; all review findings resolved in the follow-up commit.
- The e2e path (`tea_test` + its seed step) is untouched.
- Remaining check: this PR's CI run is the first execution in the Actions environment (the service container's user already has the required database-creation rights — same mechanism the previous setup used).
