### PR TITLE
feat(plugins): UI extension slots — registry, element badge, element panel

### DIFF
--- a/app/(authenticated)/dashboard/settings/_components/__tests__/plugin-settings-slot-registry.test.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/__tests__/plugin-settings-slot-registry.test.tsx
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { settingsSectionSlot } from "@/lib/plugins/slots";
+import {
+	renderWithoutProviders,
+	screen,
+} from "@/src/__tests__/utils/test-utils";
+import { PluginSettingsSlot } from "../plugin-settings-slot";
+
+function FakeSettings({ pluginId }: { pluginId: string }) {
+	return <div data-testid="fake-settings">{`settings for ${pluginId}`}</div>;
+}
+
+afterEach(() => {
+	settingsSectionSlot.resetForTests();
+});
+
+describe("PluginSettingsSlot — registry wiring ([[TEA — UI extension slots]])", () => {
+	it("still renders nothing for a pluginId with no registration (registry empty by default in 1.0)", () => {
+		const { container } = renderWithoutProviders(
+			<PluginSettingsSlot pluginId="tea.health" />
+		);
+
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("renders a registered plugin's own settings component", () => {
+		settingsSectionSlot.register({
+			pluginId: "tea.health",
+			Component: FakeSettings,
+		});
+
+		renderWithoutProviders(<PluginSettingsSlot pluginId="tea.health" />);
+
+		expect(screen.getByTestId("fake-settings")).toHaveTextContent(
+			"settings for tea.health"
+		);
+	});
+
+	it("does not render another plugin's registration", () => {
+		settingsSectionSlot.register({
+			pluginId: "tea.health",
+			Component: FakeSettings,
+		});
+
+		const { container } = renderWithoutProviders(
+			<PluginSettingsSlot pluginId="tea.other" />
+		);
+
+		expect(container).toBeEmptyDOMElement();
+	});
+});

--- a/app/(authenticated)/dashboard/settings/_components/__tests__/plugin-toggle-row.test.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/__tests__/plugin-toggle-row.test.tsx
@@ -1,11 +1,16 @@
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PluginSettingsListItem } from "@/hooks/use-plugin-settings";
+import { settingsSectionSlot } from "@/lib/plugins/slots";
 import {
 	renderWithoutProviders,
 	screen,
 } from "@/src/__tests__/utils/test-utils";
 import { PluginToggleRow } from "../plugin-toggle-row";
+
+function FakeSettings({ pluginId }: { pluginId: string }) {
+	return <div data-testid="fake-settings">{`settings for ${pluginId}`}</div>;
+}
 
 const UNAVAILABLE_REGEX = /unavailable on this deployment/i;
 const ORGANISATION_REGEX = /turned off by your organisation/i;
@@ -179,6 +184,41 @@ describe("PluginToggleRow", () => {
 			expect(
 				screen.queryByTestId("plugin-settings-slot")
 			).not.toBeInTheDocument();
+		});
+
+		describe("gated on the row's effective checked state", () => {
+			afterEach(() => {
+				settingsSectionSlot.resetForTests();
+			});
+
+			it("does not render a registered settings component when the plugin is not effectively enabled", () => {
+				settingsSectionSlot.register({
+					pluginId: "tea.health",
+					Component: FakeSettings,
+				});
+
+				renderWithoutProviders(
+					<PluginToggleRow
+						onToggle={vi.fn()}
+						plugin={makePlugin({ enabled: false, pinnedAt: "USER" })}
+					/>
+				);
+
+				expect(screen.queryByTestId("fake-settings")).not.toBeInTheDocument();
+			});
+
+			it("renders a registered settings component when the plugin is effectively enabled", () => {
+				settingsSectionSlot.register({
+					pluginId: "tea.health",
+					Component: FakeSettings,
+				});
+
+				renderWithoutProviders(
+					<PluginToggleRow onToggle={vi.fn()} plugin={makePlugin()} />
+				);
+
+				expect(screen.getByTestId("fake-settings")).toBeInTheDocument();
+			});
 		});
 	});
 });

--- a/app/(authenticated)/dashboard/settings/_components/plugin-settings-slot.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/plugin-settings-slot.tsx
@@ -1,16 +1,43 @@
+import { settingsSectionSlot } from "@/lib/plugins/slots";
+
 /**
  * The `settings-section` extension point (ADR 0002 v2 §2.3) — the region
- * within a plugin's row where an enabled plugin will one day contribute its
- * own settings UI (e.g. the health plugin's scoring thresholds).
+ * within a plugin's row where an enabled plugin contributes its own settings
+ * UI (e.g. the health plugin's scoring thresholds), wired through the
+ * build-time slot registry (`[[TEA — UI extension slots]]`).
  *
- * No plugin registers into this slot yet — the registry that would let a
- * plugin do so is `[[TEA — UI extension slots]]` (separate issue, out of
- * scope here). This component is the seam that registry will fill in: it
- * renders nothing now, matching §2.3's rule that "slots render nothing when
- * no enabled plugin registers into them" — core screens must be complete
- * with every slot empty, so this must never leave a layout artefact
- * (an empty border, a stray heading) behind it.
+ * No official plugin registers into this slot yet, so this renders nothing
+ * in every 1.0 deployment — matching §2.3's rule that "slots render nothing
+ * when no enabled plugin registers into them": core screens must be
+ * complete with every slot empty, so this must never leave a layout
+ * artefact (an empty border, a stray heading) behind it.
+ *
+ * Deliberately does not itself gate on enablement (unlike the canvas slots,
+ * which read `use-plugin-enablement.ts`): the caller (`PluginToggleRow`)
+ * already has the plugin's effective `enabled` state in scope from
+ * `usePluginSettings`, so re-fetching it here would just be a second
+ * request answering a question the pane already has the answer to. Gating
+ * this slot's visibility on `enabled` is left to that call site.
  */
