### PR TITLE
feat(plugins): health plugin UI — badge, evidence panel, bootstrap, live updates

### DIFF
--- a/app/api/elements/[id]/health/route.ts
+++ b/app/api/elements/[id]/health/route.ts
@@ -1,0 +1,58 @@
+import type { NextRequest } from "next/server";
+import {
+	apiError,
+	apiErrorFromUnknown,
+	apiSuccess,
+	requireAuthSession,
+	serviceErrorToAppError,
+} from "@/lib/api-response";
+import { validationError } from "@/lib/errors";
+import { uuidSchema } from "@/lib/schemas/base";
+import { readHealthState } from "@/lib/services/health-scoring-service";
+
+/**
+ * GET /api/elements/[id]/health
+ *
+ * The `tea.health` plugin's per-claim score read (ADR 0002 v2 §3) — the
+ * `element-badge`/`element-panel` UI slots' data source for
+ * `{ score, lastEvaluatedAt, validityWindowSeconds }`. Human session only,
+ * mirroring the auth shape of sibling routes in `app/api/elements/[id]/*`
+ * (comments, attach, detach, move) rather than the machine-token dual-auth
+ * of `/api/machine/health/elements/[id]/evidence`: no integration needs to
+ * read a derived score directly, only the evidence log it writes.
+ *
+ * @description Refuses with a clean error (never a 500) when `tea.health`
+ * is unavailable/disabled for the session user, or when the element isn't a
+ * claim this session can access. `health: null` (200, not an error) means
+ * the claim exists and is accessible but has never been scored.
+ * @response 200 - `{ health: { score, lastEvaluatedAt, validityWindowSeconds } | null }`
+ * @response 400 - `id` is not a UUID
+ * @response 401 - No session
+ * @response 403 - The `tea.health` plugin is not enabled for this deployment/user
+ * @response 404 - Claim not found (covers non-existent, soft-deleted, and no-access — same message, no enumeration oracle)
+ * @auth SessionAuth
+ * @tag Elements
+ */
+export async function GET(
+	_request: NextRequest,
+	{ params }: { params: Promise<{ id: string }> }
+) {
+	try {
+		const session = await requireAuthSession();
+		const { id } = await params;
+
+		const parsedId = uuidSchema.safeParse(id);
+		if (!parsedId.success) {
+			return apiError(validationError("Invalid element id"));
+		}
+
+		const result = await readHealthState(session.userId, parsedId.data);
+		if ("error" in result) {
+			return apiError(serviceErrorToAppError(result.error));
+		}
+
+		return apiSuccess({ health: result.data });
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}

--- a/hooks/__tests__/use-case-events.test.ts
+++ b/hooks/__tests__/use-case-events.test.ts
@@ -1,0 +1,130 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SSEEvent } from "@/lib/services/sse-connection-manager";
+import { CASE_EVENT_TYPES, useCaseEvents } from "../use-case-events";
+
+/**
+ * A fake `EventSource` — jsdom does not implement the real thing, and the
+ * component-level tests (`health-badge.test.tsx`, `health-panel.test.tsx`)
+ * mock `useCaseEvents` itself rather than exercising its SSE wiring. This is
+ * the one test that actually drives `connect()`'s `addEventListener` calls,
+ * so a regression here (a dropped event type, a broken JSON.parse) is the
+ * only thing that would ever catch it (n-F1).
+ */
+class FakeEventSource {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSED = 2;
+	static instances: FakeEventSource[] = [];
+
+	readonly url: string;
+	readyState = FakeEventSource.CONNECTING;
+	onopen: (() => void) | null = null;
+	onerror: (() => void) | null = null;
+	private readonly listeners = new Map<
+		string,
+		Set<(e: MessageEvent) => void>
+	>();
+
+	constructor(url: string) {
+		this.url = url;
+		FakeEventSource.instances.push(this);
+	}
+
+	addEventListener(type: string, listener: (e: MessageEvent) => void): void {
+		if (!this.listeners.has(type)) {
+			this.listeners.set(type, new Set());
+		}
+		this.listeners.get(type)?.add(listener);
+	}
+
+	removeEventListener(type: string, listener: (e: MessageEvent) => void): void {
+		this.listeners.get(type)?.delete(listener);
+	}
+
+	close(): void {
+		this.readyState = FakeEventSource.CLOSED;
+	}
+
+	/** Test helper: fires every listener registered for `type` with `data` JSON-serialised, as the real EventSource would. */
+	dispatch(type: string, data: unknown): void {
+		const event = { data: JSON.stringify(data) } as MessageEvent;
+		for (const listener of this.listeners.get(type) ?? []) {
+			listener(event);
+		}
+	}
+
+	hasListenerFor(type: string): boolean {
+		return (this.listeners.get(type)?.size ?? 0) > 0;
+	}
+}
+
+function stateChangedEvent(overrides: Partial<SSEEvent> = {}): SSEEvent {
+	return {
+		type: "tea.health/state-changed",
+		caseId: "case-1",
+		timestamp: new Date().toISOString(),
+		payload: { claimId: "claim-1" },
+		...overrides,
+	} as SSEEvent;
+}
+
+let originalEventSource: typeof EventSource;
+
+beforeEach(() => {
+	FakeEventSource.instances = [];
+	originalEventSource = global.EventSource;
+	global.EventSource = FakeEventSource as unknown as typeof EventSource;
+});
+
+afterEach(() => {
+	global.EventSource = originalEventSource;
+	vi.restoreAllMocks();
+});
+
+describe("useCaseEvents — SSE listener registration", () => {
+	it("registers an addEventListener for every entry in CASE_EVENT_TYPES", () => {
+		renderHook(() => useCaseEvents({ caseId: "case-1" }));
+
+		const instance = FakeEventSource.instances.at(-1);
+		expect(instance).toBeDefined();
+		for (const eventType of CASE_EVENT_TYPES) {
+			expect(instance?.hasListenerFor(eventType)).toBe(true);
+		}
+	});
+
+	it("registers a listener for the health plugin's namespaced event type specifically", () => {
+		renderHook(() => useCaseEvents({ caseId: "case-1" }));
+
+		const instance = FakeEventSource.instances.at(-1);
+		expect(instance?.hasListenerFor("tea.health/state-changed")).toBe(true);
+	});
+});
+
+describe("useCaseEvents — event delivery", () => {
+	it("delivers a dispatched tea.health/state-changed message to onEvent", () => {
+		const onEvent = vi.fn();
+		renderHook(() => useCaseEvents({ caseId: "case-1", onEvent }));
+		const instance = FakeEventSource.instances.at(-1);
+		const event = stateChangedEvent();
+
+		act(() => {
+			instance?.dispatch("tea.health/state-changed", event);
+		});
+
+		expect(onEvent).toHaveBeenCalledTimes(1);
+		expect(onEvent).toHaveBeenCalledWith(event);
+	});
+
+	it("exposes the same event as lastEvent", () => {
+		const { result } = renderHook(() => useCaseEvents({ caseId: "case-1" }));
+		const instance = FakeEventSource.instances.at(-1);
+		const event = stateChangedEvent({ payload: { claimId: "claim-42" } });
+
+		act(() => {
+			instance?.dispatch("tea.health/state-changed", event);
+		});
+
+		expect(result.current.lastEvent).toEqual(event);
+	});
+});

