### PR TITLE
fix(deps): bound @babel/runtime override + TS 6 forward-compat shims

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
       "vite": ">=7.0.8",
       "hono": ">=4.11.10",
       "valibot": ">=1.2.0",
-      "@babel/runtime": ">=7.26.10",
+      "@babel/runtime": ">=7.26.10 <8",
       "js-yaml": ">=4.1.1",
       "cross-spawn": ">=7.0.5",
       "minimatch": ">=10.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   vite: '>=7.0.8'
   hono: '>=4.11.10'
   valibot: '>=1.2.0'
-  '@babel/runtime': '>=7.26.10'
+  '@babel/runtime': '>=7.26.10 <8'
   js-yaml: '>=4.1.1'
   cross-spawn: '>=7.0.5'
   minimatch: '>=10.2.3'
@@ -3339,7 +3339,7 @@ packages:
   '@uiw/react-codemirror@4.25.8':
     resolution: {integrity: sha512-A0aLOuJZm2yJ+U9GlMFwxwFciztjd5LhcAG4SMqFxdD58wH+sCQXuY4UU5J2hqgS390qAlShtUgREvJPUonbuQ==}
     peerDependencies:
-      '@babel/runtime': '>=7.26.10'
+      '@babel/runtime': '>=7.26.10 <8'
       '@codemirror/state': '>=6.0.0'
       '@codemirror/theme-one-dark': '>=6.0.0'
       '@codemirror/view': '>=6.0.0'

--- a/src/__tests__/utils/websocket-test-utils.ts
+++ b/src/__tests__/utils/websocket-test-utils.ts
@@ -76,7 +76,7 @@ export interface WebSocketMessage<T = unknown> {
  */
 export class MockWebSocket implements Partial<WebSocket> {
 	url: string;
-	readyState: number = WS_READY_STATE.CONNECTING;
+	readyState: WS_READY_STATE = WS_READY_STATE.CONNECTING;
 
 	private readonly eventListeners: Map<string, Set<EventListener>> = new Map();
 	private sentMessages: WebSocketMessage[] = [];

--- a/types/css.d.ts
+++ b/types/css.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Ambient shim for CSS side-effect imports (`import "./foo.css"`).
+ *
+ * TypeScript 5.9 (current) already resolves these via Next.js's built-in
+ * module augmentation, so this declaration is currently inert. TypeScript 6
+ * tightens module resolution in a way that would otherwise error on bare
+ * side-effect CSS imports — this file is forward-compat cover for that
+ * upgrade, added ahead of time rather than as a reactive fix.
+ */
+declare module "*.css";


### PR DESCRIPTION
## Summary

Three small preventive fixes so the July dependency batch (dependabot #837/#838) can land, plus closure of a latent production risk found while diagnosing them:

1. **`@babel/runtime` upper bound in `pnpm.overrides`** (`>=7.26.10` → `>=7.26.10 <8`). The unbounded range meant any lockfile regeneration would resolve `@babel/runtime@8.0.0`, whose restructured `exports` map drops the `./regenerator` subpath that `next-auth` requires at load time — breaking auth at runtime on the next dependency change of any kind. The lockfile regeneration in this PR is itself the proof: all resolutions remain 7.x.
2. **`types/css.d.ts`** — ambient `declare module "*.css";` shim. Inert under TypeScript 5.9; forward-compatibility for TS 6's stricter side-effect-import checking (four files import CSS for side effects).
3. **`MockWebSocket.readyState`** typed to the existing `WS_READY_STATE` literal union (was `number`). Type-only; required by TS 6's narrowed `lib.dom.d.ts` `WebSocket.readyState`; verified sound at all fifteen usage sites.

## Review chain

Single commit, reviewed frozen with no post-review changes:

- **QA:** pass, zero findings — typecheck, unit (902/902) and integration (543/543) suites independently re-run; the auth canary test (`lib/__tests__/errors.test.ts`, the one suite exercising real unmocked next-auth) additionally run in isolation: 20/20.
- **Code review:** approve — override range semantics verified against pnpm's documented behaviour; shim verified additive (no CSS-module imports exist for it to weaken; wildcard specificity protects future ones); narrowing verified strict and type-only. Dead-code/duplication/complexity audit: pass, nothing introduced.

Noted for follow-up (tracked separately, not in this PR): the sixteen other `pnpm.overrides` entries share the same unbounded-range pattern and will be capped in one pass.

## After merge

Dependabot on #837/#838 will be instructed to drop the five problem packages (ultracite; lucide-react, @vitejs/plugin-react, jsdom, next-openapi-gen) and rebase — the regenerated lockfiles then inherit this pin, and both PRs are expected green.