-export function PluginSettingsSlot(_props: { pluginId: string }) {
-	return null;
+export function PluginSettingsSlot({ pluginId }: { pluginId: string }) {
+	const registrations = settingsSectionSlot
+		.list()
+		.filter((registration) => registration.pluginId === pluginId);
+
+	if (registrations.length === 0) {
+		return null;
+	}
+
+	// A plugin registers into this slot at most once in practice — the
+	// manifest carries one entry per pluginId, and a second registration for
+	// the same plugin would be a bug in that plugin's module, not a case to
+	// design a synthetic key around. `pluginId` alone is therefore a stable
+	// key for the (expected) single element this renders.
+	return (
+		<>
+			{registrations.map(({ Component }) => (
+				<Component key={pluginId} pluginId={pluginId} />
+			))}
+		</>
+	);
 }

--- a/app/(authenticated)/dashboard/settings/_components/plugin-settings-slot.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/plugin-settings-slot.tsx
@@ -17,7 +17,10 @@ import { settingsSectionSlot } from "@/lib/plugins/slots";
  * already has the plugin's effective `enabled` state in scope from
  * `usePluginSettings`, so re-fetching it here would just be a second
  * request answering a question the pane already has the answer to. Gating
- * this slot's visibility on `enabled` is left to that call site.
+ * this slot's visibility on `enabled` is the call site's job —
+ * `PluginToggleRow` renders this component only when its own `checked`
+ * (`plugin.available && plugin.enabled`) is true, so an unavailable or
+ * user-disabled plugin never mounts its settings UI at all.
  */
 export function PluginSettingsSlot({ pluginId }: { pluginId: string }) {
 	const registrations = settingsSectionSlot

--- a/app/(authenticated)/dashboard/settings/_components/plugin-toggle-row.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/plugin-toggle-row.tsx
@@ -89,7 +89,7 @@ export function PluginToggleRow({
 				</div>
 			</div>
 
-			<PluginSettingsSlot pluginId={plugin.pluginId} />
+			{checked && <PluginSettingsSlot pluginId={plugin.pluginId} />}
 		</div>
 	);
 }

--- a/components/cases/__tests__/node-edit-dialog.test.tsx
+++ b/components/cases/__tests__/node-edit-dialog.test.tsx
@@ -1,0 +1,138 @@
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import type { Node } from "reactflow";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ElementSlotContext } from "@/lib/plugins/slots";
+import { elementPanelSlot } from "@/lib/plugins/slots";
+import { server } from "@/src/__tests__/mocks/server";
+import { render, screen, waitFor } from "@/src/__tests__/utils/test-utils";
+import NodeEditDialog from "../node-edit-dialog";
+
+const NODE: Node = {
+	id: "1",
+	type: "goal",
+	position: { x: 0, y: 0 },
+	data: {
+		id: 1,
+		name: "G1",
+		description: "System is acceptably safe",
+	},
+};
+
+function FakePanel({ elementId }: ElementSlotContext) {
+	return <div data-testid="fake-panel-content">{`panel for ${elementId}`}</div>;
+}
+
+function mockPluginsResponse(enabled: boolean) {
+	server.use(
+		http.get("/api/user/plugins", () =>
+			HttpResponse.json({
+				plugins: [
+					{
+						pluginId: "tea.health",
+						name: "Claim/Evidence Health",
+						version: "0.1.0",
+						available: true,
+						enabled,
+						pinnedAt: enabled ? null : "USER",
+						settings: null,
+					},
+				],
+			})
+		)
+	);
+}
+
+afterEach(() => {
+	elementPanelSlot.resetForTests();
+	vi.restoreAllMocks();
+});
+
+describe("NodeEditDialog — element-panel slot", () => {
+	it("renders no tab strip when no plugin has registered a panel (pixel-equivalent to pre-slot dialog)", async () => {
+		mockPluginsResponse(true);
+
+		render(
+			<NodeEditDialog
+				node={NODE}
+				nodeType="goal"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={true}
+			/>,
+			{ withProviders: false }
+		);
+
+		await waitFor(() =>
+			expect(screen.getByLabelText("Description")).toBeInTheDocument()
+		);
+		expect(screen.queryByRole("tablist")).not.toBeInTheDocument();
+	});
+
+	it("adds a Details tab plus the plugin's tab once an enabled plugin registers a panel", async () => {
+		const user = userEvent.setup();
+		elementPanelSlot.register({
+			pluginId: "tea.health",
+			tabId: "tea.health",
+			label: "Evidence",
+			Component: FakePanel,
+		});
+		mockPluginsResponse(true);
+
+		render(
+			<NodeEditDialog
+				node={NODE}
+				nodeType="goal"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={true}
+			/>,
+			{ withProviders: false }
+		);
+
+		await waitFor(() =>
+			expect(screen.getByRole("tablist")).toBeInTheDocument()
+		);
+		expect(screen.getByRole("tab", { name: "Details" })).toBeInTheDocument();
+		const evidenceTab = screen.getByRole("tab", { name: "Evidence" });
+		expect(evidenceTab).toBeInTheDocument();
+
+		await user.click(evidenceTab);
+
+		await waitFor(() =>
+			expect(screen.getByTestId("fake-panel-content")).toHaveTextContent(
+				"panel for 1"
+			)
+		);
+	});
+
+	it("falls back to no tab strip when the registering plugin is disabled — off as if never registered", async () => {
+		elementPanelSlot.register({
+			pluginId: "tea.health",
+			tabId: "tea.health",
+			label: "Evidence",
+			Component: FakePanel,
+		});
+		mockPluginsResponse(false);
+
+		render(
+			<NodeEditDialog
+				node={NODE}
+				nodeType="goal"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={true}
+			/>,
+			{ withProviders: false }
+		);
+
+		await waitFor(() =>
+			expect(screen.getByLabelText("Description")).toBeInTheDocument()
+		);
+		expect(screen.queryByRole("tablist")).not.toBeInTheDocument();
+		expect(screen.queryByText("Evidence")).not.toBeInTheDocument();
+	});
+});

--- a/components/cases/__tests__/node-edit-dialog.test.tsx
+++ b/components/cases/__tests__/node-edit-dialog.test.tsx
@@ -1,11 +1,13 @@
+import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import type { Node } from "reactflow";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ElementSlotContext } from "@/lib/plugins/slots";
 import { elementPanelSlot } from "@/lib/plugins/slots";
+import type { PluginSettingsListItem } from "@/lib/schemas/plugin";
 import { server } from "@/src/__tests__/mocks/server";
-import { render, screen, waitFor } from "@/src/__tests__/utils/test-utils";
+import { render, screen } from "@/src/__tests__/utils/test-utils";
 import NodeEditDialog from "../node-edit-dialog";
 
 const NODE: Node = {
@@ -37,7 +39,7 @@ function mockPluginsResponse(enabled: boolean) {
 						pinnedAt: enabled ? null : "USER",
 						settings: null,
 					},
-				],
+				] satisfies PluginSettingsListItem[],
 			})
 		)
 	);

--- a/components/cases/evidence-node.tsx
+++ b/components/cases/evidence-node.tsx
@@ -4,15 +4,24 @@ import { ExternalLink } from "lucide-react";
 import { memo, useState } from "react";
 import type { NodeProps } from "reactflow";
 import { BaseNode, NodeActionGroup } from "@/components/shared/nodes";
