### PR TITLE
feat(plugins): user-facing settings pane and /api/user/plugins route

### DIFF
--- a/app/(authenticated)/dashboard/settings/_components/__tests__/plugin-settings-slot.test.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/__tests__/plugin-settings-slot.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { renderWithoutProviders } from "@/src/__tests__/utils/test-utils";
+import { PluginSettingsSlot } from "../plugin-settings-slot";
+
+describe("PluginSettingsSlot", () => {
+	it("renders nothing when no plugin has registered into the slot (1.0 has no consumers yet)", () => {
+		const { container } = renderWithoutProviders(
+			<PluginSettingsSlot pluginId="tea.health" />
+		);
+
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("renders nothing regardless of which pluginId is passed", () => {
+		const { container } = renderWithoutProviders(
+			<PluginSettingsSlot pluginId="tea.does-not-exist" />
+		);
+
+		expect(container).toBeEmptyDOMElement();
+	});
+});

--- a/app/(authenticated)/dashboard/settings/_components/__tests__/plugin-toggle-row.test.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/__tests__/plugin-toggle-row.test.tsx
@@ -1,0 +1,184 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { PluginSettingsListItem } from "@/hooks/use-plugin-settings";
+import {
+	renderWithoutProviders,
+	screen,
+} from "@/src/__tests__/utils/test-utils";
+import { PluginToggleRow } from "../plugin-toggle-row";
+
+const UNAVAILABLE_REGEX = /unavailable on this deployment/i;
+const ORGANISATION_REGEX = /turned off by your organisation/i;
+const TEAM_REGEX = /turned off by your team/i;
+const SAVING_REGEX = /saving/i;
+
+function makePlugin(
+	overrides: Partial<PluginSettingsListItem> = {}
+): PluginSettingsListItem {
+	return {
+		pluginId: "tea.health",
+		name: "Claim/Evidence Health",
+		version: "0.1.0",
+		available: true,
+		enabled: true,
+		pinnedAt: null,
+		settings: null,
+		...overrides,
+	};
+}
+
+describe("PluginToggleRow", () => {
+	describe("available x enabled matrix", () => {
+		it("renders an interactive, checked switch and 'On' when available and enabled", () => {
+			renderWithoutProviders(
+				<PluginToggleRow onToggle={vi.fn()} plugin={makePlugin()} />
+			);
+
+			const toggle = screen.getByRole("switch");
+			expect(toggle).toBeChecked();
+			expect(toggle).not.toBeDisabled();
+			expect(screen.getByText("On")).toBeInTheDocument();
+		});
+
+		it("renders an interactive, unchecked switch and 'Off' when available but disabled by the user themselves", () => {
+			renderWithoutProviders(
+				<PluginToggleRow
+					onToggle={vi.fn()}
+					plugin={makePlugin({ enabled: false, pinnedAt: "USER" })}
+				/>
+			);
+
+			const toggle = screen.getByRole("switch");
+			expect(toggle).not.toBeChecked();
+			expect(toggle).not.toBeDisabled();
+			expect(screen.getByText("Off")).toBeInTheDocument();
+		});
+
+		it("renders a disabled, unchecked switch and an 'unavailable' message when unavailable at the deployment — even if a stale enabled:true slips through", () => {
+			renderWithoutProviders(
+				<PluginToggleRow
+					onToggle={vi.fn()}
+					plugin={makePlugin({
+						available: false,
+						enabled: true,
+						pinnedAt: "DEPLOYMENT",
+					})}
+				/>
+			);
+
+			const toggle = screen.getByRole("switch");
+			expect(toggle).not.toBeChecked();
+			expect(toggle).toBeDisabled();
+			expect(screen.getByText(UNAVAILABLE_REGEX)).toBeInTheDocument();
+		});
+
+		it("renders a disabled, unchecked switch when unavailable and disabled", () => {
+			renderWithoutProviders(
+				<PluginToggleRow
+					onToggle={vi.fn()}
+					plugin={makePlugin({
+						available: false,
+						enabled: false,
+						pinnedAt: "DEPLOYMENT",
+					})}
+				/>
+			);
+
+			const toggle = screen.getByRole("switch");
+			expect(toggle).not.toBeChecked();
+			expect(toggle).toBeDisabled();
+			expect(screen.getByText(UNAVAILABLE_REGEX)).toBeInTheDocument();
+		});
+	});
+
+	describe("pinned-level display", () => {
+		it("shows the organisation as the pinning level and locks the switch", () => {
+			renderWithoutProviders(
+				<PluginToggleRow
+					onToggle={vi.fn()}
+					plugin={makePlugin({ enabled: false, pinnedAt: "ORGANISATION" })}
+				/>
+			);
+
+			expect(screen.getByText(ORGANISATION_REGEX)).toBeInTheDocument();
+			expect(screen.getByRole("switch")).toBeDisabled();
+		});
+
+		it("shows the team as the pinning level and locks the switch", () => {
+			renderWithoutProviders(
+				<PluginToggleRow
+					onToggle={vi.fn()}
+					plugin={makePlugin({ enabled: false, pinnedAt: "TEAM" })}
+				/>
+			);
+
+			expect(screen.getByText(TEAM_REGEX)).toBeInTheDocument();
+			expect(screen.getByRole("switch")).toBeDisabled();
+		});
+
+		it("does not lock the switch when pinnedAt is USER — the user's own toggle stays interactive", () => {
+			renderWithoutProviders(
+				<PluginToggleRow
+					onToggle={vi.fn()}
+					plugin={makePlugin({ enabled: false, pinnedAt: "USER" })}
+				/>
+			);
+
+			expect(screen.getByRole("switch")).not.toBeDisabled();
+		});
+	});
+
+	describe("interaction", () => {
+		it("calls onToggle with the pluginId and the new state when clicked", async () => {
+			const user = userEvent.setup();
+			const onToggle = vi.fn();
+			renderWithoutProviders(
+				<PluginToggleRow
+					onToggle={onToggle}
+					plugin={makePlugin({ enabled: false, pinnedAt: "USER" })}
+				/>
+			);
+
+			await user.click(screen.getByRole("switch"));
+			expect(onToggle).toHaveBeenCalledWith("tea.health", true);
+		});
+
+		it("does not call onToggle when the switch is locked by a higher scope", async () => {
+			const user = userEvent.setup();
+			const onToggle = vi.fn();
+			renderWithoutProviders(
+				<PluginToggleRow
+					onToggle={onToggle}
+					plugin={makePlugin({ enabled: false, pinnedAt: "ORGANISATION" })}
+				/>
+			);
+
+			await user.click(screen.getByRole("switch"));
+			expect(onToggle).not.toHaveBeenCalled();
+		});
+
+		it("disables the switch and shows 'Saving…' while a toggle is pending", () => {
+			renderWithoutProviders(
+				<PluginToggleRow onToggle={vi.fn()} pending plugin={makePlugin()} />
+			);
+
+			expect(screen.getByRole("switch")).toBeDisabled();
+			expect(screen.getByText(SAVING_REGEX)).toBeInTheDocument();
+		});
+	});
+
+	describe("settings-section slot", () => {
+		it("renders no layout artefact for the empty settings slot", () => {
+			const { container } = renderWithoutProviders(
+				<PluginToggleRow onToggle={vi.fn()} plugin={makePlugin()} />
+			);
+
+			// The row itself (name, status, switch) plus nothing else — the
+			// settings-section slot (`PluginSettingsSlot`) contributes no DOM.
+			expect(container.querySelectorAll("div").length).toBeGreaterThan(0);
+			expect(
+				screen.queryByTestId("plugin-settings-slot")
+			).not.toBeInTheDocument();
+		});
+	});
+});

--- a/app/(authenticated)/dashboard/settings/_components/__tests__/plugins-section.test.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/__tests__/plugins-section.test.tsx
@@ -1,0 +1,119 @@
+import { waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { server } from "@/src/__tests__/mocks/server";
+import {
+	renderWithoutProviders,
+	screen,
+} from "@/src/__tests__/utils/test-utils";
+import { PluginsSection } from "../plugins-section";
+
+const HEALTH_PLUGIN = {
+	pluginId: "tea.health",
+	name: "Claim/Evidence Health",
+	version: "0.1.0",
+	available: true,
+	enabled: true,
+	pinnedAt: null,
+	settings: null,
+};
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("PluginsSection", () => {
+	it("shows a loading state before the list resolves, then renders the plugin", async () => {
+		server.use(
+			http.get("/api/user/plugins", () =>
+				HttpResponse.json({ plugins: [HEALTH_PLUGIN] })
+			)
+		);
+
+		renderWithoutProviders(<PluginsSection />);
+
+		expect(screen.getByTestId("plugins-section-loading")).toBeInTheDocument();
+
+		await waitFor(() =>
+			expect(screen.getByText("Claim/Evidence Health")).toBeInTheDocument()
+		);
+		expect(
+			screen.queryByTestId("plugins-section-loading")
+		).not.toBeInTheDocument();
+	});
+
+	it("shows an error message when the GET route fails", async () => {
+		server.use(
+			http.get("/api/user/plugins", () =>
+				HttpResponse.json(
+					{ error: "Failed to resolve plugin state" },
+					{
+						status: 500,
+					}
+				)
+			)
+		);
+
+		renderWithoutProviders(<PluginsSection />);
+
+		await waitFor(() =>
+			expect(
+				screen.getByText("Failed to resolve plugin state")
+			).toBeInTheDocument()
+		);
+	});
+
+	it("shows an empty-deployment message when the manifest has no plugins", async () => {
+		server.use(
+			http.get("/api/user/plugins", () => HttpResponse.json({ plugins: [] }))
+		);
+
+		renderWithoutProviders(<PluginsSection />);
+
+		await waitFor(() =>
+			expect(
+				screen.getByText("No plugins are registered for this deployment.")
+			).toBeInTheDocument()
+		);
+	});
+
+	it("toggles a plugin through PATCH and reflects the refetched state", async () => {
+		const user = userEvent.setup();
+		let currentlyEnabled = true;
+
+		server.use(
+			http.get("/api/user/plugins", () =>
+				HttpResponse.json({
+					plugins: [{ ...HEALTH_PLUGIN, enabled: currentlyEnabled }],
+				})
+			),
+			http.patch("/api/user/plugins", async ({ request }) => {
+				const body = (await request.json()) as {
+					enabled: boolean;
+					pluginId: string;
+				};
+				currentlyEnabled = body.enabled;
+				return HttpResponse.json({
+					pluginId: body.pluginId,
+					enabled: currentlyEnabled,
+					settings: null,
+				});
+			})
+		);
+
+		renderWithoutProviders(<PluginsSection />);
+
+		await waitFor(() =>
+			expect(screen.getByText("Claim/Evidence Health")).toBeInTheDocument()
+		);
+
+		const toggle = screen.getByRole("switch");
+		expect(toggle).toBeChecked();
+
+		await user.click(toggle);
+
+		await waitFor(() => expect(screen.getByRole("switch")).not.toBeChecked());
+		expect(currentlyEnabled).toBe(false);
+	});
+});

--- a/app/(authenticated)/dashboard/settings/_components/plugin-settings-slot.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/plugin-settings-slot.tsx
@@ -1,0 +1,16 @@
+/**
+ * The `settings-section` extension point (ADR 0002 v2 §2.3) — the region
+ * within a plugin's row where an enabled plugin will one day contribute its
+ * own settings UI (e.g. the health plugin's scoring thresholds).
+ *
+ * No plugin registers into this slot yet — the registry that would let a
+ * plugin do so is `[[TEA — UI extension slots]]` (separate issue, out of
+ * scope here). This component is the seam that registry will fill in: it
+ * renders nothing now, matching §2.3's rule that "slots render nothing when
+ * no enabled plugin registers into them" — core screens must be complete
+ * with every slot empty, so this must never leave a layout artefact
+ * (an empty border, a stray heading) behind it.
+ */
+export function PluginSettingsSlot(_props: { pluginId: string }) {
+	return null;
+}

--- a/app/(authenticated)/dashboard/settings/_components/plugin-toggle-row.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/plugin-toggle-row.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import type { PluginSettingsListItem } from "@/hooks/use-plugin-settings";
+import { cn } from "@/lib/utils";
+import { PluginSettingsSlot } from "./plugin-settings-slot";
+
+export interface PluginToggleRowProps {
+	onToggle: (pluginId: string, enabled: boolean) => void;
+	/** True while a toggle request for this row is in flight. */
+	pending?: boolean;
+	plugin: PluginSettingsListItem;
+}
+
+/**
+ * The effective-state message shown under a plugin's name. Deployment
+ * unavailability takes priority over everything else — an unavailable
+ * plugin must read as unavailable, never as a dead toggle (brief
+ * acceptance criteria). A block from ORGANISATION/TEAM reads distinctly
+ * from the user's own off state: "off wins downward" (ADR §2.2) means the
+ * user cannot override either, but their own toggle is exactly what set a
+ * plain "Off".
+ */
+function statusMessage(plugin: PluginSettingsListItem): string {
+	if (!plugin.available) {
+		return "Unavailable on this deployment";
+	}
+	if (plugin.pinnedAt === "ORGANISATION") {
+		return "Turned off by your organisation — you cannot turn this on yourself";
+	}
+	if (plugin.pinnedAt === "TEAM") {
+		return "Turned off by your team — you cannot turn this on yourself";
+	}
+	return plugin.enabled ? "On" : "Off";
+}
+
+/**
+ * A single plugin's row in the settings pane: name/version, the
+ * user-tier toggle, the effective-state message (incl. which level pinned
+ * it), and that plugin's `settings-section` slot. Presentational — all data
+ * fetching and toggle plumbing live in `usePluginSettings`.
+ */
+export function PluginToggleRow({
+	onToggle,
+	pending = false,
+	plugin,
+}: PluginToggleRowProps) {
+	const lockedByHigherScope =
+		plugin.pinnedAt === "ORGANISATION" || plugin.pinnedAt === "TEAM";
+	const locked = !plugin.available || lockedByHigherScope;
+	const toggleId = `plugin-toggle-${plugin.pluginId}`;
+	// available is always paired with enabled: false in the effective-state
+	// resolver, but this stays explicit rather than trusting that invariant.
+	const checked = plugin.available && plugin.enabled;
+
+	return (
+		<div className="rounded-lg border border-border bg-card p-4">
+			<div className="flex items-center justify-between gap-4">
+				<div className="space-y-1">
+					<div className="flex items-center gap-2">
+						<span className="font-medium text-foreground text-sm">
+							{plugin.name}
+						</span>
+						<span className="text-muted-foreground text-xs">
+							v{plugin.version}
+						</span>
+					</div>
+					<p
+						className={cn(
+							"text-sm",
+							locked ? "text-muted-foreground" : "text-foreground"
+						)}
+					>
+						{pending ? "Saving…" : statusMessage(plugin)}
+					</p>
+				</div>
+
+				<div className="flex shrink-0 items-center">
+					<Label className="sr-only" htmlFor={toggleId}>
+						{`Turn ${plugin.name} ${checked ? "off" : "on"}`}
+					</Label>
+					<Switch
+						checked={checked}
+						disabled={locked || pending}
+						id={toggleId}
+						onCheckedChange={(next) => onToggle(plugin.pluginId, next)}
+					/>
+				</div>
+			</div>
+
+			<PluginSettingsSlot pluginId={plugin.pluginId} />
+		</div>
+	);
+}

--- a/app/(authenticated)/dashboard/settings/_components/plugins-section.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/plugins-section.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { AlertCircle } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { usePluginSettings } from "@/hooks/use-plugin-settings";
+import { PluginToggleRow } from "./plugin-toggle-row";
+
+/**
+ * The plugins settings pane (ADR 0002 v2 §2.2: "a settings section ... lists
+ * available plugins with toggle + per-plugin settings, showing the
+ * effective state and which level pinned it"). Fetches and toggles entirely
+ * through `usePluginSettings` (`/api/user/plugins`) — no other data source,
+ * per the house rule for this pane.
+ */
+export function PluginsSection() {
+	const { plugins, loading, error, togglingId, togglePlugin } =
+		usePluginSettings();
+
+	return (
+		<div className="grid max-w-7xl grid-cols-1 gap-x-8 gap-y-10 px-4 py-16 sm:px-6 md:grid-cols-3 lg:px-8">
+			<div>
+				<h2 className="font-semibold text-base text-foreground leading-7">
+					Plugins
+				</h2>
+				<p className="mt-1 text-muted-foreground text-sm leading-6">
+					Official plugins extend the case builder. Turning a plugin off here
+					hides it for your account only — data other collaborators have written
+					stays inert, never deleted.
+				</p>
+			</div>
+
+			<div className="space-y-3 md:col-span-2">
+				{loading && (
+					<div className="space-y-3" data-testid="plugins-section-loading">
+						<Skeleton className="h-20 w-full rounded-lg" />
+						<Skeleton className="h-20 w-full rounded-lg" />
+					</div>
+				)}
+
+				{!loading && error && (
+					<div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-destructive text-sm">
+						<AlertCircle aria-hidden="true" className="h-4 w-4 shrink-0" />
+						<span>{error}</span>
+					</div>
+				)}
+
+				{!(loading || error) && plugins.length === 0 && (
+					<p className="text-muted-foreground text-sm">
+						No plugins are registered for this deployment.
+					</p>
+				)}
+
+				{!(loading || error) &&
+					plugins.map((plugin) => (
+						<PluginToggleRow
+							key={plugin.pluginId}
+							onToggle={togglePlugin}
+							pending={togglingId === plugin.pluginId}
+							plugin={plugin}
+						/>
+					))}
+			</div>
+		</div>
+	);
+}

--- a/app/(authenticated)/dashboard/settings/page.tsx
+++ b/app/(authenticated)/dashboard/settings/page.tsx
@@ -7,6 +7,7 @@ import { ConnectedAccountsForm } from "./_components/connected-accounts-form";
 import { DeleteForm } from "./_components/delete-form";
 import { PasswordForm } from "./_components/password-form";
 import { PersonalInfoForm } from "./_components/personal-info-form";
+import { PluginsSection } from "./_components/plugins-section";
 
 const SettingsPage = async () => {
 	const session = await validateSession();
@@ -26,6 +27,7 @@ const SettingsPage = async () => {
 				<AppearanceForm />
 				<PersonalInfoForm data={currentUser} />
 				<ConnectedAccountsForm data={connectedAccounts} />
+				<PluginsSection />
 				<PasswordForm data={currentUser} />
 				<DeleteForm user={currentUser} />
 			</div>

--- a/app/api/user/plugins/route.ts
+++ b/app/api/user/plugins/route.ts
@@ -10,35 +10,15 @@ import {
 	getManifestEntry,
 	listManifestPluginIds,
 } from "@/lib/plugins/manifest";
-import { pluginToggleSchema } from "@/lib/schemas/plugin";
+import {
+	type PluginSettingsListItem,
+	pluginToggleSchema,
+} from "@/lib/schemas/plugin";
 import {
 	getUserPluginSettings,
 	resolveEffectivePluginState,
 	setPluginEnabledForUser,
 } from "@/lib/services/plugin-enablement-service";
-import type { PluginScopeType, Prisma } from "@/src/generated/prisma";
-
-export interface UserPluginListItem {
-	/** Deployment concern (ADR §2.2) — withheld entirely means `false`. */
-	available: boolean;
-	/** Effective state for the session user across the full scope chain. */
-	enabled: boolean;
-	name: string;
-	/**
-	 * The scope that is currently pinning this plugin OFF — `"DEPLOYMENT"`,
-	 * the topmost `PluginScopeType` whose row disabled it, or `null` if the
-	 * plugin is ON. A pane renders the toggle as user-editable only when
-	 * this is `null` or `"USER"`; `"DEPLOYMENT"`/`"ORGANISATION"`/`"TEAM"`
-	 * mean a level above the user has switched it off (off wins downward —
-	 * the user cannot override it from here).
-	 */
-	pinnedAt: "DEPLOYMENT" | PluginScopeType | null;
-	/** The `PluginState`/`PluginData` namespace, e.g. `"tea.health"`. */
-	pluginId: string;
-	/** The user's own saved settings for this plugin, or `null` if never set. */
-	settings: Prisma.JsonValue | null;
-	version: string;
-}
 
 /**
  * GET /api/user/plugins
@@ -54,7 +34,7 @@ export async function GET() {
 
 		const plugins = await Promise.all(
 			listManifestPluginIds().map(
-				async (pluginId): Promise<UserPluginListItem> => {
+				async (pluginId): Promise<PluginSettingsListItem> => {
 					const entry = getManifestEntry(pluginId);
 					if (!entry) {
 						// Cannot happen — pluginId is sourced from the manifest itself.
@@ -67,10 +47,10 @@ export async function GET() {
 					]);
 
 					if ("error" in stateResult) {
-						throw new Error(stateResult.error);
+						throw serviceErrorToAppError(stateResult.error);
 					}
 					if ("error" in settingsResult) {
-						throw new Error(settingsResult.error);
+						throw serviceErrorToAppError(settingsResult.error);
 					}
 
 					return {

--- a/app/api/user/plugins/route.ts
+++ b/app/api/user/plugins/route.ts
@@ -1,0 +1,138 @@
+import {
+	apiError,
+	apiErrorFromUnknown,
+	apiSuccess,
+	requireAuth,
+	serviceErrorToAppError,
+} from "@/lib/api-response";
+import { validationError } from "@/lib/errors";
+import {
+	getManifestEntry,
+	listManifestPluginIds,
+} from "@/lib/plugins/manifest";
+import { pluginToggleSchema } from "@/lib/schemas/plugin";
+import {
+	getUserPluginSettings,
+	resolveEffectivePluginState,
+	setPluginEnabledForUser,
+} from "@/lib/services/plugin-enablement-service";
+import type { PluginScopeType, Prisma } from "@/src/generated/prisma";
+
+export interface UserPluginListItem {
+	/** Deployment concern (ADR §2.2) — withheld entirely means `false`. */
+	available: boolean;
+	/** Effective state for the session user across the full scope chain. */
+	enabled: boolean;
+	name: string;
+	/**
+	 * The scope that is currently pinning this plugin OFF — `"DEPLOYMENT"`,
+	 * the topmost `PluginScopeType` whose row disabled it, or `null` if the
+	 * plugin is ON. A pane renders the toggle as user-editable only when
+	 * this is `null` or `"USER"`; `"DEPLOYMENT"`/`"ORGANISATION"`/`"TEAM"`
+	 * mean a level above the user has switched it off (off wins downward —
+	 * the user cannot override it from here).
+	 */
+	pinnedAt: "DEPLOYMENT" | PluginScopeType | null;
+	/** The `PluginState`/`PluginData` namespace, e.g. `"tea.health"`. */
+	pluginId: string;
+	/** The user's own saved settings for this plugin, or `null` if never set. */
+	settings: Prisma.JsonValue | null;
+	version: string;
+}
+
+/**
+ * GET /api/user/plugins
+ *
+ * Effective plugin state for the session user across every manifest entry —
+ * the settings pane's only data source (ADR 0002 v2 §2.2: "a settings
+ * section ... lists available plugins with toggle + per-plugin settings,
+ * showing the effective state and which level pinned it").
+ */
+export async function GET() {
+	try {
+		const userId = await requireAuth();
+
+		const plugins = await Promise.all(
+			listManifestPluginIds().map(
+				async (pluginId): Promise<UserPluginListItem> => {
+					const entry = getManifestEntry(pluginId);
+					if (!entry) {
+						// Cannot happen — pluginId is sourced from the manifest itself.
+						throw new Error(`Manifest entry missing for '${pluginId}'`);
+					}
+
+					const [stateResult, settingsResult] = await Promise.all([
+						resolveEffectivePluginState(pluginId, { userId }),
+						getUserPluginSettings(pluginId, userId),
+					]);
+
+					if ("error" in stateResult) {
+						throw new Error(stateResult.error);
+					}
+					if ("error" in settingsResult) {
+						throw new Error(settingsResult.error);
+					}
+
+					return {
+						pluginId,
+						name: entry.name,
+						version: entry.version,
+						available: stateResult.data.availableAtDeployment,
+						enabled: stateResult.data.enabled,
+						pinnedAt: stateResult.data.disabledAt,
+						settings: settingsResult.data,
+					};
+				}
+			)
+		);
+
+		return apiSuccess({ plugins });
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}
+
+/**
+ * PATCH /api/user/plugins
+ *
+ * Toggles a plugin's USER-scope enablement (and optionally replaces its
+ * settings) for the session user — the only scope 1.0 writes to (ADR
+ * §2.2). Security-critical (vincent's 2026-07-03 backend review, both
+ * non-negotiable):
+ * - The acting userId comes from `requireAuth()` — the session — never
+ *   from the request body.
+ * - `pluginToggleSchema` caps `settings` size/shape and rejects any
+ *   pluginId absent from the manifest before this ever reaches the
+ *   service layer, which trusts schema-validated input.
+ */
+export async function PATCH(req: Request) {
+	try {
+		const userId = await requireAuth();
+
+		const body = await req.json();
+		const parsed = pluginToggleSchema.safeParse(body);
+		if (!parsed.success) {
+			return apiError(
+				validationError(parsed.error.issues[0]?.message ?? "Invalid input")
+			);
+		}
+
+		const { pluginId, enabled, settings } = parsed.data;
+
+		const result = await setPluginEnabledForUser(pluginId, userId, {
+			enabled,
+			settings,
+		});
+		if ("error" in result) {
+			return apiError(serviceErrorToAppError(result.error));
+		}
+
+		return apiSuccess({
+			pluginId: result.data.pluginId,
+			enabled: result.data.enabled,
+			settings: result.data.settings,
+		});
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}

--- a/hooks/use-plugin-settings.ts
+++ b/hooks/use-plugin-settings.ts
@@ -1,25 +1,19 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import type { PluginSettingsListItem } from "@/lib/schemas/plugin";
 import { toast } from "@/lib/toast";
 
-/** The scope currently pinning a plugin's state, or `null` if nothing is. */
-export type PluginPinnedAt =
-	| "DEPLOYMENT"
-	| "ORGANISATION"
-	| "TEAM"
-	| "USER"
-	| null;
-
-export interface PluginSettingsListItem {
-	available: boolean;
-	enabled: boolean;
-	name: string;
-	pinnedAt: PluginPinnedAt;
-	pluginId: string;
-	settings: unknown;
-	version: string;
-}
+// Re-exported so existing consumers (e.g. `PluginToggleRow`) keep importing
+// the settings pane's item shape from this hook — `lib/schemas/plugin.ts` is
+// the single definition (was hand-duplicated with `UserPluginListItem` in
+// `app/api/user/plugins/route.ts`; consolidated 2026-07-04). A second,
+// separate `export ... from` (not re-exporting the local import above) so
+// biome's `noExportedImports` doesn't fire.
+export type {
+	PluginPinnedAt,
+	PluginSettingsListItem,
+} from "@/lib/schemas/plugin";
 
 interface PluginsResponseBody {
 	plugins: PluginSettingsListItem[];

--- a/hooks/use-plugin-settings.ts
+++ b/hooks/use-plugin-settings.ts
@@ -1,0 +1,123 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "@/lib/toast";
+
+/** The scope currently pinning a plugin's state, or `null` if nothing is. */
+export type PluginPinnedAt =
+	| "DEPLOYMENT"
+	| "ORGANISATION"
+	| "TEAM"
+	| "USER"
+	| null;
+
+export interface PluginSettingsListItem {
+	available: boolean;
+	enabled: boolean;
+	name: string;
+	pinnedAt: PluginPinnedAt;
+	pluginId: string;
+	settings: unknown;
+	version: string;
+}
+
+interface PluginsResponseBody {
+	plugins: PluginSettingsListItem[];
+}
+
+interface ApiErrorBody {
+	error?: string;
+}
+
+async function parseErrorMessage(response: Response): Promise<string> {
+	const body = (await response.json().catch(() => null)) as ApiErrorBody | null;
+	return body?.error ?? "Something went wrong";
+}
+
+async function fetchPlugins(): Promise<PluginSettingsListItem[]> {
+	const response = await fetch("/api/user/plugins");
+	if (!response.ok) {
+		throw new Error(await parseErrorMessage(response));
+	}
+	const body = (await response.json()) as PluginsResponseBody;
+	return body.plugins;
+}
+
+async function requestPluginToggle(
+	pluginId: string,
+	enabled: boolean
+): Promise<void> {
+	const response = await fetch("/api/user/plugins", {
+		method: "PATCH",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ pluginId, enabled }),
+	});
+	if (!response.ok) {
+		throw new Error(await parseErrorMessage(response));
+	}
+}
+
+export interface UsePluginSettingsResult {
+	error: string | null;
+	loading: boolean;
+	plugins: PluginSettingsListItem[];
+	togglePlugin: (pluginId: string, enabled: boolean) => Promise<void>;
+	/** The pluginId currently mid-toggle, or `null` if none is in flight. */
+	togglingId: string | null;
+}
+
+/**
+ * Fetches and toggles the session user's effective plugin state via
+ * `/api/user/plugins` — the settings pane's only data source (house rule:
+ * "data via the new route only"). Owns all UI state (loading / error /
+ * which row is mid-toggle) so the pane components stay presentational.
+ *
+ * A toggle re-fetches the full list on success rather than patching local
+ * state from the PATCH response — the effective state can, in principle,
+ * depend on scopes this hook has no local copy of (organisation/team rows),
+ * so re-resolving through the same GET the pane renders from is the only
+ * way to stay honest about "which level pinned it".
+ */
+export function usePluginSettings(): UsePluginSettingsResult {
+	const [plugins, setPlugins] = useState<PluginSettingsListItem[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [togglingId, setTogglingId] = useState<string | null>(null);
+
+	const load = useCallback(async () => {
+		try {
+			const data = await fetchPlugins();
+			setPlugins(data);
+			setError(null);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to load plugins");
+		}
+	}, []);
+
+	useEffect(() => {
+		setLoading(true);
+		load().finally(() => setLoading(false));
+	}, [load]);
+
+	const togglePlugin = useCallback(
+		async (pluginId: string, enabled: boolean) => {
+			setTogglingId(pluginId);
+			try {
+				await requestPluginToggle(pluginId, enabled);
+				await load();
+			} catch (err) {
+				toast({
+					variant: "destructive",
+					title: "Couldn't update plugin",
+					description:
+						err instanceof Error ? err.message : "Something went wrong",
+				});
+			} finally {
+				setTogglingId(null);
+			}
+		},
+		[load]
+	);
+
+	return { plugins, loading, error, togglingId, togglePlugin };
+}

--- a/lib/schemas/index.ts
+++ b/lib/schemas/index.ts
@@ -9,6 +9,7 @@ export * from "./comment";
 export * from "./element";
 export * from "./google-drive";
 export * from "./permission";
+export * from "./plugin";
 export * from "./status";
 // Domain schemas for API routes
 export * from "./team";

--- a/lib/schemas/plugin.ts
+++ b/lib/schemas/plugin.ts
@@ -1,0 +1,120 @@
+import { z } from "zod";
+import { listManifestPluginIds } from "@/lib/plugins/manifest";
+
+/**
+ * Zod schemas for the plugin lifecycle core's user-facing surface (ADR 0002
+ * v2 §2.2) — `GET`/`PATCH /api/user/plugins`, the settings pane's only data
+ * source. See `lib/services/plugin-enablement-service.ts` for the service
+ * these validate input for.
+ */
+
+// ============================================
+// Bounded JSON — plugin `settings`
+// ============================================
+
+/**
+ * `setPluginEnabledForUser` (the service this schema guards) deliberately
+ * trusts schema-validated input and imposes no bound of its own on
+ * `settings` (vincent finding 7, 2026-07-03 backend review: "the zod schema
+ * on any route wiring to `setPluginEnabledForUser` MUST cap `settings`
+ * size/shape"). These constants are that cap — generous enough for a
+ * plugin's user-facing preferences, small enough that no caller can smuggle
+ * an unbounded JSON blob into a tier-1 row through this route.
+ */
+const PLUGIN_SETTINGS_MAX_DEPTH = 4;
+const PLUGIN_SETTINGS_MAX_KEYS = 20;
+const PLUGIN_SETTINGS_MAX_ARRAY_ITEMS = 20;
+const PLUGIN_SETTINGS_MAX_STRING_LENGTH = 500;
+/** Final belt-and-braces bound on the whole payload, serialized as UTF-8 bytes. */
+export const PLUGIN_SETTINGS_MAX_BYTES = 4096;
+
+const jsonPrimitiveSchema = z.union([
+	z.string().max(PLUGIN_SETTINGS_MAX_STRING_LENGTH),
+	z.number(),
+	z.boolean(),
+	z.null(),
+]);
+
+/**
+ * A bounded JSON value, at most `depth` further levels of array/object
+ * nesting below this call — `depth <= 0` collapses to primitives only, so
+ * the recursion structurally terminates rather than relying on a runtime
+ * counter. Each level down is a fresh schema (cheap: `PLUGIN_SETTINGS_MAX_DEPTH`
+ * is small and fixed), not unbounded recursion.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: Required for Zod recursive schema typing (same pattern as lib/schemas/case-export.ts's TreeNodeSchema)
+function boundedJsonValueSchema(depth: number): z.ZodType<any> {
+	if (depth <= 0) {
+		return jsonPrimitiveSchema;
+	}
+	return z.lazy(() =>
+		z.union([
+			jsonPrimitiveSchema,
+			z
+				.array(boundedJsonValueSchema(depth - 1))
+				.max(PLUGIN_SETTINGS_MAX_ARRAY_ITEMS),
+			z
+				.record(z.string(), boundedJsonValueSchema(depth - 1))
+				.refine((obj) => Object.keys(obj).length <= PLUGIN_SETTINGS_MAX_KEYS, {
+					message: `Must have at most ${PLUGIN_SETTINGS_MAX_KEYS} keys`,
+				}),
+		])
+	);
+}
+
+function serializedByteLength(value: unknown): number {
+	return new TextEncoder().encode(JSON.stringify(value)).length;
+}
+
+/**
+ * A plugin's `settings` JSON (ADR §2.2: "`PluginState` ... settings JSON,
+ * unique per plugin+scope"). The top level must be a plain object — a
+ * settings blob is a bag of named preferences, never a bare array or
+ * scalar — nested up to `PLUGIN_SETTINGS_MAX_DEPTH` levels, with per-object
+ * key counts, per-array lengths, and per-string lengths all capped, and the
+ * whole payload capped at `PLUGIN_SETTINGS_MAX_BYTES` serialized bytes as a
+ * final structural-bypass-proof bound (a payload could satisfy every
+ * per-node cap and still be enormous via many small keys — this refine
+ * closes that gap).
+ */
+export const pluginSettingsSchema = z
+	.record(z.string(), boundedJsonValueSchema(PLUGIN_SETTINGS_MAX_DEPTH - 1))
+	.refine((obj) => Object.keys(obj).length <= PLUGIN_SETTINGS_MAX_KEYS, {
+		message: `settings must have at most ${PLUGIN_SETTINGS_MAX_KEYS} top-level keys`,
+	})
+	.refine((obj) => serializedByteLength(obj) <= PLUGIN_SETTINGS_MAX_BYTES, {
+		message: `settings must serialize to at most ${PLUGIN_SETTINGS_MAX_BYTES} bytes`,
+	});
+
+// ============================================
+// PATCH /api/user/plugins
+// ============================================
+
+/**
+ * Body schema for `PATCH /api/user/plugins`. `pluginId` is checked against
+ * the live manifest (`listManifestPluginIds()`, read at parse time — not
+ * baked into a `z.enum` at module load) so shipping a new official plugin
+ * needs no schema change, and — the direction that matters for security —
+ * an id absent from the manifest is rejected HERE, before the service
+ * layer, with a proper 400. `setPluginEnabledForUser` also rejects unknown
+ * ids, but its error string ("Unknown plugin '...'") matches none of
+ * `serviceErrorToAppError`'s patterns and would otherwise surface as an
+ * unmapped 500.
+ *
+ * The acting user is never part of this schema — the route derives it from
+ * the session (`requireAuth()`), never from the request body.
+ */
+export const pluginToggleSchema = z.object({
+	pluginId: z
+		.string()
+		.min(1, "pluginId is required")
+		.max(100, "pluginId must be less than 100 characters")
+		.refine((id) => listManifestPluginIds().includes(id), {
+			message: "Unknown plugin id",
+		}),
+	enabled: z.boolean({ message: "enabled must be a boolean" }),
+	settings: pluginSettingsSchema.optional(),
+});
+
+export type PluginToggleInput = z.input<typeof pluginToggleSchema>;
+export type PluginToggleOutput = z.output<typeof pluginToggleSchema>;

--- a/lib/schemas/plugin.ts
+++ b/lib/schemas/plugin.ts
@@ -26,7 +26,7 @@ const PLUGIN_SETTINGS_MAX_KEYS = 20;
 const PLUGIN_SETTINGS_MAX_ARRAY_ITEMS = 20;
 const PLUGIN_SETTINGS_MAX_STRING_LENGTH = 500;
 /** Final belt-and-braces bound on the whole payload, serialized as UTF-8 bytes. */
-export const PLUGIN_SETTINGS_MAX_BYTES = 4096;
+const PLUGIN_SETTINGS_MAX_BYTES = 4096;
 
 const jsonPrimitiveSchema = z.union([
 	z.string().max(PLUGIN_SETTINGS_MAX_STRING_LENGTH),
@@ -77,7 +77,7 @@ function serializedByteLength(value: unknown): number {
  * per-node cap and still be enormous via many small keys — this refine
  * closes that gap).
  */
-export const pluginSettingsSchema = z
+const pluginSettingsSchema = z
 	.record(z.string(), boundedJsonValueSchema(PLUGIN_SETTINGS_MAX_DEPTH - 1))
 	.refine((obj) => Object.keys(obj).length <= PLUGIN_SETTINGS_MAX_KEYS, {
 		message: `settings must have at most ${PLUGIN_SETTINGS_MAX_KEYS} top-level keys`,
@@ -116,5 +116,49 @@ export const pluginToggleSchema = z.object({
 	settings: pluginSettingsSchema.optional(),
 });
 
-export type PluginToggleInput = z.input<typeof pluginToggleSchema>;
-export type PluginToggleOutput = z.output<typeof pluginToggleSchema>;
+// ============================================
+// GET /api/user/plugins — response item
+// ============================================
+
+/**
+ * The scope currently pinning a plugin's state, or `null` if nothing is —
+ * mirrors `EffectivePluginState["disabledAt"]`
+ * (`lib/services/plugin-enablement-service.ts`) as a plain string union
+ * rather than importing `PluginScopeType` from the generated Prisma client,
+ * so client components (`hooks/use-plugin-settings.ts`) can use this type
+ * without depending on Prisma.
+ */
+export type PluginPinnedAt =
+	| "DEPLOYMENT"
+	| "ORGANISATION"
+	| "TEAM"
+	| "USER"
+	| null;
+
+/**
+ * A single plugin's effective state as returned by `GET /api/user/plugins`
+ * — the settings pane's only data source. Shared by the route (which builds
+ * it, `app/api/user/plugins/route.ts`) and `usePluginSettings` (which
+ * consumes it, `hooks/use-plugin-settings.ts`) so the shape has exactly one
+ * definition.
+ */
+export interface PluginSettingsListItem {
+	/** Deployment concern (ADR §2.2) — withheld entirely means `false`. */
+	available: boolean;
+	/** Effective state for the session user across the full scope chain. */
+	enabled: boolean;
+	name: string;
+	/**
+	 * The scope that is currently pinning this plugin OFF — see
+	 * `PluginPinnedAt`. A pane renders the toggle as user-editable only when
+	 * this is `null` or `"USER"`; `"DEPLOYMENT"`/`"ORGANISATION"`/`"TEAM"`
+	 * mean a level above the user has switched it off (off wins downward —
+	 * the user cannot override it from here).
+	 */
+	pinnedAt: PluginPinnedAt;
+	/** The `PluginState`/`PluginData` namespace, e.g. `"tea.health"`. */
+	pluginId: string;
+	/** The user's own saved settings for this plugin, or `null` if never set. */
+	settings: unknown;
+	version: string;
+}

--- a/lib/services/plugin-enablement-service.ts
+++ b/lib/services/plugin-enablement-service.ts
@@ -154,6 +154,42 @@ export async function isPluginEnabledForUser(
 	return "data" in result;
 }
 
+/**
+ * Reads the current USER-scope `settings` JSON for `pluginId`, or `null` if
+ * no USER-scope row exists yet (a user who has never touched this plugin's
+ * toggle has no row at all). Separate from `resolveEffectivePluginState`
+ * deliberately: that resolver answers "is this plugin ON", walking the full
+ * scope chain, and never needed to surface a settings payload; this answers
+ * "what did the USER save", a single-scope lookup with no chain-walking.
+ * Added for the settings pane (`GET /api/user/plugins`) to round-trip a
+ * user's saved settings without duplicating enablement logic in the route.
+ */
+export async function getUserPluginSettings(
+	pluginId: string,
+	userId: string
+): ServiceResult<Prisma.JsonValue | null> {
+	if (!getManifestEntry(pluginId)) {
+		return { error: `Unknown plugin '${pluginId}'` };
+	}
+
+	try {
+		const row = await prisma.pluginState.findUnique({
+			where: {
+				pluginId_scopeType_scopeId: {
+					pluginId,
+					scopeType: "USER",
+					scopeId: userId,
+				},
+			},
+			select: { settings: true },
+		});
+		return { data: row?.settings ?? null };
+	} catch (error) {
+		console.error("Failed to read plugin settings:", error);
+		return { error: "Failed to read plugin settings" };
+	}
+}
+
 export interface SetUserPluginEnabledInput {
 	enabled: boolean;
 	settings?: Prisma.InputJsonValue;

--- a/src/__tests__/integration/api-user-plugins.test.ts
+++ b/src/__tests__/integration/api-user-plugins.test.ts
@@ -256,6 +256,76 @@ describe("PATCH /api/user/plugins — validation", () => {
 
 		expect(response.status).toBe(400);
 	});
+
+	it("rejects settings nested 5 levels deep, beyond the depth cap", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { PATCH } = await import("@/app/api/user/plugins/route");
+		const response = await PATCH(
+			patchRequest({
+				pluginId: KNOWN_PLUGIN_ID,
+				enabled: true,
+				settings: { a: { a: { a: { a: { a: 1 } } } } },
+			})
+		);
+
+		expect(response.status).toBe(400);
+	});
+
+	it("accepts settings nested exactly 4 levels deep, at the depth cap", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { PATCH } = await import("@/app/api/user/plugins/route");
+		const response = await PATCH(
+			patchRequest({
+				pluginId: KNOWN_PLUGIN_ID,
+				enabled: true,
+				settings: { a: { a: { a: { a: 1 } } } },
+			})
+		);
+
+		expect(response.status).toBe(200);
+	});
+
+	it("rejects a settings array exceeding the per-array item cap", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const tooManyItems = Array.from({ length: 21 }, (_, i) => i);
+
+		const { PATCH } = await import("@/app/api/user/plugins/route");
+		const response = await PATCH(
+			patchRequest({
+				pluginId: KNOWN_PLUGIN_ID,
+				enabled: true,
+				settings: { items: tooManyItems },
+			})
+		);
+
+		expect(response.status).toBe(400);
+	});
+
+	it("rejects a nested object exceeding the per-object key cap (enforced below the top level)", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const tooManyNestedKeys = Object.fromEntries(
+			Array.from({ length: 21 }, (_, i) => [`key${i}`, i])
+		);
+
+		const { PATCH } = await import("@/app/api/user/plugins/route");
+		const response = await PATCH(
+			patchRequest({
+				pluginId: KNOWN_PLUGIN_ID,
+				enabled: true,
+				settings: { nested: tooManyNestedKeys },
+			})
+		);
+
+		expect(response.status).toBe(400);
+	});
 });
 
 // ============================================

--- a/src/__tests__/integration/api-user-plugins.test.ts
+++ b/src/__tests__/integration/api-user-plugins.test.ts
@@ -1,0 +1,321 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	createTestPluginState,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+const KNOWN_PLUGIN_ID = "tea.health";
+const UNKNOWN_PLUGIN_ID = "tea.does-not-exist";
+
+function patchRequest(body: unknown): NextRequest {
+	return new NextRequest("http://localhost:3000/api/user/plugins", {
+		method: "PATCH",
+		body: JSON.stringify(body),
+	});
+}
+
+beforeEach(async () => {
+	await mockNoAuth();
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+// ============================================
+// GET /api/user/plugins
+// ============================================
+
+describe("GET /api/user/plugins", () => {
+	it("returns 401 when the request is not authenticated", async () => {
+		const { GET } = await import("@/app/api/user/plugins/route");
+		const response = await GET();
+		expect(response.status).toBe(401);
+	});
+
+	it("returns the manifest plugin with its effective state for the session user", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { GET } = await import("@/app/api/user/plugins/route");
+		const response = await GET();
+		expect(response.status).toBe(200);
+
+		const body = await response.json();
+		expect(body.plugins).toHaveLength(1);
+		expect(body.plugins[0]).toMatchObject({
+			pluginId: KNOWN_PLUGIN_ID,
+			name: "Claim/Evidence Health",
+			version: "0.1.0",
+			available: true,
+			enabled: true,
+			pinnedAt: null,
+			settings: null,
+		});
+	});
+
+	it("reports available: false and pinnedAt: DEPLOYMENT when withheld via TEA_PLUGINS_DISABLED", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+		vi.stubEnv("TEA_PLUGINS_DISABLED", KNOWN_PLUGIN_ID);
+
+		const { GET } = await import("@/app/api/user/plugins/route");
+		const response = await GET();
+		const body = await response.json();
+
+		expect(body.plugins[0]).toMatchObject({
+			available: false,
+			enabled: false,
+			pinnedAt: "DEPLOYMENT",
+		});
+	});
+
+	it("reports pinnedAt: USER and the persisted settings after the user has toggled the plugin off", async () => {
+		const user = await createTestUser();
+		await createTestPluginState(user.id, {
+			pluginId: KNOWN_PLUGIN_ID,
+			scopeType: "USER",
+			enabled: false,
+			settings: { threshold: 0.8 },
+		});
+		await mockAuth(user.id, user.username, user.email);
+
+		const { GET } = await import("@/app/api/user/plugins/route");
+		const response = await GET();
+		const body = await response.json();
+
+		expect(body.plugins[0]).toMatchObject({
+			enabled: false,
+			pinnedAt: "USER",
+			settings: { threshold: 0.8 },
+		});
+	});
+});
+
+// ============================================
+// PATCH /api/user/plugins — auth & identity
+// ============================================
+
+describe("PATCH /api/user/plugins — auth and session-derived identity", () => {
+	it("returns 401 when the request is not authenticated", async () => {
+		const { PATCH } = await import("@/app/api/user/plugins/route");
+		const response = await PATCH(
+			patchRequest({ pluginId: KNOWN_PLUGIN_ID, enabled: false })
+		);
+		expect(response.status).toBe(401);
+	});
+
+	it("ignores a body-supplied userId — the row is written for the session user, never the body's userId", async () => {
+		const actingUser = await createTestUser();
+		const otherUser = await createTestUser();
+		await mockAuth(actingUser.id, actingUser.username, actingUser.email);
+
+		const { PATCH } = await import("@/app/api/user/plugins/route");
+		const response = await PATCH(
+			patchRequest({
+				pluginId: KNOWN_PLUGIN_ID,
+				enabled: false,
+				userId: otherUser.id,
+			})
+		);
+
+		expect(response.status).toBe(200);
+
+		const actingUserRow = await prisma.pluginState.findUnique({
+			where: {
+				pluginId_scopeType_scopeId: {
+					pluginId: KNOWN_PLUGIN_ID,
+					scopeType: "USER",
+					scopeId: actingUser.id,
+				},
+			},
+		});
+		const otherUserRow = await prisma.pluginState.findUnique({
+			where: {
+				pluginId_scopeType_scopeId: {
+					pluginId: KNOWN_PLUGIN_ID,
+					scopeType: "USER",
+					scopeId: otherUser.id,
+				},
+			},
+		});
+
+		expect(actingUserRow).not.toBeNull();
+		expect(actingUserRow?.enabled).toBe(false);
+		expect(otherUserRow).toBeNull();
+	});
+});
+
+// ============================================
+// PATCH /api/user/plugins — validation
+// ============================================
+
+describe("PATCH /api/user/plugins — validation", () => {
+	it("rejects an unknown pluginId with 400, and persists nothing", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { PATCH } = await import("@/app/api/user/plugins/route");
+		const response = await PATCH(
+			patchRequest({ pluginId: UNKNOWN_PLUGIN_ID, enabled: false })
+		);
+
+		expect(response.status).toBe(400);
+
+		const rows = await prisma.pluginState.findMany({
+			where: { pluginId: UNKNOWN_PLUGIN_ID },
+		});
+		expect(rows).toHaveLength(0);
+	});
+
+	it("rejects settings exceeding the per-string-length cap, and persists nothing", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { PATCH } = await import("@/app/api/user/plugins/route");
+		const response = await PATCH(
+			patchRequest({
+				pluginId: KNOWN_PLUGIN_ID,
+				enabled: true,
+				settings: { note: "a".repeat(600) },
+			})
+		);
+
+		expect(response.status).toBe(400);
+
+		const row = await prisma.pluginState.findUnique({
+			where: {
+				pluginId_scopeType_scopeId: {
+					pluginId: KNOWN_PLUGIN_ID,
+					scopeType: "USER",
+					scopeId: user.id,
+				},
+			},
+		});
+		expect(row).toBeNull();
+	});
+
+	it("rejects settings exceeding the top-level key-count cap", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const tooManyKeys = Object.fromEntries(
+			Array.from({ length: 25 }, (_, i) => [`key${i}`, i])
+		);
+
+		const { PATCH } = await import("@/app/api/user/plugins/route");
+		const response = await PATCH(
+			patchRequest({
+				pluginId: KNOWN_PLUGIN_ID,
+				enabled: true,
+				settings: tooManyKeys,
+			})
+		);
+
+		expect(response.status).toBe(400);
+	});
+
+	it("rejects settings that satisfy every per-node cap but exceed the total serialized byte cap", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		// 20 keys (at the key-count cap) x a 300-char string (under the
+		// per-string cap) each — individually legal, ~6000 bytes together,
+		// over the 4096-byte whole-payload cap.
+		const nearCapKeys = Object.fromEntries(
+			Array.from({ length: 20 }, (_, i) => [`key${i}`, "x".repeat(300)])
+		);
+
+		const { PATCH } = await import("@/app/api/user/plugins/route");
+		const response = await PATCH(
+			patchRequest({
+				pluginId: KNOWN_PLUGIN_ID,
+				enabled: true,
+				settings: nearCapKeys,
+			})
+		);
+
+		expect(response.status).toBe(400);
+	});
+
+	it("rejects a non-boolean enabled value", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { PATCH } = await import("@/app/api/user/plugins/route");
+		const response = await PATCH(
+			patchRequest({ pluginId: KNOWN_PLUGIN_ID, enabled: "yes" })
+		);
+
+		expect(response.status).toBe(400);
+	});
+});
+
+// ============================================
+// PATCH /api/user/plugins — toggle round-trip
+// ============================================
+
+describe("PATCH /api/user/plugins — toggle round-trip", () => {
+	it("persists a toggle and the change is visible through GET", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { GET, PATCH } = await import("@/app/api/user/plugins/route");
+
+		const offResponse = await PATCH(
+			patchRequest({ pluginId: KNOWN_PLUGIN_ID, enabled: false })
+		);
+		expect(offResponse.status).toBe(200);
+
+		const afterOff = await (await GET()).json();
+		expect(afterOff.plugins[0]).toMatchObject({
+			enabled: false,
+			pinnedAt: "USER",
+		});
+
+		const onResponse = await PATCH(
+			patchRequest({ pluginId: KNOWN_PLUGIN_ID, enabled: true })
+		);
+		expect(onResponse.status).toBe(200);
+
+		const afterOn = await (await GET()).json();
+		expect(afterOn.plugins[0]).toMatchObject({
+			enabled: true,
+			pinnedAt: null,
+		});
+	});
+
+	it("does not lose settings JSON when a later toggle only changes enabled", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { GET, PATCH } = await import("@/app/api/user/plugins/route");
+
+		const withSettings = await PATCH(
+			patchRequest({
+				pluginId: KNOWN_PLUGIN_ID,
+				enabled: true,
+				settings: { threshold: 0.8 },
+			})
+		);
+		expect(withSettings.status).toBe(200);
+
+		const enabledOnlyToggle = await PATCH(
+			patchRequest({ pluginId: KNOWN_PLUGIN_ID, enabled: false })
+		);
+		expect(enabledOnlyToggle.status).toBe(200);
+
+		const body = await (await GET()).json();
+		expect(body.plugins[0]).toMatchObject({
+			enabled: false,
+			settings: { threshold: 0.8 },
+		});
+	});
+});