--- a/hooks/use-case-events.ts
+++ b/hooks/use-case-events.ts
@@ -8,7 +8,7 @@ import type {
 
 type ConnectionStatus = "disconnected" | "connecting" | "connected" | "error";
 
-interface UseCaseEventsOptions {
+export interface UseCaseEventsOptions {
 	/** Case ID to subscribe to */
 	caseId: string;
 	/** Whether the hook is enabled */
@@ -161,6 +161,15 @@ export function useCaseEvents({
 			"element:detached",
 			"element:moved",
 			"permission:changed",
+			// Plugin-emitted events are namespaced (ADR 0002 v2 §2.5) but still
+			// flow through this generic case-event stream — `browser EventSource`
+			// only fires for event names it has a registered listener for, so a
+			// namespaced type omitted here is silently dropped even though the
+			// connection manager broadcasts it. This hook stays plugin-neutral
+			// (it doesn't know what "tea.health/state-changed" MEANS, only that
+			// the closed `SSEEventType` union names it) — see the health plugin's
+			// UI module (`lib/plugins/health/`) for the consumer.
+			"tea.health/state-changed",
 		];
 
 		for (const eventType of eventTypes) {

--- a/hooks/use-case-events.ts
+++ b/hooks/use-case-events.ts
@@ -40,6 +40,36 @@ const DEFAULT_MAX_RECONNECT_ATTEMPTS = 5;
 const DEFAULT_RECONNECT_DELAY = 1000;
 
 /**
+ * Every event type this hook registers an `EventSource.addEventListener` for
+ * — exported (rather than kept function-local) so a test can assert
+ * registration coverage against the SAME list the hook actually uses,
+ * instead of a hand-copied second list that could silently drift.
+ * Plugin-emitted events are namespaced (ADR 0002 v2 §2.5) but still flow
+ * through this generic case-event stream — `EventSource` only fires for
+ * event names it has a registered listener for, so a namespaced type omitted
+ * here is silently dropped even though the connection manager broadcasts it.
+ * This hook stays plugin-neutral (it doesn't know what
+ * "tea.health/state-changed" MEANS, only that the closed `SSEEventType`
+ * union names it) — see the health plugin's UI module (`lib/plugins/
+ * health/`) for the consumer.
+ */
+export const CASE_EVENT_TYPES: SSEEventType[] = [
+	"case:updated",
+	"comment:created",
+	"comment:updated",
+	"comment:deleted",
+	"element:created",
+	"element:updated",
+	"element:deleted",
+	"element:restored",
+	"element:attached",
+	"element:detached",
+	"element:moved",
+	"permission:changed",
+	"tea.health/state-changed",
+];
+
+/**
  * React hook for subscribing to real-time case events via SSE.
  *
  * @example
@@ -147,32 +177,8 @@ export function useCaseEvents({
 			}
 		});
 
-		// Set up event type handlers
-		const eventTypes: SSEEventType[] = [
-			"case:updated",
-			"comment:created",
-			"comment:updated",
-			"comment:deleted",
-			"element:created",
-			"element:updated",
-			"element:deleted",
-			"element:restored",
-			"element:attached",
-			"element:detached",
-			"element:moved",
-			"permission:changed",
-			// Plugin-emitted events are namespaced (ADR 0002 v2 §2.5) but still
-			// flow through this generic case-event stream — `browser EventSource`
-			// only fires for event names it has a registered listener for, so a
-			// namespaced type omitted here is silently dropped even though the
-			// connection manager broadcasts it. This hook stays plugin-neutral
-			// (it doesn't know what "tea.health/state-changed" MEANS, only that
-			// the closed `SSEEventType` union names it) — see the health plugin's
-			// UI module (`lib/plugins/health/`) for the consumer.
-			"tea.health/state-changed",
-		];
-
-		for (const eventType of eventTypes) {
+		// Set up event type handlers — see `CASE_EVENT_TYPES`'s doc comment.
+		for (const eventType of CASE_EVENT_TYPES) {
 			eventSource.addEventListener(eventType, (e) => {
 				try {
 					const event = JSON.parse(e.data) as SSEEvent;

--- a/lib/__tests__/date.test.ts
+++ b/lib/__tests__/date.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatRelativeToNow } from "../date";
+
+describe("formatRelativeToNow", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-07-04T12:00:00.000Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe("the date branch", () => {
+		it("formats a Date object relative to now, with the default 'ago' suffix", () => {
+			const threeDaysAgo = new Date("2026-07-01T12:00:00.000Z");
+			expect(formatRelativeToNow(threeDaysAgo)).toBe("3 days ago");
+		});
+
+		it("formats an ISO string relative to now", () => {
+			expect(formatRelativeToNow("2026-07-04T09:00:00.000Z")).toBe(
+				"about 3 hours ago"
+			);
+		});
+
+		it("formats a numeric timestamp relative to now", () => {
+			const oneHourAgoMs = new Date("2026-07-04T11:00:00.000Z").getTime();
+			expect(formatRelativeToNow(oneHourAgoMs)).toBe("about 1 hour ago");
+		});
+
+		it("formats a future date with the 'in' prefix, not 'ago'", () => {
+			expect(formatRelativeToNow("2026-07-05T12:00:00.000Z")).toBe("in 1 day");
+		});
+	});
+
+	describe("the null/undefined fallback branch", () => {
+		it("returns the default 'N/A' fallback for undefined", () => {
+			expect(formatRelativeToNow(undefined)).toBe("N/A");
+		});
+
+		it("returns the default 'N/A' fallback for null", () => {
+			expect(formatRelativeToNow(null)).toBe("N/A");
+		});
+
+		it("returns a caller-supplied fallback instead of 'N/A' when given one", () => {
+			expect(formatRelativeToNow(null, "Never")).toBe("Never");
+			expect(formatRelativeToNow(undefined, "Never")).toBe("Never");
+		});
+
+		it("does not fall back for a defined date, even one that is falsy-adjacent (epoch 0)", () => {
+			// Guards against a `!date` check standing in for the intended
+			// `date === undefined || date === null` — epoch (timestamp 0) is a
+			// valid date, not a missing one.
+			expect(formatRelativeToNow(0)).not.toBe("N/A");
+		});
+	});
+});

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -3,7 +3,7 @@
  * Uses date-fns for consistent, locale-aware date formatting.
  */
 
-import { format, parseISO } from "date-fns";
+import { format, formatDistanceToNow, parseISO } from "date-fns";
 
 /**
  * Formats a date in DD/MM/YYYY format (British date format).
@@ -48,4 +48,26 @@ export function formatFullDate(
 	}
 	const dateObj = typeof date === "string" ? parseISO(date) : new Date(date);
 	return format(dateObj, "EEEE, d MMMM yyyy 'at' h:mm a");
+}
+
+/**
+ * Formats a date relative to now (e.g., "3 days ago").
+ *
+ * @param date - Date object, ISO string, timestamp, or undefined/null
+ * @param fallback - Optional fallback string if date is undefined/null (defaults to "N/A")
+ * @returns Relative date string (e.g., "3 days ago") or fallback
+ *
+ * @example
+ * formatRelativeToNow("2024-12-15T10:30:00Z") // "3 days ago"
+ * formatRelativeToNow(undefined) // "N/A"
+ */
+export function formatRelativeToNow(
+	date: Date | string | number | undefined | null,
+	fallback = "N/A"
+): string {
+	if (date === undefined || date === null) {
+		return fallback;
+	}
+	const dateObj = typeof date === "string" ? parseISO(date) : new Date(date);
+	return formatDistanceToNow(dateObj, { addSuffix: true });
 }

--- a/lib/plugins/__tests__/bootstrap.test.tsx
+++ b/lib/plugins/__tests__/bootstrap.test.tsx
@@ -1,0 +1,208 @@
+import { waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import type { Node } from "reactflow";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import NodeEditDialog from "@/components/cases/node-edit-dialog";
+import { useCaseEvents } from "@/hooks/use-case-events";
+import { useElementBadgeSlot } from "@/hooks/use-element-badge-slot";
+import { HealthBadge } from "@/lib/plugins/health/health-badge";
+import { HealthPanel } from "@/lib/plugins/health/health-panel";
+import type { ElementSlotContext } from "@/lib/plugins/slots";
+import { elementBadgeSlot, elementPanelSlot } from "@/lib/plugins/slots";
+import type { PluginSettingsListItem } from "@/lib/schemas/plugin";
+import { server } from "@/src/__tests__/mocks/server";
+import { render, screen } from "@/src/__tests__/utils/test-utils";
+
+/**
+ * `lib/plugins/bootstrap.ts` — THE sanctioned import point (ADR 0002 v2
+ * §2.3 implementation decision, cid 2026-07-04) — imported for its real
+ * module-load side effect, exactly as `providers/modal-provider.tsx` imports
+ * it in the running app. This is deliberately NOT test-only registration:
+ * every other health-plugin test either renders `HealthBadge`/`HealthPanel`
+ * directly or (in `node-edit-dialog.test.tsx`) hand-registers a `FakePanel`
+ * test double. This file is the one place proving the production import
+ * chain itself — bootstrap -> health/register -> the slot registries -> the
+ * render-time hooks (`useElementBadgeSlot`/`useElementPanelSlot`) — actually
+ * wires the real components up, with nothing standing in for anything.
+ */
+import "@/lib/plugins/bootstrap";
+
+vi.mock("@/hooks/use-case-events", () => ({
+	useCaseEvents: vi.fn(),
+}));
+
+const CLAIM_ELEMENT_ID = "1";
+const CASE_ID = "case-1";
+const DAY_SECONDS = 24 * 60 * 60;
+
+const CLAIM_CONTEXT: ElementSlotContext = {
+	caseId: CASE_ID,
+	elementId: CLAIM_ELEMENT_ID,
+	elementType: "property",
+};
+
+const PROPERTY_NODE: Node = {
+	id: "1",
+	type: "property",
+	position: { x: 0, y: 0 },
+	data: {
+		id: 1,
+		name: "P1",
+		description: "The system fails safe under load",
+	},
+};
+
+function mockPluginEnabled() {
+	server.use(
+		http.get("/api/user/plugins", () =>
+			HttpResponse.json({
+				plugins: [
+					{
+						pluginId: "tea.health",
+						name: "Claim/Evidence Health",
+						version: "0.1.0",
+						available: true,
+						enabled: true,
+						pinnedAt: null,
+						settings: null,
+					} satisfies PluginSettingsListItem,
+				],
+			})
+		)
+	);
+}
+
+function mockHealthState() {
+	server.use(
+		http.get(`/api/elements/${CLAIM_ELEMENT_ID}/health`, () =>
+			HttpResponse.json({
+				health: {
+					score: 1,
+					lastEvaluatedAt: new Date().toISOString(),
+					validityWindowSeconds: DAY_SECONDS,
+				},
+			})
+		)
+	);
+}
+
+function mockEvidenceLog() {
+	server.use(
+		http.get(`/api/machine/health/elements/${CLAIM_ELEMENT_ID}/evidence`, () =>
+			HttpResponse.json({
+				evidence: [
+					{
+						id: "evidence-1",
+						claimId: CLAIM_ELEMENT_ID,
+						metricName: "in-distribution-rate",
+						value: 0.98,
+						threshold: 0.95,
+						verdict: "PASS",
+						oddDimensions: ["traffic-density"],
+						sourceSystem: "darter-pipeline",
+						provenance: { check: "ood-monitor/kl-divergence" },
+						evaluatedAt: new Date().toISOString(),
+						formatVersion: "0.1",
+						recordHash: "hash-1",
+						previousRecordHash: null,
+						chainSequence: 1,
+						createdAt: new Date().toISOString(),
+						createdById: "system-user-1",
+					},
+				],
+			})
+		)
+	);
+}
+
+/**
+ * A minimal host for the real `useElementBadgeSlot` hook — the same hook
+ * `property-node.tsx`/`goal-node.tsx`/`evidence-node.tsx`/`strategy-node.tsx`
+ * call in production. This is not a registration shortcut: nothing here
+ * registers anything. It only mounts the render-time consumer side of the
+ * chain the top-level `bootstrap` import already populated, without dragging
+ * in the full canvas-node chrome (`BaseNode`/`NodeActionGroup`/
+ * `ToggleButton`/`NodeOptionsMenu`) that this feature doesn't touch and that
+ * `reactflow`'s test-suite-wide mock (`useNodes`/`useEdges` are absent from
+ * it) can't currently support rendering anyway.
+ */
+function ElementBadgeSlotHost(context: ElementSlotContext) {
+	return <>{useElementBadgeSlot(context)}</>;
+}
+
+afterEach(() => {
+	elementBadgeSlot.resetForTests();
+	elementPanelSlot.resetForTests();
+	vi.restoreAllMocks();
+});
+
+describe("lib/plugins/bootstrap — real end-to-end wiring", () => {
+	it("registers the health plugin's real HealthBadge/HealthPanel, then renders both the badge and the Evidence tab through the production hooks", async () => {
+		// The bootstrap's module-load side effect (the bare `import` above)
+		// already ran by the time this test executes — assert it registered
+		// the actual production components (reference equality, not a
+		// look-alike) before rendering anything.
+		expect(elementBadgeSlot.list()).toEqual([
+			{ pluginId: "tea.health", Component: HealthBadge },
+		]);
+		expect(elementPanelSlot.list()).toEqual([
+			{
+				pluginId: "tea.health",
+				tabId: "tea.health",
+				label: "Evidence",
+				Component: HealthPanel,
+			},
+		]);
+
+		vi.mocked(useCaseEvents).mockReturnValue({
+			status: "connected",
+			isConnected: true,
+			lastEvent: null,
+			reconnect: vi.fn(),
+			disconnect: vi.fn(),
+		});
+		mockPluginEnabled();
+		mockHealthState();
+		mockEvidenceLog();
+
+		// --- element-badge slot: the real useElementBadgeSlot hook renders
+		// the real HealthBadge it read out of the registry ---
+		render(<ElementBadgeSlotHost {...CLAIM_CONTEXT} />, {
+			withProviders: false,
+		});
+
+		await waitFor(() =>
+			expect(screen.getByTestId("health-badge-dot")).toBeInTheDocument()
+		);
+		expect(screen.getByTestId("health-badge-dot")).toHaveClass("bg-success");
+
+		// --- element-panel slot: the real NodeEditDialog grows an "Evidence"
+		// tab and renders the real HealthPanel's evidence log inside it ---
+		const user = userEvent.setup();
+		render(
+			<NodeEditDialog
+				node={PROPERTY_NODE}
+				nodeType="property"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={true}
+			/>,
+			{ withProviders: false }
+		);
+
+		await waitFor(() =>
+			expect(screen.getByRole("tablist")).toBeInTheDocument()
+		);
+		expect(screen.getByRole("tab", { name: "Details" })).toBeInTheDocument();
+		const evidenceTab = screen.getByRole("tab", { name: "Evidence" });
+		await user.click(evidenceTab);
+
+		await waitFor(() =>
+			expect(screen.getByTestId("health-evidence-log")).toBeInTheDocument()
+		);
+		expect(screen.getByText("in-distribution-rate")).toBeInTheDocument();
+		expect(screen.getByText("Pass")).toBeInTheDocument();
+	});
+});

--- a/lib/plugins/bootstrap.ts
+++ b/lib/plugins/bootstrap.ts
@@ -1,0 +1,27 @@
+"use client";
+
+/**
+ * THE sanctioned import point for official plugin UI modules (ADR 0002 v2
+ * §2.3 implementation decision, cid 2026-07-04).
+ *
+ * Every official plugin's UI registration module gets one line here — e.g.
+ * `import "@/lib/plugins/health/register";` below — and nothing else. Core
+ * code imports this barrel only, never a plugin module directly: the
+ * one-way dependency rule (ADR §1) stays structural, because there is no
+ * other sanctioned path from app code into a plugin's UI module. Marketplace
+ * / 1.1 plugins register through the same one-line-per-plugin pattern.
+ *
+ * `"use client"` here is load-bearing, not decorative. The slot registries
+ * this chain populates (`lib/plugins/slots/registry.ts`) are client-side
+ * singletons by design — a copy executed on the server would silently
+ * desync from the one the browser's `useElementBadgeSlot`/
+ * `useElementPanelSlot` hooks read from, registering a plugin that never
+ * appears to any real user (see `registry.ts`'s boundary docstring). Putting
+ * the directive on this one sanctioned entry point — rather than relying on
+ * every register module, or every importer of this file, to also carry
+ * it — means the whole chain (this file, `health/register.ts`, the slot
+ * registries, `HealthBadge`/`HealthPanel`) rides a single, structural client
+ * boundary regardless of where this bare import ends up landing.
+ */
+
+import "@/lib/plugins/health/register";

--- a/lib/plugins/health/__tests__/health-badge.test.tsx
+++ b/lib/plugins/health/__tests__/health-badge.test.tsx
@@ -57,6 +57,27 @@ function mockHealthError(elementId: string) {
 	);
 }
 
+/** Mocks `GET /api/user/plugins` — the source `useHealthBandScores` reads `tea.health`'s `verdictScores` settings from. */
+function mockPluginSettings(settings: unknown) {
+	server.use(
+		http.get("/api/user/plugins", () =>
+			HttpResponse.json({
+				plugins: [
+					{
+						pluginId: "tea.health",
+						name: "Claim/Evidence Health",
+						version: "0.1.0",
+						available: true,
+						enabled: true,
+						pinnedAt: null,
+						settings,
+					},
+				],
+			})
+		)
+	);
+}
+
 beforeEach(() => {
 	capturedOptions = undefined;
 	mockUseCaseEvents();
@@ -134,6 +155,54 @@ describe("HealthBadge — bands", () => {
 		expect(screen.getByTestId("health-badge-dot")).toHaveAttribute(
 			"aria-label",
 			"Health: failing"
+		);
+	});
+});
+
+describe("HealthBadge — score→band via plugin settings", () => {
+	it("uses the user's custom verdictScores instead of the defaults", async () => {
+		// A rescaled mapping where a score of 0.7 is the PASS threshold — under
+		// the defaults, 0.7 would land in the "pass" band anyway (closer to
+		// 1 than 0.5); under this custom mapping fail=0/degraded=0.3/pass=0.7,
+		// it's still nearest pass, so this alone wouldn't prove the wiring.
+		// Score 0.3 is unambiguous: default bands would call it "fail" (nearest
+		// to 0), the custom mapping calls it "degraded" (exact match).
+		mockPluginSettings({
+			verdictScores: { PASS: 0.7, DEGRADED: 0.3, FAIL: 0 },
+		});
+		mockHealthResponse(CLAIM_CONTEXT.elementId, {
+			score: 0.3,
+			lastEvaluatedAt: hoursAgo(0),
+			validityWindowSeconds: DAY_SECONDS,
+		});
+		render(<HealthBadge {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.getByTestId("health-badge-dot")).toHaveClass("bg-warning")
+		);
+		expect(screen.getByTestId("health-badge-dot")).toHaveAttribute(
+			"aria-label",
+			"Health: degraded"
+		);
+	});
+
+	it("falls back to the defaults when the settings fetch fails", async () => {
+		server.use(
+			http.get("/api/user/plugins", () =>
+				HttpResponse.json({ error: "boom" }, { status: 500 })
+			)
+		);
+		mockHealthResponse(CLAIM_CONTEXT.elementId, {
+			score: 0,
+			lastEvaluatedAt: hoursAgo(0),
+			validityWindowSeconds: DAY_SECONDS,
+		});
+		render(<HealthBadge {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.getByTestId("health-badge-dot")).toHaveClass(
+				"bg-destructive"
+			)
 		);
 	});
 });

--- a/lib/plugins/health/__tests__/health-badge.test.tsx
+++ b/lib/plugins/health/__tests__/health-badge.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { UseCaseEventsOptions } from "@/hooks/use-case-events";
 import { useCaseEvents } from "@/hooks/use-case-events";
 import type { ElementSlotContext } from "@/lib/plugins/slots";
+import type { PluginSettingsListItem } from "@/lib/schemas/plugin";
 import { server } from "@/src/__tests__/mocks/server";
 import { render, screen } from "@/src/__tests__/utils/test-utils";
 import { HealthBadge } from "../health-badge";
@@ -71,7 +72,7 @@ function mockPluginSettings(settings: unknown) {
 						enabled: true,
 						pinnedAt: null,
 						settings,
-					},
+					} satisfies PluginSettingsListItem,
 				],
 			})
 		)
@@ -203,6 +204,31 @@ describe("HealthBadge — score→band via plugin settings", () => {
 			expect(screen.getByTestId("health-badge-dot")).toHaveClass(
 				"bg-destructive"
 			)
+		);
+	});
+
+	it("falls back to the defaults when the settings response is schema-invalid (200, but verdictScores.PASS is not a number)", async () => {
+		// A 200 response, unlike the fetch-failure case above — the settings
+		// endpoint is up, but `tea.health`'s saved settings blob doesn't parse
+		// as `bandScoresSettingsSchema`. Score 1 is the discriminator: under a
+		// correctly-applied DEFAULT_BAND_SCORES fallback it's an exact match
+		// for "pass" (bg-success); a bug that used the malformed PASS value
+		// literally would make every distance to "pass" resolve to NaN,
+		// leaving the loop stuck on "degraded" (bg-warning) instead.
+		mockPluginSettings({ verdictScores: { PASS: "not-a-number" } });
+		mockHealthResponse(CLAIM_CONTEXT.elementId, {
+			score: 1,
+			lastEvaluatedAt: hoursAgo(0),
+			validityWindowSeconds: DAY_SECONDS,
+		});
+		render(<HealthBadge {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.getByTestId("health-badge-dot")).toHaveClass("bg-success")
+		);
+		expect(screen.getByTestId("health-badge-dot")).toHaveAttribute(
+			"aria-label",
+			"Health: passing"
 		);
 	});
 });