+import { useElementBadgeSlot } from "@/hooks/use-element-badge-slot";
+import useStore from "@/store/store";
 import NodeEditDialog from "./node-edit-dialog";
 
 function EvidenceNode({ data, ...props }: NodeProps) {
 	const [editDialogOpen, setEditDialogOpen] = useState(false);
+	const { assuranceCase } = useStore();
 
 	const url = data.URL || data.url;
 	const fallback = url ? [url] : [];
 	const urls: string[] = data.urls?.length ? data.urls : fallback;
 	const node = { data, position: { x: 0, y: 0 }, ...props };
+
+	const badgeSlot = useElementBadgeSlot({
+		caseId: assuranceCase?.id?.toString() ?? "",
+		elementId: String(data.id),
+		elementType: "evidence",
+	});
 
 	const dataTour =
 		data.isDemo && data.name === "E1" ? "demo-evidence-1" : undefined;
@@ -37,6 +46,7 @@ function EvidenceNode({ data, ...props }: NodeProps) {
 				name={data.name}
 				nodeType="evidence"
 				selected={props.selected}
+				topRightActions={badgeSlot}
 			>
 				{urls.length > 0 && (
 					<div className="space-y-1">

--- a/components/cases/goal-node.tsx
+++ b/components/cases/goal-node.tsx
@@ -5,6 +5,8 @@ import { memo, useState } from "react";
 import type { NodeProps } from "reactflow";
 import { BaseNode, NodeActionGroup } from "@/components/shared/nodes";
 import ActionTooltip from "@/components/ui/action-tooltip";
+import { useElementBadgeSlot } from "@/hooks/use-element-badge-slot";
+import useStore from "@/store/store";
 import NodeAddPopover from "./node-add-popover";
 import NodeEditDialog from "./node-edit-dialog";
 import ToggleButton from "./toggle-button";
@@ -12,8 +14,15 @@ import ToggleButton from "./toggle-button";
 function GoalNode({ data, ...props }: NodeProps) {
 	const [editDialogOpen, setEditDialogOpen] = useState(false);
 	const [addPopoverOpen, setAddPopoverOpen] = useState(false);
+	const { assuranceCase } = useStore();
 
 	const node = { data, position: { x: 0, y: 0 }, ...props };
+
+	const badgeSlot = useElementBadgeSlot({
+		caseId: assuranceCase?.id?.toString() ?? "",
+		elementId: String(data.id),
+		elementType: "goal",
+	});
 
 	const addPopover = (
 		<NodeAddPopover
@@ -67,6 +76,7 @@ function GoalNode({ data, ...props }: NodeProps) {
 				name={data.name}
 				nodeType="goal"
 				selected={props.selected}
+				topRightActions={badgeSlot}
 			/>
 
 			{/* Edit Dialog */}

--- a/components/cases/node-edit-dialog.tsx
+++ b/components/cases/node-edit-dialog.tsx
@@ -24,13 +24,16 @@ import {
 	FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { useElementPanelSlot } from "@/hooks/use-element-panel-slot";
 import { updateAssuranceCaseNode } from "@/lib/case";
 import {
 	type NodeEditFormInput,
 	nodeEditFormSchema,
 } from "@/lib/schemas/element";
 import { recordUpdate } from "@/lib/services/history-service";
+import useStore from "@/store/store";
 
 type FormValues = NodeEditFormInput;
 
@@ -296,6 +299,8 @@ export default function NodeEditDialog({
 	const [newContextValue, setNewContextValue] = useState("");
 	const componentId = useId();
 	const [idCounter, setIdCounter] = useState(0);
+	const { assuranceCase } = useStore();
+	const panelSlot = useElementPanelSlot();
 
 	const form = useForm<FormValues>({
 		resolver: zodResolver(nodeEditFormSchema),
@@ -414,6 +419,90 @@ export default function NodeEditDialog({
 	const nodeName = (node.data?.name as string) || "Element";
 	const nodeTypeLabel = nodeType.charAt(0).toUpperCase() + nodeType.slice(1);
 
+	// The `element-panel` slot (ADR 0002 v2 §2.3): when no enabled plugin has
+	// registered a panel, `detailsForm` renders directly with no `Tabs`
+	// wrapper at all — the DOM stays identical to the pre-slot dialog (no
+	// ghost tab, no extra strip). Only once a registration exists does the
+	// dialog grow a "Details" tab alongside the plugin's own.
+	const detailsForm = (
+		<Form {...form}>
+			<form className="space-y-4" onSubmit={form.handleSubmit(handleSubmit)}>
+				<TextFieldSection
+					form={form}
+					label="Description"
+					name="description"
+					placeholder="Type your description here."
+					readOnly={readOnly}
+				/>
+
+				{supportsAttributes(nodeType) && (
+					<>
+						<TextFieldSection
+							form={form}
+							label="Assumption"
+							name="assumption"
+							placeholder="Type your assumption here (optional)."
+							readOnly={readOnly}
+						/>
+						<TextFieldSection
+							form={form}
+							label="Justification"
+							name="justification"
+							placeholder="Type your justification here (optional)."
+							readOnly={readOnly}
+						/>
+						<ContextSection
+							contextItems={contextItems}
+							newContextValue={newContextValue}
+							onAddContext={addContext}
+							onNewContextChange={setNewContextValue}
+							onRemoveContext={removeContext}
+							readOnly={readOnly}
+						/>
+					</>
+				)}
+
+				{nodeType === "evidence" && (
+					<UrlsSection
+						fields={fields}
+						form={form}
+						onAppend={() => append({ value: "" })}
+						onRemove={remove}
+						readOnly={readOnly}
+					/>
+				)}
+
+				<DialogFooter className="pt-4">
+					<Button onClick={handleClose} type="button" variant="outline">
+						{readOnly ? "Close" : "Cancel"}
+					</Button>
+					{!readOnly && (
+						<Button
+							className="bg-primary text-primary-foreground hover:bg-primary/90"
+							disabled={loading}
+							type="submit"
+						>
+							{loading ? (
+								<span className="flex items-center gap-2">
+									<Loader2 className="h-4 w-4 animate-spin" />
+									Updating...
+								</span>
+							) : (
+								<span>Update {nodeTypeLabel}</span>
+							)}
+						</Button>
+					)}
+				</DialogFooter>
+			</form>
+		</Form>
+	);
+
+	const panelContext = {
+		caseId: assuranceCase?.id?.toString() ?? "",
+		elementId: String(node.data?.id ?? ""),
+		elementType: nodeType,
+	};
+
 	return (
 		<Dialog onOpenChange={handleOpenChange} open={open}>
 			<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
@@ -428,79 +517,29 @@ export default function NodeEditDialog({
 					</DialogDescription>
 				</DialogHeader>
 
-				<Form {...form}>
-					<form
-						className="space-y-4"
-						onSubmit={form.handleSubmit(handleSubmit)}
-					>
-						<TextFieldSection
-							form={form}
-							label="Description"
-							name="description"
-							placeholder="Type your description here."
-							readOnly={readOnly}
-						/>
-
-						{supportsAttributes(nodeType) && (
-							<>
-								<TextFieldSection
-									form={form}
-									label="Assumption"
-									name="assumption"
-									placeholder="Type your assumption here (optional)."
-									readOnly={readOnly}
-								/>
-								<TextFieldSection
-									form={form}
-									label="Justification"
-									name="justification"
-									placeholder="Type your justification here (optional)."
-									readOnly={readOnly}
-								/>
-								<ContextSection
-									contextItems={contextItems}
-									newContextValue={newContextValue}
-									onAddContext={addContext}
-									onNewContextChange={setNewContextValue}
-									onRemoveContext={removeContext}
-									readOnly={readOnly}
-								/>
-							</>
-						)}
-
-						{nodeType === "evidence" && (
-							<UrlsSection
-								fields={fields}
-								form={form}
-								onAppend={() => append({ value: "" })}
-								onRemove={remove}
-								readOnly={readOnly}
-							/>
-						)}
-
-						<DialogFooter className="pt-4">
-							<Button onClick={handleClose} type="button" variant="outline">
-								{readOnly ? "Close" : "Cancel"}
-							</Button>
-							{!readOnly && (
-								<Button
-									className="bg-primary text-primary-foreground hover:bg-primary/90"
-									disabled={loading}
-									type="submit"
-								>
-									{loading ? (
-										<span className="flex items-center gap-2">
-											<Loader2 className="h-4 w-4 animate-spin" />
-											Updating...
-										</span>
-									) : (
-										<span>Update {nodeTypeLabel}</span>
-									)}
-								</Button>
+				{panelSlot.registrations.length === 0 ? (
+					detailsForm
+				) : (
+					<Tabs defaultValue="details">
+						<TabsList>
+							<TabsTrigger value="details">Details</TabsTrigger>
+							{panelSlot.registrations.map(
+								({ pluginId, tabId, label, icon: Icon }) => (
+									<TabsTrigger key={pluginId} value={tabId}>
+										{Icon && <Icon className="mr-1.5 h-3.5 w-3.5" />}
+										{label}
+									</TabsTrigger>
+								)
 							)}
-						</DialogFooter>
-					</form>
-				</Form>
+						</TabsList>
+						<TabsContent value="details">{detailsForm}</TabsContent>
+						{panelSlot.registrations.map(({ pluginId, tabId, Component }) => (
+							<TabsContent key={pluginId} value={tabId}>
+								<Component {...panelContext} />
+							</TabsContent>
+						))}
+					</Tabs>
+				)}
 			</DialogContent>
 		</Dialog>
 	);

--- a/components/cases/property-node.tsx
+++ b/components/cases/property-node.tsx
@@ -5,6 +5,8 @@ import { memo, useState } from "react";
 import type { NodeProps } from "reactflow";
 import { BaseNode, NodeActionGroup } from "@/components/shared/nodes";
 import ActionTooltip from "@/components/ui/action-tooltip";
+import { useElementBadgeSlot } from "@/hooks/use-element-badge-slot";
+import useStore from "@/store/store";
 import NodeAddPopover from "./node-add-popover";
 import NodeEditDialog from "./node-edit-dialog";
 import ToggleButton from "./toggle-button";
@@ -12,8 +14,15 @@ import ToggleButton from "./toggle-button";
 function PropertyNode({ data, ...props }: NodeProps) {
 	const [editDialogOpen, setEditDialogOpen] = useState(false);
 	const [addPopoverOpen, setAddPopoverOpen] = useState(false);
+	const { assuranceCase } = useStore();
 
 	const node = { data, position: { x: 0, y: 0 }, ...props };
+
+	const badgeSlot = useElementBadgeSlot({
+		caseId: assuranceCase?.id?.toString() ?? "",
+		elementId: String(data.id),
+		elementType: "property",
+	});
 
 	const addPopover = (
 		<NodeAddPopover
@@ -65,6 +74,7 @@ function PropertyNode({ data, ...props }: NodeProps) {
 				name={data.name}
 				nodeType="property"
 				selected={props.selected}
+				topRightActions={badgeSlot}
 			/>
 
 			{/* Edit Dialog */}

--- a/components/cases/strategy-node.tsx
+++ b/components/cases/strategy-node.tsx
@@ -5,6 +5,8 @@ import { memo, useState } from "react";
 import type { NodeProps } from "reactflow";
 import { BaseNode, NodeActionGroup } from "@/components/shared/nodes";
 import ActionTooltip from "@/components/ui/action-tooltip";
+import { useElementBadgeSlot } from "@/hooks/use-element-badge-slot";
+import useStore from "@/store/store";
 import NodeAddPopover from "./node-add-popover";
 import NodeEditDialog from "./node-edit-dialog";
 import ToggleButton from "./toggle-button";
@@ -12,8 +14,15 @@ import ToggleButton from "./toggle-button";
 function StrategyNode({ data, ...props }: NodeProps) {
 	const [editDialogOpen, setEditDialogOpen] = useState(false);
 	const [addPopoverOpen, setAddPopoverOpen] = useState(false);
+	const { assuranceCase } = useStore();
 
 	const node = { data, position: { x: 0, y: 0 }, ...props };
+
+	const badgeSlot = useElementBadgeSlot({
+		caseId: assuranceCase?.id?.toString() ?? "",
+		elementId: String(data.id),
+		elementType: "strategy",
+	});
 
 	const addPopover = (
 		<NodeAddPopover
@@ -65,6 +74,7 @@ function StrategyNode({ data, ...props }: NodeProps) {
 				name={data.name}
 				nodeType="strategy"
 				selected={props.selected}
+				topRightActions={badgeSlot}
 			/>
 
 			{/* Edit Dialog */}

--- a/hooks/__tests__/use-element-badge-slot.test.tsx
+++ b/hooks/__tests__/use-element-badge-slot.test.tsx
@@ -1,0 +1,87 @@
+import { waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ElementSlotContext } from "@/lib/plugins/slots";
+import { elementBadgeSlot } from "@/lib/plugins/slots";
+import { server } from "@/src/__tests__/mocks/server";
+import { render, screen } from "@/src/__tests__/utils/test-utils";
+import { useElementBadgeSlot } from "../use-element-badge-slot";
+
+const CONTEXT: ElementSlotContext = {
+	caseId: "case-1",
+	elementId: "42",
+	elementType: "goal",
+};
+
+function FakeBadge({ elementId }: ElementSlotContext) {
+	return <span data-testid="fake-badge">{`badge for ${elementId}`}</span>;
+}
+
+function Host({ context }: { context: ElementSlotContext }) {
+	const badge = useElementBadgeSlot(context);
+	return <div data-testid="host">{badge}</div>;
+}
+
+function mockPluginsResponse(enabled: boolean) {
+	server.use(
+		http.get("/api/user/plugins", () =>
+			HttpResponse.json({
+				plugins: [
+					{
+						pluginId: "tea.health",
+						name: "Claim/Evidence Health",
+						version: "0.1.0",
+						available: true,
+						enabled,
+						pinnedAt: enabled ? null : "USER",
+						settings: null,
+					},
+				],
+			})
+		)
+	);
+}
+
+afterEach(() => {
+	elementBadgeSlot.resetForTests();
+	vi.restoreAllMocks();
+});
+
+describe("useElementBadgeSlot", () => {
+	it("renders nothing when the registry has no registrations at all (empty-slot completeness)", async () => {
+		mockPluginsResponse(true);
+
+		render(<Host context={CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.queryByTestId("element-badge-slot")).not.toBeInTheDocument()
+		);
+		expect(screen.getByTestId("host")).toBeEmptyDOMElement();
+	});
+
+	it("renders the badge when an enabled plugin has registered", async () => {
+		elementBadgeSlot.register({ pluginId: "tea.health", Component: FakeBadge });
+		mockPluginsResponse(true);
+
+		render(<Host context={CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.getByTestId("element-badge-slot")).toBeInTheDocument()
+		);
+		expect(screen.getByTestId("fake-badge")).toHaveTextContent("badge for 42");
+	});
+
+	it("renders nothing when the registering plugin is disabled — off as if never registered", async () => {
+		elementBadgeSlot.register({ pluginId: "tea.health", Component: FakeBadge });
+		mockPluginsResponse(false);
+
+		render(<Host context={CONTEXT} />, { withProviders: false });
+
+		await waitFor(() => {
+			// Wait for the fetch to resolve before asserting absence.
+			expect(screen.queryByTestId("fake-badge")).not.toBeInTheDocument();
+		});
+		expect(screen.queryByTestId("element-badge-slot")).not.toBeInTheDocument();
+		expect(screen.getByTestId("host")).toBeEmptyDOMElement();
+	});
+});

--- a/hooks/__tests__/use-element-badge-slot.test.tsx
+++ b/hooks/__tests__/use-element-badge-slot.test.tsx
@@ -3,6 +3,7 @@ import { HttpResponse, http } from "msw";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ElementSlotContext } from "@/lib/plugins/slots";
 import { elementBadgeSlot } from "@/lib/plugins/slots";
+import type { PluginSettingsListItem } from "@/lib/schemas/plugin";
 import { server } from "@/src/__tests__/mocks/server";
 import { render, screen } from "@/src/__tests__/utils/test-utils";
 import { useElementBadgeSlot } from "../use-element-badge-slot";
@@ -36,7 +37,7 @@ function mockPluginsResponse(enabled: boolean) {
 						pinnedAt: enabled ? null : "USER",
 						settings: null,
 					},
-				],
+				] satisfies PluginSettingsListItem[],
 			})
 		)
 	);

--- a/hooks/__tests__/use-element-panel-slot.test.tsx
+++ b/hooks/__tests__/use-element-panel-slot.test.tsx
@@ -3,6 +3,7 @@ import { HttpResponse, http } from "msw";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ElementSlotContext } from "@/lib/plugins/slots";
 import { elementPanelSlot } from "@/lib/plugins/slots";
+import type { PluginSettingsListItem } from "@/lib/schemas/plugin";
 import { server } from "@/src/__tests__/mocks/server";
 import { useElementPanelSlot } from "../use-element-panel-slot";
 
@@ -24,7 +25,7 @@ function mockPluginsResponse(enabled: boolean) {
 						pinnedAt: enabled ? null : "USER",
 						settings: null,
 					},
-				],
+				] satisfies PluginSettingsListItem[],
 			})
 		)
 	);

--- a/hooks/__tests__/use-element-panel-slot.test.tsx
+++ b/hooks/__tests__/use-element-panel-slot.test.tsx
@@ -1,0 +1,78 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ElementSlotContext } from "@/lib/plugins/slots";
+import { elementPanelSlot } from "@/lib/plugins/slots";
+import { server } from "@/src/__tests__/mocks/server";
+import { useElementPanelSlot } from "../use-element-panel-slot";
+
+function FakePanel(_props: ElementSlotContext) {
+	return null;
+}
+
+function mockPluginsResponse(enabled: boolean) {
+	server.use(
+		http.get("/api/user/plugins", () =>
+			HttpResponse.json({
+				plugins: [
+					{
+						pluginId: "tea.health",
+						name: "Claim/Evidence Health",
+						version: "0.1.0",
+						available: true,
+						enabled,
+						pinnedAt: enabled ? null : "USER",
+						settings: null,
+					},
+				],
+			})
+		)
+	);
+}
+
+afterEach(() => {
+	elementPanelSlot.resetForTests();
+	vi.restoreAllMocks();
+});
+
+describe("useElementPanelSlot", () => {
+	it("returns no registrations when the registry is empty", async () => {
+		mockPluginsResponse(true);
+
+		const { result } = renderHook(() => useElementPanelSlot());
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		expect(result.current.registrations).toEqual([]);
+	});
+
+	it("returns the registration when its plugin is enabled", async () => {
+		elementPanelSlot.register({
+			pluginId: "tea.health",
+			tabId: "tea.health",
+			label: "Evidence",
+			Component: FakePanel,
+		});
+		mockPluginsResponse(true);
+
+		const { result } = renderHook(() => useElementPanelSlot());
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		expect(result.current.registrations).toHaveLength(1);
+		expect(result.current.registrations[0]?.tabId).toBe("tea.health");
+	});
+
+	it("omits the registration when its plugin is disabled — off as if never registered", async () => {
+		elementPanelSlot.register({
+			pluginId: "tea.health",
+			tabId: "tea.health",
+			label: "Evidence",
+			Component: FakePanel,
+		});
+		mockPluginsResponse(false);
+
+		const { result } = renderHook(() => useElementPanelSlot());
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		expect(result.current.registrations).toEqual([]);
+	});
+});

--- a/hooks/__tests__/use-plugin-enablement.test.ts
+++ b/hooks/__tests__/use-plugin-enablement.test.ts
@@ -1,0 +1,47 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { server } from "@/src/__tests__/mocks/server";
+import { useEnabledPluginIds } from "../use-plugin-enablement";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("useEnabledPluginIds", () => {
+	it("starts loading, then resolves to only the enabled plugin ids", async () => {
+		server.use(
+			http.get("/api/user/plugins", () =>
+				HttpResponse.json({
+					plugins: [
+						{ pluginId: "tea.health", enabled: true },
+						{ pluginId: "tea.off", enabled: false },
+					],
+				})
+			)
+		);
+
+		const { result } = renderHook(() => useEnabledPluginIds());
+
+		expect(result.current.loading).toBe(true);
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.enabledPluginIds.has("tea.health")).toBe(true);
+		expect(result.current.enabledPluginIds.has("tea.off")).toBe(false);
+	});
+
+	it("degrades to an empty set (never throws) when the fetch fails", async () => {
+		server.use(
+			http.get("/api/user/plugins", () =>
+				HttpResponse.json({ error: "boom" }, { status: 500 })
+			)
+		);
+
+		const { result } = renderHook(() => useEnabledPluginIds());
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.enabledPluginIds.size).toBe(0);
+	});
+});

--- a/hooks/__tests__/use-plugin-enablement.test.ts
+++ b/hooks/__tests__/use-plugin-enablement.test.ts
@@ -1,10 +1,15 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PluginSettingsListItem } from "@/lib/schemas/plugin";
 import { server } from "@/src/__tests__/mocks/server";
-import { useEnabledPluginIds } from "../use-plugin-enablement";
+import {
+	resetPluginFetchDedupeForTests,
+	useEnabledPluginIds,
+} from "../use-plugin-enablement";
 
 afterEach(() => {
+	resetPluginFetchDedupeForTests();
 	vi.restoreAllMocks();
 });
 
@@ -14,9 +19,25 @@ describe("useEnabledPluginIds", () => {
 			http.get("/api/user/plugins", () =>
 				HttpResponse.json({
 					plugins: [
-						{ pluginId: "tea.health", enabled: true },
-						{ pluginId: "tea.off", enabled: false },
-					],
+						{
+							pluginId: "tea.health",
+							name: "Claim/Evidence Health",
+							version: "0.1.0",
+							available: true,
+							enabled: true,
+							pinnedAt: null,
+							settings: null,
+						},
+						{
+							pluginId: "tea.off",
+							name: "Off Plugin",
+							version: "0.1.0",
+							available: true,
+							enabled: false,
+							pinnedAt: "USER",
+							settings: null,
+						},
+					] satisfies PluginSettingsListItem[],
 				})
 			)
 		);
@@ -43,5 +64,49 @@ describe("useEnabledPluginIds", () => {
 		await waitFor(() => expect(result.current.loading).toBe(false));
 
 		expect(result.current.enabledPluginIds.size).toBe(0);
+	});
+
+	it("de-dupes concurrent mounts onto a single in-flight network request", async () => {
+		let hitCount = 0;
+		server.use(
+			http.get("/api/user/plugins", () => {
+				hitCount += 1;
+				return HttpResponse.json({
+					plugins: [
+						{
+							pluginId: "tea.health",
+							name: "Claim/Evidence Health",
+							version: "0.1.0",
+							available: true,
+							enabled: true,
+							pinnedAt: null,
+							settings: null,
+						},
+					] satisfies PluginSettingsListItem[],
+				});
+			})
+		);
+
+		// Mount N hook instances back-to-back with no `await` between them —
+		// this is the canvas's shape (N node components, each pulling
+		// enablement through this hook) rather than a single caller. Every
+		// instance's mount-time effect fires in this same synchronous stretch,
+		// before the mocked fetch above has had a chance to settle, so they
+		// must all observe (and share) the same in-flight promise if the
+		// dedupe is doing its job.
+		const instances = Array.from({ length: 5 }, () =>
+			renderHook(() => useEnabledPluginIds())
+		);
+
+		await waitFor(() => {
+			for (const { result } of instances) {
+				expect(result.current.loading).toBe(false);
+			}
+		});
+
+		for (const { result } of instances) {
+			expect(result.current.enabledPluginIds.has("tea.health")).toBe(true);
+		}
+		expect(hitCount).toBe(1);
 	});
 });

--- a/hooks/use-element-badge-slot.tsx
+++ b/hooks/use-element-badge-slot.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useMemo } from "react";
+import type { ElementSlotContext } from "@/lib/plugins/slots";
+import { elementBadgeSlot } from "@/lib/plugins/slots";
+import { useEnabledPluginIds } from "./use-plugin-enablement";
+
+/**
+ * The `element-badge` slot (ADR 0002 v2 §2.3) for one canvas node.
+ *
+ * Returns `null` — not a component that itself renders null — when no
+ * enabled plugin has registered, or while enablement is still loading.
+ * That distinction matters: a caller passes the result straight into
+ * `BaseNode`'s `topRightActions` prop, which already guards rendering with
+ * `topRightActions && <div>...</div>`. A literal `null` keeps that guard
+ * false, so no wrapper element appears at all — zero layout shift, core
+ * screens stay pixel-identical with the registry empty. Returning a React
+ * element that merely renders null internally would defeat that guard: the
+ * element is truthy even when its own output is nothing.
+ */
+export function useElementBadgeSlot(
+	context: ElementSlotContext
+): ReactNode | null {
+	const { enabledPluginIds, loading } = useEnabledPluginIds();
+
+	const registrations = useMemo(
+		() =>
+			elementBadgeSlot
+				.list()
+				.filter((registration) => enabledPluginIds.has(registration.pluginId)),
+		[enabledPluginIds]
+	);
+
+	if (loading || registrations.length === 0) {
+		return null;
+	}
+
+	return (
+		<div className="flex items-center gap-1" data-testid="element-badge-slot">
+			{registrations.map(({ pluginId, Component }) => (
+				// `key` after the spread so it can't be clobbered if `context`
+				// ever gained a same-named field.
+				<Component {...context} key={pluginId} />
+			))}
+		</div>
+	);
+}

--- a/hooks/use-element-panel-slot.ts
+++ b/hooks/use-element-panel-slot.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useMemo } from "react";
+import type { ElementPanelRegistration } from "@/lib/plugins/slots";
+import { elementPanelSlot } from "@/lib/plugins/slots";
+import { useEnabledPluginIds } from "./use-plugin-enablement";
+
+export interface UseElementPanelSlotResult {
+	/** True until enablement resolves. Treated as "no registrations yet" by callers, matching the settings pane's own loading pattern. */
+	loading: boolean;
+	/** The `element-panel` registrations currently enabled for the session user, in registration order. */
+	registrations: readonly ElementPanelRegistration[];
+}
+
+/**
+ * The enabled `element-panel` registrations for the session user (ADR 0002
+ * v2 §2.3), filtered from the build-time registry by the same effective
+ * enablement state the settings pane reads. Presentational callers (e.g.
+ * `NodeEditDialog`) decide how to lay these out — this hook only answers
+ * "which, if any" — so the tab strip they build never has to know anything
+ * about a plugin beyond `label` / `icon` / `Component`.
+ */
+export function useElementPanelSlot(): UseElementPanelSlotResult {
+	const { enabledPluginIds, loading } = useEnabledPluginIds();
+
+	const registrations = useMemo(
+		() =>
+			elementPanelSlot
+				.list()
+				.filter((registration) => enabledPluginIds.has(registration.pluginId)),
+		[enabledPluginIds]
+	);
+
+	return { registrations, loading };
+}

--- a/hooks/use-plugin-enablement.ts
+++ b/hooks/use-plugin-enablement.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+/** The scope currently pinning a plugin's state, or `null` if nothing is. */
+export type PluginPinnedAt =
+	| "DEPLOYMENT"
+	| "ORGANISATION"
+	| "TEAM"
+	| "USER"
+	| null;
+
+export interface PluginSettingsListItem {
+	available: boolean;
+	enabled: boolean;
+	name: string;
+	pinnedAt: PluginPinnedAt;
+	pluginId: string;
+	settings: unknown;
+	version: string;
+}
+
+interface PluginsResponseBody {
+	plugins: PluginSettingsListItem[];
+}
+
+interface ApiErrorBody {
+	error?: string;
+}
+
+async function parseErrorMessage(response: Response): Promise<string> {
+	const body = (await response.json().catch(() => null)) as ApiErrorBody | null;
+	return body?.error ?? "Something went wrong";
+}
+
+/**
+ * The one fetch mechanism for effective plugin state (ADR 0002 v2 §2.2/§2.3):
+ * both the settings pane (`usePluginSettings`, the full list plus toggling)
+ * and build-time UI slots (`useEnabledPluginIds` below, on/off only) read
+ * through this single call to `/api/user/plugins` — one endpoint, one
+ * response shape, no parallel mechanism invented for slots.
+ */
+export async function fetchPlugins(): Promise<PluginSettingsListItem[]> {
+	const response = await fetch("/api/user/plugins");
+	if (!response.ok) {
+		throw new Error(await parseErrorMessage(response));
+	}
+	const body = (await response.json()) as PluginsResponseBody;
+	return body.plugins;
+}
+
+export interface UseEnabledPluginIdsResult {
+	/** Plugin ids that are effectively ON for the session user right now. */
+	enabledPluginIds: ReadonlySet<string>;
+	/** True until the first fetch resolves (or fails). Slots should render nothing meanwhile, never a placeholder. */
+	loading: boolean;
+}
+
+const EMPTY_SET: ReadonlySet<string> = new Set();
+
+/**
+ * The narrow read UI extension slots need: which plugin ids are effectively
+ * enabled for the session user (ADR 0002 v2 §2.3). Slot components filter
+ * their registry entries (`lib/plugins/slots`) against this set — a
+ * registration whose `pluginId` is absent here renders as if it were never
+ * registered at all.
+ *
+ * A failed fetch degrades to "nothing enabled" rather than risking plugin UI
+ * the server hasn't actually confirmed is on; the settings pane
+ * (`usePluginSettings`) is where the real error surfaces to the user.
+ */
+export function useEnabledPluginIds(): UseEnabledPluginIdsResult {
+	const [enabledPluginIds, setEnabledPluginIds] =
+		useState<ReadonlySet<string>>(EMPTY_SET);
+	const [loading, setLoading] = useState(true);
+
+	const load = useCallback(async () => {
+		try {
+			const plugins = await fetchPlugins();
+			setEnabledPluginIds(
+				new Set(plugins.filter((p) => p.enabled).map((p) => p.pluginId))
+			);
+		} catch {
+			setEnabledPluginIds(EMPTY_SET);
+		}
+	}, []);
+
+	useEffect(() => {
+		setLoading(true);
+		load().finally(() => setLoading(false));
+	}, [load]);
+
+	return { enabledPluginIds, loading };
+}

--- a/hooks/use-plugin-enablement.ts
+++ b/hooks/use-plugin-enablement.ts
@@ -1,24 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-
-/** The scope currently pinning a plugin's state, or `null` if nothing is. */
-export type PluginPinnedAt =
-	| "DEPLOYMENT"
-	| "ORGANISATION"
-	| "TEAM"
-	| "USER"
-	| null;
-
-export interface PluginSettingsListItem {
-	available: boolean;
-	enabled: boolean;
-	name: string;
-	pinnedAt: PluginPinnedAt;
-	pluginId: string;
-	settings: unknown;
-	version: string;
-}
+import type { PluginSettingsListItem } from "@/lib/schemas/plugin";
 
 interface PluginsResponseBody {
 	plugins: PluginSettingsListItem[];
@@ -33,6 +16,31 @@ async function parseErrorMessage(response: Response): Promise<string> {
 	return body?.error ?? "Something went wrong";
 }
 
+async function requestPlugins(): Promise<PluginSettingsListItem[]> {
+	const response = await fetch("/api/user/plugins");
+	if (!response.ok) {
+		throw new Error(await parseErrorMessage(response));
+	}
+	const body = (await response.json()) as PluginsResponseBody;
+	return body.plugins;
+}
+
+/**
+ * De-dupes concurrent callers onto one in-flight request. A canvas full of N
+ * nodes mounts N `useElementBadgeSlot`/`useElementPanelSlot` instances
+ * together (plus, potentially, the settings pane) — without this, each one's
+ * effect fires its own `GET /api/user/plugins` in the same tick, an N+1 fan-
+ * out for data that's identical across every caller (vincent finding,
+ * 2026-07-04 UI-slots review).
+ *
+ * Deliberately NOT a response cache: the slot holds the promise only while
+ * a request is outstanding and clears it (success or failure) as soon as
+ * that request settles, so a later, non-concurrent call — e.g. the refetch
+ * `usePluginSettings.togglePlugin` issues after a PATCH — always goes to the
+ * network rather than replaying stale state.
+ */
+let inFlightFetch: Promise<PluginSettingsListItem[]> | null = null;
+
 /**
  * The one fetch mechanism for effective plugin state (ADR 0002 v2 §2.2/§2.3):
  * both the settings pane (`usePluginSettings`, the full list plus toggling)
@@ -40,13 +48,24 @@ async function parseErrorMessage(response: Response): Promise<string> {
  * through this single call to `/api/user/plugins` — one endpoint, one
  * response shape, no parallel mechanism invented for slots.
  */
-export async function fetchPlugins(): Promise<PluginSettingsListItem[]> {
-	const response = await fetch("/api/user/plugins");
-	if (!response.ok) {
-		throw new Error(await parseErrorMessage(response));
+export function fetchPlugins(): Promise<PluginSettingsListItem[]> {
+	if (inFlightFetch) {
+		return inFlightFetch;
 	}
-	const body = (await response.json()) as PluginsResponseBody;
-	return body.plugins;
+	const promise = requestPlugins().finally(() => {
+		inFlightFetch = null;
+	});
+	inFlightFetch = promise;
+	return promise;
+}
+
+/**
+ * Test-only. Clears any in-flight fetch this module is tracking, so each
+ * test file starts without carrying a pending (or already-settled, awaiting
+ * microtask cleanup) promise over from a previous case.
+ */
+export function resetPluginFetchDedupeForTests(): void {
+	inFlightFetch = null;
 }
 
 export interface UseEnabledPluginIdsResult {

--- a/hooks/use-plugin-settings.ts
+++ b/hooks/use-plugin-settings.ts
@@ -5,15 +5,20 @@ import { fetchPlugins } from "@/hooks/use-plugin-enablement";
 import type { PluginSettingsListItem } from "@/lib/schemas/plugin";
 import { toast } from "@/lib/toast";
 
-// Re-exported so existing consumers (e.g. `PluginToggleRow`) keep importing
-// the settings pane's item shape from this hook — `lib/schemas/plugin.ts` is
-// the single definition (was hand-duplicated with `UserPluginListItem` in
-// `app/api/user/plugins/route.ts`; consolidated 2026-07-04). A second,
-// separate `export ... from` (not re-exporting the local import above) so
-// biome's `noExportedImports` doesn't fire. The fetch itself is delegated to
-// `use-plugin-enablement.ts` — the shared fetch mechanism both this pane and
-// the build-time UI slots read through (`[[TEA — UI extension slots]]`); this
-// hook keeps its own public API unchanged.
+// `PluginSettingsListItem` is re-exported so existing consumers (e.g.
+// `PluginToggleRow`) keep importing the settings pane's item shape from this
+// hook — `lib/schemas/plugin.ts` is the single definition (was hand-
+// duplicated with `UserPluginListItem` in `app/api/user/plugins/route.ts`;
+// consolidated 2026-07-04). `PluginPinnedAt` has no consumer of its own
+// through this module today — it's re-exported alongside purely as an
+// API-compat shim, so this hook's public surface doesn't silently shrink
+// for whatever eventually needs the pinning-scope type without going
+// straight to `lib/schemas/plugin.ts`. A second, separate `export ... from`
+// (not re-exporting the local import above) so biome's `noExportedImports`
+// doesn't fire. The fetch itself is delegated to `use-plugin-enablement.ts`
+// — the shared fetch mechanism both this pane and the build-time UI slots
+// read through (`[[TEA — UI extension slots]]`); this hook keeps its own
+// public API unchanged.
 export type {
 	PluginPinnedAt,
 	PluginSettingsListItem,

--- a/hooks/use-plugin-settings.ts
+++ b/hooks/use-plugin-settings.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { fetchPlugins } from "@/hooks/use-plugin-enablement";
 import type { PluginSettingsListItem } from "@/lib/schemas/plugin";
 import { toast } from "@/lib/toast";
 
@@ -9,15 +10,14 @@ import { toast } from "@/lib/toast";
 // the single definition (was hand-duplicated with `UserPluginListItem` in
 // `app/api/user/plugins/route.ts`; consolidated 2026-07-04). A second,
 // separate `export ... from` (not re-exporting the local import above) so
-// biome's `noExportedImports` doesn't fire.
+// biome's `noExportedImports` doesn't fire. The fetch itself is delegated to
+// `use-plugin-enablement.ts` — the shared fetch mechanism both this pane and
+// the build-time UI slots read through (`[[TEA — UI extension slots]]`); this
+// hook keeps its own public API unchanged.
 export type {
 	PluginPinnedAt,
 	PluginSettingsListItem,
 } from "@/lib/schemas/plugin";
-
-interface PluginsResponseBody {
-	plugins: PluginSettingsListItem[];
-}
 
 interface ApiErrorBody {
 	error?: string;
@@ -26,15 +26,6 @@ interface ApiErrorBody {
 async function parseErrorMessage(response: Response): Promise<string> {
 	const body = (await response.json().catch(() => null)) as ApiErrorBody | null;
 	return body?.error ?? "Something went wrong";
-}
-
-async function fetchPlugins(): Promise<PluginSettingsListItem[]> {
-	const response = await fetch("/api/user/plugins");
-	if (!response.ok) {
-		throw new Error(await parseErrorMessage(response));
-	}
-	const body = (await response.json()) as PluginsResponseBody;
-	return body.plugins;
 }
 
 async function requestPluginToggle(

--- a/lib/plugins/slots/__tests__/registry.test.ts
+++ b/lib/plugins/slots/__tests__/registry.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginManifestEntry } from "@/lib/plugins/manifest";
+
+const UNKNOWN_PLUGIN_MESSAGE = /unknown plugin/i;
+const UNDECLARED_SURFACE_MESSAGE = /does not declare this surface/i;
+
+const mockGetManifestEntry =
+	vi.fn<(pluginId: string) => PluginManifestEntry | undefined>();
+
+vi.mock("@/lib/plugins/manifest", () => ({
+	getManifestEntry: (pluginId: string) => mockGetManifestEntry(pluginId),
+}));
+
+// Imported after the mock so the registry module picks up the mocked manifest.
+const { SlotRegistry } = await import("../registry");
+
+const FAKE_PLUGIN: PluginManifestEntry = {
+	id: "tea.fake",
+	name: "Fake Plugin",
+	version: "0.0.1",
+	surfaces: ["element-badge"],
+};
+
+describe("SlotRegistry", () => {
+	beforeEach(() => {
+		mockGetManifestEntry.mockReset();
+	});
+
+	it("registers a plugin whose manifest entry declares this slot's surface", () => {
+		mockGetManifestEntry.mockReturnValue(FAKE_PLUGIN);
+		const registry = new SlotRegistry<{ pluginId: string }>("element-badge");
+
+		registry.register({ pluginId: "tea.fake" });
+
+		expect(registry.list()).toEqual([{ pluginId: "tea.fake" }]);
+	});
+
+	it("rejects a pluginId absent from the manifest", () => {
+		mockGetManifestEntry.mockReturnValue(undefined);
+		const registry = new SlotRegistry<{ pluginId: string }>("element-badge");
+
+		expect(() => registry.register({ pluginId: "tea.does-not-exist" })).toThrow(
+			UNKNOWN_PLUGIN_MESSAGE
+		);
+		expect(registry.list()).toEqual([]);
+	});
+
+	it("rejects a registration into a slot the plugin's manifest entry does not declare", () => {
+		mockGetManifestEntry.mockReturnValue({
+			...FAKE_PLUGIN,
+			surfaces: ["machine-endpoints"], // does not include "element-panel"
+		});
+		const registry = new SlotRegistry<{ pluginId: string }>("element-panel");
+
+		expect(() => registry.register({ pluginId: "tea.fake" })).toThrow(
+			UNDECLARED_SURFACE_MESSAGE
+		);
+		expect(registry.list()).toEqual([]);
+	});
+
+	it("keeps registrations in registration order", () => {
+		mockGetManifestEntry.mockReturnValue(FAKE_PLUGIN);
+		const registry = new SlotRegistry<{ pluginId: string }>("element-badge");
+
+		registry.register({ pluginId: "tea.fake" });
+		registry.register({ pluginId: "tea.fake" });
+
+		expect(registry.list()).toHaveLength(2);
+	});
+
+	it("resetForTests clears every registration", () => {
+		mockGetManifestEntry.mockReturnValue(FAKE_PLUGIN);
+		const registry = new SlotRegistry<{ pluginId: string }>("element-badge");
+		registry.register({ pluginId: "tea.fake" });
+
+		registry.resetForTests();
+
+		expect(registry.list()).toEqual([]);
+	});
+
+	it("keeps distinct slot instances independent of one another", async () => {
+		mockGetManifestEntry.mockReturnValue({
+			...FAKE_PLUGIN,
+			surfaces: ["element-badge", "element-panel"],
+		});
+		const { elementBadgeSlot, elementPanelSlot } = await import("../registry");
+		elementBadgeSlot.resetForTests();
+		elementPanelSlot.resetForTests();
+
+		elementBadgeSlot.register({
+			pluginId: "tea.fake",
+			Component: () => null,
+		});
+
+		expect(elementBadgeSlot.list()).toHaveLength(1);
+		expect(elementPanelSlot.list()).toHaveLength(0);
+
+		elementBadgeSlot.resetForTests();
+	});
+});

--- a/lib/plugins/slots/__tests__/registry.test.ts
+++ b/lib/plugins/slots/__tests__/registry.test.ts
@@ -59,13 +59,24 @@ describe("SlotRegistry", () => {
 	});
 
 	it("keeps registrations in registration order", () => {
-		mockGetManifestEntry.mockReturnValue(FAKE_PLUGIN);
+		const OTHER_PLUGIN: PluginManifestEntry = {
+			id: "tea.other",
+			name: "Other Plugin",
+			version: "0.0.1",
+			surfaces: ["element-badge"],
+		};
+		mockGetManifestEntry.mockImplementation((pluginId) =>
+			pluginId === "tea.fake" ? FAKE_PLUGIN : OTHER_PLUGIN
+		);
 		const registry = new SlotRegistry<{ pluginId: string }>("element-badge");
 
-		registry.register({ pluginId: "tea.fake" });
+		registry.register({ pluginId: "tea.other" });
 		registry.register({ pluginId: "tea.fake" });
 
-		expect(registry.list()).toHaveLength(2);
+		expect(registry.list()).toEqual([
+			{ pluginId: "tea.other" },
+			{ pluginId: "tea.fake" },
+		]);
 	});
 
 	it("resetForTests clears every registration", () => {

--- a/lib/plugins/slots/index.ts
+++ b/lib/plugins/slots/index.ts
@@ -1,0 +1,22 @@
+/**
+ * The UI extension slot registry — public surface (ADR 0002 v2 §2.3).
+ *
+ * Core components import from here only, never from a plugin module
+ * directly (the one-way dependency rule, ADR §1) — there is no plugin
+ * module to import from in 1.0 regardless; this barrel is what makes that
+ * structurally true rather than merely coincidental.
+ */
+
+export {
+	elementBadgeSlot,
+	elementPanelSlot,
+	settingsSectionSlot,
+} from "./registry";
+export type {
+	ElementBadgeRegistration,
+	ElementPanelRegistration,
+	ElementSlotContext,
+	ElementType,
+	SettingsSectionRegistration,
+	SlotId,
+} from "./types";

--- a/lib/plugins/slots/index.ts
+++ b/lib/plugins/slots/index.ts
@@ -5,6 +5,9 @@
  * directly (the one-way dependency rule, ADR §1) — there is no plugin
  * module to import from in 1.0 regardless; this barrel is what makes that
  * structurally true rather than merely coincidental.
+ *
+ * Client-side only — see `./registry`'s module docstring for why a server
+ * import would silently desync from the client's registry instead of erroring.
  */
 
 export {
@@ -13,10 +16,22 @@ export {
 	settingsSectionSlot,
 } from "./registry";
 export type {
+	// Staged re-exports (ADR 0002 v2 §2.3): no consumer imports these four
+	// yet in 1.0 — they exist for the health plugin (1.0's only official
+	// plugin) to register `element-badge`/`settings-section` slots against,
+	// and for the `element-panel`/`case-panel`/`canvas-decorator` id space
+	// `SlotId` already spans. `ElementPanelRegistration` and
+	// `ElementSlotContext` below have real consumers today, so they're
+	// unmarked; these four are dead by fallow's count only because the thing
+	// that will use them hasn't shipped.
+	// fallow-ignore-next-line unused-type
 	ElementBadgeRegistration,
 	ElementPanelRegistration,
 	ElementSlotContext,
+	// fallow-ignore-next-line unused-type
 	ElementType,
+	// fallow-ignore-next-line unused-type
 	SettingsSectionRegistration,
+	// fallow-ignore-next-line unused-type
 	SlotId,
 } from "./types";

--- a/lib/plugins/slots/registry.ts
+++ b/lib/plugins/slots/registry.ts
@@ -1,0 +1,83 @@
+/**
+ * The UI extension slot registry (ADR 0002 v2 §2.3) — the pattern
+ * `lib/export/exporters/base-exporter.ts` already proves, applied to
+ * build-time-registered plugin UI instead of export formats.
+ *
+ * A `SlotRegistry` holds every plugin's registration for one slot id, in
+ * registration order. Registration is validated against the manifest
+ * (`lib/plugins/manifest.ts`) — a plugin can only register into a slot its
+ * own manifest entry admits to using — but says nothing about whether that
+ * registration is currently *enabled* for any given user; that's a runtime
+ * question the render-time consumers (`hooks/use-element-badge-slot.tsx`,
+ * `hooks/use-element-panel-slot.ts`) answer by filtering `.list()` against
+ * effective enablement.
+ */
+
+import { getManifestEntry } from "@/lib/plugins/manifest";
+import type {
+	ElementBadgeRegistration,
+	ElementPanelRegistration,
+	SettingsSectionRegistration,
+	SlotId,
+} from "./types";
+
+export class SlotRegistry<TRegistration extends { pluginId: string }> {
+	private readonly registrations: TRegistration[] = [];
+	private readonly slotId: SlotId;
+
+	constructor(slotId: SlotId) {
+		this.slotId = slotId;
+	}
+
+	/**
+	 * Registers a plugin's contribution to this slot. Call once per plugin
+	 * module, at import time — never per-request. Throws rather than
+	 * returning a `ServiceResult`: an invalid registration is a programming
+	 * error in a first-party plugin module, not user input to report
+	 * gracefully.
+	 *
+	 * Two checks, both load-bearing for the one-way dependency rule (ADR
+	 * §1): the pluginId must be a real manifest entry, and that entry must
+	 * declare this slot's id among its `surfaces` — a plugin cannot show up
+	 * somewhere its own manifest doesn't admit to reaching.
+	 */
+	register(registration: TRegistration): void {
+		const entry = getManifestEntry(registration.pluginId);
+		if (!entry) {
+			throw new Error(
+				`Cannot register '${registration.pluginId}' into slot '${this.slotId}': unknown plugin (not in PLUGIN_MANIFEST)`
+			);
+		}
+		if (!entry.surfaces.includes(this.slotId)) {
+			throw new Error(
+				`Cannot register '${registration.pluginId}' into slot '${this.slotId}': its manifest entry does not declare this surface`
+			);
+		}
+		this.registrations.push(registration);
+	}
+
+	/** Every registration for this slot, in registration order. Callers filter by effective enablement before rendering. */
+	list(): readonly TRegistration[] {
+		return this.registrations;
+	}
+
+	/**
+	 * Test-only. Clears every registration so each test file starts from a
+	 * clean slate — production code must never call this; registrations are
+	 * meant to live for the process lifetime (build-time registration, not
+	 * request-scoped state).
+	 */
+	resetForTests(): void {
+		this.registrations.length = 0;
+	}
+}
+
+/** 1.0 slot registries — one instance per slot id, shared process-wide. */
+export const elementBadgeSlot = new SlotRegistry<ElementBadgeRegistration>(
+	"element-badge"
+);
+export const elementPanelSlot = new SlotRegistry<ElementPanelRegistration>(
+	"element-panel"
+);
+export const settingsSectionSlot =
+	new SlotRegistry<SettingsSectionRegistration>("settings-section");

--- a/lib/plugins/slots/registry.ts
+++ b/lib/plugins/slots/registry.ts
@@ -11,6 +11,16 @@
  * question the render-time consumers (`hooks/use-element-badge-slot.tsx`,
  * `hooks/use-element-panel-slot.ts`) answer by filtering `.list()` against
  * effective enablement.
+ *
+ * Client-side by intent, despite living under `lib/`: the exported instances
+ * below (`elementBadgeSlot` et al.) are one module-level singleton per slot,
+ * populated by official plugin modules calling `.register()` at import time
+ * in the client bundle. Importing this module from server code (a route, a
+ * server action) would spin up a second, unsynchronised registry in the
+ * server runtime — registrations made in one would simply be invisible to
+ * the other, with no error to flag the split. Nothing server-side needs to
+ * import from here yet; enforcing that structurally (an eslint/biome
+ * boundary rule) is a 1.1 concern, not a 1.0 blocker.
  */
 
 import { getManifestEntry } from "@/lib/plugins/manifest";

--- a/lib/plugins/slots/types.ts
+++ b/lib/plugins/slots/types.ts
@@ -1,0 +1,75 @@
+/**
+ * Types for the build-time UI extension slot registry (ADR 0002 v2 §2.3).
+ *
+ * "Build-time" is the operative word: a slot is filled by an official
+ * plugin's module calling `.register()` at import time (see `registry.ts`),
+ * not by anything resolved per-request. Which registrations actually render
+ * for a given user is a separate, later question answered by consulting
+ * effective plugin enablement (`hooks/use-plugin-enablement.ts`) — this
+ * module only knows "what could show up here", never "is it on right now".
+ */
+
+import type { ComponentType } from "react";
+import type { PluginSurface } from "@/lib/plugins/manifest";
+
+/**
+ * Mirrors `DiagramNodeType` (`components/shared/nodes/node-config.ts`) as a
+ * standalone literal union rather than importing it. `lib/` does not import
+ * from `components/` anywhere else in this codebase — only the reverse
+ * direction is established — and pulling a component-layer type in here
+ * would be the first crack in that layering for a type that is,
+ * structurally, just a string enum. The two unions are identical, so a
+ * `DiagramNodeType` value passes through call sites with no cast needed.
+ */
+export type ElementType = "evidence" | "goal" | "property" | "strategy";
+
+/**
+ * The UI slot ids a plugin may register into — a subset of `PluginSurface`
+ * (`extension-data` / `plugin-tables` / `machine-endpoints` / `events` are
+ * non-UI surfaces with no registry here). ADR §2.3 also names `case-panel`
+ * and `canvas-decorator` as 1.1 slots; they're included in this union so
+ * their eventual registries slot in without a type redesign, but 1.0 builds
+ * a live `SlotRegistry` instance only for the three below (`registry.ts`) —
+ * there is no official plugin consuming the other two yet.
+ */
+export type SlotId = Extract<
+	PluginSurface,
+	| "canvas-decorator"
+	| "case-panel"
+	| "element-badge"
+	| "element-panel"
+	| "settings-section"
+>;
+
+/** Everything an element-scoped slot's render function needs to key its own data (tier-1 `PluginData` is namespaced by case + element). */
+export interface ElementSlotContext {
+	caseId: string;
+	elementId: string;
+	elementType: ElementType;
+}
+
+interface SlotRegistrationBase {
+	/** Must name a `PluginManifestEntry.id` whose `surfaces` includes this slot's id — enforced at `.register()` time, not just documented. */
+	pluginId: string;
+}
+
+/** A small status affordance rendered on a canvas node (ADR §2.3: "the state dot"). */
+export interface ElementBadgeRegistration extends SlotRegistrationBase {
+	Component: ComponentType<ElementSlotContext>;
+}
+
+/** A tab contributed to the element detail view (ADR §2.3: "the evidence log / trace view"). */
+export interface ElementPanelRegistration extends SlotRegistrationBase {
+	Component: ComponentType<ElementSlotContext>;
+	/** Optional leading icon for the tab trigger. */
+	icon?: ComponentType<{ className?: string }>;
+	/** Tab trigger label, e.g. "Evidence". */
+	label: string;
+	/** Stable per registration — becomes the Radix `Tabs` value; must be unique among a given element's panel tabs. */
+	tabId: string;
+}
+
+/** A plugin's own settings UI within its row in the plugins pane (ADR §2.3: "settings-section ... All"). */
+export interface SettingsSectionRegistration extends SlotRegistrationBase {
+	Component: ComponentType<{ pluginId: string }>;
+}


### PR DESCRIPTION
## Summary

Adds the build-time UI extension points for official plugins (ADR 0002 v2 §2.3) — the two slots the health plugin needs in 1.0, plus the registry that fills them:

- **Slot registry** (`lib/plugins/slots/`): typed, build-time registration validated against the plugin manifest's declared surfaces; client-side singletons with the one-way import rule made structural (core imports the registry; no path reaches a plugin module).
- **`element-badge`** — a status-affordance region on canvas nodes, wired through `BaseNode`'s existing `topRightActions` prop: zero edits to `BaseNode` itself, zero layout shift when empty.
- **`element-panel`** — a plugin-contributed tab in the element detail dialog; with no registrations the dialog renders the bare form byte-identically to before (no tab strip in the DOM).
- **Enablement-aware rendering**: slots consult the per-user effective plugin state through one shared fetch (`use-plugin-enablement.ts`, also now backing the settings pane's hook); a disabled plugin is treated as never registered. Concurrent mounts (an N-node canvas) de-dupe onto a single in-flight request — proven by a 5-instance concurrent-mount test asserting exactly one network call.
- The pane's settings-section slot now renders only for effectively-enabled plugins, with tests for both states.

The 1.1 slot ids (`case-panel`, `canvas-decorator`) are typed but deliberately have no registry instances — designed-for, not built.

## Review chain

Implementation reviewed frozen; all findings addressed in one follow-up commit; reviewed-to-final delta (including the rebase onto #840) read in full before this PR:

- **QA:** pass with findings — the headline catch was a documented-but-unwired contract (the settings slot claimed call-site gating that didn't exist); now enforced and tested. A tautological ordering test was made real; test fixtures are now type-tied to the API contract (`satisfies`) so drift breaks the build; React `act()` warnings root-caused to a non-act-aware local test helper and fixed.
- **Code review:** approve with comments — one-way import rule verified line-by-line; fail-closed fetch behaviour confirmed (fetch failure renders nothing, never broken UI); the N+1 fetch fan-out flagged and fixed as above. Dead-code audit: the four intentionally-staged type re-exports (consumers arrive with the health plugin) carry explicit staged suppressions; nothing else introduced.

## Test evidence (final commit)

- Lint: 647 files clean · typecheck clean · react-doctor 88/100, no issues
- Unit: 925/925 · Integration: 543/543 (full suite)

Base TEA with no plugins enabled renders pixel-equivalent to pre-slot screens; enabling the health plugin (next issue) surfaces badge + panel with no core-component edits.