--- a/src/__tests__/integration/plugin-enablement-service.test.ts
+++ b/src/__tests__/integration/plugin-enablement-service.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/lib/prisma";
 import {
 	assertPluginEnabledForUser,
+	getUserPluginSettings,
 	isPluginEnabledForUser,
 	resolveEffectivePluginState,
 	setPluginEnabledForUser,
@@ -426,5 +427,52 @@ describe("setPluginEnabledForUser", () => {
 			await resolveEffectivePluginState(KNOWN_PLUGIN_ID, { userId: user.id })
 		);
 		expect(state.enabled).toBe(false);
+	});
+});
+
+// ============================================
+// getUserPluginSettings — the settings pane's per-user read
+// ============================================
+
+describe("getUserPluginSettings", () => {
+	it("returns null when the user has no USER-scope row yet", async () => {
+		const user = await createTestUser();
+
+		// `expectSuccess` treats `data === null` as a void-result success and
+		// returns `undefined` — asserted directly here rather than through the
+		// helper (nanaki 5) so a future regression that silently drops the
+		// settings payload can't hide behind that shortcut.
+		const result = await getUserPluginSettings(KNOWN_PLUGIN_ID, user.id);
+		expect(result).toEqual({ data: null });
+	});
+
+	it("rejects an unknown plugin id", async () => {
+		const user = await createTestUser();
+		expectError(
+			await getUserPluginSettings(UNKNOWN_PLUGIN_ID, user.id),
+			UNKNOWN_PLUGIN_PATTERN
+		);
+	});
+
+	it("does not let one user's settings affect another user", async () => {
+		const owner = await createTestUser();
+		const otherUser = await createTestUser();
+		await createTestPluginState(owner.id, {
+			pluginId: KNOWN_PLUGIN_ID,
+			scopeType: "USER",
+			enabled: true,
+			settings: { threshold: 0.8 },
+		});
+
+		const ownerSettings = expectSuccess(
+			await getUserPluginSettings(KNOWN_PLUGIN_ID, owner.id)
+		);
+		expect(ownerSettings).toEqual({ threshold: 0.8 });
+
+		const otherUserResult = await getUserPluginSettings(
+			KNOWN_PLUGIN_ID,
+			otherUser.id
+		);
+		expect(otherUserResult).toEqual({ data: null });
 	});
 });