@@ -354,6 +380,40 @@ describe("HealthBadge — live update over SSE", () => {
 			caseId: CLAIM_CONTEXT.caseId,
 			timestamp: hoursAgo(0),
 			payload: { claimId: "some-other-claim" },
+		});
+
+		// Give any (unwanted) refetch a chance to resolve, then assert the
+		// badge did NOT move off the original band.
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(screen.getByTestId("health-badge-dot")).toHaveClass(
+			"bg-destructive"
+		);
+	});
+
+	it("ignores an event of a DIFFERENT type even when the claimId matches (proves the type half of the guard, n-F2)", async () => {
+		mockHealthResponse(CLAIM_CONTEXT.elementId, {
+			score: 0,
+			lastEvaluatedAt: hoursAgo(0),
+			validityWindowSeconds: DAY_SECONDS,
+		});
+		render(<HealthBadge {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.getByTestId("health-badge-dot")).toHaveClass(
+				"bg-destructive"
+			)
+		);
+
+		mockHealthResponse(CLAIM_CONTEXT.elementId, {
+			score: 1,
+			lastEvaluatedAt: hoursAgo(0),
+			validityWindowSeconds: DAY_SECONDS,
+		});
+		capturedOptions?.onEvent?.({
+			type: "element:moved",
+			caseId: CLAIM_CONTEXT.caseId,
+			timestamp: hoursAgo(0),
+			payload: { claimId: CLAIM_CONTEXT.elementId },
 		});
 
 		// Give any (unwanted) refetch a chance to resolve, then assert the

--- a/lib/plugins/health/__tests__/health-badge.test.tsx
+++ b/lib/plugins/health/__tests__/health-badge.test.tsx
@@ -1,0 +1,297 @@
+import { waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UseCaseEventsOptions } from "@/hooks/use-case-events";
+import { useCaseEvents } from "@/hooks/use-case-events";
+import type { ElementSlotContext } from "@/lib/plugins/slots";
+import { server } from "@/src/__tests__/mocks/server";
+import { render, screen } from "@/src/__tests__/utils/test-utils";
+import { HealthBadge } from "../health-badge";
+import type { HealthState } from "../health-bands";
+
+vi.mock("@/hooks/use-case-events", () => ({
+	useCaseEvents: vi.fn(),
+}));
+
+const CLAIM_CONTEXT: ElementSlotContext = {
+	caseId: "case-1",
+	elementId: "claim-42",
+	elementType: "property",
+};
+
+const DAY_SECONDS = 24 * 60 * 60;
+const HOUR_MS = 60 * 60 * 1000;
+
+/** Relative-to-real-time helpers — avoids combining fake timers with RTL's `waitFor` polling. */
+const hoursAgo = (hours: number) =>
+	new Date(Date.now() - hours * HOUR_MS).toISOString();
+
+let capturedOptions: UseCaseEventsOptions | undefined;
+
+function mockUseCaseEvents() {
+	vi.mocked(useCaseEvents).mockImplementation((options) => {
+		capturedOptions = options;
+		return {
+			status: "connected",
+			isConnected: true,
+			lastEvent: null,
+			reconnect: vi.fn(),
+			disconnect: vi.fn(),
+		};
+	});
+}
+
+function mockHealthResponse(elementId: string, health: HealthState | null) {
+	server.use(
+		http.get(`/api/elements/${elementId}/health`, () =>
+			HttpResponse.json({ health })
+		)
+	);
+}
+
+function mockHealthError(elementId: string) {
+	server.use(
+		http.get(`/api/elements/${elementId}/health`, () =>
+			HttpResponse.json({ error: "boom" }, { status: 500 })
+		)
+	);
+}
+
+beforeEach(() => {
+	capturedOptions = undefined;
+	mockUseCaseEvents();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("HealthBadge — bands", () => {
+	it("renders nothing while loading", async () => {
+		mockHealthResponse(CLAIM_CONTEXT.elementId, {
+			score: 1,
+			lastEvaluatedAt: hoursAgo(0),
+			validityWindowSeconds: DAY_SECONDS,
+		});
+		const { container } = render(<HealthBadge {...CLAIM_CONTEXT} />, {
+			withProviders: false,
+		});
+		expect(container).toBeEmptyDOMElement();
+
+		// Let the in-flight fetch settle before the test tears down, so its
+		// state update doesn't land outside an act() batch.
+		await waitFor(() =>
+			expect(screen.getByTestId("health-badge-dot")).toBeInTheDocument()
+		);
+	});
+
+	it("renders the pass band for a score of 1", async () => {
+		mockHealthResponse(CLAIM_CONTEXT.elementId, {
+			score: 1,
+			lastEvaluatedAt: hoursAgo(0),
+			validityWindowSeconds: DAY_SECONDS,
+		});
+		render(<HealthBadge {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.getByTestId("health-badge-dot")).toBeInTheDocument()
+		);
+		const dot = screen.getByTestId("health-badge-dot");
+		expect(dot).toHaveClass("bg-success");
+		expect(dot).toHaveAttribute("aria-label", "Health: passing");
+	});
+
+	it("renders the degraded band for a score of 0.5", async () => {
+		mockHealthResponse(CLAIM_CONTEXT.elementId, {
+			score: 0.5,
+			lastEvaluatedAt: hoursAgo(0),
+			validityWindowSeconds: DAY_SECONDS,
+		});
+		render(<HealthBadge {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.getByTestId("health-badge-dot")).toHaveClass("bg-warning")
+		);
+		expect(screen.getByTestId("health-badge-dot")).toHaveAttribute(
+			"aria-label",
+			"Health: degraded"
+		);
+	});
+
+	it("renders the fail band for a score of 0", async () => {
+		mockHealthResponse(CLAIM_CONTEXT.elementId, {
+			score: 0,
+			lastEvaluatedAt: hoursAgo(0),
+			validityWindowSeconds: DAY_SECONDS,
+		});
+		render(<HealthBadge {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.getByTestId("health-badge-dot")).toHaveClass(
+				"bg-destructive"
+			)
+		);
+		expect(screen.getByTestId("health-badge-dot")).toHaveAttribute(
+			"aria-label",
+			"Health: failing"
+		);
+	});
+});
+
+describe("HealthBadge — staleness", () => {
+	it("shows the quiet stale treatment when lastEvaluatedAt is outside the validity window", async () => {
+		mockHealthResponse(CLAIM_CONTEXT.elementId, {
+			score: 1,
+			lastEvaluatedAt: hoursAgo(72), // 3 days ago, window is 24h
+			validityWindowSeconds: DAY_SECONDS,
+		});
+		render(<HealthBadge {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.getByTestId("health-badge-dot")).toHaveClass(
+				"bg-muted-foreground"
+			)
+		);
+		expect(screen.getByTestId("health-badge-dot")).toHaveAttribute(
+			"aria-label",
+			expect.stringContaining("Health: stale")
+		);
+	});
+
+	it("does not show stale for a score within the validity window", async () => {
+		mockHealthResponse(CLAIM_CONTEXT.elementId, {
+			score: 1,
+			lastEvaluatedAt: hoursAgo(1),
+			validityWindowSeconds: DAY_SECONDS,
+		});
+		render(<HealthBadge {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.getByTestId("health-badge-dot")).toHaveClass("bg-success")
+		);
+	});
+});
+
+describe("HealthBadge — fail-closed rendering", () => {
+	it("renders nothing when there is no health data for the element", async () => {
+		mockHealthResponse(CLAIM_CONTEXT.elementId, null);
+		const { container } = render(<HealthBadge {...CLAIM_CONTEXT} />, {
+			withProviders: false,
+		});
+
+		await waitFor(() => {
+			expect(container).toBeEmptyDOMElement();
+		});
+	});
+
+	it("renders nothing when the fetch fails", async () => {
+		mockHealthError(CLAIM_CONTEXT.elementId);
+		const { container } = render(<HealthBadge {...CLAIM_CONTEXT} />, {
+			withProviders: false,
+		});
+
+		await waitFor(() => {
+			expect(container).toBeEmptyDOMElement();
+		});
+	});
+
+	it("renders nothing for a non-claim element type, without making a request", async () => {
+		const goalContext: ElementSlotContext = {
+			caseId: "case-1",
+			elementId: "goal-1",
+			elementType: "goal",
+		};
+		let requestMade = false;
+		server.use(
+			http.get(`/api/elements/${goalContext.elementId}/health`, () => {
+				requestMade = true;
+				return HttpResponse.json({
+					health: {
+						score: 1,
+						lastEvaluatedAt: hoursAgo(0),
+						validityWindowSeconds: DAY_SECONDS,
+					},
+				});
+			})
+		);
+
+		const { container } = render(<HealthBadge {...goalContext} />, {
+			withProviders: false,
+		});
+
+		// Give any (unwanted) effect a chance to fire before asserting absence.
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(container).toBeEmptyDOMElement();
+		expect(requestMade).toBe(false);
+	});
+});
+
+describe("HealthBadge — live update over SSE", () => {
+	it("refetches when tea.health/state-changed arrives for this element", async () => {
+		mockHealthResponse(CLAIM_CONTEXT.elementId, {
+			score: 0,
+			lastEvaluatedAt: hoursAgo(0),
+			validityWindowSeconds: DAY_SECONDS,
+		});
+		render(<HealthBadge {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.getByTestId("health-badge-dot")).toHaveClass(
+				"bg-destructive"
+			)
+		);
+
+		// The score changes server-side; a fresh evidence POST flips it to PASS.
+		mockHealthResponse(CLAIM_CONTEXT.elementId, {
+			score: 1,
+			lastEvaluatedAt: hoursAgo(0),
+			validityWindowSeconds: DAY_SECONDS,
+		});
+
+		expect(capturedOptions?.onEvent).toBeDefined();
+		capturedOptions?.onEvent?.({
+			type: "tea.health/state-changed",
+			caseId: CLAIM_CONTEXT.caseId,
+			timestamp: hoursAgo(0),
+			payload: { claimId: CLAIM_CONTEXT.elementId },
+		});
+
+		await waitFor(() =>
+			expect(screen.getByTestId("health-badge-dot")).toHaveClass("bg-success")
+		);
+	});
+
+	it("ignores a state-changed event for a different claim", async () => {
+		mockHealthResponse(CLAIM_CONTEXT.elementId, {
+			score: 0,
+			lastEvaluatedAt: hoursAgo(0),
+			validityWindowSeconds: DAY_SECONDS,
+		});
+		render(<HealthBadge {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.getByTestId("health-badge-dot")).toHaveClass(
+				"bg-destructive"
+			)
+		);
+
+		mockHealthResponse(CLAIM_CONTEXT.elementId, {
+			score: 1,
+			lastEvaluatedAt: hoursAgo(0),
+			validityWindowSeconds: DAY_SECONDS,
+		});
+		capturedOptions?.onEvent?.({
+			type: "tea.health/state-changed",
+			caseId: CLAIM_CONTEXT.caseId,
+			timestamp: hoursAgo(0),
+			payload: { claimId: "some-other-claim" },
+		});
+
+		// Give any (unwanted) refetch a chance to resolve, then assert the
+		// badge did NOT move off the original band.
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(screen.getByTestId("health-badge-dot")).toHaveClass(
+			"bg-destructive"
+		);
+	});
+});

--- a/lib/plugins/health/__tests__/health-bands.test.ts
+++ b/lib/plugins/health/__tests__/health-bands.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	DEFAULT_BAND_SCORES,
+	deriveHealthBand,
+	isHealthStale,
+} from "../health-bands";
+
+describe("deriveHealthBand — defaults", () => {
+	it("maps the default PASS score (1) to pass", () => {
+		expect(deriveHealthBand(1)).toBe("pass");
+	});
+
+	it("maps the default DEGRADED score (0.5) to degraded", () => {
+		expect(deriveHealthBand(0.5)).toBe("degraded");
+	});
+
+	it("maps the default FAIL score (0) to fail", () => {
+		expect(deriveHealthBand(0)).toBe("fail");
+	});
+
+	it("maps a score closer to pass than degraded to pass", () => {
+		expect(deriveHealthBand(0.9)).toBe("pass");
+	});
+
+	it("maps a score closer to fail than degraded to fail", () => {
+		expect(deriveHealthBand(0.1)).toBe("fail");
+	});
+
+	it("resolves an exact midpoint tie to the worse band (fail over degraded)", () => {
+		// Midpoint between fail (0) and degraded (0.5) is 0.25 — equidistant.
+		expect(deriveHealthBand(0.25)).toBe("fail");
+	});
+
+	it("resolves the other exact midpoint tie to the worse band (degraded over pass)", () => {
+		// Midpoint between degraded (0.5) and pass (1) is 0.75 — equidistant.
+		expect(deriveHealthBand(0.75)).toBe("degraded");
+	});
+});
+
+describe("deriveHealthBand — custom verdictScores (ADR §2.2 settings mechanism)", () => {
+	it("keeps bands consistent with a rescaled custom mapping", () => {
+		const custom = { fail: 0.1, degraded: 0.4, pass: 0.9 };
+		expect(deriveHealthBand(0.1, custom)).toBe("fail");
+		expect(deriveHealthBand(0.4, custom)).toBe("degraded");
+		expect(deriveHealthBand(0.9, custom)).toBe("pass");
+	});
+
+	it("still resolves ties to the worse band under a custom mapping", () => {
+		const custom = { fail: 0, degraded: 0.5, pass: 1 };
+		expect(deriveHealthBand(0.25, custom)).toBe("fail");
+	});
+
+	it("degrades to nearest-band even under a misconfigured (non-monotonic) mapping", () => {
+		// FAIL scored higher than PASS — deliberately invalid, but the
+		// nearest-distance rule still returns a defined band, never throws.
+		const misconfigured = { fail: 1, degraded: 0.5, pass: 0 };
+		expect(deriveHealthBand(0.9, misconfigured)).toBe("fail");
+		expect(deriveHealthBand(0.1, misconfigured)).toBe("pass");
+	});
+});
+
+describe("DEFAULT_BAND_SCORES", () => {
+	it("mirrors health-scoring-service.ts's DEFAULT_VERDICT_SCORES exactly", () => {
+		expect(DEFAULT_BAND_SCORES).toEqual({ fail: 0, degraded: 0.5, pass: 1 });
+	});
+});
+
+describe("isHealthStale", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-07-04T12:00:00.000Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("is not stale when lastEvaluatedAt is well within the validity window", () => {
+		expect(
+			isHealthStale({
+				score: 1,
+				lastEvaluatedAt: "2026-07-04T11:00:00.000Z", // 1h ago
+				validityWindowSeconds: 24 * 60 * 60, // 24h
+			})
+		).toBe(false);
+	});
+
+	it("is stale when lastEvaluatedAt is outside the validity window", () => {
+		expect(
+			isHealthStale({
+				score: 1,
+				lastEvaluatedAt: "2026-07-01T12:00:00.000Z", // 3 days ago
+				validityWindowSeconds: 24 * 60 * 60, // 24h
+			})
+		).toBe(true);
+	});
+
+	it("treats the exact boundary (age === window) as not stale", () => {
+		expect(
+			isHealthStale({
+				score: 1,
+				lastEvaluatedAt: "2026-07-03T12:00:00.000Z", // exactly 24h ago
+				validityWindowSeconds: 24 * 60 * 60,
+			})
+		).toBe(false);
+	});
+
+	it("treats null lastEvaluatedAt as stale (defensive — currently unreachable in practice)", () => {
+		expect(
+			isHealthStale({
+				score: 1,
+				lastEvaluatedAt: null,
+				validityWindowSeconds: 24 * 60 * 60,
+			})
+		).toBe(true);
+	});
+});

--- a/lib/plugins/health/__tests__/health-panel.test.tsx
+++ b/lib/plugins/health/__tests__/health-panel.test.tsx
@@ -176,18 +176,19 @@ describe("HealthPanel — renders the log", () => {
 
 		const entries = screen.getAllByTestId("health-evidence-entry");
 		expect(entries).toHaveLength(2);
+		const [newest, oldest] = entries as [HTMLElement, HTMLElement];
 		// Newest first: chainSequence 2 (FAIL/ood-divergence) before 1 (PASS).
-		expect(within(entries[0]).getByText("Fail")).toBeInTheDocument();
-		expect(within(entries[0]).getByText("ood-divergence")).toBeInTheDocument();
+		expect(within(newest).getByText("Fail")).toBeInTheDocument();
+		expect(within(newest).getByText("ood-divergence")).toBeInTheDocument();
 		expect(
-			within(entries[0]).getByText("Value: 0.2 — Threshold: 0.1")
+			within(newest).getByText("Value: 0.2 — Threshold: 0.1")
 		).toBeInTheDocument();
 		expect(
-			within(entries[0]).getByText("Source: darter-monitor")
+			within(newest).getByText("Source: darter-monitor")
 		).toBeInTheDocument();
-		expect(within(entries[1]).getByText("Pass")).toBeInTheDocument();
+		expect(within(oldest).getByText("Pass")).toBeInTheDocument();
 		expect(
-			within(entries[1]).getByText("in-distribution-rate")
+			within(oldest).getByText("in-distribution-rate")
 		).toBeInTheDocument();
 	});
 

--- a/lib/plugins/health/__tests__/health-panel.test.tsx
+++ b/lib/plugins/health/__tests__/health-panel.test.tsx
@@ -1,0 +1,246 @@
+import { waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UseCaseEventsOptions } from "@/hooks/use-case-events";
+import { useCaseEvents } from "@/hooks/use-case-events";
+import type { ElementSlotContext } from "@/lib/plugins/slots";
+import { server } from "@/src/__tests__/mocks/server";
+import { render, screen, within } from "@/src/__tests__/utils/test-utils";
+import { HealthPanel } from "../health-panel";
+import type { HealthEvidenceLogItem } from "../use-health-evidence";
+
+vi.mock("@/hooks/use-case-events", () => ({
+	useCaseEvents: vi.fn(),
+}));
+
+const CLAIM_CONTEXT: ElementSlotContext = {
+	caseId: "case-1",
+	elementId: "claim-42",
+	elementType: "property",
+};
+
+const RUN_ID_PROVENANCE_PATTERN = /"runId": "run-42"/;
+
+let capturedOptions: UseCaseEventsOptions | undefined;
+
+function mockUseCaseEvents() {
+	vi.mocked(useCaseEvents).mockImplementation((options) => {
+		capturedOptions = options;
+		return {
+			status: "connected",
+			isConnected: true,
+			lastEvent: null,
+			reconnect: vi.fn(),
+			disconnect: vi.fn(),
+		};
+	});
+}
+
+/** A fixture `satisfies` the real machine-endpoint response item shape (the contract-drift rule). */
+function evidenceItem(
+	overrides: Partial<HealthEvidenceLogItem> = {}
+): HealthEvidenceLogItem {
+	return {
+		id: "evidence-1",
+		claimId: CLAIM_CONTEXT.elementId,
+		metricName: "in-distribution-rate",
+		value: 0.98,
+		threshold: 0.95,
+		verdict: "PASS",
+		oddDimensions: ["traffic-density"],
+		sourceSystem: "darter-pipeline",
+		provenance: { check: "ood-monitor/kl-divergence", runId: "run-1" },
+		evaluatedAt: "2026-07-01T09:00:00.000Z",
+		formatVersion: "0.1",
+		recordHash: "hash-1",
+		previousRecordHash: null,
+		chainSequence: 1,
+		createdAt: "2026-07-01T09:00:01.000Z",
+		createdById: "system-user-1",
+		...overrides,
+	} satisfies HealthEvidenceLogItem;
+}
+
+function mockEvidenceResponse(
+	claimId: string,
+	evidence: HealthEvidenceLogItem[]
+) {
+	server.use(
+		http.get(`/api/machine/health/elements/${claimId}/evidence`, () =>
+			HttpResponse.json({ evidence })
+		)
+	);
+}
+
+function mockEvidenceError(claimId: string) {
+	server.use(
+		http.get(`/api/machine/health/elements/${claimId}/evidence`, () =>
+			HttpResponse.json({ error: "boom" }, { status: 500 })
+		)
+	);
+}
+
+beforeEach(() => {
+	capturedOptions = undefined;
+	mockUseCaseEvents();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("HealthPanel — not applicable to non-claim elements", () => {
+	it("renders a distinct 'not applicable' state for a goal, without making a request", async () => {
+		const goalContext: ElementSlotContext = {
+			caseId: "case-1",
+			elementId: "goal-1",
+			elementType: "goal",
+		};
+		let requestMade = false;
+		server.use(
+			http.get(
+				`/api/machine/health/elements/${goalContext.elementId}/evidence`,
+				() => {
+					requestMade = true;
+					return HttpResponse.json({ evidence: [] });
+				}
+			)
+		);
+
+		render(<HealthPanel {...goalContext} />, { withProviders: false });
+
+		expect(screen.getByText("Not applicable")).toBeInTheDocument();
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(requestMade).toBe(false);
+	});
+});
+
+describe("HealthPanel — loading and error states", () => {
+	it("shows a loading skeleton before the log resolves", async () => {
+		mockEvidenceResponse(CLAIM_CONTEXT.elementId, [evidenceItem()]);
+		render(<HealthPanel {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		expect(screen.getByTestId("health-panel-loading")).toBeInTheDocument();
+
+		// Let the in-flight fetch settle before the test tears down, so its
+		// state update doesn't land outside an act() batch.
+		await waitFor(() =>
+			expect(screen.getByTestId("health-evidence-log")).toBeInTheDocument()
+		);
+	});
+
+	it("shows an empty state when the log fetch fails", async () => {
+		mockEvidenceError(CLAIM_CONTEXT.elementId);
+		render(<HealthPanel {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.getByText("Evidence unavailable")).toBeInTheDocument()
+		);
+	});
+
+	it("shows an empty state when the claim has no evidence yet", async () => {
+		mockEvidenceResponse(CLAIM_CONTEXT.elementId, []);
+		render(<HealthPanel {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.getByText("No evidence yet")).toBeInTheDocument()
+		);
+	});
+});
+
+describe("HealthPanel — renders the log", () => {
+	it("renders entries newest-first with verdict, metric, value/threshold, source, and timestamp", async () => {
+		mockEvidenceResponse(CLAIM_CONTEXT.elementId, [
+			evidenceItem({
+				id: "evidence-1",
+				chainSequence: 1,
+				verdict: "PASS",
+				metricName: "in-distribution-rate",
+			}),
+			evidenceItem({
+				id: "evidence-2",
+				chainSequence: 2,
+				verdict: "FAIL",
+				metricName: "ood-divergence",
+				value: 0.2,
+				threshold: 0.1,
+				sourceSystem: "darter-monitor",
+			}),
+		]);
+		render(<HealthPanel {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.getByTestId("health-evidence-log")).toBeInTheDocument()
+		);
+
+		const entries = screen.getAllByTestId("health-evidence-entry");
+		expect(entries).toHaveLength(2);
+		// Newest first: chainSequence 2 (FAIL/ood-divergence) before 1 (PASS).
+		expect(within(entries[0]).getByText("Fail")).toBeInTheDocument();
+		expect(within(entries[0]).getByText("ood-divergence")).toBeInTheDocument();
+		expect(
+			within(entries[0]).getByText("Value: 0.2 — Threshold: 0.1")
+		).toBeInTheDocument();
+		expect(
+			within(entries[0]).getByText("Source: darter-monitor")
+		).toBeInTheDocument();
+		expect(within(entries[1]).getByText("Pass")).toBeInTheDocument();
+		expect(
+			within(entries[1]).getByText("in-distribution-rate")
+		).toBeInTheDocument();
+	});
+
+	it("keeps provenance behind a closed-by-default disclosure", async () => {
+		const user = userEvent.setup();
+		mockEvidenceResponse(CLAIM_CONTEXT.elementId, [
+			evidenceItem({
+				provenance: { check: "ood-monitor/kl-divergence", runId: "run-42" },
+			}),
+		]);
+		render(<HealthPanel {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.getByTestId("health-evidence-log")).toBeInTheDocument()
+		);
+
+		// jsdom has no layout engine, so it never applies the UA stylesheet
+		// that visually hides a closed <details>'s children — the content is
+		// present in the DOM tree either way. The `open` attribute is the
+		// actual, testable signal that the disclosure starts closed.
+		const disclosure = screen.getByTestId("health-evidence-provenance");
+		expect(disclosure).not.toHaveAttribute("open");
+		expect(screen.getByText(RUN_ID_PROVENANCE_PATTERN)).toBeInTheDocument();
+
+		await user.click(screen.getByText("Provenance"));
+
+		expect(disclosure).toHaveAttribute("open");
+	});
+});
+
+describe("HealthPanel — live update over SSE", () => {
+	it("refetches the log when tea.health/state-changed arrives for this claim", async () => {
+		mockEvidenceResponse(CLAIM_CONTEXT.elementId, [evidenceItem()]);
+		render(<HealthPanel {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.getAllByTestId("health-evidence-entry")).toHaveLength(1)
+		);
+
+		mockEvidenceResponse(CLAIM_CONTEXT.elementId, [
+			evidenceItem({ id: "evidence-1", chainSequence: 1 }),
+			evidenceItem({ id: "evidence-2", chainSequence: 2 }),
+		]);
+		expect(capturedOptions?.onEvent).toBeDefined();
+		capturedOptions?.onEvent?.({
+			type: "tea.health/state-changed",
+			caseId: CLAIM_CONTEXT.caseId,
+			timestamp: new Date().toISOString(),
+			payload: { claimId: CLAIM_CONTEXT.elementId },
+		});
+
+		await waitFor(() =>
+			expect(screen.getAllByTestId("health-evidence-entry")).toHaveLength(2)
+		);
+	});
+});

--- a/lib/plugins/health/__tests__/health-panel.test.tsx
+++ b/lib/plugins/health/__tests__/health-panel.test.tsx
@@ -244,4 +244,29 @@ describe("HealthPanel — live update over SSE", () => {
 			expect(screen.getAllByTestId("health-evidence-entry")).toHaveLength(2)
 		);
 	});
+
+	it("ignores an event of a DIFFERENT type even when the claimId matches (proves the type half of the guard, n-F2)", async () => {
+		mockEvidenceResponse(CLAIM_CONTEXT.elementId, [evidenceItem()]);
+		render(<HealthPanel {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		await waitFor(() =>
+			expect(screen.getAllByTestId("health-evidence-entry")).toHaveLength(1)
+		);
+
+		mockEvidenceResponse(CLAIM_CONTEXT.elementId, [
+			evidenceItem({ id: "evidence-1", chainSequence: 1 }),
+			evidenceItem({ id: "evidence-2", chainSequence: 2 }),
+		]);
+		capturedOptions?.onEvent?.({
+			type: "element:moved",
+			caseId: CLAIM_CONTEXT.caseId,
+			timestamp: new Date().toISOString(),
+			payload: { claimId: CLAIM_CONTEXT.elementId },
+		});
+
+		// Give any (unwanted) refetch a chance to resolve, then assert the log
+		// did NOT pick up the second entry.
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(screen.getAllByTestId("health-evidence-entry")).toHaveLength(1);
+	});
 });

--- a/lib/plugins/health/__tests__/register.test.ts
+++ b/lib/plugins/health/__tests__/register.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { elementBadgeSlot, elementPanelSlot } from "@/lib/plugins/slots";
+import { HealthBadge } from "../health-badge";
+import { HealthPanel } from "../health-panel";
+import { registerHealthPlugin } from "../register";
+
+const PLUGIN_ID = "tea.health";
+
+afterEach(() => {
+	elementBadgeSlot.resetForTests();
+	elementPanelSlot.resetForTests();
+	vi.restoreAllMocks();
+});
+
+describe("registerHealthPlugin — wiring", () => {
+	it("registers HealthBadge into elementBadgeSlot", () => {
+		elementBadgeSlot.resetForTests();
+		elementPanelSlot.resetForTests();
+
+		registerHealthPlugin();
+
+		const registrations = elementBadgeSlot.list();
+		expect(registrations).toHaveLength(1);
+		expect(registrations[0]).toEqual({
+			pluginId: PLUGIN_ID,
+			Component: HealthBadge,
+		});
+	});
+
+	it("registers HealthPanel into elementPanelSlot as the 'Evidence' tab", () => {
+		elementBadgeSlot.resetForTests();
+		elementPanelSlot.resetForTests();
+
+		registerHealthPlugin();
+
+		const registrations = elementPanelSlot.list();
+		expect(registrations).toHaveLength(1);
+		expect(registrations[0]).toEqual({
+			pluginId: PLUGIN_ID,
+			tabId: PLUGIN_ID,
+			label: "Evidence",
+			Component: HealthPanel,
+		});
+	});
+});
+
+describe("registerHealthPlugin — bootstrap safety (review forward-note v4)", () => {
+	it("catches a throwing registration instead of propagating — degrades to unregistered", () => {
+		elementBadgeSlot.resetForTests();
+		elementPanelSlot.resetForTests();
+		const consoleErrorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => undefined);
+		vi.spyOn(elementBadgeSlot, "register").mockImplementation(() => {
+			throw new Error("simulated registration failure");
+		});
+
+		expect(() => registerHealthPlugin()).not.toThrow();
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining("[tea.health]"),
+			expect.any(Error)
+		);
+		// The badge registration threw before it could be recorded, and the
+		// panel registration never ran (the try/catch wraps both calls) —
+		// both slots end up exactly as unregistered as a disabled plugin.
+		expect(elementBadgeSlot.list()).toEqual([]);
+		expect(elementPanelSlot.list()).toEqual([]);
+	});
+});

--- a/lib/plugins/health/evidence-log-entry.tsx
+++ b/lib/plugins/health/evidence-log-entry.tsx
@@ -1,0 +1,96 @@
+import { formatFullDate } from "@/lib/date";
+import { cn } from "@/lib/utils";
+import type {
+	HealthEvidenceLogItem,
+	HealthEvidenceVerdict,
+} from "./use-health-evidence";
+
+const VERDICT_LABELS: Record<HealthEvidenceVerdict, string> = {
+	PASS: "Pass",
+	DEGRADED: "Degraded",
+	FAIL: "Fail",
+};
+
+const VERDICT_DOT_CLASSES: Record<HealthEvidenceVerdict, string> = {
+	PASS: "bg-success",
+	DEGRADED: "bg-warning",
+	FAIL: "bg-destructive",
+};
+
+function ValueThresholdLine({
+	value,
+	threshold,
+}: {
+	value: number | null;
+	threshold: number | null;
+}) {
+	if (value === null && threshold === null) {
+		return null;
+	}
+	const parts = [
+		value === null ? null : `Value: ${value}`,
+		threshold === null ? null : `Threshold: ${threshold}`,
+	].filter((part): part is string => part !== null);
+
+	return (
+		<p className="mt-1 text-muted-foreground text-sm">{parts.join(" — ")}</p>
+	);
+}
+
+interface EvidenceLogEntryProps {
+	item: HealthEvidenceLogItem;
+}
+
+/**
+ * One row of the evidence-trace tab (ADR 0002 v2 §3): verdict, metric,
+ * value/threshold, source system, evaluatedAt — with provenance behind a
+ * native `<details>` disclosure (delegation brief item 3). The log is
+ * regulator-grade and preserved verbatim, but not every reader of a trace
+ * wants the full provenance JSON open by default; a native disclosure
+ * element is fully keyboard/screen-reader accessible with no added
+ * dependency, unlike a hand-rolled toggle.
+ */
+export function EvidenceLogEntry({ item }: EvidenceLogEntryProps) {
+	return (
+		<div className="rounded-md border p-3" data-testid="health-evidence-entry">
+			<div className="flex items-center justify-between gap-2">
+				<div className="flex items-center gap-2">
+					<span
+						aria-hidden="true"
+						className={cn(
+							"inline-block size-2 shrink-0 rounded-full",
+							VERDICT_DOT_CLASSES[item.verdict]
+						)}
+					/>
+					<span className="font-medium text-sm">
+						{VERDICT_LABELS[item.verdict]}
+					</span>
+					<span className="text-muted-foreground text-sm">
+						{item.metricName}
+					</span>
+				</div>
+				<span className="whitespace-nowrap text-muted-foreground text-xs">
+					{formatFullDate(item.evaluatedAt)}
+				</span>
+			</div>
+
+			<ValueThresholdLine threshold={item.threshold} value={item.value} />
+
+			<p className="mt-1 text-muted-foreground text-xs">
+				Source: {item.sourceSystem}
+			</p>
+
+			<details
+				className="mt-2 text-xs"
+				data-testid="health-evidence-provenance"
+			>
+				<summary className="cursor-pointer text-muted-foreground">
+					Provenance
+				</summary>
+				<pre className="mt-1 overflow-x-auto rounded bg-muted p-2 text-xs">
+					{JSON.stringify(item.provenance, null, 2)}
+				</pre>
+			</details>
+		</div>
+	);
+}

--- a/lib/plugins/health/health-badge.tsx
+++ b/lib/plugins/health/health-badge.tsx
@@ -11,6 +11,7 @@ import type { ElementSlotContext } from "@/lib/plugins/slots";
 import { cn } from "@/lib/utils";
 import type { HealthBand } from "./health-bands";
 import { deriveHealthBand, isHealthStale } from "./health-bands";
+import { useHealthBandScores } from "./use-health-band-scores";
 import { useHealthState } from "./use-health-state";
 
 const BAND_DOT_CLASSES: Record<HealthBand, string> = {
@@ -47,13 +48,14 @@ export function HealthBadge({
 	elementType,
 }: ElementSlotContext) {
 	const { health, status } = useHealthState({ caseId, elementId, elementType });
+	const bandScores = useHealthBandScores();
 
 	if (status !== "ready" || !health) {
 		return null;
 	}
 
 	const stale = isHealthStale(health);
-	const band = deriveHealthBand(health.score);
+	const band = deriveHealthBand(health.score, bandScores);
 	const dotClassName = stale ? STALE_DOT_CLASS : BAND_DOT_CLASSES[band];
 	const label = stale
 		? `Health: stale (last evaluated ${formatRelativeToNow(health.lastEvaluatedAt)})`

--- a/lib/plugins/health/health-badge.tsx
+++ b/lib/plugins/health/health-badge.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { formatRelativeToNow } from "@/lib/date";
+import type { ElementSlotContext } from "@/lib/plugins/slots";
+import { cn } from "@/lib/utils";
+import type { HealthBand } from "./health-bands";
+import { deriveHealthBand, isHealthStale } from "./health-bands";
+import { useHealthState } from "./use-health-state";
+
+const BAND_DOT_CLASSES: Record<HealthBand, string> = {
+	pass: "bg-success",
+	degraded: "bg-warning",
+	fail: "bg-destructive",
+};
+
+const BAND_LABELS: Record<HealthBand, string> = {
+	pass: "Health: passing",
+	degraded: "Health: degraded",
+	fail: "Health: failing",
+};
+
+const STALE_DOT_CLASS = "bg-muted-foreground";
+
+/**
+ * The `element-badge` slot's health state dot (ADR 0002 v2 §3 — "the state
+ * dot"). Renders nothing for anything `useHealthState` can't turn into a
+ * confident answer: not a claim, no health data yet, or a fetch error —
+ * fail-closed rather than guess (delegation brief, item 2). Plugin-disabled
+ * is already handled one layer up: `useElementBadgeSlot` filters this
+ * registration out of the list entirely before it would ever mount.
+ *
+ * Colour is never the only signal: the dot is an `<output>` element (an
+ * implicit `status` live region — apt, since this genuinely updates live
+ * over SSE) with an `aria-label` naming the band/staleness in words, so the
+ * state reaches assistive tech independent of the tooltip, which repeats it
+ * for sighted hover users.
+ */
+export function HealthBadge({
+	caseId,
+	elementId,
+	elementType,
+}: ElementSlotContext) {
+	const { health, status } = useHealthState({ caseId, elementId, elementType });
+
+	if (status !== "ready" || !health) {
+		return null;
+	}
+
+	const stale = isHealthStale(health);
+	const band = deriveHealthBand(health.score);
+	const dotClassName = stale ? STALE_DOT_CLASS : BAND_DOT_CLASSES[band];
+	const label = stale
+		? `Health: stale (last evaluated ${formatRelativeToNow(health.lastEvaluatedAt)})`
+		: BAND_LABELS[band];
+
+	return (
+		<TooltipProvider>
+			<Tooltip delayDuration={200}>
+				<TooltipTrigger asChild>
+					<output
+						aria-label={label}
+						className={cn("inline-block size-2 rounded-full", dotClassName)}
+						data-testid="health-badge-dot"
+					/>
+				</TooltipTrigger>
+				<TooltipContent>{label}</TooltipContent>
+			</Tooltip>
+		</TooltipProvider>
+	);
+}

--- a/lib/plugins/health/health-bands.ts
+++ b/lib/plugins/health/health-bands.ts
@@ -1,0 +1,93 @@
+/**
+ * Score -> band derivation for the health plugin's UI (ADR 0002 v2 §3, work
+ * item 4 — the `element-badge`/`element-panel` slots). Bands are a UI-only,
+ * runtime-derived concept — never a stored enum ("bands NOT hardcoded in
+ * schema", per the delegation brief) — so a future settings UI for
+ * `tea.health`'s `verdictScores` (already a live mechanism server-side, see
+ * `lib/services/health-scoring-service.ts`) changes what a score MEANS here
+ * for free, with no migration.
+ */
+
+export type HealthBand = "degraded" | "fail" | "pass";
+
+/**
+ * What the `element-badge`/`element-panel` slots need per claim — the same
+ * shape `health-scoring-service.ts`'s `HealthState` writes into `PluginData`
+ * (and `readHealthState` reads back).
+ */
+export interface HealthState {
+	lastEvaluatedAt: string | null;
+	score: number;
+	validityWindowSeconds: number;
+}
+
+/**
+ * Mirrors `health-scoring-service.ts`'s `DEFAULT_VERDICT_SCORES` exactly (v1
+ * default: FAIL 0, DEGRADED 0.5, PASS 1). Kept as an independent constant
+ * rather than imported from there: that module imports `@/lib/prisma` and is
+ * server-only, so pulling it into a "use client" badge would drag a Prisma
+ * client into the browser bundle. Duplicating three numbers is cheaper than
+ * making a shared module carry the weight of staying prisma-free forever —
+ * `health-bands.test.ts`'s default-boundary assertions are the tripwire if
+ * the two ever drift.
+ */
+export const DEFAULT_BAND_SCORES: Record<HealthBand, number> = {
+	fail: 0,
+	degraded: 0.5,
+	pass: 1,
+};
+
+/** Worse-wins tie-break order — lower is worse. */
+const BAND_SEVERITY: Record<HealthBand, number> = {
+	fail: 0,
+	degraded: 1,
+	pass: 2,
+};
+
+const ALL_BANDS: readonly HealthBand[] = ["fail", "degraded", "pass"];
+
+/**
+ * Maps a continuous score to the band whose configured score it sits closest
+ * to — not a fixed range check — so a custom `verdictScores` setting (a live
+ * mechanism today via `PATCH /api/user/plugins`, ADR §2.2) keeps the badge's
+ * bands consistent with whatever a score of, say, 0.7 is now supposed to
+ * mean, with no code change here. Ties (equidistant from two bands) resolve
+ * to the WORSE one — an assurance tool's badge should never round an
+ * ambiguous score up (mirrors `recomputeHealthScore`'s "silence is never
+ * read as health" conservatism).
+ */
+export function deriveHealthBand(
+	score: number,
+	bandScores: Record<HealthBand, number> = DEFAULT_BAND_SCORES
+): HealthBand {
+	let best: HealthBand = "fail";
+	let bestDistance = Number.POSITIVE_INFINITY;
+
+	for (const band of ALL_BANDS) {
+		const distance = Math.abs(score - bandScores[band]);
+		const isCloser = distance < bestDistance;
+		const isTieButWorse =
+			distance === bestDistance && BAND_SEVERITY[band] < BAND_SEVERITY[best];
+		if (isCloser || isTieButWorse) {
+			best = band;
+			bestDistance = distance;
+		}
+	}
+
+	return best;
+}
+
+/**
+ * Health ⊥ freshness (ADR 0002 v2 §3): a claim can be green-but-stale.
+ * `lastEvaluatedAt: null` (no evidence ever recorded) counts as stale —
+ * defensive only, since `readHealthState` never returns a `HealthState` at
+ * all until at least one evidence item has been scored, so this branch is
+ * currently unreachable in practice, not a designed state.
+ */
+export function isHealthStale(health: HealthState): boolean {
+	if (!health.lastEvaluatedAt) {
+		return true;
+	}
+	const evaluatedAtMs = new Date(health.lastEvaluatedAt).getTime();
+	return Date.now() - evaluatedAtMs > health.validityWindowSeconds * 1000;
+}

--- a/lib/plugins/health/health-panel.tsx
+++ b/lib/plugins/health/health-panel.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { FileText } from "lucide-react";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { ElementSlotContext } from "@/lib/plugins/slots";
+import { EvidenceLogEntry } from "./evidence-log-entry";
+import { useHealthEvidence } from "./use-health-evidence";
+
+function EvidenceSkeleton() {
+	return (
+		<div className="space-y-2" data-testid="health-panel-loading">
+			<Skeleton className="h-20 w-full rounded-md" />
+			<Skeleton className="h-20 w-full rounded-md" />
+		</div>
+	);
+}
+
+/**
+ * The `element-panel` slot's evidence-trace tab (ADR 0002 v2 §3): the
+ * claim's append-only `tea.health` log, newest first. `useHealthEvidence`
+ * returns the log in append (oldest-first, hash-chain) order — the reversal
+ * here is display-only, never re-persisted.
+ *
+ * The `element-panel` slot has no per-element-type filtering of its own
+ * (`node-edit-dialog.tsx` shows one registered tab strip for every element
+ * type), so this component handles the "not a claim" case itself rather
+ * than showing a misleading fetch error on every goal/strategy/evidence
+ * node's dialog — `useHealthEvidence` never makes a request for a non-claim
+ * element, and this renders a distinct "not applicable" state instead.
+ */
+export function HealthPanel({
+	caseId,
+	elementId,
+	elementType,
+}: ElementSlotContext) {
+	const { evidence, status } = useHealthEvidence({
+		caseId,
+		elementId,
+		elementType,
+	});
+
+	if (elementType !== "property") {
+		return (
+			<EmptyState
+				icon={FileText}
+				message="Evidence tracking applies to property claims only."
+				title="Not applicable"
+			/>
+		);
+	}
+
+	if (status === "loading") {
+		return <EvidenceSkeleton />;
+	}
+
+	if (status === "error" || !evidence) {
+		return (
+			<EmptyState
+				icon={FileText}
+				message="Could not load the evidence log. Try reopening this element."
+				title="Evidence unavailable"
+			/>
+		);
+	}
+
+	if (evidence.length === 0) {
+		return (
+			<EmptyState
+				icon={FileText}
+				message="No evidence has been recorded against this claim yet."
+				title="No evidence yet"
+			/>
+		);
+	}
+
+	const newestFirst = [...evidence].reverse();
+
+	return (
+		<div className="space-y-2" data-testid="health-evidence-log">
+			{newestFirst.map((item) => (
+				<EvidenceLogEntry item={item} key={item.id} />
+			))}
+		</div>
+	);
+}

--- a/lib/plugins/health/register.ts
+++ b/lib/plugins/health/register.ts
@@ -1,0 +1,59 @@
+/**
+ * The `tea.health` plugin's UI registration (ADR 0002 v2 §2.3/§3): registers
+ * `HealthBadge` into `elementBadgeSlot` and `HealthPanel` into
+ * `elementPanelSlot`. The registry's contract (`lib/plugins/slots/
+ * registry.ts`) requires this to happen once, at import time — never
+ * per-request — which is why `registerHealthPlugin()` both runs immediately
+ * below AND is exported: a real bootstrap import gets the module-load side
+ * effect for free, while tests call it explicitly after
+ * `elementBadgeSlot.resetForTests()` / `elementPanelSlot.resetForTests()`.
+ *
+ * Bootstrap point — OPEN QUESTION (flagged in the delegation return):
+ * nothing in the app imports this module yet. ADR 0002 v2 §2.3 says official
+ * plugins register "through one registry module" but does not name where an
+ * official plugin's UI module itself gets imported into the running app —
+ * unlike, say, `lib/export/exporters/`'s pattern, which this registry
+ * otherwise mirrors. Until cid settles that, this module is wired against
+ * test-only registration; the badge/panel will not appear in a real running
+ * app until something imports `lib/plugins/health/register`.
+ *
+ * Bootstrap safety (review forward-note v4): `SlotRegistry.register()`
+ * throws on a bad registration (unknown plugin id, undeclared surface) by
+ * design — a programming error in first-party code, not user input. Once a
+ * real bootstrap point imports this module, a throw here must not
+ * white-screen the whole bundle, so the calls are wrapped defensively:
+ * catch, log, degrade to "unregistered" (the badge/panel simply never
+ * appear — the same observable behaviour as the plugin being disabled).
+ */
+
+import { elementBadgeSlot, elementPanelSlot } from "@/lib/plugins/slots";
+import { HealthBadge } from "./health-badge";
+import { HealthPanel } from "./health-panel";
+
+const PLUGIN_ID = "tea.health";
+
+export function registerHealthPlugin(): void {
+	try {
+		elementBadgeSlot.register({
+			pluginId: PLUGIN_ID,
+			Component: HealthBadge,
+		});
+		elementPanelSlot.register({
+			pluginId: PLUGIN_ID,
+			tabId: PLUGIN_ID,
+			label: "Evidence",
+			Component: HealthPanel,
+		});
+	} catch (error) {
+		// No structured logger exists in this codebase yet (CLAUDE.md names
+		// one; none of the merged health-plugin server-core files use it
+		// either) — console.error matches the prevailing actual pattern, not a
+		// deviation introduced here.
+		console.error(
+			"[tea.health] UI slot registration failed — badge/panel will not render:",
+			error
+		);
+	}
+}
+
+registerHealthPlugin();

--- a/lib/plugins/health/use-claim-scoped-fetch.ts
+++ b/lib/plugins/health/use-claim-scoped-fetch.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { SSEEvent } from "@/hooks/use-case-events";
+import { useCaseEvents } from "@/hooks/use-case-events";
+import type { ElementSlotContext } from "@/lib/plugins/slots";
+
+const HEALTH_STATE_EVENT_TYPE = "tea.health/state-changed";
+
+function isHealthStateEventForElement(
+	event: SSEEvent,
+	elementId: string
+): boolean {
+	return (
+		event.type === HEALTH_STATE_EVENT_TYPE &&
+		event.payload?.claimId === elementId
+	);
+}
+
+export type ClaimScopedFetchStatus = "error" | "loading" | "ready";
+
+export interface ClaimScopedFetchResult<T> {
+	data: T;
+	status: ClaimScopedFetchStatus;
+}
+
+export interface UseClaimScopedFetchOptions<T> extends ElementSlotContext {
+	/**
+	 * Value to fall back to when `fetchFn` throws. Passed explicitly (rather
+	 * than assumed to be `null`) because `T` is caller-defined and not every
+	 * caller's `T` includes `null` in principle — in practice both current
+	 * callers' `T` does, but the hook itself makes no such assumption.
+	 */
+	errorValue: T;
+	/**
+	 * What `fetchFn` resolves to. Fetched once on mount and refetched whenever
+	 * `tea.health/state-changed` arrives for this element over the case's SSE
+	 * stream (`useCaseEvents`) — never merged from the event payload directly,
+	 * so this hook's contract stays stable regardless of what any given
+	 * plugin event happens to carry.
+	 */
+	fetchFn: (elementId: string) => Promise<T>;
+	/**
+	 * Value to use for a non-claim element — `fetchFn` is never called for
+	 * one (evidence-format-v0.1 / `tea.health`'s scoring only ever bears on
+	 * `PROPERTY_CLAIM` elements), so this is what the "ready" state carries
+	 * instead of a request that would never resolve.
+	 */
+	notApplicableValue: T;
+}
+
+/**
+ * Shared refetch + SSE wiring behind `useHealthState` and `useHealthEvidence`
+ * — the identical 19-line "fetch once on mount, refetch on
+ * `tea.health/state-changed`, no-op entirely for non-claim elements" pattern
+ * that was duplicated between them (fallow clone, n-F...). Generic over the
+ * fetched shape `T` so both hooks (one fetching a `HealthState | null`, the
+ * other a `HealthEvidenceLogItem[]`) share one implementation rather than one
+ * copying the other's wiring by hand.
+ */
+export function useClaimScopedFetch<T>({
+	caseId,
+	elementId,
+	elementType,
+	errorValue,
+	notApplicableValue,
+	fetchFn,
+}: UseClaimScopedFetchOptions<T>): ClaimScopedFetchResult<T> {
+	const isClaim = elementType === "property";
+	const [data, setData] = useState<T>(
+		isClaim ? errorValue : notApplicableValue
+	);
+	const [status, setStatus] = useState<ClaimScopedFetchStatus>(
+		isClaim ? "loading" : "ready"
+	);
+
+	const refetch = useCallback(async () => {
+		if (!isClaim) {
+			return;
+		}
+		try {
+			const result = await fetchFn(elementId);
+			setData(result);
+			setStatus("ready");
+		} catch {
+			setData(errorValue);
+			setStatus("error");
+		}
+	}, [elementId, isClaim, fetchFn, errorValue]);
+
+	useEffect(() => {
+		refetch();
+	}, [refetch]);
+
+	useCaseEvents({
+		caseId,
+		enabled: isClaim && Boolean(caseId),
+		onEvent: (event) => {
+			if (isHealthStateEventForElement(event, elementId)) {
+				refetch();
+			}
+		},
+	});
+
+	return { data, status };
+}

--- a/lib/plugins/health/use-health-band-scores.ts
+++ b/lib/plugins/health/use-health-band-scores.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { z } from "zod";
+import { fetchPlugins } from "@/hooks/use-plugin-enablement";
+import { DEFAULT_BAND_SCORES, type HealthBand } from "./health-bands";
+
+const PLUGIN_ID = "tea.health";
+
+/**
+ * Mirrors `health-scoring-service.ts`'s (private) `scoringSettingsSchema`
+ * for the one field the badge needs — `verdictScores`. Kept as an
+ * independent, narrower schema rather than imported, for the same reason
+ * `DEFAULT_BAND_SCORES` is duplicated in `health-bands.ts`: that module
+ * imports `@/lib/prisma` and is server-only.
+ */
+const bandScoresSettingsSchema = z.object({
+	verdictScores: z
+		.object({
+			PASS: z.number().min(0).max(1).optional(),
+			DEGRADED: z.number().min(0).max(1).optional(),
+			FAIL: z.number().min(0).max(1).optional(),
+		})
+		.optional(),
+});
+
+function resolveBandScores(settings: unknown): Record<HealthBand, number> {
+	const parsed = bandScoresSettingsSchema.safeParse(settings ?? {});
+	const verdictScores = parsed.success ? parsed.data.verdictScores : undefined;
+	return {
+		fail: verdictScores?.FAIL ?? DEFAULT_BAND_SCORES.fail,
+		degraded: verdictScores?.DEGRADED ?? DEFAULT_BAND_SCORES.degraded,
+		pass: verdictScores?.PASS ?? DEFAULT_BAND_SCORES.pass,
+	};
+}
+
+/**
+ * The badge's band thresholds, sourced from the SAME `tea.health`
+ * `PluginState.settings` blob `health-scoring-service.ts`'s
+ * `resolveScoringSettings` reads server-side for scoring — never a second,
+ * independent settings surface (delegation brief: "score→band via plugin
+ * settings ... bands NOT hardcoded in schema"). Reuses `fetchPlugins()`
+ * (`hooks/use-plugin-enablement.ts`) rather than inventing a second fetch
+ * mechanism — its in-flight de-dupe already exists for exactly this "many
+ * slot instances read the same settings response" shape (the vincent
+ * finding that motivated it in the first place).
+ *
+ * Falls back field-by-field to `DEFAULT_BAND_SCORES` exactly as the server
+ * does, so an unset or partially-set settings blob behaves identically on
+ * both sides. A failed fetch or malformed settings both degrade to the
+ * defaults, never a crash — this is display-only; the actual score
+ * computation already went through the server's own equally-defensive
+ * parse.
+ */
+export function useHealthBandScores(): Record<HealthBand, number> {
+	const [bandScores, setBandScores] =
+		useState<Record<HealthBand, number>>(DEFAULT_BAND_SCORES);
+
+	useEffect(() => {
+		let cancelled = false;
+
+		fetchPlugins()
+			.then((plugins) => {
+				if (cancelled) {
+					return;
+				}
+				const entry = plugins.find((p) => p.pluginId === PLUGIN_ID);
+				setBandScores(resolveBandScores(entry?.settings));
+			})
+			.catch(() => {
+				if (!cancelled) {
+					setBandScores(DEFAULT_BAND_SCORES);
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	return bandScores;
+}

--- a/lib/plugins/health/use-health-evidence.ts
+++ b/lib/plugins/health/use-health-evidence.ts
@@ -1,10 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import { useCaseEvents } from "@/hooks/use-case-events";
 import type { ElementSlotContext } from "@/lib/plugins/slots";
-
-const HEALTH_STATE_EVENT_TYPE = "tea.health/state-changed";
+import { useClaimScopedFetch } from "./use-claim-scoped-fetch";
 
 export type HealthEvidenceVerdict = "DEGRADED" | "FAIL" | "PASS";
 
@@ -64,7 +61,9 @@ export interface UseHealthEvidenceResult {
  * `GET /api/machine/health/elements/[id]/evidence` alongside a scoped bearer
  * token (verified in the server-core review). No new route: the
  * `element-panel` slot is simply the second, already-anticipated consumer of
- * an endpoint built for DARTER.
+ * an endpoint built for DARTER. Fetch-once-on-mount + SSE refetch wiring is
+ * shared with `useHealthState` via `useClaimScopedFetch`
+ * (`use-claim-scoped-fetch.ts`).
  *
  * Only meaningful for `PROPERTY_CLAIM` elements — see `useHealthState`'s
  * doc. Non-claim callers get `status: "ready"`, `evidence: []` without a
@@ -76,44 +75,14 @@ export function useHealthEvidence({
 	elementId,
 	elementType,
 }: ElementSlotContext): UseHealthEvidenceResult {
-	const isClaim = elementType === "property";
-	const [evidence, setEvidence] = useState<HealthEvidenceLogItem[] | null>(
-		isClaim ? null : []
-	);
-	const [status, setStatus] = useState<HealthEvidenceStatus>(
-		isClaim ? "loading" : "ready"
-	);
-
-	const refetch = useCallback(async () => {
-		if (!isClaim) {
-			return;
-		}
-		try {
-			const log = await fetchEvidenceLog(elementId);
-			setEvidence(log);
-			setStatus("ready");
-		} catch {
-			setEvidence(null);
-			setStatus("error");
-		}
-	}, [elementId, isClaim]);
-
-	useEffect(() => {
-		refetch();
-	}, [refetch]);
-
-	useCaseEvents({
+	const { data, status } = useClaimScopedFetch<HealthEvidenceLogItem[] | null>({
 		caseId,
-		enabled: isClaim && Boolean(caseId),
-		onEvent: (event) => {
-			if (
-				event.type === HEALTH_STATE_EVENT_TYPE &&
-				event.payload?.claimId === elementId
-			) {
-				refetch();
-			}
-		},
+		elementId,
+		elementType,
+		fetchFn: fetchEvidenceLog,
+		errorValue: null,
+		notApplicableValue: [],
 	});
 
-	return { evidence, status };
+	return { evidence: data, status };
 }

--- a/lib/plugins/health/use-health-evidence.ts
+++ b/lib/plugins/health/use-health-evidence.ts
@@ -1,0 +1,119 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useCaseEvents } from "@/hooks/use-case-events";
+import type { ElementSlotContext } from "@/lib/plugins/slots";
+
+const HEALTH_STATE_EVENT_TYPE = "tea.health/state-changed";
+
+export type HealthEvidenceVerdict = "DEGRADED" | "FAIL" | "PASS";
+
+/**
+ * One evidence-format-v0.1 item as returned by
+ * `GET /api/machine/health/elements/[id]/evidence` — mirrors
+ * `PluginHealthEvidence` (`prisma/schema.prisma`) field-for-field so a mock
+ * fixture can be checked with `satisfies` against the real response shape.
+ */
+export interface HealthEvidenceLogItem {
+	chainSequence: number;
+	claimId: string;
+	createdAt: string;
+	createdById: string;
+	evaluatedAt: string;
+	formatVersion: string;
+	id: string;
+	metricName: string;
+	oddDimensions: string[];
+	previousRecordHash: string | null;
+	provenance: Record<string, unknown>;
+	recordHash: string;
+	sourceSystem: string;
+	threshold: number | null;
+	value: number | null;
+	verdict: HealthEvidenceVerdict;
+}
+
+interface EvidenceResponseBody {
+	evidence: HealthEvidenceLogItem[];
+}
+
+async function fetchEvidenceLog(
+	claimId: string
+): Promise<HealthEvidenceLogItem[]> {
+	const response = await fetch(
+		`/api/machine/health/elements/${claimId}/evidence`
+	);
+	if (!response.ok) {
+		throw new Error(`Failed to fetch evidence log (${response.status})`);
+	}
+	const body = (await response.json()) as EvidenceResponseBody;
+	return body.evidence;
+}
+
+export type HealthEvidenceStatus = "error" | "loading" | "ready";
+
+export interface UseHealthEvidenceResult {
+	evidence: HealthEvidenceLogItem[] | null;
+	status: HealthEvidenceStatus;
+}
+
+/**
+ * The `tea.health` append-only evidence log for one claim (ADR 0002 v2 §3),
+ * via the existing machine endpoint's human-session auth path — a session
+ * with case VIEW access is an accepted caller of
+ * `GET /api/machine/health/elements/[id]/evidence` alongside a scoped bearer
+ * token (verified in the server-core review). No new route: the
+ * `element-panel` slot is simply the second, already-anticipated consumer of
+ * an endpoint built for DARTER.
+ *
+ * Only meaningful for `PROPERTY_CLAIM` elements — see `useHealthState`'s
+ * doc. Non-claim callers get `status: "ready"`, `evidence: []` without a
+ * request ever being made, so the panel can render a distinct "not
+ * applicable" state instead of a misleading fetch error.
+ */
+export function useHealthEvidence({
+	caseId,
+	elementId,
+	elementType,
+}: ElementSlotContext): UseHealthEvidenceResult {
+	const isClaim = elementType === "property";
+	const [evidence, setEvidence] = useState<HealthEvidenceLogItem[] | null>(
+		isClaim ? null : []
+	);
+	const [status, setStatus] = useState<HealthEvidenceStatus>(
+		isClaim ? "loading" : "ready"
+	);
+
+	const refetch = useCallback(async () => {
+		if (!isClaim) {
+			return;
+		}
+		try {
+			const log = await fetchEvidenceLog(elementId);
+			setEvidence(log);
+			setStatus("ready");
+		} catch {
+			setEvidence(null);
+			setStatus("error");
+		}
+	}, [elementId, isClaim]);
+
+	useEffect(() => {
+		refetch();
+	}, [refetch]);
+
+	useCaseEvents({
+		caseId,
+		enabled: isClaim && Boolean(caseId),
+		onEvent: (event) => {
+			if (
+				event.type === HEALTH_STATE_EVENT_TYPE &&
+				event.payload?.claimId === elementId
+			) {
+				refetch();
+			}
+		},
+	});
+
+	return { evidence, status };
+}

--- a/lib/plugins/health/use-health-state.ts
+++ b/lib/plugins/health/use-health-state.ts
@@ -1,12 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import type { SSEEvent } from "@/hooks/use-case-events";
-import { useCaseEvents } from "@/hooks/use-case-events";
 import type { ElementSlotContext } from "@/lib/plugins/slots";
 import type { HealthState } from "./health-bands";
-
-const HEALTH_STATE_EVENT_TYPE = "tea.health/state-changed";
+import { useClaimScopedFetch } from "./use-claim-scoped-fetch";
 
 interface HealthStateResponseBody {
 	health: HealthState | null;
@@ -23,16 +19,6 @@ async function fetchHealthState(
 	return body.health;
 }
 
-function isHealthStateEventForElement(
-	event: SSEEvent,
-	elementId: string
-): boolean {
-	return (
-		event.type === HEALTH_STATE_EVENT_TYPE &&
-		event.payload?.claimId === elementId
-	);
-}
-
 export type HealthStateStatus = "error" | "loading" | "ready";
 
 export interface UseHealthStateResult {
@@ -43,11 +29,13 @@ export interface UseHealthStateResult {
 /**
  * The `tea.health` score for one claim (ADR 0002 v2 §3), fetched once on
  * mount and refetched whenever `tea.health/state-changed` arrives for this
- * element over the case's existing SSE stream (`useCaseEvents`). A plain
- * refetch, not the event payload merged in directly: the payload happens to
- * carry the full state today (the machine evidence route emits it after
- * `recomputeHealthScore`), but a refetch keeps this hook's contract stable
- * regardless of what any given plugin event carries.
+ * element over the case's existing SSE stream — via the shared
+ * `useClaimScopedFetch` (`use-claim-scoped-fetch.ts`), which also backs
+ * `useHealthEvidence`. A plain refetch, not the event payload merged in
+ * directly: the payload happens to carry the full state today (the machine
+ * evidence route emits it after `recomputeHealthScore`), but a refetch keeps
+ * this hook's contract stable regardless of what any given plugin event
+ * carries.
  *
  * Only meaningful for `PROPERTY_CLAIM` elements ("property" in
  * `ElementSlotContext.elementType` terms) — evidence-format-v0.1 only ever
@@ -63,39 +51,14 @@ export function useHealthState({
 	elementId,
 	elementType,
 }: ElementSlotContext): UseHealthStateResult {
-	const isClaim = elementType === "property";
-	const [health, setHealth] = useState<HealthState | null>(null);
-	const [status, setStatus] = useState<HealthStateStatus>(
-		isClaim ? "loading" : "ready"
-	);
-
-	const refetch = useCallback(async () => {
-		if (!isClaim) {
-			return;
-		}
-		try {
-			const result = await fetchHealthState(elementId);
-			setHealth(result);
-			setStatus("ready");
-		} catch {
-			setHealth(null);
-			setStatus("error");
-		}
-	}, [elementId, isClaim]);
-
-	useEffect(() => {
-		refetch();
-	}, [refetch]);
-
-	useCaseEvents({
+	const { data, status } = useClaimScopedFetch<HealthState | null>({
 		caseId,
-		enabled: isClaim && Boolean(caseId),
-		onEvent: (event) => {
-			if (isHealthStateEventForElement(event, elementId)) {
-				refetch();
-			}
-		},
+		elementId,
+		elementType,
+		fetchFn: fetchHealthState,
+		errorValue: null,
+		notApplicableValue: null,
 	});
 
-	return { health, status };
+	return { health: data, status };
 }

--- a/lib/plugins/health/use-health-state.ts
+++ b/lib/plugins/health/use-health-state.ts
@@ -1,0 +1,101 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { SSEEvent } from "@/hooks/use-case-events";
+import { useCaseEvents } from "@/hooks/use-case-events";
+import type { ElementSlotContext } from "@/lib/plugins/slots";
+import type { HealthState } from "./health-bands";
+
+const HEALTH_STATE_EVENT_TYPE = "tea.health/state-changed";
+
+interface HealthStateResponseBody {
+	health: HealthState | null;
+}
+
+async function fetchHealthState(
+	elementId: string
+): Promise<HealthState | null> {
+	const response = await fetch(`/api/elements/${elementId}/health`);
+	if (!response.ok) {
+		throw new Error(`Failed to fetch health state (${response.status})`);
+	}
+	const body = (await response.json()) as HealthStateResponseBody;
+	return body.health;
+}
+
+function isHealthStateEventForElement(
+	event: SSEEvent,
+	elementId: string
+): boolean {
+	return (
+		event.type === HEALTH_STATE_EVENT_TYPE &&
+		event.payload?.claimId === elementId
+	);
+}
+
+export type HealthStateStatus = "error" | "loading" | "ready";
+
+export interface UseHealthStateResult {
+	health: HealthState | null;
+	status: HealthStateStatus;
+}
+
+/**
+ * The `tea.health` score for one claim (ADR 0002 v2 §3), fetched once on
+ * mount and refetched whenever `tea.health/state-changed` arrives for this
+ * element over the case's existing SSE stream (`useCaseEvents`). A plain
+ * refetch, not the event payload merged in directly: the payload happens to
+ * carry the full state today (the machine evidence route emits it after
+ * `recomputeHealthScore`), but a refetch keeps this hook's contract stable
+ * regardless of what any given plugin event carries.
+ *
+ * Only meaningful for `PROPERTY_CLAIM` elements ("property" in
+ * `ElementSlotContext.elementType` terms) — evidence-format-v0.1 only ever
+ * bears on claims. Callers for any other element type get `status: "ready"`,
+ * `health: null` without a request ever being made.
+ *
+ * Fails closed: a non-OK response or a network error both resolve to
+ * `status: "error"`, `health: null` — the badge slot renders nothing rather
+ * than guess.
+ */
+export function useHealthState({
+	caseId,
+	elementId,
+	elementType,
+}: ElementSlotContext): UseHealthStateResult {
+	const isClaim = elementType === "property";
+	const [health, setHealth] = useState<HealthState | null>(null);
+	const [status, setStatus] = useState<HealthStateStatus>(
+		isClaim ? "loading" : "ready"
+	);
+
+	const refetch = useCallback(async () => {
+		if (!isClaim) {
+			return;
+		}
+		try {
+			const result = await fetchHealthState(elementId);
+			setHealth(result);
+			setStatus("ready");
+		} catch {
+			setHealth(null);
+			setStatus("error");
+		}
+	}, [elementId, isClaim]);
+
+	useEffect(() => {
+		refetch();
+	}, [refetch]);
+
+	useCaseEvents({
+		caseId,
+		enabled: isClaim && Boolean(caseId),
+		onEvent: (event) => {
+			if (isHealthStateEventForElement(event, elementId)) {
+				refetch();
+			}
+		},
+	});
+
+	return { health, status };
+}

--- a/lib/plugins/slots/__tests__/registry.test.ts
+++ b/lib/plugins/slots/__tests__/registry.test.ts
@@ -3,6 +3,7 @@ import type { PluginManifestEntry } from "@/lib/plugins/manifest";
 
 const UNKNOWN_PLUGIN_MESSAGE = /unknown plugin/i;
 const UNDECLARED_SURFACE_MESSAGE = /does not declare this surface/i;
+const CONFLICTING_REGISTRATION_MESSAGE = /conflicting registration/i;
 
 const mockGetManifestEntry =
 	vi.fn<(pluginId: string) => PluginManifestEntry | undefined>();
@@ -79,7 +80,29 @@ describe("SlotRegistry", () => {
 		]);
 	});
 
-	it("ignores a second registration for a pluginId already registered in this slot", () => {
+	it("silently no-ops a second registration for a pluginId already registered, when it is IDENTICAL to the first", () => {
+		mockGetManifestEntry.mockReturnValue(FAKE_PLUGIN);
+		const registry = new SlotRegistry<{
+			Component: () => null;
+			pluginId: string;
+		}>("element-badge");
+		const component = () => null;
+
+		registry.register({ pluginId: "tea.fake", Component: component });
+		// Same pluginId, same Component reference — e.g. a plugin's bootstrap
+		// module re-running its import-time `register()` call (imported by
+		// both a test and the real providers path in one process) — must not
+		// double the badge, and must not throw.
+		expect(() =>
+			registry.register({ pluginId: "tea.fake", Component: component })
+		).not.toThrow();
+
+		expect(registry.list()).toEqual([
+			{ pluginId: "tea.fake", Component: component },
+		]);
+	});
+
+	it("throws on a second registration for a pluginId already registered, when it CONFLICTS with the first", () => {
 		mockGetManifestEntry.mockReturnValue(FAKE_PLUGIN);
 		const registry = new SlotRegistry<{
 			Component: () => null;
@@ -89,12 +112,16 @@ describe("SlotRegistry", () => {
 		const secondComponent = () => null;
 
 		registry.register({ pluginId: "tea.fake", Component: firstComponent });
-		registry.register({ pluginId: "tea.fake", Component: secondComponent });
 
-		// The first registration wins; the second is a silent no-op rather
-		// than a duplicate entry — a plugin's bootstrap module re-running its
-		// import-time `register()` call (e.g. imported by both a test and the
-		// real providers path in one process) must not double the badge.
+		// A DIFFERENT Component for the same pluginId in the same slot is not
+		// a re-run bootstrap — it's a first-party programming error (two
+		// distinct registrations claiming the same pluginId) and must throw,
+		// exactly like the unknown-plugin and undeclared-surface checks.
+		expect(() =>
+			registry.register({ pluginId: "tea.fake", Component: secondComponent })
+		).toThrow(CONFLICTING_REGISTRATION_MESSAGE);
+
+		// The first (conflicting-free) registration is left untouched.
 		expect(registry.list()).toEqual([
 			{ pluginId: "tea.fake", Component: firstComponent },
 		]);
@@ -128,5 +155,27 @@ describe("SlotRegistry", () => {
 		expect(elementPanelSlot.list()).toHaveLength(0);
 
 		elementBadgeSlot.resetForTests();
+	});
+
+	it("lets the same pluginId register independently into two different slot instances", () => {
+		mockGetManifestEntry.mockReturnValue({
+			...FAKE_PLUGIN,
+			surfaces: ["element-badge", "element-panel"],
+		});
+		const badgeRegistry = new SlotRegistry<{ pluginId: string }>(
+			"element-badge"
+		);
+		const panelRegistry = new SlotRegistry<{ pluginId: string }>(
+			"element-panel"
+		);
+
+		badgeRegistry.register({ pluginId: "tea.fake" });
+		panelRegistry.register({ pluginId: "tea.fake" });
+
+		// Two independent `SlotRegistry` instances — the SAME pluginId in each
+		// is not a conflict, since `register()` only ever compares against
+		// registrations already held in ITS OWN slot.
+		expect(badgeRegistry.list()).toEqual([{ pluginId: "tea.fake" }]);
+		expect(panelRegistry.list()).toEqual([{ pluginId: "tea.fake" }]);
 	});
 });

--- a/lib/plugins/slots/__tests__/registry.test.ts
+++ b/lib/plugins/slots/__tests__/registry.test.ts
@@ -79,6 +79,27 @@ describe("SlotRegistry", () => {
 		]);
 	});
 
+	it("ignores a second registration for a pluginId already registered in this slot", () => {
+		mockGetManifestEntry.mockReturnValue(FAKE_PLUGIN);
+		const registry = new SlotRegistry<{
+			Component: () => null;
+			pluginId: string;
+		}>("element-badge");
+		const firstComponent = () => null;
+		const secondComponent = () => null;
+
+		registry.register({ pluginId: "tea.fake", Component: firstComponent });
+		registry.register({ pluginId: "tea.fake", Component: secondComponent });
+
+		// The first registration wins; the second is a silent no-op rather
+		// than a duplicate entry — a plugin's bootstrap module re-running its
+		// import-time `register()` call (e.g. imported by both a test and the
+		// real providers path in one process) must not double the badge.
+		expect(registry.list()).toEqual([
+			{ pluginId: "tea.fake", Component: firstComponent },
+		]);
+	});
+
 	it("resetForTests clears every registration", () => {
 		mockGetManifestEntry.mockReturnValue(FAKE_PLUGIN);
 		const registry = new SlotRegistry<{ pluginId: string }>("element-badge");

--- a/lib/plugins/slots/registry.ts
+++ b/lib/plugins/slots/registry.ts
@@ -50,6 +50,18 @@ export class SlotRegistry<TRegistration extends { pluginId: string }> {
 	 * §1): the pluginId must be a real manifest entry, and that entry must
 	 * declare this slot's id among its `surfaces` — a plugin cannot show up
 	 * somewhere its own manifest doesn't admit to reaching.
+	 *
+	 * Idempotent by pluginId (bootstrap safety, `lib/plugins/bootstrap.ts`):
+	 * a plugin's register module runs its top-level `register()` calls as an
+	 * import side effect, and nothing here guarantees that module's import
+	 * graph is only ever entered once in a given process — a test file that
+	 * imports the bootstrap alongside the real providers path importing it
+	 * too, for instance. A second call for a pluginId already present in
+	 * this slot is a silent no-op rather than a second entry: without this,
+	 * `.list()` would return the same registration twice, and every render-
+	 * time consumer that maps over it keyed by `pluginId`
+	 * (`useElementBadgeSlot`, `useElementPanelSlot`) would render the
+	 * plugin's UI twice under a duplicate React key.
 	 */
 	register(registration: TRegistration): void {
 		const entry = getManifestEntry(registration.pluginId);
@@ -62,6 +74,12 @@ export class SlotRegistry<TRegistration extends { pluginId: string }> {
 			throw new Error(
 				`Cannot register '${registration.pluginId}' into slot '${this.slotId}': its manifest entry does not declare this surface`
 			);
+		}
+		const alreadyRegistered = this.registrations.some(
+			(existing) => existing.pluginId === registration.pluginId
+		);
+		if (alreadyRegistered) {
+			return;
 		}
 		this.registrations.push(registration);
 	}

--- a/lib/plugins/slots/registry.ts
+++ b/lib/plugins/slots/registry.ts
@@ -31,6 +31,28 @@ import type {
 	SlotId,
 } from "./types";
 
+/**
+ * Own-enumerable-key shallow compare (`Object.is` per value, so a `Component`
+ * field only counts as equal when it's the SAME function reference — two
+ * components that merely render the same output are still a conflict).
+ * Deliberately generic rather than hand-listing `Component`/`tabId`/`label`:
+ * `SlotRegistry` is shared across three differently-shaped registration
+ * types (`ElementBadgeRegistration`, `ElementPanelRegistration`,
+ * `SettingsSectionRegistration`), and this way a future field added to any
+ * of them is compared for free, with no change here.
+ */
+function isShallowEqualRegistration<T extends { pluginId: string }>(
+	a: T,
+	b: T
+): boolean {
+	const aKeys = Object.keys(a) as (keyof T)[];
+	const bKeys = Object.keys(b) as (keyof T)[];
+	if (aKeys.length !== bKeys.length) {
+		return false;
+	}
+	return aKeys.every((key) => Object.is(a[key], b[key]));
+}
+
 export class SlotRegistry<TRegistration extends { pluginId: string }> {
 	private readonly registrations: TRegistration[] = [];
 	private readonly slotId: SlotId;
@@ -57,11 +79,25 @@ export class SlotRegistry<TRegistration extends { pluginId: string }> {
 	 * graph is only ever entered once in a given process — a test file that
 	 * imports the bootstrap alongside the real providers path importing it
 	 * too, for instance. A second call for a pluginId already present in
-	 * this slot is a silent no-op rather than a second entry: without this,
+	 * this slot is a silent no-op ONLY when it is the identical registration
+	 * (every field shallow-equal to the one already held) — without this,
 	 * `.list()` would return the same registration twice, and every render-
 	 * time consumer that maps over it keyed by `pluginId`
 	 * (`useElementBadgeSlot`, `useElementPanelSlot`) would render the
 	 * plugin's UI twice under a duplicate React key.
+	 *
+	 * A second call that differs from the first (a different `Component`,
+	 * `tabId`, or `label` for the SAME pluginId) is not a re-run bootstrap —
+	 * it is a first-party programming error (two plugin modules, or two
+	 * versions of one, both claiming the same pluginId in this slot with
+	 * different contents) and throws, exactly like the unknown-plugin and
+	 * undeclared-surface checks above it (vincent review, 2026-07-04). One
+	 * accepted source of a legitimate-looking "conflict": dev-mode HMR
+	 * reloading a plugin's register module gives its `Component` a fresh
+	 * function identity on every reload, so a second registration after a
+	 * hot reload IS a shallow-compare mismatch and WILL throw here — caught
+	 * and logged by `register.ts`'s try/catch (degrades to "unregistered"
+	 * for that reload), not a bug in this method.
 	 */
 	register(registration: TRegistration): void {
 		const entry = getManifestEntry(registration.pluginId);
@@ -75,11 +111,16 @@ export class SlotRegistry<TRegistration extends { pluginId: string }> {
 				`Cannot register '${registration.pluginId}' into slot '${this.slotId}': its manifest entry does not declare this surface`
 			);
 		}
-		const alreadyRegistered = this.registrations.some(
-			(existing) => existing.pluginId === registration.pluginId
+		const existing = this.registrations.find(
+			(candidate) => candidate.pluginId === registration.pluginId
 		);
-		if (alreadyRegistered) {
-			return;
+		if (existing) {
+			if (isShallowEqualRegistration(existing, registration)) {
+				return;
+			}
+			throw new Error(
+				`Cannot register '${registration.pluginId}' into slot '${this.slotId}': a conflicting registration already exists for this plugin (different Component/tabId/label)`
+			);
 		}
 		this.registrations.push(registration);
 	}

--- a/lib/services/health-scoring-service.ts
+++ b/lib/services/health-scoring-service.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import {
 	type PluginDataLocation,
+	readPluginData,
 	writePluginData,
 } from "@/lib/services/plugin-data-service";
 import { getUserPluginSettings } from "@/lib/services/plugin-enablement-service";
@@ -196,4 +197,62 @@ export async function recomputeHealthScore(
 	}
 
 	return { data: healthState };
+}
+
+/** Validates a `PluginData.data` blob shapes up as a `HealthState` before handing it to a UI caller — defensive against a future settings/shape change leaving old rows on disk. */
+const healthStateSchema = z.object({
+	lastEvaluatedAt: z.string().nullable(),
+	score: z.number(),
+	validityWindowSeconds: z.number(),
+});
+
+/**
+ * Reads the current `{ score, lastEvaluatedAt, validityWindowSeconds }` for
+ * one claim — the human-facing read path the `element-badge`/`element-panel`
+ * UI slots use (ADR 0002 v2 §3: "state dot via element-badge"). Delegates to
+ * `readPluginData` (`plugin-data-service.ts`) for the actual row access,
+ * which is what enforces plugin enablement + case permission + namespace
+ * isolation; this function's only job is resolving `claimId` to the
+ * `caseId` that `PluginData`'s location key needs — the route layer
+ * (`app/api/elements/[id]/health/route.ts`) only has the element id,
+ * mirroring every other route in the `app/api/elements/[id]/*` family.
+ *
+ * Returns `{ data: null }` (NOT an error) when no `tea.health` row exists yet
+ * for this claim — "never evaluated" is a valid, expected state a claim with
+ * no evidence is in, not a failure — or when a row exists but its `data`
+ * doesn't parse as a `HealthState` (defensive: a future change to what this
+ * plugin stores should degrade old rows to "nothing to show" on this read
+ * path, never a 500).
+ */
+export async function readHealthState(
+	actingUserId: string,
+	claimId: string
+): ServiceResult<HealthState | null> {
+	let element: { caseId: string; deletedAt: Date | null } | null;
+	try {
+		element = await prisma.assuranceElement.findUnique({
+			where: { id: claimId },
+			select: { caseId: true, deletedAt: true },
+		});
+	} catch (error) {
+		console.error("Failed to resolve claim for health state read:", error);
+		return { error: "Failed to read health state" };
+	}
+	if (!element || element.deletedAt) {
+		return { error: "Claim not found" };
+	}
+
+	const result = await readPluginData(PLUGIN_ID, actingUserId, {
+		caseId: element.caseId,
+		elementId: claimId,
+	});
+	if ("error" in result) {
+		return { error: result.error };
+	}
+	if (!result.data) {
+		return { data: null };
+	}
+
+	const parsed = healthStateSchema.safeParse(result.data.data);
+	return { data: parsed.success ? parsed.data : null };
 }

--- a/lib/services/health-scoring-service.ts
+++ b/lib/services/health-scoring-service.ts
@@ -207,6 +207,23 @@ const healthStateSchema = z.object({
 });
 
 /**
+ * A single generic message for every reason this read can fail to resolve a
+ * claim — doesn't exist, is soft-deleted, or the caller lacks case access —
+ * mirroring `health-evidence-service.ts`'s `CLAIM_NOT_FOUND` precedent.
+ * Distinguishing "doesn't exist" from "no permission" would let any caller
+ * with access to ANY case probe arbitrary ids and learn, from which message
+ * came back, whether a claim exists elsewhere on the platform — the same
+ * enumeration oracle that precedent (and `plugin-data-service.ts`'s own
+ * "same error for not-found and no-permission" convention) exists to close.
+ * `readPluginData`'s OWN generic message for a permission failure is
+ * `"Case not found"` (a different string, since it's shared by non-claim
+ * callers too) — remapped to this one below so both failure modes are
+ * byte-identical from this function's callers' point of view.
+ */
+const CLAIM_NOT_FOUND = "Claim not found";
+const PLUGIN_DATA_CASE_NOT_FOUND = "Case not found";
+
+/**
  * Reads the current `{ score, lastEvaluatedAt, validityWindowSeconds }` for
  * one claim — the human-facing read path the `element-badge`/`element-panel`
  * UI slots use (ADR 0002 v2 §3: "state dot via element-badge"). Delegates to
@@ -239,7 +256,7 @@ export async function readHealthState(
 		return { error: "Failed to read health state" };
 	}
 	if (!element || element.deletedAt) {
-		return { error: "Claim not found" };
+		return { error: CLAIM_NOT_FOUND };
 	}
 
 	const result = await readPluginData(PLUGIN_ID, actingUserId, {
@@ -247,7 +264,11 @@ export async function readHealthState(
 		elementId: claimId,
 	});
 	if ("error" in result) {
-		return { error: result.error };
+		const error =
+			result.error === PLUGIN_DATA_CASE_NOT_FOUND
+				? CLAIM_NOT_FOUND
+				: result.error;
+		return { error };
 	}
 	if (!result.data) {
 		return { data: null };

--- a/lib/services/health-scoring-service.ts
+++ b/lib/services/health-scoring-service.ts
@@ -5,8 +5,12 @@ import {
 	readPluginData,
 	writePluginData,
 } from "@/lib/services/plugin-data-service";
-import { getUserPluginSettings } from "@/lib/services/plugin-enablement-service";
+import {
+	assertPluginEnabledForUser,
+	getUserPluginSettings,
+} from "@/lib/services/plugin-enablement-service";
 import type {
+	ElementType,
 	PluginHealthEvidenceVerdict,
 	Prisma,
 } from "@/src/generated/prisma";
@@ -208,13 +212,13 @@ const healthStateSchema = z.object({
 
 /**
  * A single generic message for every reason this read can fail to resolve a
- * claim — doesn't exist, is soft-deleted, or the caller lacks case access —
- * mirroring `health-evidence-service.ts`'s `CLAIM_NOT_FOUND` precedent.
- * Distinguishing "doesn't exist" from "no permission" would let any caller
- * with access to ANY case probe arbitrary ids and learn, from which message
- * came back, whether a claim exists elsewhere on the platform — the same
- * enumeration oracle that precedent (and `plugin-data-service.ts`'s own
- * "same error for not-found and no-permission" convention) exists to close.
+ * claim — doesn't exist, is soft-deleted, isn't a `PROPERTY_CLAIM`, or the
+ * caller lacks case access — mirroring `health-evidence-service.ts`'s
+ * `CLAIM_NOT_FOUND` precedent. Distinguishing any of these would let a
+ * caller learn, from which message came back, something about an element it
+ * has no business knowing about — the same enumeration oracle that
+ * precedent (and `plugin-data-service.ts`'s own "same error for not-found
+ * and no-permission" convention) exists to close.
  * `readPluginData`'s OWN generic message for a permission failure is
  * `"Case not found"` (a different string, since it's shared by non-claim
  * callers too) — remapped to this one below so both failure modes are
@@ -228,11 +232,32 @@ const PLUGIN_DATA_CASE_NOT_FOUND = "Case not found";
  * one claim — the human-facing read path the `element-badge`/`element-panel`
  * UI slots use (ADR 0002 v2 §3: "state dot via element-badge"). Delegates to
  * `readPluginData` (`plugin-data-service.ts`) for the actual row access,
- * which is what enforces plugin enablement + case permission + namespace
- * isolation; this function's only job is resolving `claimId` to the
- * `caseId` that `PluginData`'s location key needs — the route layer
+ * which is what enforces case permission + namespace isolation; this
+ * function's only job is resolving `claimId` to the `caseId` that
+ * `PluginData`'s location key needs — the route layer
  * (`app/api/elements/[id]/health/route.ts`) only has the element id,
  * mirroring every other route in the `app/api/elements/[id]/*` family.
+ *
+ * Enablement is checked FIRST, before the element lookup even runs (vincent
+ * review, BLOCKER, 2026-07-04): the element lookup below queries
+ * `assuranceElement` directly, with no case-permission check of its own, so
+ * running it before enablement made this function a platform-wide
+ * element-existence oracle for any user who had self-disabled `tea.health` —
+ * every REAL element id (any case, no access required) resolved past this
+ * lookup into `readPluginData`'s enablement check and came back
+ * `"Plugin 'tea.health' is not enabled"` (403), while a nonexistent id never
+ * got that far and came back `CLAIM_NOT_FOUND` (404). Checking enablement
+ * first closes that: a disabled plugin now refuses every id — real,
+ * soft-deleted, wrong-typed, or fabricated — with the exact same error
+ * before a single row is even queried.
+ *
+ * The element lookup also selects `elementType` and refuses anything that
+ * isn't a `PROPERTY_CLAIM` with the SAME `CLAIM_NOT_FOUND` message (not a
+ * distinct one) — evidence-format-v0.1 only ever bears on claims, so a
+ * goal/strategy/evidence id has no health state to read, but saying so in a
+ * different message would itself be a (smaller) oracle: "exists but wrong
+ * type" vs "doesn't exist" leaks whether an id resolves to *something* on
+ * the platform. Mirrors `health-evidence-service.ts`'s `resolveClaim`.
  *
  * Returns `{ data: null }` (NOT an error) when no `tea.health` row exists yet
  * for this claim — "never evaluated" is a valid, expected state a claim with
@@ -245,17 +270,30 @@ export async function readHealthState(
 	actingUserId: string,
 	claimId: string
 ): ServiceResult<HealthState | null> {
-	let element: { caseId: string; deletedAt: Date | null } | null;
+	const enablement = await assertPluginEnabledForUser(PLUGIN_ID, actingUserId);
+	if ("error" in enablement) {
+		return { error: enablement.error };
+	}
+
+	let element: {
+		caseId: string;
+		deletedAt: Date | null;
+		elementType: ElementType;
+	} | null;
 	try {
 		element = await prisma.assuranceElement.findUnique({
 			where: { id: claimId },
-			select: { caseId: true, deletedAt: true },
+			select: { caseId: true, deletedAt: true, elementType: true },
 		});
 	} catch (error) {
 		console.error("Failed to resolve claim for health state read:", error);
 		return { error: "Failed to read health state" };
 	}
-	if (!element || element.deletedAt) {
+	if (
+		!element ||
+		element.deletedAt ||
+		element.elementType !== "PROPERTY_CLAIM"
+	) {
 		return { error: CLAIM_NOT_FOUND };
 	}
 

--- a/providers/modal-provider.tsx
+++ b/providers/modal-provider.tsx
@@ -1,9 +1,15 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import type { JSX } from "react";
+import type { ReactNode } from "react";
 
 import { ErrorBoundary } from "@/components/ui/error-boundary";
+// Registers every official plugin's UI modules for the running app (ADR 0002
+// v2 §2.3 implementation decision, cid 2026-07-04) — a bare side-effect
+// import, so it runs once as this always-mounted, root-level client
+// component loads (`app/layout.tsx` renders `<ModalProvider />` for every
+// route), before any canvas node or the node-edit dialog can render a slot.
+import "@/lib/plugins/bootstrap";
 
 // Dynamic imports with ssr: false to reduce initial bundle size
 const CaseCreateModal = dynamic(
@@ -71,9 +77,9 @@ const InviteMemberDialog = dynamic(
  *
  * All child modals use `dynamic(..., { ssr: false })`, so no mounted gate is needed here.
  *
- * @returns {JSX.Element} The JSX for the modals.
+ * @returns {ReactNode} The JSX for the modals.
  */
-export const ModalProvider = (): JSX.Element => (
+export const ModalProvider = (): ReactNode => (
 	<>
 		<CaseCreateModal />
 		<ErrorBoundary

--- a/src/__tests__/integration/api-elements-health.test.ts
+++ b/src/__tests__/integration/api-elements-health.test.ts
@@ -1,0 +1,188 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { appendHealthEvidence } from "@/lib/services/health-evidence-service";
+import { recomputeHealthScore } from "@/lib/services/health-scoring-service";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	createTestCase,
+	createTestElement,
+	createTestPermission,
+	createTestPluginData,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+const HEALTH_PATH = (elementId: string) =>
+	`http://localhost:3000/api/elements/${elementId}/health`;
+const NONEXISTENT_ID = "00000000-0000-0000-0000-000000000000";
+const NOT_ENABLED_PATTERN = /is not enabled/;
+
+beforeEach(async () => {
+	await mockNoAuth();
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+async function setup() {
+	const owner = await createTestUser();
+	const testCase = await createTestCase(owner.id);
+	const claim = await createTestElement(testCase.id, owner.id, {
+		elementType: "PROPERTY_CLAIM",
+	});
+	return { owner, testCase, claim };
+}
+
+function getRequest(elementId: string): NextRequest {
+	return new NextRequest(HEALTH_PATH(elementId));
+}
+
+function importRoute() {
+	return import("@/app/api/elements/[id]/health/route");
+}
+
+describe("GET /api/elements/[id]/health — happy path", () => {
+	it("returns the score written by recomputeHealthScore, end to end", async () => {
+		const { owner, testCase, claim } = await setup();
+		await mockAuth(owner.id, owner.username, owner.email);
+		const appended = await appendHealthEvidence(owner.id, {
+			claimId: claim.id,
+			metricName: "in-distribution-rate",
+			value: 0.98,
+			threshold: 0.95,
+			verdict: "PASS",
+			oddDimensions: [],
+			sourceSystem: "darter-pipeline",
+			provenance: { check: "ood-monitor/kl-divergence", runId: "run-1" },
+			evaluatedAt: new Date().toISOString(),
+		});
+		expect("data" in appended).toBe(true);
+		await recomputeHealthScore(owner.id, claim.id, testCase.id);
+
+		const { GET } = await importRoute();
+		const response = await GET(getRequest(claim.id), {
+			params: Promise.resolve({ id: claim.id }),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.health.score).toBe(1);
+		expect(body.health.lastEvaluatedAt).not.toBeNull();
+	});
+
+	it("returns health: null for a claim that has never been scored", async () => {
+		const { owner, claim } = await setup();
+		await mockAuth(owner.id, owner.username, owner.email);
+		const { GET } = await importRoute();
+
+		const response = await GET(getRequest(claim.id), {
+			params: Promise.resolve({ id: claim.id }),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.health).toBeNull();
+	});
+
+	it("reads via a viewer's session with only VIEW access", async () => {
+		const { owner, testCase, claim } = await setup();
+		const viewer = await createTestUser();
+		await createTestPermission(testCase.id, viewer.id, owner.id, "VIEW");
+		await createTestPluginData(testCase.id, {
+			pluginId: "tea.health",
+			elementId: claim.id,
+			data: {
+				score: 0.5,
+				lastEvaluatedAt: null,
+				validityWindowSeconds: 86_400,
+			},
+		});
+		await mockAuth(viewer.id, viewer.username, viewer.email);
+		const { GET } = await importRoute();
+
+		const response = await GET(getRequest(claim.id), {
+			params: Promise.resolve({ id: claim.id }),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.health.score).toBe(0.5);
+	});
+});
+
+describe("GET /api/elements/[id]/health — validation and auth", () => {
+	it("rejects a non-UUID id with 400", async () => {
+		const { owner } = await setup();
+		await mockAuth(owner.id, owner.username, owner.email);
+		const { GET } = await importRoute();
+
+		const response = await GET(getRequest("not-a-uuid"), {
+			params: Promise.resolve({ id: "not-a-uuid" }),
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.code).toBe("VALIDATION");
+	});
+
+	it("returns 401 with no session", async () => {
+		const { claim } = await setup();
+		const { GET } = await importRoute();
+
+		const response = await GET(getRequest(claim.id), {
+			params: Promise.resolve({ id: claim.id }),
+		});
+
+		expect(response.status).toBe(401);
+	});
+});
+
+describe("GET /api/elements/[id]/health — permission matrix", () => {
+	it("returns 404 'Claim not found' for a non-existent claim id", async () => {
+		const { owner } = await setup();
+		await mockAuth(owner.id, owner.username, owner.email);
+		const { GET } = await importRoute();
+
+		const response = await GET(getRequest(NONEXISTENT_ID), {
+			params: Promise.resolve({ id: NONEXISTENT_ID }),
+		});
+
+		expect(response.status).toBe(404);
+		const body = await response.json();
+		expect(body.error).toBe("Claim not found");
+	});
+
+	it("returns 404 (generic, not an enumeration oracle) for a session with no case access", async () => {
+		const { claim } = await setup();
+		const outsider = await createTestUser();
+		await mockAuth(outsider.id, outsider.username, outsider.email);
+		const { GET } = await importRoute();
+
+		const response = await GET(getRequest(claim.id), {
+			params: Promise.resolve({ id: claim.id }),
+		});
+
+		expect(response.status).toBe(404);
+	});
+});
+
+describe("GET /api/elements/[id]/health — disabled-plugin refusal", () => {
+	it("refuses cleanly (403, not a 500) when tea.health is disabled at the deployment level", async () => {
+		const { owner, claim } = await setup();
+		await mockAuth(owner.id, owner.username, owner.email);
+		vi.stubEnv("TEA_PLUGINS_DISABLED", "tea.health");
+		const { GET } = await importRoute();
+
+		const response = await GET(getRequest(claim.id), {
+			params: Promise.resolve({ id: claim.id }),
+		});
+
+		expect(response.status).toBe(403);
+		const body = await response.json();
+		expect(body.error).toMatch(NOT_ENABLED_PATTERN);
+	});
+});

--- a/src/__tests__/integration/api-elements-health.test.ts
+++ b/src/__tests__/integration/api-elements-health.test.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { appendHealthEvidence } from "@/lib/services/health-evidence-service";
 import { recomputeHealthScore } from "@/lib/services/health-scoring-service";
+import { setPluginEnabledForUser } from "@/lib/services/plugin-enablement-service";
 import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
 import {
 	createTestCase,
@@ -19,6 +20,7 @@ const HEALTH_PATH = (elementId: string) =>
 	`http://localhost:3000/api/elements/${elementId}/health`;
 const NONEXISTENT_ID = "00000000-0000-0000-0000-000000000000";
 const NOT_ENABLED_PATTERN = /is not enabled/;
+const PLUGIN_ID = "tea.health";
 
 beforeEach(async () => {
 	await mockNoAuth();
@@ -189,6 +191,28 @@ describe("GET /api/elements/[id]/health — permission matrix", () => {
 		const nonexistentBody = await nonexistentResponse.json();
 		expect(noAccessBody).toEqual(nonexistentBody);
 	});
+
+	it("returns byte-identical 404s for a non-claim element (a GOAL) vs. a nonexistent id (no type-existence oracle)", async () => {
+		const { owner, testCase } = await setup();
+		const goal = await createTestElement(testCase.id, owner.id, {
+			elementType: "GOAL",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+		const { GET } = await importRoute();
+
+		const goalResponse = await GET(getRequest(goal.id), {
+			params: Promise.resolve({ id: goal.id }),
+		});
+		const nonexistentResponse = await GET(getRequest(NONEXISTENT_ID), {
+			params: Promise.resolve({ id: NONEXISTENT_ID }),
+		});
+
+		expect(goalResponse.status).toBe(404);
+		expect(goalResponse.status).toBe(nonexistentResponse.status);
+		const goalBody = await goalResponse.json();
+		const nonexistentBody = await nonexistentResponse.json();
+		expect(goalBody).toEqual(nonexistentBody);
+	});
 });
 
 describe("GET /api/elements/[id]/health — disabled-plugin refusal", () => {
@@ -205,5 +229,38 @@ describe("GET /api/elements/[id]/health — disabled-plugin refusal", () => {
 		expect(response.status).toBe(403);
 		const body = await response.json();
 		expect(body.error).toMatch(NOT_ENABLED_PATTERN);
+	});
+});
+
+describe("GET /api/elements/[id]/health — enablement-ordering side channel (vincent review, BLOCKER, 2026-07-04)", () => {
+	it("returns byte-identical 403s for a real claim in an inaccessible case vs. a nonexistent id, once tea.health is self-disabled", async () => {
+		const { claim } = await setup();
+		const outsider = await createTestUser();
+		// Self-disable via the SAME unprivileged path a real user has
+		// (PATCH /api/user/plugins) — `outsider` has no access whatsoever to
+		// the case `claim` lives in.
+		await setPluginEnabledForUser(PLUGIN_ID, outsider.id, { enabled: false });
+		await mockAuth(outsider.id, outsider.username, outsider.email);
+		const { GET } = await importRoute();
+
+		const realClaimResponse = await GET(getRequest(claim.id), {
+			params: Promise.resolve({ id: claim.id }),
+		});
+		const nonexistentResponse = await GET(getRequest(NONEXISTENT_ID), {
+			params: Promise.resolve({ id: NONEXISTENT_ID }),
+		});
+
+		// Before the fix: a REAL id (any case, no access needed) resolved the
+		// element lookup before enablement was ever checked, then fell through
+		// to `readPluginData`'s "not enabled" 403 — while a nonexistent id
+		// short-circuited on the element lookup itself and returned 404. That
+		// difference IS the platform-wide element-existence oracle; asserting
+		// byte-identical responses here is what would catch its return.
+		expect(realClaimResponse.status).toBe(403);
+		expect(realClaimResponse.status).toBe(nonexistentResponse.status);
+		const realClaimBody = await realClaimResponse.json();
+		const nonexistentBody = await nonexistentResponse.json();
+		expect(realClaimBody).toEqual(nonexistentBody);
+		expect(realClaimBody.error).toMatch(NOT_ENABLED_PATTERN);
 	});
 });

--- a/src/__tests__/integration/api-elements-health.test.ts
+++ b/src/__tests__/integration/api-elements-health.test.ts
@@ -156,7 +156,7 @@ describe("GET /api/elements/[id]/health — permission matrix", () => {
 		expect(body.error).toBe("Claim not found");
 	});
 
-	it("returns 404 (generic, not an enumeration oracle) for a session with no case access", async () => {
+	it("returns 404 'Claim not found' for a session with no case access", async () => {
 		const { claim } = await setup();
 		const outsider = await createTestUser();
 		await mockAuth(outsider.id, outsider.username, outsider.email);
@@ -167,6 +167,27 @@ describe("GET /api/elements/[id]/health — permission matrix", () => {
 		});
 
 		expect(response.status).toBe(404);
+		const body = await response.json();
+		expect(body.error).toBe("Claim not found");
+	});
+
+	it("returns byte-identical 404s for a non-existent claim vs. one an outsider can't access (no enumeration oracle)", async () => {
+		const { claim } = await setup();
+		const outsider = await createTestUser();
+		await mockAuth(outsider.id, outsider.username, outsider.email);
+		const { GET } = await importRoute();
+
+		const noAccessResponse = await GET(getRequest(claim.id), {
+			params: Promise.resolve({ id: claim.id }),
+		});
+		const nonexistentResponse = await GET(getRequest(NONEXISTENT_ID), {
+			params: Promise.resolve({ id: NONEXISTENT_ID }),
+		});
+
+		expect(noAccessResponse.status).toBe(nonexistentResponse.status);
+		const noAccessBody = await noAccessResponse.json();
+		const nonexistentBody = await nonexistentResponse.json();
+		expect(noAccessBody).toEqual(nonexistentBody);
 	});
 });
 


### PR DESCRIPTION
## Summary

The health plugin's user-facing half — the final piece of the 1.0 keystone chain. With this merged, `tea.health` is a complete, active plugin: evidence posted by a machine integration flips a claim's badge live in the browser.

- **Badge (`element-badge` slot):** a state dot on canvas claim nodes, derived from the plugin's per-claim health score. Bands come from plugin settings (defaults mirror the scoring service); an out-of-window score renders a distinct muted "stale" treatment. Accessible by construction — an `<output>` live region with a text label, never colour-only.
- **Evidence panel (`element-panel` slot):** an "Evidence" tab in the element dialog showing the claim's append-only log newest-first (verdict, metric, value/threshold, source, evaluated time; provenance behind a native disclosure). Non-claim elements show a clean not-applicable state and fire no requests.
- **Plugin bootstrap:** `lib/plugins/bootstrap.ts` is the sanctioned import point for official plugin UI modules (ADR 0002 §2.3 implementation decision) — one side-effect import per plugin, wired once from the root client providers; the one-way import rule stays structural. Registration is fail-safe (a throwing registration degrades to unregistered rather than breaking the bundle) and the slot registry now no-ops identical re-registrations while throwing on conflicting ones.
- **Read path:** a thin session-authenticated `GET /api/elements/[id]/health` delegating to the plugin-data access service (case permission + namespace isolation enforced there).
- **Live updates:** the browser event stream now registers a listener for `tea.health/state-changed` (previously the server broadcast it into the void — no listener existed); badge and panel refetch on the event via one shared claim-scoped fetch hook.

## Review chain

Implementation reviewed frozen by QA and code review; findings addressed across one completion round and one fix round; every reviewed-to-final delta read in full before this PR.

- **Code review's blocking find, fixed and regression-tested:** the read path checked plugin enablement *after* looking up the element, which turned a self-serve plugin toggle into a platform-wide element-existence oracle (real ids answered "plugin not enabled", fake ids "not found"). Enablement is now checked first; a disabled plugin refuses every id — real, wrong-typed, soft-deleted, or fabricated — byte-identically (proven by paired-response tests). A wrong-type guard was added under the same uniform response.
- **QA's highest find, fixed:** the one-line event-listener fix shipped here had no test that would fail if reverted; the new hook-level test asserts listener registration against the hook's own exported event list, so the test cannot drift from the code it guards.
- Also addressed: conflict-vs-identical re-registration semantics, dark fallback branches (schema-invalid settings, relative-time formatting), the type-half of the event guard, and extraction of duplicated refetch wiring flagged by the dead-code audit.

## Test evidence (final commit)

- Lint: 673 files clean · typecheck clean
- Unit: 982/982 · Integration: 613/613 (full suite, re-verified independently on the final commit)