### PR DESCRIPTION
## Summary

Adds the user-facing half of the plugin lifecycle core (ADR 0002 v2 §2.2): a settings pane where a user can see each official plugin's effective state and toggle it at the user tier, plus the thin `/api/user/plugins` route it consumes.

- **GET /api/user/plugins** — per-plugin effective state for the session user (availability, enablement, pinning scope, saved settings), delegating to the merged enablement service (#834).
- **PATCH /api/user/plugins** — user-tier toggle with optional settings write. The zod schema bounds `settings` (depth ≤ 4, ≤ 20 keys per object at every level, ≤ 20 array items, ≤ 500-char strings, ≤ 4096 UTF-8 bytes total); the acting user is always derived from the session, never the request body.
- **Settings pane** (`dashboard/settings`): plugin list with honest effective-state display (deployment-unavailable and above-user pins render as locked, not as dead toggles), user-tier toggle, and an empty per-plugin settings slot for later plugin contributions.

## Review chain

Two-stage internal review on the frozen implementation commit (`ca3f020f`), findings addressed in a follow-up commit (`2ed5cec7`), reviewed-to-final delta verified in full before this PR:

- **QA:** pass with findings — four coverage gaps (each independently probe-verified as correct-but-untested), closed by 7 added tests: boundary pins on every settings bound (depth 5 rejected / depth 4 accepted, array and nested-key caps) and direct coverage of the new `getUserPluginSettings` service read, including cross-user isolation.
- **Code review:** approve with comments — no blockers. Both security mandates from the backend review re-verified empirically against the installed zod version: prototype-pollution vectors (`__proto__`, `constructor.prototype`) are dropped by the schema, and cap enforcement measures linear (~265 ms on a 300k-key payload — no amplification). Dead exports removed; the duplicated route/hook response type consolidated to a single definition in `lib/schemas/plugin.ts`.

One platform-wide observation from review (no route guards request body size pre-parse; 34 routes share the pattern) was deliberately excluded from this change and is tracked separately.

## Test evidence (final commit)

- Lint: 634 files clean; typecheck clean
- Unit: 902/902; integration: 543/543 (full suite)
