### PR TITLE
Integration management API — owner-only service-boundary auth, lifecycle and token routes

### DIFF
--- a/app/api/integrations/[id]/reactivate/route.ts
+++ b/app/api/integrations/[id]/reactivate/route.ts
@@ -1,0 +1,50 @@
+import {
+	apiError,
+	apiErrorFromUnknown,
+	apiSuccess,
+	requireAuth,
+	serviceErrorToAppError,
+} from "@/lib/api-response";
+import { validationError } from "@/lib/errors";
+import { uuidSchema } from "@/lib/schemas/base";
+import { reactivateIntegration } from "@/lib/services/integration-registry-service";
+
+/**
+ * POST /api/integrations/[id]/reactivate
+ *
+ * Reverses `suspend` (SUSPENDED → ACTIVE). Owner-only, audited.
+ *
+ * @description REVOKED stays terminal — reactivating a revoked integration
+ * is a 409, never a resurrection. Reactivating an already-ACTIVE
+ * integration is also a 409 (no-op success would hide a caller mistake).
+ * @pathParam id - Integration ID (UUID)
+ * @response 200 - The reactivated integration
+ * @response 401 - Unauthorised
+ * @response 404 - Integration not found (covers non-existent and not-owned — same message)
+ * @response 409 - The integration is REVOKED, or already ACTIVE
+ * @auth SessionAuth
+ * @tag Integrations
+ */
+export async function POST(
+	_request: Request,
+	{ params }: { params: Promise<{ id: string }> }
+) {
+	try {
+		const userId = await requireAuth();
+		const { id } = await params;
+
+		const parsedId = uuidSchema.safeParse(id);
+		if (!parsedId.success) {
+			return apiError(validationError("Invalid integration id"));
+		}
+
+		const result = await reactivateIntegration(parsedId.data, userId);
+		if ("error" in result) {
+			return apiError(serviceErrorToAppError(result.error));
+		}
+
+		return apiSuccess({ integration: result.data });
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}

--- a/app/api/integrations/[id]/revoke/route.ts
+++ b/app/api/integrations/[id]/revoke/route.ts
@@ -1,0 +1,49 @@
+import {
+	apiError,
+	apiErrorFromUnknown,
+	apiSuccess,
+	requireAuth,
+	serviceErrorToAppError,
+} from "@/lib/api-response";
+import { validationError } from "@/lib/errors";
+import { uuidSchema } from "@/lib/schemas/base";
+import { revokeIntegration } from "@/lib/services/integration-registry-service";
+
+/**
+ * POST /api/integrations/[id]/revoke
+ *
+ * Revokes an integration permanently (→ REVOKED) and, in the same
+ * transaction, revokes every one of its currently-unrevoked tokens.
+ * Terminal — there is no un-revoke (`reactivate` refuses a REVOKED
+ * integration). Owner-only, audited.
+ *
+ * @pathParam id - Integration ID (UUID)
+ * @response 200 - The revoked integration
+ * @response 401 - Unauthorised
+ * @response 404 - Integration not found (covers non-existent and not-owned — same message)
+ * @auth SessionAuth
+ * @tag Integrations
+ */
+export async function POST(
+	_request: Request,
+	{ params }: { params: Promise<{ id: string }> }
+) {
+	try {
+		const userId = await requireAuth();
+		const { id } = await params;
+
+		const parsedId = uuidSchema.safeParse(id);
+		if (!parsedId.success) {
+			return apiError(validationError("Invalid integration id"));
+		}
+
+		const result = await revokeIntegration(parsedId.data, userId);
+		if ("error" in result) {
+			return apiError(serviceErrorToAppError(result.error));
+		}
+
+		return apiSuccess({ integration: result.data });
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}

--- a/app/api/integrations/[id]/route.ts
+++ b/app/api/integrations/[id]/route.ts
@@ -8,7 +8,10 @@ import {
 import { validationError } from "@/lib/errors";
 import { uuidSchema } from "@/lib/schemas/base";
 import { updateIntegrationSchema } from "@/lib/schemas/integration";
-import { updateIntegration } from "@/lib/services/integration-registry-service";
+import {
+	deleteIntegrationRegistration,
+	updateIntegration,
+} from "@/lib/services/integration-registry-service";
 
 /**
  * PATCH /api/integrations/[id]
@@ -61,6 +64,50 @@ export async function PATCH(
 		}
 
 		return apiSuccess({ integration: result.data });
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}
+
+/**
+ * DELETE /api/integrations/[id]
+ *
+ * Deletes an integration's registration outright — its dedicated system
+ * user artefacts and every one of its tokens go with it (cascade), per
+ * `deleteIntegrationRegistration`'s existing semantics, unchanged here.
+ * Owner-only — a non-owner gets the exact same 404 as a nonexistent id (no
+ * enumeration oracle; `getOwnedIntegrationOrError` in the service layer).
+ *
+ * @description Prefer `POST .../revoke` when the integration's own
+ * accountability trail matters (it keeps the row, terminally revoked);
+ * use this when a human owner needs the row itself gone, with no new
+ * owner to reassign to (`deleteIntegrationRegistration`'s doc comment).
+ * @pathParam id - Integration ID (UUID)
+ * @response 200 - `{ success: true }`
+ * @response 401 - Unauthorised
+ * @response 404 - Integration not found (covers non-existent and not-owned — same message)
+ * @auth SessionAuth
+ * @tag Integrations
+ */
+export async function DELETE(
+	_request: Request,
+	{ params }: { params: Promise<{ id: string }> }
+) {
+	try {
+		const userId = await requireAuth();
+		const { id } = await params;
+
+		const parsedId = uuidSchema.safeParse(id);
+		if (!parsedId.success) {
+			return apiError(validationError("Invalid integration id"));
+		}
+
+		const result = await deleteIntegrationRegistration(parsedId.data, userId);
+		if ("error" in result) {
+			return apiError(serviceErrorToAppError(result.error));
+		}
+
+		return apiSuccess({ success: true });
 	} catch (error) {
 		return apiErrorFromUnknown(error);
 	}

--- a/app/api/integrations/[id]/route.ts
+++ b/app/api/integrations/[id]/route.ts
@@ -1,0 +1,67 @@
+import {
+	apiError,
+	apiErrorFromUnknown,
+	apiSuccess,
+	requireAuth,
+	serviceErrorToAppError,
+} from "@/lib/api-response";
+import { validationError } from "@/lib/errors";
+import { uuidSchema } from "@/lib/schemas/base";
+import { updateIntegrationSchema } from "@/lib/schemas/integration";
+import { updateIntegration } from "@/lib/services/integration-registry-service";
+
+/**
+ * PATCH /api/integrations/[id]
+ *
+ * Updates an integration's description and/or scopes. Owner-only — a
+ * non-owner gets the exact same 404 as a nonexistent id (no enumeration
+ * oracle; `getOwnedIntegrationOrError` in the service layer).
+ *
+ * @description At least one of `description`/`scopes` must be present.
+ * `scopes` is validated against the closed vocabulary in
+ * `lib/auth/scopes.ts` — an unknown scope is a 400.
+ * @pathParam id - Integration ID (UUID)
+ * @body { description?: string, scopes?: string[] }
+ * @response 200 - The updated integration
+ * @response 400 - Validation error (including an unknown scope)
+ * @response 401 - Unauthorised
+ * @response 404 - Integration not found (covers non-existent and not-owned — same message)
+ * @auth SessionAuth
+ * @tag Integrations
+ */
+export async function PATCH(
+	request: Request,
+	{ params }: { params: Promise<{ id: string }> }
+) {
+	try {
+		const userId = await requireAuth();
+		const { id } = await params;
+
+		const parsedId = uuidSchema.safeParse(id);
+		if (!parsedId.success) {
+			return apiError(validationError("Invalid integration id"));
+		}
+
+		const parsed = updateIntegrationSchema.safeParse(
+			await request.json().catch(() => null)
+		);
+		if (!parsed.success) {
+			return apiError(
+				validationError(parsed.error.issues[0]?.message ?? "Invalid input")
+			);
+		}
+
+		const result = await updateIntegration(
+			parsedId.data,
+			{ description: parsed.data.description, scopes: parsed.data.scopes },
+			userId
+		);
+		if ("error" in result) {
+			return apiError(serviceErrorToAppError(result.error));
+		}
+
+		return apiSuccess({ integration: result.data });
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}

--- a/app/api/integrations/[id]/suspend/route.ts
+++ b/app/api/integrations/[id]/suspend/route.ts
@@ -1,0 +1,51 @@
+import {
+	apiError,
+	apiErrorFromUnknown,
+	apiSuccess,
+	requireAuth,
+	serviceErrorToAppError,
+} from "@/lib/api-response";
+import { validationError } from "@/lib/errors";
+import { uuidSchema } from "@/lib/schemas/base";
+import { suspendIntegration } from "@/lib/services/integration-registry-service";
+
+/**
+ * POST /api/integrations/[id]/suspend
+ *
+ * Suspends an ACTIVE integration (ACTIVE → SUSPENDED) — every token it has
+ * issued stops authenticating for as long as it stays suspended, but
+ * nothing is destroyed; `POST .../reactivate` reverses this. Owner-only.
+ *
+ * @description A REVOKED integration cannot be suspended (REVOKED is
+ * terminal) — that request is a 409, not a silent status flip.
+ * @pathParam id - Integration ID (UUID)
+ * @response 200 - The suspended integration
+ * @response 401 - Unauthorised
+ * @response 404 - Integration not found (covers non-existent and not-owned — same message)
+ * @response 409 - The integration is REVOKED (terminal — cannot be suspended)
+ * @auth SessionAuth
+ * @tag Integrations
+ */
+export async function POST(
+	_request: Request,
+	{ params }: { params: Promise<{ id: string }> }
+) {
+	try {
+		const userId = await requireAuth();
+		const { id } = await params;
+
+		const parsedId = uuidSchema.safeParse(id);
+		if (!parsedId.success) {
+			return apiError(validationError("Invalid integration id"));
+		}
+
+		const result = await suspendIntegration(parsedId.data, userId);
+		if ("error" in result) {
+			return apiError(serviceErrorToAppError(result.error));
+		}
+
+		return apiSuccess({ integration: result.data });
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}

--- a/app/api/integrations/[id]/tokens/[tokenId]/rotate/route.ts
+++ b/app/api/integrations/[id]/tokens/[tokenId]/rotate/route.ts
@@ -1,0 +1,67 @@
+import {
+	apiError,
+	apiErrorFromUnknown,
+	apiSuccess,
+	requireAuth,
+	serviceErrorToAppError,
+} from "@/lib/api-response";
+import { validationError } from "@/lib/errors";
+import { uuidSchema } from "@/lib/schemas/base";
+import { rotateToken } from "@/lib/services/integration-registry-service";
+
+/**
+ * POST /api/integrations/[id]/tokens/[tokenId]/rotate
+ *
+ * Issues a replacement token and brings the old token's expiry forward to
+ * a short overlap window (both authenticate during it — see
+ * `TOKEN_ROTATION_OVERLAP_MS` in `integration-registry-service.ts`). The
+ * new plaintext secret is returned EXACTLY ONCE, here. Owner-only —
+ * ownership rides the token's OWN integration, not the path `[id]`
+ * (`rotateToken` doesn't take the path integration id as a parameter).
+ *
+ * @description Refuses a token that is already revoked, or whose
+ * integration isn't ACTIVE.
+ * @pathParam id - Integration ID (UUID) — informational; not itself checked against the token's integration
+ * @pathParam tokenId - Token ID (UUID)
+ * @response 200 - `{ secret, token: { id, tokenPrefix, createdAt, expiresAt }, oldTokenId, overlapUntil }`
+ * @response 400 - Validation error
+ * @response 401 - Unauthorised
+ * @response 404 - Token not found (covers non-existent and not-owned — same message)
+ * @response 409 - The token is already revoked, or its integration isn't ACTIVE
+ * @auth SessionAuth
+ * @tag Integrations
+ */
+export async function POST(
+	_request: Request,
+	{ params }: { params: Promise<{ id: string; tokenId: string }> }
+) {
+	try {
+		const userId = await requireAuth();
+		const { id, tokenId } = await params;
+
+		const parsedId = uuidSchema.safeParse(id);
+		const parsedTokenId = uuidSchema.safeParse(tokenId);
+		if (!(parsedId.success && parsedTokenId.success)) {
+			return apiError(validationError("Invalid id"));
+		}
+
+		const result = await rotateToken(parsedTokenId.data, userId);
+		if ("error" in result) {
+			return apiError(serviceErrorToAppError(result.error));
+		}
+
+		return apiSuccess({
+			secret: result.data.newToken.secret,
+			token: {
+				id: result.data.newToken.apiToken.id,
+				tokenPrefix: result.data.newToken.apiToken.tokenPrefix,
+				createdAt: result.data.newToken.apiToken.createdAt,
+				expiresAt: result.data.newToken.apiToken.expiresAt,
+			},
+			oldTokenId: result.data.oldTokenId,
+			overlapUntil: result.data.overlapUntil,
+		});
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}

--- a/app/api/integrations/[id]/tokens/[tokenId]/rotate/route.ts
+++ b/app/api/integrations/[id]/tokens/[tokenId]/rotate/route.ts
@@ -16,17 +16,22 @@ import { rotateToken } from "@/lib/services/integration-registry-service";
  * a short overlap window (both authenticate during it — see
  * `TOKEN_ROTATION_OVERLAP_MS` in `integration-registry-service.ts`). The
  * new plaintext secret is returned EXACTLY ONCE, here. Owner-only —
- * ownership rides the token's OWN integration, not the path `[id]`
- * (`rotateToken` doesn't take the path integration id as a parameter).
+ * ownership rides the token's OWN integration, not the path `[id]`. The
+ * path `[id]` IS still checked, though, for a different reason: a `tokenId`
+ * that exists and is owned by the caller but actually belongs to a
+ * DIFFERENT integration the caller also owns is rejected with the exact
+ * same generic 404 as a nonexistent `tokenId` (deviation-5 fix, work item
+ * 2 — no enumeration oracle, and no cross-integration token operations via
+ * a mismatched path).
  *
  * @description Refuses a token that is already revoked, or whose
  * integration isn't ACTIVE.
- * @pathParam id - Integration ID (UUID) — informational; not itself checked against the token's integration
+ * @pathParam id - Integration ID (UUID) — checked against the token's OWN integration; a mismatch is a 404 identical to a nonexistent tokenId
  * @pathParam tokenId - Token ID (UUID)
  * @response 200 - `{ secret, token: { id, tokenPrefix, createdAt, expiresAt }, oldTokenId, overlapUntil }`
  * @response 400 - Validation error
  * @response 401 - Unauthorised
- * @response 404 - Token not found (covers non-existent and not-owned — same message)
+ * @response 404 - Token not found (covers non-existent, not-owned, and belonging to a different integration than the path — same message)
  * @response 409 - The token is already revoked, or its integration isn't ACTIVE
  * @auth SessionAuth
  * @tag Integrations
@@ -45,7 +50,9 @@ export async function POST(
 			return apiError(validationError("Invalid id"));
 		}
 
-		const result = await rotateToken(parsedTokenId.data, userId);
+		const result = await rotateToken(parsedTokenId.data, userId, {
+			integrationId: parsedId.data,
+		});
 		if ("error" in result) {
 			return apiError(serviceErrorToAppError(result.error));
 		}

--- a/app/api/integrations/[id]/tokens/[tokenId]/route.ts
+++ b/app/api/integrations/[id]/tokens/[tokenId]/route.ts
@@ -14,15 +14,19 @@ import { revokeToken } from "@/lib/services/integration-registry-service";
  *
  * Revokes a single token immediately — no grace period (unlike rotation's
  * overlap window). Owner-only — ownership rides the token's OWN
- * integration, not the path `[id]` (`revokeToken` doesn't take the path
- * integration id as a parameter).
+ * integration, not the path `[id]`. The path `[id]` IS still checked,
+ * though, for a different reason: a `tokenId` that exists and is owned by
+ * the caller but actually belongs to a DIFFERENT integration the caller
+ * also owns is rejected with the exact same generic 404 as a nonexistent
+ * `tokenId` (deviation-5 fix, work item 2 — no enumeration oracle, and no
+ * cross-integration token operations via a mismatched path).
  *
- * @pathParam id - Integration ID (UUID) — informational; not itself checked against the token's integration
+ * @pathParam id - Integration ID (UUID) — checked against the token's OWN integration; a mismatch is a 404 identical to a nonexistent tokenId
  * @pathParam tokenId - Token ID (UUID)
  * @response 200 - `{ success: true }`
  * @response 400 - Validation error
  * @response 401 - Unauthorised
- * @response 404 - Token not found (covers non-existent and not-owned — same message)
+ * @response 404 - Token not found (covers non-existent, not-owned, and belonging to a different integration than the path — same message)
  * @response 409 - The token is already revoked
  * @auth SessionAuth
  * @tag Integrations
@@ -41,7 +45,9 @@ export async function DELETE(
 			return apiError(validationError("Invalid id"));
 		}
 
-		const result = await revokeToken(parsedTokenId.data, userId);
+		const result = await revokeToken(parsedTokenId.data, userId, {
+			integrationId: parsedId.data,
+		});
 		if ("error" in result) {
 			return apiError(serviceErrorToAppError(result.error));
 		}

--- a/app/api/integrations/[id]/tokens/[tokenId]/route.ts
+++ b/app/api/integrations/[id]/tokens/[tokenId]/route.ts
@@ -1,0 +1,53 @@
+import {
+	apiError,
+	apiErrorFromUnknown,
+	apiSuccess,
+	requireAuth,
+	serviceErrorToAppError,
+} from "@/lib/api-response";
+import { validationError } from "@/lib/errors";
+import { uuidSchema } from "@/lib/schemas/base";
+import { revokeToken } from "@/lib/services/integration-registry-service";
+
+/**
+ * DELETE /api/integrations/[id]/tokens/[tokenId]
+ *
+ * Revokes a single token immediately — no grace period (unlike rotation's
+ * overlap window). Owner-only — ownership rides the token's OWN
+ * integration, not the path `[id]` (`revokeToken` doesn't take the path
+ * integration id as a parameter).
+ *
+ * @pathParam id - Integration ID (UUID) — informational; not itself checked against the token's integration
+ * @pathParam tokenId - Token ID (UUID)
+ * @response 200 - `{ success: true }`
+ * @response 400 - Validation error
+ * @response 401 - Unauthorised
+ * @response 404 - Token not found (covers non-existent and not-owned — same message)
+ * @response 409 - The token is already revoked
+ * @auth SessionAuth
+ * @tag Integrations
+ */
+export async function DELETE(
+	_request: Request,
+	{ params }: { params: Promise<{ id: string; tokenId: string }> }
+) {
+	try {
+		const userId = await requireAuth();
+		const { id, tokenId } = await params;
+
+		const parsedId = uuidSchema.safeParse(id);
+		const parsedTokenId = uuidSchema.safeParse(tokenId);
+		if (!(parsedId.success && parsedTokenId.success)) {
+			return apiError(validationError("Invalid id"));
+		}
+
+		const result = await revokeToken(parsedTokenId.data, userId);
+		if ("error" in result) {
+			return apiError(serviceErrorToAppError(result.error));
+		}
+
+		return apiSuccess({ success: true });
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}

--- a/app/api/integrations/[id]/tokens/route.ts
+++ b/app/api/integrations/[id]/tokens/route.ts
@@ -1,0 +1,80 @@
+import {
+	apiError,
+	apiErrorFromUnknown,
+	apiSuccess,
+	requireAuth,
+	serviceErrorToAppError,
+} from "@/lib/api-response";
+import { validationError } from "@/lib/errors";
+import { uuidSchema } from "@/lib/schemas/base";
+import { issueTokenSchema } from "@/lib/schemas/integration";
+import { issueToken } from "@/lib/services/integration-registry-service";
+
+/**
+ * POST /api/integrations/[id]/tokens
+ *
+ * Issues a new bearer token for an ACTIVE integration. The plaintext
+ * secret is returned EXACTLY ONCE, here, in this response — it is never
+ * persisted anywhere, never shown again, and never appears in
+ * `GET /api/integrations` (which shows only the token's prefix and
+ * timestamps). Owner-only.
+ *
+ * @description `expiresAt` is optional — omitted means the token never
+ * expires on its own (revocation is the primary kill switch; see
+ * `issueToken`'s doc comment in `integration-registry-service.ts`). When
+ * provided it must be in the future.
+ * @pathParam id - Integration ID (UUID)
+ * @body { expiresAt?: string }
+ * @response 201 - `{ secret: string, token: { id, tokenPrefix, createdAt, expiresAt } }`
+ * @response 400 - Validation error
+ * @response 401 - Unauthorised
+ * @response 404 - Integration not found (covers non-existent and not-owned — same message)
+ * @response 409 - The integration is not ACTIVE
+ * @auth SessionAuth
+ * @tag Integrations
+ */
+export async function POST(
+	request: Request,
+	{ params }: { params: Promise<{ id: string }> }
+) {
+	try {
+		const userId = await requireAuth();
+		const { id } = await params;
+
+		const parsedId = uuidSchema.safeParse(id);
+		if (!parsedId.success) {
+			return apiError(validationError("Invalid integration id"));
+		}
+
+		const parsed = issueTokenSchema.safeParse(
+			await request.json().catch(() => ({}))
+		);
+		if (!parsed.success) {
+			return apiError(
+				validationError(parsed.error.issues[0]?.message ?? "Invalid input")
+			);
+		}
+
+		const result = await issueToken(parsedId.data, userId, {
+			expiresAt: parsed.data.expiresAt,
+		});
+		if ("error" in result) {
+			return apiError(serviceErrorToAppError(result.error));
+		}
+
+		return apiSuccess(
+			{
+				secret: result.data.secret,
+				token: {
+					id: result.data.apiToken.id,
+					tokenPrefix: result.data.apiToken.tokenPrefix,
+					createdAt: result.data.apiToken.createdAt,
+					expiresAt: result.data.apiToken.expiresAt,
+				},
+			},
+			201
+		);
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}

--- a/app/api/integrations/route.ts
+++ b/app/api/integrations/route.ts
@@ -1,0 +1,95 @@
+import {
+	apiError,
+	apiErrorFromUnknown,
+	apiSuccess,
+	requireAuth,
+	serviceErrorToAppError,
+} from "@/lib/api-response";
+import { validationError } from "@/lib/errors";
+import { registerIntegrationSchema } from "@/lib/schemas/integration";
+import {
+	listIntegrationsForOwner,
+	registerIntegration,
+} from "@/lib/services/integration-registry-service";
+
+/**
+ * GET /api/integrations
+ *
+ * Lists every integration the SESSION USER owns — never anyone else's
+ * (ADR 0002 v2 §2.4, work item 7). Each entry carries a token SUMMARY per
+ * issued token (prefix, timestamps, expiry/revocation state); the
+ * plaintext secret and hash are never part of this response — issuance
+ * (`POST .../tokens`) is the only moment a secret is ever shown.
+ *
+ * @description Owner-only listing — the caller's own integrations only.
+ * @response 200 - `{ integrations: IntegrationListItem[] }`
+ * @response 401 - Unauthorised
+ * @auth SessionAuth
+ * @tag Integrations
+ */
+export async function GET() {
+	try {
+		const userId = await requireAuth();
+
+		const result = await listIntegrationsForOwner(userId);
+		if ("error" in result) {
+			return apiError(serviceErrorToAppError(result.error));
+		}
+
+		return apiSuccess({ integrations: result.data });
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}
+
+/**
+ * POST /api/integrations
+ *
+ * Registers a new integration owned by the SESSION USER. `ownerId` is not
+ * an accepted field — it is always derived from the session, never from
+ * the request body (vincent's session-derived-identity trust statement,
+ * 2026-07-03), so a caller cannot register on someone else's behalf.
+ * Returns the integration only — no token. Issuing a token is a separate,
+ * explicit step (`POST /api/integrations/[id]/tokens`).
+ *
+ * @description Any authenticated user may register an integration; the
+ * registrant becomes its owner. `scopes` is validated against the closed
+ * vocabulary in `lib/auth/scopes.ts` — an unknown scope is a 400.
+ * @body { name: string, description?: string, scopes: string[] }
+ * @response 201 - The created integration (no token)
+ * @response 400 - Validation error (including an unknown scope)
+ * @response 401 - Unauthorised
+ * @response 409 - An integration with this name already exists
+ * @auth SessionAuth
+ * @tag Integrations
+ */
+export async function POST(request: Request) {
+	try {
+		const userId = await requireAuth();
+
+		const parsed = registerIntegrationSchema.safeParse(
+			await request.json().catch(() => null)
+		);
+		if (!parsed.success) {
+			return apiError(
+				validationError(parsed.error.issues[0]?.message ?? "Invalid input")
+			);
+		}
+
+		const result = await registerIntegration(
+			{
+				name: parsed.data.name,
+				description: parsed.data.description,
+				scopes: parsed.data.scopes,
+			},
+			userId
+		);
+		if ("error" in result) {
+			return apiError(serviceErrorToAppError(result.error));
+		}
+
+		return apiSuccess({ integration: result.data.integration }, 201);
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}

--- a/e2e/machine-whoami.spec.ts
+++ b/e2e/machine-whoami.spec.ts
@@ -53,7 +53,7 @@ test.describe("/api/machine/whoami — e2e smoke (R1)", () => {
 		ownerId = owner.id;
 
 		const registered = await registerIntegration(
-			{ name: unique, ownerId: owner.id, scopes: ["case:read"] },
+			{ name: unique, scopes: ["case:read"] },
 			owner.id
 		);
 		if ("error" in registered) {

--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -142,8 +142,15 @@ const ERROR_MAPPINGS: Array<{
 		factory: conflict,
 	},
 	// `user-management-service.ts`'s `deleteAccount` — owned integrations
-	// (ON DELETE RESTRICT) block account deletion until reassigned/removed.
-	{ pattern: /reassign or remove your \d+ integrations?/i, factory: conflict },
+	// (ON DELETE RESTRICT) block account deletion until removed (no
+	// reassignment path in 1.0). Anchored `^...$` like its two siblings
+	// above, not a bare substring (vincent minor, review round 2 — this
+	// used to be unanchored, the odd one out of the three lifecycle
+	// patterns in this array).
+	{
+		pattern: /^Remove your \d+ integrations? before deleting your account$/,
+		factory: conflict,
+	},
 ];
 
 /**

--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -10,6 +10,7 @@ import {
 	handleError,
 	notFound,
 	unauthorised,
+	validationError,
 } from "./errors";
 
 // ---------------------------------------------------------------------------
@@ -103,6 +104,9 @@ function matchesPattern(error: string, pattern: ErrorPattern): boolean {
 	return pattern.test(error);
 }
 
+/** Shared factory for every "the resource exists but is in the wrong state for this action" error below. */
+const conflict = () => new AppError({ code: "CONFLICT", message: "" });
+
 const ERROR_MAPPINGS: Array<{
 	pattern: ErrorPattern;
 	factory: () => AppError;
@@ -110,10 +114,7 @@ const ERROR_MAPPINGS: Array<{
 	{ pattern: "Permission denied", factory: () => forbidden() },
 	{ pattern: "unauthorised", factory: () => unauthorised() },
 	{ pattern: "not found", factory: () => notFound() },
-	{
-		pattern: "already",
-		factory: () => new AppError({ code: "CONFLICT", message: "" }),
-	},
+	{ pattern: "already", factory: conflict },
 	// `assertPluginEnabledForUser` ("Plugin '<id>' is not enabled",
 	// `plugin-enablement-service.ts`'s `assertPluginEnabledForUser`) — a
 	// plugin switched off (deployment, or user-level) is a clean, expected
@@ -124,6 +125,25 @@ const ERROR_MAPPINGS: Array<{
 	// error that happens to contain that phrase for a different reason isn't
 	// misclassified as a plugin-disabled 403.
 	{ pattern: /^Plugin '.+' is not enabled$/, factory: () => forbidden() },
+	// `integration-registry-service.ts` / `lib/schemas/integration.ts`
+	// (integration management API, work item 7): an unknown scope is a
+	// validation failure (400), not an unmapped 500.
+	{ pattern: /^Unknown scope/, factory: () => validationError("") },
+	// Lifecycle/state-guard errors from the integration registry service —
+	// the integration or token exists and is owned by the caller, but its
+	// current status makes the requested action a no-op or a terminal-state
+	// violation (e.g. reactivating a REVOKED integration, or issuing/
+	// rotating a token against one that isn't ACTIVE). None of these contain
+	// "already" or "not found", so without this entry they'd fall through to
+	// INTERNAL (500) the first time an HTTP route ever surfaced them.
+	{
+		pattern:
+			/^Cannot (suspend|reactivate) a revoked integration$|^Cannot (issue|rotate) a token for a non-active integration$|^Cannot rotate a revoked token$/,
+		factory: conflict,
+	},
+	// `user-management-service.ts`'s `deleteAccount` — owned integrations
+	// (ON DELETE RESTRICT) block account deletion until reassigned/removed.
+	{ pattern: /reassign or remove your \d+ integrations?/i, factory: conflict },
 ];
 
 /**

--- a/lib/schemas/__tests__/integration.test.ts
+++ b/lib/schemas/__tests__/integration.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { SCOPES } from "@/lib/auth/scopes";
+import {
+	integrationScopesSchema,
+	registerIntegrationSchema,
+	updateIntegrationSchema,
+} from "../integration";
+
+/**
+ * Pins the zod caps that gate `POST /api/integrations` and
+ * `PATCH /api/integrations/[id]` — `lib/schemas/base.ts`'s
+ * `requiredString`/`optionalString` factories take the max length as a
+ * plain argument, so these boundaries are only as good as the numbers the
+ * schema passes them; a future edit that silently changes 100 to 1000 (or
+ * vice versa) should break a test, not slip through unnoticed (nanaki
+ * info finding, work item 11).
+ */
+describe("registerIntegrationSchema — boundary caps", () => {
+	it("accepts a name at exactly 100 characters", () => {
+		const result = registerIntegrationSchema.safeParse({
+			name: "a".repeat(100),
+			scopes: ["case:read"],
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects a name at 101 characters", () => {
+		const result = registerIntegrationSchema.safeParse({
+			name: "a".repeat(101),
+			scopes: ["case:read"],
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("accepts a description at exactly 1000 characters", () => {
+		const result = registerIntegrationSchema.safeParse({
+			name: "boundary-description",
+			description: "a".repeat(1000),
+			scopes: ["case:read"],
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects a description at 1001 characters", () => {
+		const result = registerIntegrationSchema.safeParse({
+			name: "boundary-description",
+			description: "a".repeat(1001),
+			scopes: ["case:read"],
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("updateIntegrationSchema — description cap (shares optionalString(1000))", () => {
+	it("accepts a description at exactly 1000 characters", () => {
+		const result = updateIntegrationSchema.safeParse({
+			description: "a".repeat(1000),
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects a description at 1001 characters", () => {
+		const result = updateIntegrationSchema.safeParse({
+			description: "a".repeat(1001),
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+/**
+ * `MAX_SCOPES` is 20, but the CLOSED scope vocabulary (`SCOPES`,
+ * `lib/auth/scopes.ts`) currently has only 3 members — there is no way to
+ * construct a 21-item array of 21 DISTINCT valid scopes to pin the true
+ * "one over the cap" boundary with unique values. Padding the array with
+ * repeated valid scope values is the only way to reach the length that
+ * matters. `integrationScopesSchema` has no separate uniqueness rule, so
+ * this pins the CURRENT behaviour (duplicates count towards the cap and
+ * are otherwise allowed) rather than testing the cap in total isolation —
+ * noted per work item 11's instruction for when the catalogue is smaller
+ * than the cap.
+ */
+describe("integrationScopesSchema — MAX_SCOPES=20 cap (padded with duplicates)", () => {
+	it("accepts exactly 20 scopes, even with repeats (catalogue has only 3 distinct values)", () => {
+		const scopes = Array.from(
+			{ length: 20 },
+			(_, i) => SCOPES[i % SCOPES.length]
+		);
+		const result = integrationScopesSchema.safeParse(scopes);
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects 21 scopes", () => {
+		const scopes = Array.from(
+			{ length: 21 },
+			(_, i) => SCOPES[i % SCOPES.length]
+		);
+		const result = integrationScopesSchema.safeParse(scopes);
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects an empty array", () => {
+		const result = integrationScopesSchema.safeParse([]);
+		expect(result.success).toBe(false);
+	});
+});

--- a/lib/schemas/index.ts
+++ b/lib/schemas/index.ts
@@ -8,6 +8,7 @@ export * from "./case-study";
 export * from "./comment";
 export * from "./element";
 export * from "./google-drive";
+export * from "./integration";
 export * from "./permission";
 export * from "./plugin";
 export * from "./status";

--- a/lib/schemas/integration.ts
+++ b/lib/schemas/integration.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+import { SCOPES } from "@/lib/auth/scopes";
+import { optionalString, requiredString } from "@/lib/schemas/base";
+
+/**
+ * Zod schemas for the integration management API (ADR 0002 v2 §2.4, work
+ * item 7) — `app/api/integrations/**`. All routes on this surface are
+ * human-session (`requireAuth()`), owner-only, and delegate to
+ * `lib/services/integration-registry-service.ts`.
+ */
+
+// ============================================
+// Scopes
+// ============================================
+
+const MAX_SCOPES = 20;
+
+/**
+ * A single scope string, validated against the CLOSED vocabulary in
+ * `lib/auth/scopes.ts` — `SCOPES` is a compile-time `as const` tuple (unlike
+ * the plugin manifest, it isn't populated at runtime), so `z.enum` can bind
+ * it directly rather than re-checking membership in a `.refine`. An unknown
+ * scope is rejected here with a proper 400, before the service layer's own
+ * `findUnknownScopes` defence-in-depth check ever runs.
+ */
+const integrationScopeSchema = z.enum(SCOPES);
+
+/**
+ * At least one scope, capped at `MAX_SCOPES` — an integration with zero
+ * scopes can authenticate but call nothing, which is never a useful state
+ * to register or update into; suspend/revoke are the correct way to
+ * disable an integration instead of stripping every scope.
+ */
+export const integrationScopesSchema = z
+	.array(integrationScopeSchema)
+	.min(1, "At least one scope is required")
+	.max(MAX_SCOPES, `At most ${MAX_SCOPES} scopes are allowed`);
+
+// ============================================
+// POST /api/integrations
+// ============================================
+
+/**
+ * Body schema for registering an integration. `ownerId` is deliberately
+ * ABSENT — the service derives it from the session-authenticated actor
+ * (`registerIntegration`'s `actorUserId`), so nothing in this body can ever
+ * name a different owner (vincent's session-derived-identity trust
+ * statement, 2026-07-03).
+ */
+export const registerIntegrationSchema = z.object({
+	name: requiredString("Name", 1, 100),
+	description: optionalString(1000),
+	scopes: integrationScopesSchema,
+});
+
+export type RegisterIntegrationBody = z.infer<typeof registerIntegrationSchema>;
+
+// ============================================
+// PATCH /api/integrations/[id]
+// ============================================
+
+/**
+ * Body schema for updating an integration's description and/or scopes.
+ * Both fields optional, but at least one must be present — an empty PATCH
+ * is a caller bug, not a no-op success.
+ */
+export const updateIntegrationSchema = z
+	.object({
+		description: optionalString(1000),
+		scopes: integrationScopesSchema.optional(),
+	})
+	.refine(
+		(data) => data.description !== undefined || data.scopes !== undefined,
+		{ message: "At least one field to update must be provided" }
+	);
+
+export type UpdateIntegrationBody = z.infer<typeof updateIntegrationSchema>;
+
+// ============================================
+// POST /api/integrations/[id]/tokens
+// ============================================
+
+/**
+ * Body schema for issuing a token. `expiresAt` is optional — omitted means
+ * never-expiring (see `issueToken`'s doc comment in
+ * `integration-registry-service.ts` for why that's the considered default).
+ * When present, it must be in the future: the service itself accepts a
+ * past `expiresAt` (useful for internal test fixtures), but an API caller
+ * asking for an already-dead token is always a mistake worth rejecting at
+ * the boundary rather than silently honouring.
+ */
+export const issueTokenSchema = z.object({
+	expiresAt: z.coerce
+		.date()
+		.refine((date) => date.getTime() > Date.now(), {
+			message: "expiresAt must be in the future",
+		})
+		.optional(),
+});
+
+export type IssueTokenBody = z.infer<typeof issueTokenSchema>;

--- a/lib/services/integration-registry-service.ts
+++ b/lib/services/integration-registry-service.ts
@@ -30,23 +30,36 @@ import type { ServiceResult } from "@/types/service";
  * Authorisation (management API precondition — vincent security review
  * 2026-07-03, finding 3): OWNER-ONLY in 1.0, no admin override — no
  * platform-admin concept exists anywhere in this codebase, and none is
- * invented here. `suspendIntegration`, `reactivateIntegration`,
- * `revokeIntegration`, `issueToken`, `rotateToken`, `revokeToken`,
- * `updateIntegration`/`updateIntegrationScopes`, `reassignIntegrationOwner`,
- * and `deleteIntegrationRegistration` all verify, at THIS service boundary
- * (not just in a calling route), that `actorUserId` owns the integration
- * before acting — `getOwnedIntegrationOrError` is the single choke point
- * for that check. `registerIntegration` binds the new integration's
- * `ownerId` to `actorUserId` directly (any authenticated user may
- * register; the registrant becomes owner — policy settled by cid,
- * 2026-07-05) — there is no `ownerId` input a caller could use to name a
- * different owner. A non-owner acting on someone else's integration
- * (or token) gets the EXACT SAME error as acting on a nonexistent id —
- * the repo's enumeration-prevention convention
- * (`element-service.ts`'s `getElement` precedent) — never a distinct
- * "Permission denied". `validateApiToken` is the one exception: it has no
- * human actor at all (it authenticates a bearer token), and its semantics
- * are unchanged.
+ * invented here. Every mutating operation below verifies, at THIS service
+ * boundary (not just in a calling route), that `actorUserId` owns the
+ * integration before acting — through exactly ONE of two choke points,
+ * chosen by which id the operation is keyed on (vincent MAJOR, review
+ * round 2: the single-choke-point claim used to be false — `rotateToken`/
+ * `revokeToken` had their own duplicated inline checks — this is now
+ * literally true for both families):
+ *   - INTEGRATION-keyed ops — `suspendIntegration`, `reactivateIntegration`,
+ *     `revokeIntegration`, `issueToken`, `updateIntegration`/
+ *     `updateIntegrationScopes`, `reassignIntegrationOwner`,
+ *     `deleteIntegrationRegistration` — go through
+ *     `getOwnedIntegrationOrError`.
+ *   - TOKEN-keyed ops — `rotateToken`, `revokeToken` — go through
+ *     `getOwnedApiTokenOrError`, its symmetrical twin. Ownership rides the
+ *     token's OWN integration, not a path-supplied integration id; a caller
+ *     may additionally pass `options.integrationId` to also require the
+ *     token belong to THAT specific integration (a tokenId that exists,
+ *     is owned by the actor, but hangs off a DIFFERENT integration the
+ *     actor also owns is rejected identically to a nonexistent tokenId —
+ *     deviation-5 fix, work item 2).
+ * `registerIntegration` binds the new integration's `ownerId` to
+ * `actorUserId` directly (any authenticated user may register; the
+ * registrant becomes owner — policy settled by cid, 2026-07-05) — there is
+ * no `ownerId` input a caller could use to name a different owner. A
+ * non-owner acting on someone else's integration (or token) gets the EXACT
+ * SAME error as acting on a nonexistent id — the repo's
+ * enumeration-prevention convention (`element-service.ts`'s `getElement`
+ * precedent) — never a distinct "Permission denied". `validateApiToken` is
+ * the one exception: it has no human actor at all (it authenticates a
+ * bearer token), and its semantics are unchanged.
  */
 
 // ============================================
@@ -195,6 +208,48 @@ async function getOwnedIntegrationOrError<S extends Prisma.IntegrationSelect>(
 	// distinct instantiations of the same generated type. Runtime shape is
 	// identical; this cast just reconciles the two static instantiations.
 	return { data: integration as Prisma.IntegrationGetPayload<{ select: S }> };
+}
+
+/**
+ * Loads an `ApiToken` by id with the given `select`, verifying it both
+ * EXISTS and its OWNING INTEGRATION is owned by `actorUserId` — the
+ * token-keyed twin of `getOwnedIntegrationOrError` above (vincent MAJOR,
+ * review round 2: `rotateToken`/`revokeToken` used to each run their own
+ * duplicated inline version of this check; this is now the single choke
+ * point for both, matching the module doc comment). A token has no
+ * `ownerId` of its own — ownership rides its `integration.ownerId` — so
+ * this is a distinct helper, not a generic rename of the integration one.
+ *
+ * Returns the SAME "Token not found" error whether the id doesn't exist at
+ * all or exists but its integration belongs to someone else — a caller
+ * cannot distinguish "no such token" from "not yours".
+ */
+async function getOwnedApiTokenOrError<S extends Prisma.ApiTokenSelect>(
+	tokenId: string,
+	actorUserId: string,
+	select: S
+): ServiceResult<Prisma.ApiTokenGetPayload<{ select: S }>> {
+	// Same two-query shape as `getOwnedIntegrationOrError`, for the same
+	// reason (see its comment): a generic `S` can't be safely merged with
+	// the nested `integration.ownerId` select at the type level.
+	const ownerRow = await prisma.apiToken.findUnique({
+		where: { id: tokenId },
+		select: { integration: { select: { ownerId: true } } },
+	});
+	if (!ownerRow || ownerRow.integration.ownerId !== actorUserId) {
+		return { error: "Token not found" };
+	}
+
+	const apiToken = await prisma.apiToken.findUnique({
+		where: { id: tokenId },
+		select,
+	});
+	if (!apiToken) {
+		return { error: "Token not found" };
+	}
+	// Same `$extends()` static/runtime reconciliation cast as
+	// `getOwnedIntegrationOrError` — see its comment for why this is safe.
+	return { data: apiToken as Prisma.ApiTokenGetPayload<{ select: S }> };
 }
 
 function issueTokenRecord(integrationId: string, expiresAt?: Date) {
@@ -514,6 +569,27 @@ export async function getIntegrationsOwnedBy(
 	}
 }
 
+/**
+ * Counts integrations owned by a user — the cheap existence-and-magnitude
+ * check `deleteAccount`'s pre-flight actually needs (vincent minor, work
+ * item 7). `deleteAccount` used to call `getIntegrationsOwnedBy` and
+ * discard every row but the length, forcing a full `Integration[]` fetch
+ * (columns, ORDER BY) to answer a question `COUNT(*)` answers directly.
+ * `getIntegrationsOwnedBy` itself is UNCHANGED and kept — other flows still
+ * need the actual rows. Same trust contract: `ownerId` must be the
+ * caller's own id.
+ */
+export async function countIntegrationsOwnedBy(
+	ownerId: string
+): ServiceResult<number> {
+	try {
+		const count = await prisma.integration.count({ where: { ownerId } });
+		return { data: count };
+	} catch {
+		return { error: "Failed to count owned integrations" };
+	}
+}
+
 export interface IntegrationTokenSummary {
 	createdAt: Date;
 	expiresAt: Date | null;
@@ -706,6 +782,21 @@ export async function issueToken(
 	}
 }
 
+export interface TokenScopedOptions {
+	/**
+	 * The PATH's integration id (e.g. `[id]` in
+	 * `/api/integrations/[id]/tokens/[tokenId]/rotate`). When present, the
+	 * token must belong to THIS integration or the call fails with the same
+	 * generic "Token not found" as a nonexistent tokenId — a caller who owns
+	 * BOTH Integration A and Integration B cannot rotate/revoke a token that
+	 * actually belongs to B by naming A in the URL (deviation-5 fix, work
+	 * item 2). Optional — and left unchecked when omitted — so existing
+	 * direct service callers (tests, scripts) that have no "path" concept at
+	 * all are unaffected.
+	 */
+	integrationId?: string;
+}
+
 /**
  * Issues a replacement token and brings the old token's expiry forward to
  * `now + TOKEN_ROTATION_OVERLAP_MS` (unless it already expires sooner) —
@@ -716,18 +807,28 @@ export async function issueToken(
  */
 export async function rotateToken(
 	tokenId: string,
-	actorUserId: string
+	actorUserId: string,
+	options: TokenScopedOptions = {}
 ): ServiceResult<RotatedToken> {
 	try {
-		const oldToken = await prisma.apiToken.findUnique({
-			where: { id: tokenId },
-			include: {
-				integration: { select: { id: true, status: true, ownerId: true } },
-			},
+		const owned = await getOwnedApiTokenOrError(tokenId, actorUserId, {
+			id: true,
+			integrationId: true,
+			expiresAt: true,
+			revokedAt: true,
+			integration: { select: { status: true } },
 		});
-		if (!oldToken || oldToken.integration.ownerId !== actorUserId) {
+		if ("error" in owned) {
+			return owned;
+		}
+		if (
+			options.integrationId &&
+			owned.data.integrationId !== options.integrationId
+		) {
 			return { error: "Token not found" };
 		}
+		const oldToken = owned.data;
+
 		if (oldToken.revokedAt) {
 			return { error: "Cannot rotate a revoked token" };
 		}
@@ -776,22 +877,25 @@ export async function rotateToken(
 
 export async function revokeToken(
 	tokenId: string,
-	actorUserId: string
+	actorUserId: string,
+	options: TokenScopedOptions = {}
 ): ServiceResult<ApiToken> {
 	try {
-		const existing = await prisma.apiToken.findUnique({
-			where: { id: tokenId },
-			select: {
-				id: true,
-				revokedAt: true,
-				integrationId: true,
-				integration: { select: { ownerId: true } },
-			},
+		const owned = await getOwnedApiTokenOrError(tokenId, actorUserId, {
+			id: true,
+			integrationId: true,
+			revokedAt: true,
 		});
-		if (!existing || existing.integration.ownerId !== actorUserId) {
+		if ("error" in owned) {
+			return owned;
+		}
+		if (
+			options.integrationId &&
+			owned.data.integrationId !== options.integrationId
+		) {
 			return { error: "Token not found" };
 		}
-		if (existing.revokedAt) {
+		if (owned.data.revokedAt) {
 			return { error: "Token already revoked" };
 		}
 
@@ -803,7 +907,7 @@ export async function revokeToken(
 		await writeAuditLog({
 			userId: actorUserId,
 			eventType: "token_revoked",
-			metadata: { integrationId: existing.integrationId, tokenId },
+			metadata: { integrationId: owned.data.integrationId, tokenId },
 		});
 
 		return { data: apiToken };

--- a/lib/services/integration-registry-service.ts
+++ b/lib/services/integration-registry-service.ts
@@ -27,10 +27,26 @@ import type { ServiceResult } from "@/types/service";
  * (ADR 0002 v2 §2.4). All Prisma access for this domain lives here — routes
  * and `lib/auth/require-api-token.ts` never import Prisma directly.
  *
- * Authorisation note: this service does not itself enforce WHO may call
- * register/suspend/revoke/issue/rotate — that authority model belongs to
- * the management API + settings UI (issue 7, not yet built). `actorUserId`
- * parameters here are for audit attribution only.
+ * Authorisation (management API precondition — vincent security review
+ * 2026-07-03, finding 3): OWNER-ONLY in 1.0, no admin override — no
+ * platform-admin concept exists anywhere in this codebase, and none is
+ * invented here. `suspendIntegration`, `reactivateIntegration`,
+ * `revokeIntegration`, `issueToken`, `rotateToken`, `revokeToken`,
+ * `updateIntegration`/`updateIntegrationScopes`, `reassignIntegrationOwner`,
+ * and `deleteIntegrationRegistration` all verify, at THIS service boundary
+ * (not just in a calling route), that `actorUserId` owns the integration
+ * before acting — `getOwnedIntegrationOrError` is the single choke point
+ * for that check. `registerIntegration` binds the new integration's
+ * `ownerId` to `actorUserId` directly (any authenticated user may
+ * register; the registrant becomes owner — policy settled by cid,
+ * 2026-07-05) — there is no `ownerId` input a caller could use to name a
+ * different owner. A non-owner acting on someone else's integration
+ * (or token) gets the EXACT SAME error as acting on a nonexistent id —
+ * the repo's enumeration-prevention convention
+ * (`element-service.ts`'s `getElement` precedent) — never a distinct
+ * "Permission denied". `validateApiToken` is the one exception: it has no
+ * human actor at all (it authenticates a bearer token), and its semantics
+ * are unchanged.
  */
 
 // ============================================
@@ -40,7 +56,6 @@ import type { ServiceResult } from "@/types/service";
 export interface RegisterIntegrationInput {
 	description?: string;
 	name: string;
-	ownerId: string;
 	scopes: string[];
 }
 
@@ -129,15 +144,43 @@ async function writeAuditLog(input: AuditLogInput): Promise<void> {
 }
 
 /**
- * Loads an `Integration` by id with the given `select`, or the shared
- * not-found error. Dedupes the "load integration, fail if absent"
- * boilerplate repeated across the register/suspend/revoke/reassign/
- * delete/issue call sites below (fallow clone finding, fix round).
+ * Loads an `Integration` by id with the given `select`, verifying it both
+ * EXISTS and is owned by `actorUserId` — the service-boundary authorisation
+ * check every mutating operation below relies on (module doc comment
+ * above; vincent security review 2026-07-03, finding 3). Dedupes the "load
+ * integration, fail if absent-or-not-mine" boilerplate repeated across the
+ * update/suspend/reactivate/revoke/reassign/delete/issue call sites below
+ * (fallow clone finding, fix round) — and, just as importantly, makes it
+ * structurally impossible for a call site to check existence and ownership
+ * as two separate steps with two different error messages, which is
+ * exactly how an enumeration oracle gets reintroduced by accident.
+ *
+ * Returns the SAME "Integration not found" error whether the id doesn't
+ * exist at all or exists but belongs to someone else — a caller cannot
+ * distinguish "no such integration" from "not yours".
  */
-async function getIntegrationOrError<S extends Prisma.IntegrationSelect>(
+async function getOwnedIntegrationOrError<S extends Prisma.IntegrationSelect>(
 	integrationId: string,
+	actorUserId: string,
 	select: S
 ): ServiceResult<Prisma.IntegrationGetPayload<{ select: S }>> {
+	// Two queries rather than merging `ownerId: true` into the generic `S` at
+	// the type level: spreading a generic `Prisma.IntegrationSelect` produces
+	// a mapped type Prisma's own conditional types can't statically resolve
+	// (tried, `tsc` rejected both the property access and the payload cast
+	// below it as "insufficient overlap"). A cheap extra `findUnique` on the
+	// non-hot-path owner-only management routes is a better trade than
+	// fighting the generated client's types. The two reads are int-generated
+	// UUID lookups milliseconds apart, not a meaningful race window, and a
+	// row deleted in between resolves to the same generic not-found error.
+	const ownerRow = await prisma.integration.findUnique({
+		where: { id: integrationId },
+		select: { ownerId: true },
+	});
+	if (!ownerRow || ownerRow.ownerId !== actorUserId) {
+		return { error: "Integration not found" };
+	}
+
 	const integration = await prisma.integration.findUnique({
 		where: { id: integrationId },
 		select,
@@ -176,6 +219,11 @@ function issueTokenRecord(integrationId: string, expiresAt?: Date) {
  * (`isSystemUser: true`) and the `Integration` row transactionally.
  * Rejects any scope not in the current registry (`lib/auth/scopes.ts`) —
  * loud failure, never a silent partial save.
+ *
+ * `ownerId` is NOT part of `input` — it is `actorUserId`, always. Any
+ * authenticated user may register an integration; the registrant becomes
+ * its owner, with no way to name a different one (policy settled by cid,
+ * 2026-07-05, recorded on the issue). Management is owner-only in 1.0.
  */
 export async function registerIntegration(
 	input: RegisterIntegrationInput,
@@ -188,7 +236,7 @@ export async function registerIntegration(
 		}
 
 		const owner = await prisma.user.findUnique({
-			where: { id: input.ownerId },
+			where: { id: actorUserId },
 			select: { id: true },
 		});
 		if (!owner) {
@@ -212,7 +260,7 @@ export async function registerIntegration(
 				data: {
 					name: input.name,
 					description: input.description,
-					ownerId: input.ownerId,
+					ownerId: actorUserId,
 					systemUserId: systemUser.id,
 					scopes: input.scopes,
 				},
@@ -240,38 +288,80 @@ export async function registerIntegration(
 	}
 }
 
-/** Validates and replaces an integration's scope set. Same registry check as registration. */
-export async function updateIntegrationScopes(
+export interface UpdateIntegrationInput {
+	description?: string;
+	scopes?: string[];
+}
+
+/**
+ * Partial update of an integration's description and/or scopes — the
+ * general-purpose updater behind `PATCH /api/integrations/[id]`. Same
+ * unknown-scope check as registration when `updates.scopes` is provided.
+ * Owner-only (`getOwnedIntegrationOrError`).
+ */
+export async function updateIntegration(
 	integrationId: string,
-	scopes: string[],
+	updates: UpdateIntegrationInput,
 	actorUserId: string
 ): ServiceResult<Integration> {
 	try {
-		const unknownScopes = findUnknownScopes(scopes);
-		if (unknownScopes.length > 0) {
-			return { error: `Unknown scope(s): ${unknownScopes.join(", ")}` };
+		if (updates.scopes) {
+			const unknownScopes = findUnknownScopes(updates.scopes);
+			if (unknownScopes.length > 0) {
+				return { error: `Unknown scope(s): ${unknownScopes.join(", ")}` };
+			}
 		}
 
-		const existing = await getIntegrationOrError(integrationId, { id: true });
+		const existing = await getOwnedIntegrationOrError(
+			integrationId,
+			actorUserId,
+			{ id: true }
+		);
 		if ("error" in existing) {
 			return existing;
 		}
 
 		const integration = await prisma.integration.update({
 			where: { id: integrationId },
-			data: { scopes },
+			data: {
+				...(updates.description !== undefined && {
+					description: updates.description,
+				}),
+				...(updates.scopes !== undefined && { scopes: updates.scopes }),
+			},
 		});
+
+		// `Object.keys(updates)` would report a field as "updated" merely
+		// because the route passed the key through with an `undefined` value —
+		// filter to fields actually present so the audit trail reflects what
+		// changed, not what the caller's object literal happened to mention.
+		const updatedFields = (
+			Object.keys(updates) as (keyof UpdateIntegrationInput)[]
+		).filter((field) => updates[field] !== undefined);
 
 		await writeAuditLog({
 			userId: actorUserId,
-			eventType: "integration_scopes_updated",
-			metadata: { integrationId, scopes },
+			eventType: "integration_updated",
+			metadata: { integrationId, updatedFields },
 		});
 
 		return { data: integration };
 	} catch {
-		return { error: "Failed to update integration scopes" };
+		return { error: "Failed to update integration" };
 	}
+}
+
+/**
+ * Scopes-only convenience wrapper over `updateIntegration` — kept as its
+ * own export because `scripts/seed-darter-integration.ts` reconciles ONLY
+ * scopes on every re-run.
+ */
+export function updateIntegrationScopes(
+	integrationId: string,
+	scopes: string[],
+	actorUserId: string
+): ServiceResult<Integration> {
+	return updateIntegration(integrationId, { scopes }, actorUserId);
 }
 
 export async function suspendIntegration(
@@ -279,9 +369,20 @@ export async function suspendIntegration(
 	actorUserId: string
 ): ServiceResult<Integration> {
 	try {
-		const existing = await getIntegrationOrError(integrationId, { id: true });
+		const existing = await getOwnedIntegrationOrError(
+			integrationId,
+			actorUserId,
+			{ id: true, status: true }
+		);
 		if ("error" in existing) {
 			return existing;
+		}
+		// REVOKED is terminal (ADR 0002 v2 §2.4) — without this guard,
+		// suspending a revoked integration would silently flip its status back
+		// to SUSPENDED, i.e. un-revoke it. `reactivateIntegration` enforces the
+		// same rule for the same reason.
+		if (existing.data.status === "REVOKED") {
+			return { error: "Cannot suspend a revoked integration" };
 		}
 
 		const integration = await prisma.integration.update({
@@ -302,6 +403,49 @@ export async function suspendIntegration(
 }
 
 /**
+ * Reverses `suspendIntegration` — SUSPENDED → ACTIVE (barret deviation 6,
+ * 2026-07-03: suspend was a one-way door until this method existed).
+ * REVOKED stays terminal: reactivating a revoked integration is an error,
+ * never a resurrection. Owner-only, audited.
+ */
+export async function reactivateIntegration(
+	integrationId: string,
+	actorUserId: string
+): ServiceResult<Integration> {
+	try {
+		const existing = await getOwnedIntegrationOrError(
+			integrationId,
+			actorUserId,
+			{ id: true, status: true }
+		);
+		if ("error" in existing) {
+			return existing;
+		}
+		if (existing.data.status === "REVOKED") {
+			return { error: "Cannot reactivate a revoked integration" };
+		}
+		if (existing.data.status === "ACTIVE") {
+			return { error: "Integration is already active" };
+		}
+
+		const integration = await prisma.integration.update({
+			where: { id: integrationId },
+			data: { status: "ACTIVE" },
+		});
+
+		await writeAuditLog({
+			userId: actorUserId,
+			eventType: "integration_reactivated",
+			metadata: { integrationId },
+		});
+
+		return { data: integration };
+	} catch {
+		return { error: "Failed to reactivate integration" };
+	}
+}
+
+/**
  * Revokes an integration permanently and, in the same transaction, revokes
  * every one of its currently-unrevoked tokens — a revoked integration
  * should not keep authenticating on a token issued before the revocation.
@@ -311,7 +455,11 @@ export async function revokeIntegration(
 	actorUserId: string
 ): ServiceResult<Integration> {
 	try {
-		const existing = await getIntegrationOrError(integrationId, { id: true });
+		const existing = await getOwnedIntegrationOrError(
+			integrationId,
+			actorUserId,
+			{ id: true }
+		);
 		if ("error" in existing) {
 			return existing;
 		}
@@ -345,7 +493,13 @@ export async function revokeIntegration(
 // this is the humane path layered on top)
 // ============================================
 
-/** Lists integrations owned by a user — the set that would block their account deletion. */
+/**
+ * Lists integrations owned by a user — the set that would block their
+ * account deletion (`user-management-service.ts`'s `deleteAccount`). NOT
+ * itself an authorisation boundary: `ownerId` is trusted as-is, so every
+ * caller MUST pass the acting user's own id (never a client-supplied one) —
+ * the same discipline `requireAuth()` already enforces at the route layer.
+ */
 export async function getIntegrationsOwnedBy(
 	ownerId: string
 ): ServiceResult<Integration[]> {
@@ -360,6 +514,71 @@ export async function getIntegrationsOwnedBy(
 	}
 }
 
+export interface IntegrationTokenSummary {
+	createdAt: Date;
+	expiresAt: Date | null;
+	id: string;
+	lastUsedAt: Date | null;
+	revokedAt: Date | null;
+	tokenPrefix: string;
+}
+
+export interface IntegrationListItem {
+	createdAt: Date;
+	description: string | null;
+	id: string;
+	lastSeenAt: Date | null;
+	name: string;
+	scopes: string[];
+	status: Integration["status"];
+	tokens: IntegrationTokenSummary[];
+	updatedAt: Date;
+}
+
+/**
+ * The `GET /api/integrations` data source: every integration `ownerId`
+ * owns, each with a token SUMMARY per issued token — prefix, timestamps,
+ * expiry/revocation state — never `tokenHash` or a plaintext secret. This
+ * is a `select`, not a post-hoc field strip, so leaking a hash here isn't a
+ * "remember to redact" discipline problem, it's structurally impossible:
+ * the query never reads the column. Same trust contract as
+ * `getIntegrationsOwnedBy` — `ownerId` must be the caller's own id.
+ */
+export async function listIntegrationsForOwner(
+	ownerId: string
+): ServiceResult<IntegrationListItem[]> {
+	try {
+		const integrations = await prisma.integration.findMany({
+			where: { ownerId },
+			orderBy: { createdAt: "asc" },
+			select: {
+				id: true,
+				name: true,
+				description: true,
+				scopes: true,
+				status: true,
+				createdAt: true,
+				updatedAt: true,
+				lastSeenAt: true,
+				tokens: {
+					orderBy: { createdAt: "asc" },
+					select: {
+						id: true,
+						tokenPrefix: true,
+						createdAt: true,
+						lastUsedAt: true,
+						expiresAt: true,
+						revokedAt: true,
+					},
+				},
+			},
+		});
+		return { data: integrations };
+	} catch {
+		return { error: "Failed to list integrations" };
+	}
+}
+
 export async function reassignIntegrationOwner(
 	integrationId: string,
 	newOwnerId: string,
@@ -367,7 +586,7 @@ export async function reassignIntegrationOwner(
 ): ServiceResult<Integration> {
 	try {
 		const [existing, newOwner] = await Promise.all([
-			getIntegrationOrError(integrationId, { id: true }),
+			getOwnedIntegrationOrError(integrationId, actorUserId, { id: true }),
 			prisma.user.findUnique({
 				where: { id: newOwnerId },
 				select: { id: true },
@@ -406,10 +625,11 @@ export async function deleteIntegrationRegistration(
 	actorUserId: string
 ): ServiceResult<true> {
 	try {
-		const existing = await getIntegrationOrError(integrationId, {
-			id: true,
-			name: true,
-		});
+		const existing = await getOwnedIntegrationOrError(
+			integrationId,
+			actorUserId,
+			{ id: true, name: true }
+		);
 		if ("error" in existing) {
 			return existing;
 		}
@@ -455,10 +675,11 @@ export async function issueToken(
 	options: { expiresAt?: Date } = {}
 ): ServiceResult<IssuedToken> {
 	try {
-		const integration = await getIntegrationOrError(integrationId, {
-			id: true,
-			status: true,
-		});
+		const integration = await getOwnedIntegrationOrError(
+			integrationId,
+			actorUserId,
+			{ id: true, status: true }
+		);
 		if ("error" in integration) {
 			return integration;
 		}
@@ -500,9 +721,11 @@ export async function rotateToken(
 	try {
 		const oldToken = await prisma.apiToken.findUnique({
 			where: { id: tokenId },
-			include: { integration: { select: { id: true, status: true } } },
+			include: {
+				integration: { select: { id: true, status: true, ownerId: true } },
+			},
 		});
-		if (!oldToken) {
+		if (!oldToken || oldToken.integration.ownerId !== actorUserId) {
 			return { error: "Token not found" };
 		}
 		if (oldToken.revokedAt) {
@@ -558,9 +781,14 @@ export async function revokeToken(
 	try {
 		const existing = await prisma.apiToken.findUnique({
 			where: { id: tokenId },
-			select: { id: true, revokedAt: true, integrationId: true },
+			select: {
+				id: true,
+				revokedAt: true,
+				integrationId: true,
+				integration: { select: { ownerId: true } },
+			},
 		});
-		if (!existing) {
+		if (!existing || existing.integration.ownerId !== actorUserId) {
 			return { error: "Token not found" };
 		}
 		if (existing.revokedAt) {

--- a/lib/services/user-management-service.ts
+++ b/lib/services/user-management-service.ts
@@ -4,7 +4,7 @@ import {
 	verifyPassword,
 } from "@/lib/auth/password-service";
 import { prisma } from "@/lib/prisma";
-import { getIntegrationsOwnedBy } from "@/lib/services/integration-registry-service";
+import { countIntegrationsOwnedBy } from "@/lib/services/integration-registry-service";
 import {
 	validateEmail,
 	validatePassword,
@@ -322,10 +322,14 @@ async function getOrCreateSystemUser(
  * never silently vanish). Without the pre-check below, `tx.user.delete`
  * would throw a raw Postgres P2003 that the catch-all below flattens into
  * an unhelpful "Failed to delete account". Checking
- * `getIntegrationsOwnedBy` first turns that into a clean, typed, actionable
- * error instead — "reassign or remove your integrations first" — using the
- * same owner-deletion primitives the registry service already exposes
- * (`reassignIntegrationOwner` / `deleteIntegrationRegistration`).
+ * `countIntegrationsOwnedBy` first turns that into a clean, typed,
+ * actionable error instead — "Remove your N integration(s) before deleting
+ * your account". Reassignment has no path in 1.0 (vincent minor, review
+ * round 2 — this used to promise "reassign or remove"; only removal is
+ * actually offered), so the message promises only that. `countIntegrationsOwnedBy`
+ * is a `COUNT(*)`, not the full `getIntegrationsOwnedBy` row fetch this
+ * pre-check used to do (vincent minor, work item 7) — `getIntegrationsOwnedBy`
+ * itself is unchanged and still used elsewhere.
  */
 export async function deleteAccount(
 	userId: string,
@@ -347,14 +351,14 @@ export async function deleteAccount(
 			return { error: "User not found" };
 		}
 
-		const ownedIntegrations = await getIntegrationsOwnedBy(userId);
-		if ("error" in ownedIntegrations) {
-			return ownedIntegrations;
+		const ownedIntegrationCount = await countIntegrationsOwnedBy(userId);
+		if ("error" in ownedIntegrationCount) {
+			return ownedIntegrationCount;
 		}
-		if (ownedIntegrations.data.length > 0) {
-			const count = ownedIntegrations.data.length;
+		if (ownedIntegrationCount.data > 0) {
+			const count = ownedIntegrationCount.data;
 			return {
-				error: `Reassign or remove your ${count} integration${count === 1 ? "" : "s"} before deleting your account`,
+				error: `Remove your ${count} integration${count === 1 ? "" : "s"} before deleting your account`,
 			};
 		}
 

--- a/lib/services/user-management-service.ts
+++ b/lib/services/user-management-service.ts
@@ -4,6 +4,7 @@ import {
 	verifyPassword,
 } from "@/lib/auth/password-service";
 import { prisma } from "@/lib/prisma";
+import { getIntegrationsOwnedBy } from "@/lib/services/integration-registry-service";
 import {
 	validateEmail,
 	validatePassword,
@@ -314,6 +315,17 @@ async function getOrCreateSystemUser(
  * Deletes a user account.
  * Transfers owned cases and anonymises comments before deletion.
  * Requires password confirmation for local auth users.
+ *
+ * Integrations are NOT silently cascade-deleted: `Integration.ownerId` is an
+ * unconditional `ON DELETE RESTRICT` (ADR 0002 v2 §2.4 — a revoked
+ * integration keeps its accountability trail, so its owner reference must
+ * never silently vanish). Without the pre-check below, `tx.user.delete`
+ * would throw a raw Postgres P2003 that the catch-all below flattens into
+ * an unhelpful "Failed to delete account". Checking
+ * `getIntegrationsOwnedBy` first turns that into a clean, typed, actionable
+ * error instead — "reassign or remove your integrations first" — using the
+ * same owner-deletion primitives the registry service already exposes
+ * (`reassignIntegrationOwner` / `deleteIntegrationRegistration`).
  */
 export async function deleteAccount(
 	userId: string,
@@ -333,6 +345,17 @@ export async function deleteAccount(
 
 		if (!user) {
 			return { error: "User not found" };
+		}
+
+		const ownedIntegrations = await getIntegrationsOwnedBy(userId);
+		if ("error" in ownedIntegrations) {
+			return ownedIntegrations;
+		}
+		if (ownedIntegrations.data.length > 0) {
+			const count = ownedIntegrations.data.length;
+			return {
+				error: `Reassign or remove your ${count} integration${count === 1 ? "" : "s"} before deleting your account`,
+			};
 		}
 
 		// Verify password for local auth users

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1820,6 +1820,46 @@
         }
       }
     },
+    "/elements/{id}/health": {
+      "get": {
+        "operationId": "get-elements-{id}-health",
+        "summary": "GET /api/elements/[id]/health",
+        "description": "Refuses with a clean error (never a 500) when `tea.health`",
+        "tags": [
+          "Elements"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/200 - `{ health: { score, lastEvaluatedAt, validityWindowSeconds } | null }`"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
     "/elements/{id}/move": {
       "post": {
         "operationId": "post-elements-{id}-move",
@@ -1880,6 +1920,357 @@
         ],
         "parameters": [],
         "responses": {
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
+    "/integrations": {
+      "get": {
+        "operationId": "get-integrations",
+        "summary": "GET /api/integrations",
+        "description": "Owner-only listing — the caller's own integrations only.",
+        "tags": [
+          "Integrations"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/200 - `{ integrations: IntegrationListItem[] }`"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      },
+      "post": {
+        "operationId": "post-integrations",
+        "summary": "POST /api/integrations",
+        "description": "Any authenticated user may register an integration; the",
+        "tags": [
+          "Integrations"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/201 - The created integration (no token)"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
+    "/integrations/{id}": {
+      "patch": {
+        "operationId": "patch-integrations-{id}",
+        "summary": "PATCH /api/integrations/[id]",
+        "description": "At least one of `description`/`scopes` must be present.",
+        "tags": [
+          "Integrations"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/200 - The updated integration"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
+    "/integrations/{id}/reactivate": {
+      "post": {
+        "operationId": "post-integrations-{id}-reactivate",
+        "summary": "POST /api/integrations/[id]/reactivate",
+        "description": "REVOKED stays terminal — reactivating a revoked integration",
+        "tags": [
+          "Integrations"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/200 - The reactivated integration"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
+    "/integrations/{id}/revoke": {
+      "post": {
+        "operationId": "post-integrations-{id}-revoke",
+        "summary": "POST /api/integrations/[id]/revoke",
+        "description": "",
+        "tags": [
+          "Integrations"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/200 - The revoked integration"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
+    "/integrations/{id}/suspend": {
+      "post": {
+        "operationId": "post-integrations-{id}-suspend",
+        "summary": "POST /api/integrations/[id]/suspend",
+        "description": "A REVOKED integration cannot be suspended (REVOKED is",
+        "tags": [
+          "Integrations"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/200 - The suspended integration"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
+    "/integrations/{id}/tokens": {
+      "post": {
+        "operationId": "post-integrations-{id}-tokens",
+        "summary": "POST /api/integrations/[id]/tokens",
+        "description": "`expiresAt` is optional — omitted means the token never",
+        "tags": [
+          "Integrations"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/201 - `{ secret: string, token: { id, tokenPrefix, createdAt, expiresAt } }`"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
+    "/integrations/{id}/tokens/{tokenId}": {
+      "delete": {
+        "operationId": "delete-integrations-{id}-tokens-{tokenId}",
+        "summary": "DELETE /api/integrations/[id]/tokens/[tokenId]",
+        "description": "",
+        "tags": [
+          "Integrations"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
+    "/integrations/{id}/tokens/{tokenId}/rotate": {
+      "post": {
+        "operationId": "post-integrations-{id}-tokens-{tokenId}-rotate",
+        "summary": "POST /api/integrations/[id]/tokens/[tokenId]/rotate",
+        "description": "Refuses a token that is already revoked, or whose",
+        "tags": [
+          "Integrations"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/200 - `{ secret, token: { id, tokenPrefix, createdAt, expiresAt }, oldTokenId, overlapUntil }`"
+                }
+              }
+            }
+          },
           "400": {
             "$ref": "#/components/responses/400"
           },

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -2051,6 +2051,37 @@
             "$ref": "#/components/responses/500"
           }
         }
+      },
+      "delete": {
+        "operationId": "delete-integrations-{id}",
+        "summary": "DELETE /api/integrations/[id]",
+        "description": "Prefer `POST .../revoke` when the integration's own",
+        "tags": [
+          "Integrations"
+        ],
+        "parameters": [],
+        "security": [
+          {
+            "SessionAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
       }
     },
     "/integrations/{id}/reactivate": {

--- a/scripts/seed-darter-integration.ts
+++ b/scripts/seed-darter-integration.ts
@@ -129,7 +129,6 @@ async function main() {
 				name: INTEGRATION_NAME,
 				description:
 					"DARTER evidence pipeline — machine client for the health plugin",
-				ownerId: owner.id,
 				scopes: [...EXPECTED_SCOPES],
 			},
 			owner.id

--- a/src/__tests__/integration/api-integrations.test.ts
+++ b/src/__tests__/integration/api-integrations.test.ts
@@ -1,0 +1,815 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	createTestApiToken,
+	createTestIntegrationWithSystemUser,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+beforeEach(async () => {
+	await mockNoAuth();
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+const NOT_FOUND_ID = "00000000-0000-0000-0000-000000000000";
+const INTEGRATION_NOT_FOUND = "Integration not found";
+const TOKEN_NOT_FOUND = "Token not found";
+
+function jsonRequest(url: string, method: string, body?: unknown): NextRequest {
+	return new NextRequest(`http://localhost:3000${url}`, {
+		method,
+		...(body !== undefined && { body: JSON.stringify(body) }),
+	});
+}
+
+function idParams(id: string) {
+	return { params: Promise.resolve({ id }) };
+}
+
+function tokenParams(id: string, tokenId: string) {
+	return { params: Promise.resolve({ id, tokenId }) };
+}
+
+// ============================================
+// GET / POST /api/integrations
+// ============================================
+
+describe("GET /api/integrations", () => {
+	it("returns 401 when unauthenticated", async () => {
+		const { GET } = await import("@/app/api/integrations/route");
+		const response = await GET();
+		expect(response.status).toBe(401);
+	});
+
+	it("lists only the caller's own integrations, never another user's", async () => {
+		const owner = await createTestUser();
+		const other = await createTestUser();
+		await createTestIntegrationWithSystemUser(owner.id, {
+			name: "mine",
+		});
+		await createTestIntegrationWithSystemUser(other.id, {
+			name: "not-mine",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { GET } = await import("@/app/api/integrations/route");
+		const response = await GET();
+		expect(response.status).toBe(200);
+
+		const body = await response.json();
+		expect(body.integrations).toHaveLength(1);
+		expect(body.integrations[0].name).toBe("mine");
+	});
+
+	it("includes a token summary (prefix, timestamps) but NEVER a hash or secret", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const apiToken = await createTestApiToken(integration.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { GET } = await import("@/app/api/integrations/route");
+		const response = await GET();
+		const body = await response.json();
+
+		expect(body.integrations[0].tokens).toHaveLength(1);
+		const token = body.integrations[0].tokens[0];
+		expect(token.id).toBe(apiToken.id);
+		expect(token.tokenPrefix).toBe(apiToken.tokenPrefix);
+		expect(token).not.toHaveProperty("tokenHash");
+		expect(token).not.toHaveProperty("secret");
+		expect(JSON.stringify(body)).not.toContain(apiToken.tokenHash);
+	});
+});
+
+describe("POST /api/integrations", () => {
+	it("returns 401 when unauthenticated", async () => {
+		const { POST } = await import("@/app/api/integrations/route");
+		const response = await POST(
+			jsonRequest("/api/integrations", "POST", {
+				name: "my-integration",
+				scopes: ["case:read"],
+			})
+		);
+		expect(response.status).toBe(401);
+	});
+
+	it("registers an integration owned by the session user, returning no token", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { POST } = await import("@/app/api/integrations/route");
+		const response = await POST(
+			jsonRequest("/api/integrations", "POST", {
+				name: `route-registered-${user.id}`,
+				description: "a test integration",
+				scopes: ["case:read"],
+			})
+		);
+
+		expect(response.status).toBe(201);
+		const body = await response.json();
+		expect(body.integration.ownerId).toBe(user.id);
+		expect(body.integration).not.toHaveProperty("secret");
+		expect(body.integration).not.toHaveProperty("token");
+	});
+
+	it("binds ownership to the session user even if the body names a different owner", async () => {
+		const user = await createTestUser();
+		const other = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { POST } = await import("@/app/api/integrations/route");
+		const response = await POST(
+			jsonRequest("/api/integrations", "POST", {
+				name: `spoof-attempt-${user.id}`,
+				scopes: ["case:read"],
+				ownerId: other.id,
+			})
+		);
+
+		expect(response.status).toBe(201);
+		const body = await response.json();
+		expect(body.integration.ownerId).toBe(user.id);
+		expect(body.integration.ownerId).not.toBe(other.id);
+	});
+
+	it("rejects an unknown scope with 400", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { POST } = await import("@/app/api/integrations/route");
+		const response = await POST(
+			jsonRequest("/api/integrations", "POST", {
+				name: `bad-scope-${user.id}`,
+				scopes: ["not-a-real-scope"],
+			})
+		);
+
+		expect(response.status).toBe(400);
+	});
+
+	it("rejects an empty scopes array with 400", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { POST } = await import("@/app/api/integrations/route");
+		const response = await POST(
+			jsonRequest("/api/integrations", "POST", {
+				name: `no-scopes-${user.id}`,
+				scopes: [],
+			})
+		);
+
+		expect(response.status).toBe(400);
+	});
+
+	it("rejects a missing name with 400", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { POST } = await import("@/app/api/integrations/route");
+		const response = await POST(
+			jsonRequest("/api/integrations", "POST", { scopes: ["case:read"] })
+		);
+
+		expect(response.status).toBe(400);
+	});
+
+	it("writes a SecurityAuditLog row for registration", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { POST } = await import("@/app/api/integrations/route");
+		await POST(
+			jsonRequest("/api/integrations", "POST", {
+				name: `audited-${user.id}`,
+				scopes: ["case:read"],
+			})
+		);
+
+		const event = await prisma.securityAuditLog.findFirst({
+			where: { userId: user.id, eventType: "integration_registered" },
+		});
+		expect(event).not.toBeNull();
+	});
+});
+
+// ============================================
+// PATCH /api/integrations/[id]
+// ============================================
+
+describe("PATCH /api/integrations/[id] — permission matrix", () => {
+	it("returns 401 when unauthenticated", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const { PATCH } = await import("@/app/api/integrations/[id]/route");
+
+		const response = await PATCH(
+			jsonRequest(`/api/integrations/${integration.id}`, "PATCH", {
+				description: "x",
+			}),
+			idParams(integration.id)
+		);
+		expect(response.status).toBe(401);
+	});
+
+	it("the owner can update description and scopes", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(
+			owner.id,
+			{ scopes: ["case:read"] }
+		);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PATCH } = await import("@/app/api/integrations/[id]/route");
+		const response = await PATCH(
+			jsonRequest(`/api/integrations/${integration.id}`, "PATCH", {
+				description: "updated description",
+				scopes: ["case:read", "health:evidence:read"],
+			}),
+			idParams(integration.id)
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.integration.description).toBe("updated description");
+		expect(body.integration.scopes).toEqual([
+			"case:read",
+			"health:evidence:read",
+		]);
+	});
+
+	it("returns 404 'Integration not found' for a nonexistent id", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { PATCH } = await import("@/app/api/integrations/[id]/route");
+		const response = await PATCH(
+			jsonRequest(`/api/integrations/${NOT_FOUND_ID}`, "PATCH", {
+				description: "x",
+			}),
+			idParams(NOT_FOUND_ID)
+		);
+
+		expect(response.status).toBe(404);
+		const body = await response.json();
+		expect(body.error).toBe(INTEGRATION_NOT_FOUND);
+	});
+
+	it("returns 404 'Integration not found' for a non-owner", async () => {
+		const owner = await createTestUser();
+		const outsider = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		await mockAuth(outsider.id, outsider.username, outsider.email);
+
+		const { PATCH } = await import("@/app/api/integrations/[id]/route");
+		const response = await PATCH(
+			jsonRequest(`/api/integrations/${integration.id}`, "PATCH", {
+				description: "x",
+			}),
+			idParams(integration.id)
+		);
+
+		expect(response.status).toBe(404);
+		const body = await response.json();
+		expect(body.error).toBe(INTEGRATION_NOT_FOUND);
+	});
+
+	it("returns BYTE-IDENTICAL 404s for a non-owner vs a nonexistent id (no enumeration oracle)", async () => {
+		const owner = await createTestUser();
+		const outsider = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		await mockAuth(outsider.id, outsider.username, outsider.email);
+
+		const { PATCH } = await import("@/app/api/integrations/[id]/route");
+		const nonOwnerResponse = await PATCH(
+			jsonRequest(`/api/integrations/${integration.id}`, "PATCH", {
+				description: "x",
+			}),
+			idParams(integration.id)
+		);
+		const nonexistentResponse = await PATCH(
+			jsonRequest(`/api/integrations/${NOT_FOUND_ID}`, "PATCH", {
+				description: "x",
+			}),
+			idParams(NOT_FOUND_ID)
+		);
+
+		expect(nonOwnerResponse.status).toBe(nonexistentResponse.status);
+		const nonOwnerBody = await nonOwnerResponse.json();
+		const nonexistentBody = await nonexistentResponse.json();
+		expect(nonOwnerBody).toEqual(nonexistentBody);
+	});
+
+	it("rejects an unknown scope with 400", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PATCH } = await import("@/app/api/integrations/[id]/route");
+		const response = await PATCH(
+			jsonRequest(`/api/integrations/${integration.id}`, "PATCH", {
+				scopes: ["not-a-real-scope"],
+			}),
+			idParams(integration.id)
+		);
+
+		expect(response.status).toBe(400);
+	});
+
+	it("rejects an empty body (neither description nor scopes) with 400", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PATCH } = await import("@/app/api/integrations/[id]/route");
+		const response = await PATCH(
+			jsonRequest(`/api/integrations/${integration.id}`, "PATCH", {}),
+			idParams(integration.id)
+		);
+
+		expect(response.status).toBe(400);
+	});
+
+	it("rejects a non-UUID path id with 400", async () => {
+		const owner = await createTestUser();
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PATCH } = await import("@/app/api/integrations/[id]/route");
+		const response = await PATCH(
+			jsonRequest("/api/integrations/not-a-uuid", "PATCH", {
+				description: "x",
+			}),
+			idParams("not-a-uuid")
+		);
+
+		expect(response.status).toBe(400);
+	});
+});
+
+// ============================================
+// Lifecycle: suspend / reactivate / revoke
+// ============================================
+
+describe("POST /api/integrations/[id]/suspend|reactivate|revoke — permission matrix", () => {
+	const cases: Array<{
+		importRoute: () => Promise<{
+			POST: (
+				req: Request,
+				ctx: { params: Promise<{ id: string }> }
+			) => Promise<Response>;
+		}>;
+		path: string;
+	}> = [
+		{
+			path: "suspend",
+			importRoute: () => import("@/app/api/integrations/[id]/suspend/route"),
+		},
+		{
+			path: "revoke",
+			importRoute: () => import("@/app/api/integrations/[id]/revoke/route"),
+		},
+	];
+
+	for (const { path, importRoute } of cases) {
+		it(`${path}: returns 401 when unauthenticated`, async () => {
+			const owner = await createTestUser();
+			const { integration } = await createTestIntegrationWithSystemUser(
+				owner.id
+			);
+			const { POST } = await importRoute();
+
+			const response = await POST(
+				jsonRequest(`/api/integrations/${integration.id}/${path}`, "POST"),
+				idParams(integration.id)
+			);
+			expect(response.status).toBe(401);
+		});
+
+		it(`${path}: returns BYTE-IDENTICAL 404s for a non-owner vs a nonexistent id`, async () => {
+			const owner = await createTestUser();
+			const outsider = await createTestUser();
+			const { integration } = await createTestIntegrationWithSystemUser(
+				owner.id
+			);
+			await mockAuth(outsider.id, outsider.username, outsider.email);
+
+			const { POST } = await importRoute();
+			const nonOwnerResponse = await POST(
+				jsonRequest(`/api/integrations/${integration.id}/${path}`, "POST"),
+				idParams(integration.id)
+			);
+			const nonexistentResponse = await POST(
+				jsonRequest(`/api/integrations/${NOT_FOUND_ID}/${path}`, "POST"),
+				idParams(NOT_FOUND_ID)
+			);
+
+			expect(nonOwnerResponse.status).toBe(404);
+			expect(nonOwnerResponse.status).toBe(nonexistentResponse.status);
+			const nonOwnerBody = await nonOwnerResponse.json();
+			const nonexistentBody = await nonexistentResponse.json();
+			expect(nonOwnerBody).toEqual(nonexistentBody);
+			expect(nonOwnerBody.error).toBe(INTEGRATION_NOT_FOUND);
+		});
+	}
+});
+
+describe("Lifecycle round-trip via the routes", () => {
+	it("suspend → reactivate → suspend, then revoke is terminal (reactivate-after-revoke rejected)", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST: suspend } = await import(
+			"@/app/api/integrations/[id]/suspend/route"
+		);
+		const { POST: reactivate } = await import(
+			"@/app/api/integrations/[id]/reactivate/route"
+		);
+		const { POST: revoke } = await import(
+			"@/app/api/integrations/[id]/revoke/route"
+		);
+
+		const suspended = await suspend(
+			jsonRequest(`/api/integrations/${integration.id}/suspend`, "POST"),
+			idParams(integration.id)
+		);
+		expect(suspended.status).toBe(200);
+		expect((await suspended.json()).integration.status).toBe("SUSPENDED");
+
+		const reactivated = await reactivate(
+			jsonRequest(`/api/integrations/${integration.id}/reactivate`, "POST"),
+			idParams(integration.id)
+		);
+		expect(reactivated.status).toBe(200);
+		expect((await reactivated.json()).integration.status).toBe("ACTIVE");
+
+		const suspendedAgain = await suspend(
+			jsonRequest(`/api/integrations/${integration.id}/suspend`, "POST"),
+			idParams(integration.id)
+		);
+		expect(suspendedAgain.status).toBe(200);
+
+		const revoked = await revoke(
+			jsonRequest(`/api/integrations/${integration.id}/revoke`, "POST"),
+			idParams(integration.id)
+		);
+		expect(revoked.status).toBe(200);
+		expect((await revoked.json()).integration.status).toBe("REVOKED");
+
+		const reactivateAfterRevoke = await reactivate(
+			jsonRequest(`/api/integrations/${integration.id}/reactivate`, "POST"),
+			idParams(integration.id)
+		);
+		expect(reactivateAfterRevoke.status).toBe(409);
+	});
+
+	it("a suspended integration's token fails machine auth (pinned from the route level)", async () => {
+		const owner = await createTestUser();
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST: registerRoute } = await import(
+			"@/app/api/integrations/route"
+		);
+		const registered = await registerRoute(
+			jsonRequest("/api/integrations", "POST", {
+				name: `route-suspend-token-${owner.id}`,
+				scopes: ["case:read"],
+			})
+		);
+		const { integration } = (await registered.json()) as {
+			integration: { id: string };
+		};
+
+		const { POST: issueRoute } = await import(
+			"@/app/api/integrations/[id]/tokens/route"
+		);
+		const issued = await issueRoute(
+			jsonRequest(`/api/integrations/${integration.id}/tokens`, "POST", {}),
+			idParams(integration.id)
+		);
+		const { secret } = (await issued.json()) as { secret: string };
+
+		const { POST: suspendRoute } = await import(
+			"@/app/api/integrations/[id]/suspend/route"
+		);
+		await suspendRoute(
+			jsonRequest(`/api/integrations/${integration.id}/suspend`, "POST"),
+			idParams(integration.id)
+		);
+
+		const { GET: whoami } = await import("@/app/api/machine/whoami/route");
+		const whoamiResponse = await whoami(
+			new NextRequest("http://localhost:3000/api/machine/whoami", {
+				headers: { authorization: `Bearer ${secret}` },
+			})
+		);
+		expect(whoamiResponse.status).toBe(401);
+	});
+});
+
+// ============================================
+// POST /api/integrations/[id]/tokens (issue)
+// ============================================
+
+describe("POST /api/integrations/[id]/tokens — issuance", () => {
+	it("returns 401 when unauthenticated", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const { POST } = await import("@/app/api/integrations/[id]/tokens/route");
+
+		const response = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/tokens`, "POST", {}),
+			idParams(integration.id)
+		);
+		expect(response.status).toBe(401);
+	});
+
+	it("returns the plaintext secret exactly once, absent from any subsequent GET", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import("@/app/api/integrations/[id]/tokens/route");
+		const response = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/tokens`, "POST", {}),
+			idParams(integration.id)
+		);
+		expect(response.status).toBe(201);
+		const body = await response.json();
+		expect(typeof body.secret).toBe("string");
+		expect(body.secret.length).toBeGreaterThan(0);
+		expect(body.token.tokenPrefix).toBeDefined();
+
+		const { GET } = await import("@/app/api/integrations/route");
+		const listResponse = await GET();
+		const listBody = await listResponse.json();
+		expect(JSON.stringify(listBody)).not.toContain(body.secret);
+	});
+
+	it("returns BYTE-IDENTICAL 404s for a non-owner vs a nonexistent integration id", async () => {
+		const owner = await createTestUser();
+		const outsider = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		await mockAuth(outsider.id, outsider.username, outsider.email);
+
+		const { POST } = await import("@/app/api/integrations/[id]/tokens/route");
+		const nonOwnerResponse = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/tokens`, "POST", {}),
+			idParams(integration.id)
+		);
+		const nonexistentResponse = await POST(
+			jsonRequest(`/api/integrations/${NOT_FOUND_ID}/tokens`, "POST", {}),
+			idParams(NOT_FOUND_ID)
+		);
+
+		expect(nonOwnerResponse.status).toBe(404);
+		expect(nonOwnerResponse.status).toBe(nonexistentResponse.status);
+		const nonOwnerBody = await nonOwnerResponse.json();
+		const nonexistentBody = await nonexistentResponse.json();
+		expect(nonOwnerBody).toEqual(nonexistentBody);
+		expect(nonOwnerBody.error).toBe(INTEGRATION_NOT_FOUND);
+	});
+
+	it("refuses to issue a token for a non-active (suspended) integration with 409", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(
+			owner.id,
+			{ status: "SUSPENDED" }
+		);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import("@/app/api/integrations/[id]/tokens/route");
+		const response = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/tokens`, "POST", {}),
+			idParams(integration.id)
+		);
+		expect(response.status).toBe(409);
+	});
+
+	it("rejects a past expiresAt with 400", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import("@/app/api/integrations/[id]/tokens/route");
+		const response = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/tokens`, "POST", {
+				expiresAt: new Date(Date.now() - 60_000).toISOString(),
+			}),
+			idParams(integration.id)
+		);
+		expect(response.status).toBe(400);
+	});
+
+	it("writes a SecurityAuditLog row for token issuance", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import("@/app/api/integrations/[id]/tokens/route");
+		await POST(
+			jsonRequest(`/api/integrations/${integration.id}/tokens`, "POST", {}),
+			idParams(integration.id)
+		);
+
+		const event = await prisma.securityAuditLog.findFirst({
+			where: { userId: owner.id, eventType: "token_issued" },
+		});
+		expect(event).not.toBeNull();
+	});
+});
+
+// ============================================
+// POST /api/integrations/[id]/tokens/[tokenId]/rotate
+// ============================================
+
+describe("POST /api/integrations/[id]/tokens/[tokenId]/rotate", () => {
+	it("returns 401 when unauthenticated", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const apiToken = await createTestApiToken(integration.id);
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/tokens/[tokenId]/rotate/route"
+		);
+
+		const response = await POST(
+			jsonRequest(
+				`/api/integrations/${integration.id}/tokens/${apiToken.id}/rotate`,
+				"POST"
+			),
+			tokenParams(integration.id, apiToken.id)
+		);
+		expect(response.status).toBe(401);
+	});
+
+	it("rotates the token, returning a new plaintext secret exactly once", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const apiToken = await createTestApiToken(integration.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/tokens/[tokenId]/rotate/route"
+		);
+		const response = await POST(
+			jsonRequest(
+				`/api/integrations/${integration.id}/tokens/${apiToken.id}/rotate`,
+				"POST"
+			),
+			tokenParams(integration.id, apiToken.id)
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(typeof body.secret).toBe("string");
+		expect(body.oldTokenId).toBe(apiToken.id);
+		expect(body.token.id).not.toBe(apiToken.id);
+	});
+
+	it("returns BYTE-IDENTICAL 404s for a non-owner vs a nonexistent token id", async () => {
+		const owner = await createTestUser();
+		const outsider = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const apiToken = await createTestApiToken(integration.id);
+		await mockAuth(outsider.id, outsider.username, outsider.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/tokens/[tokenId]/rotate/route"
+		);
+		const nonOwnerResponse = await POST(
+			jsonRequest(
+				`/api/integrations/${integration.id}/tokens/${apiToken.id}/rotate`,
+				"POST"
+			),
+			tokenParams(integration.id, apiToken.id)
+		);
+		const nonexistentResponse = await POST(
+			jsonRequest(
+				`/api/integrations/${integration.id}/tokens/${NOT_FOUND_ID}/rotate`,
+				"POST"
+			),
+			tokenParams(integration.id, NOT_FOUND_ID)
+		);
+
+		expect(nonOwnerResponse.status).toBe(404);
+		expect(nonOwnerResponse.status).toBe(nonexistentResponse.status);
+		const nonOwnerBody = await nonOwnerResponse.json();
+		const nonexistentBody = await nonexistentResponse.json();
+		expect(nonOwnerBody).toEqual(nonexistentBody);
+		expect(nonOwnerBody.error).toBe(TOKEN_NOT_FOUND);
+	});
+});
+
+// ============================================
+// DELETE /api/integrations/[id]/tokens/[tokenId]
+// ============================================
+
+describe("DELETE /api/integrations/[id]/tokens/[tokenId]", () => {
+	it("returns 401 when unauthenticated", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const apiToken = await createTestApiToken(integration.id);
+		const { DELETE } = await import(
+			"@/app/api/integrations/[id]/tokens/[tokenId]/route"
+		);
+
+		const response = await DELETE(
+			jsonRequest(
+				`/api/integrations/${integration.id}/tokens/${apiToken.id}`,
+				"DELETE"
+			),
+			tokenParams(integration.id, apiToken.id)
+		);
+		expect(response.status).toBe(401);
+	});
+
+	it("revokes the token immediately", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const apiToken = await createTestApiToken(integration.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { DELETE } = await import(
+			"@/app/api/integrations/[id]/tokens/[tokenId]/route"
+		);
+		const response = await DELETE(
+			jsonRequest(
+				`/api/integrations/${integration.id}/tokens/${apiToken.id}`,
+				"DELETE"
+			),
+			tokenParams(integration.id, apiToken.id)
+		);
+
+		expect(response.status).toBe(200);
+		const revoked = await prisma.apiToken.findUniqueOrThrow({
+			where: { id: apiToken.id },
+		});
+		expect(revoked.revokedAt).not.toBeNull();
+	});
+
+	it("returns BYTE-IDENTICAL 404s for a non-owner vs a nonexistent token id", async () => {
+		const owner = await createTestUser();
+		const outsider = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const apiToken = await createTestApiToken(integration.id);
+		await mockAuth(outsider.id, outsider.username, outsider.email);
+
+		const { DELETE } = await import(
+			"@/app/api/integrations/[id]/tokens/[tokenId]/route"
+		);
+		const nonOwnerResponse = await DELETE(
+			jsonRequest(
+				`/api/integrations/${integration.id}/tokens/${apiToken.id}`,
+				"DELETE"
+			),
+			tokenParams(integration.id, apiToken.id)
+		);
+		const nonexistentResponse = await DELETE(
+			jsonRequest(
+				`/api/integrations/${integration.id}/tokens/${NOT_FOUND_ID}`,
+				"DELETE"
+			),
+			tokenParams(integration.id, NOT_FOUND_ID)
+		);
+
+		expect(nonOwnerResponse.status).toBe(404);
+		expect(nonOwnerResponse.status).toBe(nonexistentResponse.status);
+		const nonOwnerBody = await nonOwnerResponse.json();
+		const nonexistentBody = await nonexistentResponse.json();
+		expect(nonOwnerBody).toEqual(nonexistentBody);
+		expect(nonOwnerBody.error).toBe(TOKEN_NOT_FOUND);
+	});
+
+	it("writes a SecurityAuditLog row for token revocation", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const apiToken = await createTestApiToken(integration.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { DELETE } = await import(
+			"@/app/api/integrations/[id]/tokens/[tokenId]/route"
+		);
+		await DELETE(
+			jsonRequest(
+				`/api/integrations/${integration.id}/tokens/${apiToken.id}`,
+				"DELETE"
+			),
+			tokenParams(integration.id, apiToken.id)
+		);
+
+		const event = await prisma.securityAuditLog.findFirst({
+			where: { userId: owner.id, eventType: "token_revoked" },
+		});
+		expect(event).not.toBeNull();
+	});
+});

--- a/src/__tests__/integration/api-integrations.test.ts
+++ b/src/__tests__/integration/api-integrations.test.ts
@@ -88,6 +88,37 @@ describe("GET /api/integrations", () => {
 		expect(token).not.toHaveProperty("secret");
 		expect(JSON.stringify(body)).not.toContain(apiToken.tokenHash);
 	});
+
+	/**
+	 * Pins that `revokedAt`/`expiresAt` survive `listIntegrationsForOwner`'s
+	 * `select` for BOTH lifecycle states, not just the "everything null"
+	 * happy path the previous test exercised (nanaki info, work item 10).
+	 */
+	it("surfaces revokedAt for a REVOKED token and expiresAt for an EXPIRED token", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const revokedToken = await createTestApiToken(integration.id, {
+			revokedAt: new Date(),
+		});
+		const expiredToken = await createTestApiToken(integration.id, {
+			expiresAt: new Date(Date.now() - 60_000),
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { GET } = await import("@/app/api/integrations/route");
+		const response = await GET();
+		const body = await response.json();
+
+		const tokens = body.integrations[0].tokens as Array<{
+			expiresAt: string | null;
+			id: string;
+			revokedAt: string | null;
+		}>;
+		const revoked = tokens.find((token) => token.id === revokedToken.id);
+		const expired = tokens.find((token) => token.id === expiredToken.id);
+		expect(revoked?.revokedAt).not.toBeNull();
+		expect(expired?.expiresAt).not.toBeNull();
+	});
 });
 
 describe("POST /api/integrations", () => {
@@ -360,42 +391,81 @@ describe("PATCH /api/integrations/[id] — permission matrix", () => {
 // Lifecycle: suspend / reactivate / revoke
 // ============================================
 
-describe("POST /api/integrations/[id]/suspend|reactivate|revoke — permission matrix", () => {
+type MutationRouteHandler = (
+	req: Request,
+	ctx: { params: Promise<{ id: string }> }
+) => Promise<Response>;
+
+/** Looks up the named HTTP-verb export on an imported route module, failing loudly (not `undefined`) if the route doesn't actually export it. */
+function requireHandler(
+	mod: Record<string, MutationRouteHandler>,
+	method: "DELETE" | "POST"
+): MutationRouteHandler {
+	const handler = mod[method];
+	if (!handler) {
+		throw new Error(`Route module has no ${method} export`);
+	}
+	return handler;
+}
+
+/**
+ * One loop generates the 401 + byte-identical-404 tests for every
+ * single-`[id]`-keyed mutation route "for free" — `reactivate` (nanaki
+ * MAJOR, work item 3) and `DELETE /api/integrations/[id]` (cid decision,
+ * work item 6) are both added here rather than as one-off describe blocks,
+ * so any FUTURE route of this same shape gets the same coverage by adding
+ * one array entry. `path: ""` + `method: "DELETE"` models the base route
+ * (no action suffix, different verb) alongside the POST action routes.
+ */
+describe("Integration mutation routes — permission matrix (suspend/reactivate/revoke/delete)", () => {
 	const cases: Array<{
-		importRoute: () => Promise<{
-			POST: (
-				req: Request,
-				ctx: { params: Promise<{ id: string }> }
-			) => Promise<Response>;
-		}>;
+		importRoute: () => Promise<Record<string, MutationRouteHandler>>;
+		method: "DELETE" | "POST";
 		path: string;
 	}> = [
 		{
+			method: "POST",
 			path: "suspend",
 			importRoute: () => import("@/app/api/integrations/[id]/suspend/route"),
 		},
 		{
+			method: "POST",
+			path: "reactivate",
+			importRoute: () => import("@/app/api/integrations/[id]/reactivate/route"),
+		},
+		{
+			method: "POST",
 			path: "revoke",
 			importRoute: () => import("@/app/api/integrations/[id]/revoke/route"),
 		},
+		{
+			method: "DELETE",
+			path: "",
+			importRoute: () => import("@/app/api/integrations/[id]/route"),
+		},
 	];
 
-	for (const { path, importRoute } of cases) {
-		it(`${path}: returns 401 when unauthenticated`, async () => {
+	for (const { method, path, importRoute } of cases) {
+		const label = path || "delete";
+		const url = (id: string) =>
+			path ? `/api/integrations/${id}/${path}` : `/api/integrations/${id}`;
+
+		it(`${label}: returns 401 when unauthenticated`, async () => {
 			const owner = await createTestUser();
 			const { integration } = await createTestIntegrationWithSystemUser(
 				owner.id
 			);
-			const { POST } = await importRoute();
+			const mod = await importRoute();
+			const handler = requireHandler(mod, method);
 
-			const response = await POST(
-				jsonRequest(`/api/integrations/${integration.id}/${path}`, "POST"),
+			const response = await handler(
+				jsonRequest(url(integration.id), method),
 				idParams(integration.id)
 			);
 			expect(response.status).toBe(401);
 		});
 
-		it(`${path}: returns BYTE-IDENTICAL 404s for a non-owner vs a nonexistent id`, async () => {
+		it(`${label}: returns BYTE-IDENTICAL 404s for a non-owner vs a nonexistent id`, async () => {
 			const owner = await createTestUser();
 			const outsider = await createTestUser();
 			const { integration } = await createTestIntegrationWithSystemUser(
@@ -403,13 +473,14 @@ describe("POST /api/integrations/[id]/suspend|reactivate|revoke — permission m
 			);
 			await mockAuth(outsider.id, outsider.username, outsider.email);
 
-			const { POST } = await importRoute();
-			const nonOwnerResponse = await POST(
-				jsonRequest(`/api/integrations/${integration.id}/${path}`, "POST"),
+			const mod = await importRoute();
+			const handler = requireHandler(mod, method);
+			const nonOwnerResponse = await handler(
+				jsonRequest(url(integration.id), method),
 				idParams(integration.id)
 			);
-			const nonexistentResponse = await POST(
-				jsonRequest(`/api/integrations/${NOT_FOUND_ID}/${path}`, "POST"),
+			const nonexistentResponse = await handler(
+				jsonRequest(url(NOT_FOUND_ID), method),
 				idParams(NOT_FOUND_ID)
 			);
 
@@ -421,6 +492,127 @@ describe("POST /api/integrations/[id]/suspend|reactivate|revoke — permission m
 			expect(nonOwnerBody.error).toBe(INTEGRATION_NOT_FOUND);
 		});
 	}
+});
+
+// ============================================
+// DELETE /api/integrations/[id] — happy path (permission matrix above)
+// ============================================
+
+describe("DELETE /api/integrations/[id]", () => {
+	it("deletes the integration — it no longer appears in GET /api/integrations", async () => {
+		const owner = await createTestUser();
+		const { integration: toDelete } = await createTestIntegrationWithSystemUser(
+			owner.id,
+			{ name: "delete-me" }
+		);
+		const { integration: toKeep } = await createTestIntegrationWithSystemUser(
+			owner.id,
+			{ name: "keep-me" }
+		);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { DELETE } = await import("@/app/api/integrations/[id]/route");
+		const response = await DELETE(
+			jsonRequest(`/api/integrations/${toDelete.id}`, "DELETE"),
+			idParams(toDelete.id)
+		);
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.success).toBe(true);
+
+		const { GET } = await import("@/app/api/integrations/route");
+		const listResponse = await GET();
+		const listBody = await listResponse.json();
+		const ids = listBody.integrations.map(
+			(integration: { id: string }) => integration.id
+		);
+		expect(ids).not.toContain(toDelete.id);
+		expect(ids).toContain(toKeep.id);
+	});
+});
+
+// ============================================
+// Lifecycle conflict responses (409) — route level
+// (nanaki minor, work item 8 — service-level coverage already exists in
+// machine-auth.test.ts; these pin the SAME conflicts reach HTTP as 409,
+// analogous to the existing route-level 409 tests below/above at the
+// reactivate-after-revoke and issue-token-on-suspended cases.)
+// ============================================
+
+describe("Lifecycle conflict responses (409) — route level", () => {
+	it("suspend: 409 when the integration is already REVOKED", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(
+			owner.id,
+			{ status: "REVOKED" }
+		);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import("@/app/api/integrations/[id]/suspend/route");
+		const response = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/suspend`, "POST"),
+			idParams(integration.id)
+		);
+		expect(response.status).toBe(409);
+	});
+
+	it("reactivate: 409 when the integration is already ACTIVE", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/reactivate/route"
+		);
+		const response = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/reactivate`, "POST"),
+			idParams(integration.id)
+		);
+		expect(response.status).toBe(409);
+	});
+
+	it("rotate: 409 when the token's integration is SUSPENDED", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(
+			owner.id,
+			{ status: "SUSPENDED" }
+		);
+		const apiToken = await createTestApiToken(integration.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/tokens/[tokenId]/rotate/route"
+		);
+		const response = await POST(
+			jsonRequest(
+				`/api/integrations/${integration.id}/tokens/${apiToken.id}/rotate`,
+				"POST"
+			),
+			tokenParams(integration.id, apiToken.id)
+		);
+		expect(response.status).toBe(409);
+	});
+
+	it("rotate: 409 when the token is already revoked", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const apiToken = await createTestApiToken(integration.id, {
+			revokedAt: new Date(),
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/tokens/[tokenId]/rotate/route"
+		);
+		const response = await POST(
+			jsonRequest(
+				`/api/integrations/${integration.id}/tokens/${apiToken.id}/rotate`,
+				"POST"
+			),
+			tokenParams(integration.id, apiToken.id)
+		);
+		expect(response.status).toBe(409);
+	});
 });
 
 describe("Lifecycle round-trip via the routes", () => {
@@ -708,6 +900,78 @@ describe("POST /api/integrations/[id]/tokens/[tokenId]/rotate", () => {
 		expect(nonOwnerBody).toEqual(nonexistentBody);
 		expect(nonOwnerBody.error).toBe(TOKEN_NOT_FOUND);
 	});
+
+	/**
+	 * Deviation-5 fix (cid SHOULD-FIX, work item 2): a tokenId that exists
+	 * and IS owned by the caller, but belongs to a DIFFERENT integration the
+	 * SAME owner also owns, must be rejected identically to a nonexistent
+	 * tokenId — not silently rotated via the "wrong" path `[id]`. Regression
+	 * pair per nanaki's prescription: two integrations under the same
+	 * owner, token issued under B, rotate attempted via A's path.
+	 */
+	it("rejects a tokenId that belongs to a DIFFERENT integration under the SAME owner, identically to a nonexistent tokenId", async () => {
+		const owner = await createTestUser();
+		const { integration: integrationA } =
+			await createTestIntegrationWithSystemUser(owner.id, { name: "int-a" });
+		const { integration: integrationB } =
+			await createTestIntegrationWithSystemUser(owner.id, { name: "int-b" });
+		const tokenB = await createTestApiToken(integrationB.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/tokens/[tokenId]/rotate/route"
+		);
+		const crossPathResponse = await POST(
+			jsonRequest(
+				`/api/integrations/${integrationA.id}/tokens/${tokenB.id}/rotate`,
+				"POST"
+			),
+			tokenParams(integrationA.id, tokenB.id)
+		);
+		const nonexistentResponse = await POST(
+			jsonRequest(
+				`/api/integrations/${integrationA.id}/tokens/${NOT_FOUND_ID}/rotate`,
+				"POST"
+			),
+			tokenParams(integrationA.id, NOT_FOUND_ID)
+		);
+
+		expect(crossPathResponse.status).toBe(404);
+		expect(crossPathResponse.status).toBe(nonexistentResponse.status);
+		const crossPathBody = await crossPathResponse.json();
+		const nonexistentBody = await nonexistentResponse.json();
+		expect(crossPathBody).toEqual(nonexistentBody);
+		expect(crossPathBody.error).toBe(TOKEN_NOT_FOUND);
+
+		// Must NOT have been rotated — still exactly one token on integration B.
+		const tokens = await prisma.apiToken.findMany({
+			where: { integrationId: integrationB.id },
+		});
+		expect(tokens).toHaveLength(1);
+	});
+
+	it("writes a SecurityAuditLog row for token rotation", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const apiToken = await createTestApiToken(integration.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/tokens/[tokenId]/rotate/route"
+		);
+		await POST(
+			jsonRequest(
+				`/api/integrations/${integration.id}/tokens/${apiToken.id}/rotate`,
+				"POST"
+			),
+			tokenParams(integration.id, apiToken.id)
+		);
+
+		const event = await prisma.securityAuditLog.findFirst({
+			where: { userId: owner.id, eventType: "token_rotated" },
+		});
+		expect(event).not.toBeNull();
+	});
 });
 
 // ============================================
@@ -788,6 +1052,51 @@ describe("DELETE /api/integrations/[id]/tokens/[tokenId]", () => {
 		const nonexistentBody = await nonexistentResponse.json();
 		expect(nonOwnerBody).toEqual(nonexistentBody);
 		expect(nonOwnerBody.error).toBe(TOKEN_NOT_FOUND);
+	});
+
+	/**
+	 * Deviation-5 fix, DELETE-revoke equivalent of the rotate-route
+	 * regression pair above (work item 2, nanaki's prescription).
+	 */
+	it("rejects a tokenId that belongs to a DIFFERENT integration under the SAME owner, identically to a nonexistent tokenId", async () => {
+		const owner = await createTestUser();
+		const { integration: integrationA } =
+			await createTestIntegrationWithSystemUser(owner.id, { name: "int-a" });
+		const { integration: integrationB } =
+			await createTestIntegrationWithSystemUser(owner.id, { name: "int-b" });
+		const tokenB = await createTestApiToken(integrationB.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { DELETE } = await import(
+			"@/app/api/integrations/[id]/tokens/[tokenId]/route"
+		);
+		const crossPathResponse = await DELETE(
+			jsonRequest(
+				`/api/integrations/${integrationA.id}/tokens/${tokenB.id}`,
+				"DELETE"
+			),
+			tokenParams(integrationA.id, tokenB.id)
+		);
+		const nonexistentResponse = await DELETE(
+			jsonRequest(
+				`/api/integrations/${integrationA.id}/tokens/${NOT_FOUND_ID}`,
+				"DELETE"
+			),
+			tokenParams(integrationA.id, NOT_FOUND_ID)
+		);
+
+		expect(crossPathResponse.status).toBe(404);
+		expect(crossPathResponse.status).toBe(nonexistentResponse.status);
+		const crossPathBody = await crossPathResponse.json();
+		const nonexistentBody = await nonexistentResponse.json();
+		expect(crossPathBody).toEqual(nonexistentBody);
+		expect(crossPathBody.error).toBe(TOKEN_NOT_FOUND);
+
+		// Must NOT have been revoked by the cross-path call.
+		const stillActive = await prisma.apiToken.findUniqueOrThrow({
+			where: { id: tokenB.id },
+		});
+		expect(stillActive.revokedAt).toBeNull();
 	});
 
 	it("writes a SecurityAuditLog row for token revocation", async () => {

--- a/src/__tests__/integration/api-machine-health-evidence.test.ts
+++ b/src/__tests__/integration/api-machine-health-evidence.test.ts
@@ -80,7 +80,6 @@ async function setupIntegration(
 		await registerIntegration(
 			{
 				name: `test-health-integration-${ownerId}-${Date.now()}`,
-				ownerId,
 				scopes,
 			},
 			ownerId

--- a/src/__tests__/integration/api-users-me.test.ts
+++ b/src/__tests__/integration/api-users-me.test.ts
@@ -1,0 +1,64 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	createTestIntegrationWithSystemUser,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+beforeEach(async () => {
+	await mockNoAuth();
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+function deleteAccountRequest(): NextRequest {
+	return new NextRequest("http://localhost:3000/api/users/me", {
+		method: "DELETE",
+	});
+}
+
+// ============================================
+// DELETE /api/users/me
+//
+// (nanaki minor, work item 9 — this route had no test file at all. Kept
+// minimal: just enough to prove work items 5+7 end to end, since
+// `user-management-service.test.ts` already covers `deleteAccount` itself
+// at the service level.)
+// ============================================
+
+describe("DELETE /api/users/me", () => {
+	it("returns 401 when unauthenticated", async () => {
+		const { DELETE } = await import("@/app/api/users/me/route");
+		const response = await DELETE(deleteAccountRequest());
+		expect(response.status).toBe(401);
+	});
+
+	/**
+	 * End-to-end proof for work items 5+7: `deleteAccount`'s owned-
+	 * integrations pre-check (now a `count`, not a full `findMany` — item 7)
+	 * surfaces through `serviceErrorToAppError`'s re-anchored ERROR_MAPPINGS
+	 * pattern (item 5) as a 409 with the reworded, removal-only message,
+	 * reaching HTTP correctly — not just the service layer.
+	 */
+	it("returns 409 with the removal-only message when the user owns an integration", async () => {
+		const owner = await createTestUser({ authProvider: "GITHUB" });
+		await createTestIntegrationWithSystemUser(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { DELETE } = await import("@/app/api/users/me/route");
+		const response = await DELETE(deleteAccountRequest());
+
+		expect(response.status).toBe(409);
+		const body = await response.json();
+		expect(body.error).toBe(
+			"Remove your 1 integration before deleting your account"
+		);
+	});
+});

--- a/src/__tests__/integration/machine-auth.test.ts
+++ b/src/__tests__/integration/machine-auth.test.ts
@@ -464,6 +464,27 @@ describe("integration-registry-service — registration & lifecycle", () => {
 		expect(token.revokedAt).not.toBeNull();
 	});
 
+	/**
+	 * `revokeIntegration` has no guard against being called twice — unlike
+	 * `suspendIntegration`/`reactivateIntegration`, which both explicitly
+	 * reject a REVOKED-state transition, re-revoking an already-REVOKED
+	 * integration is a harmless no-op success today. Pinning this is
+	 * deliberate, not an oversight rediscovery (nanaki info finding, work
+	 * item 12): a caller retrying a revoke after a dropped response
+	 * (network blip, client retry) gets a clean success, not a spurious
+	 * error. If this idempotence is ever tightened into a conflict, this
+	 * test should be updated alongside that decision, not silently broken.
+	 */
+	it("is idempotent: revoking an already-REVOKED integration succeeds harmlessly (deliberate)", async () => {
+		const { integration, owner } = await registerTestIntegration();
+
+		expectSuccess(await revokeIntegration(integration.id, owner.id));
+		const secondCall = expectSuccess(
+			await revokeIntegration(integration.id, owner.id)
+		);
+		expect(secondCall.status).toBe("REVOKED");
+	});
+
 	it("writes an audit log entry for registration, suspension, and revocation", async () => {
 		const { integration, owner } = await registerTestIntegration();
 		await suspendIntegration(integration.id, owner.id);

--- a/src/__tests__/integration/machine-auth.test.ts
+++ b/src/__tests__/integration/machine-auth.test.ts
@@ -12,6 +12,7 @@ import {
 	deleteIntegrationRegistration,
 	getIntegrationsOwnedBy,
 	issueToken,
+	reactivateIntegration,
 	reassignIntegrationOwner,
 	registerIntegration,
 	revokeIntegration,
@@ -19,11 +20,16 @@ import {
 	rotateToken,
 	suspendIntegration,
 	TOKEN_ROTATION_OVERLAP_MS,
+	updateIntegration,
 	updateIntegrationScopes,
 	validateApiToken,
 } from "@/lib/services/integration-registry-service";
 import { RATE_LIMIT_CONFIGS } from "@/lib/services/rate-limit-service";
-import { expectError, expectSuccess } from "../utils/assertion-helpers";
+import {
+	expectError,
+	expectSameError,
+	expectSuccess,
+} from "../utils/assertion-helpers";
 import { createTestUser } from "../utils/prisma-factories";
 
 const AUTH_FAILURE_MESSAGE = "Invalid or expired token";
@@ -33,6 +39,310 @@ const NON_ACTIVE_PATTERN = /non-active/;
 const ALREADY_REVOKED_PATTERN = /revoked/;
 const NOT_FOUND_PATTERN = /not found/i;
 const NOT_FOUND_ID = "00000000-0000-0000-0000-000000000000";
+const INTEGRATION_NOT_FOUND = "Integration not found";
+const TOKEN_NOT_FOUND = "Token not found";
+const CANNOT_REVOKED_PATTERN = /revoked/i;
+const ALREADY_ACTIVE_PATTERN = /already active/i;
+
+/**
+ * Ownership enforcement (vincent security review 2026-07-03, finding 3 —
+ * the management API hard precondition): every mutating function below
+ * verifies the ACTOR owns the integration (or the integration behind a
+ * token) before acting. A non-owner gets the EXACT SAME "Integration not
+ * found" / "Token not found" error as acting on a nonexistent id — never a
+ * distinct "Permission denied" — so a caller can't use the response to
+ * learn whether an id exists at all. `expectSameError` asserts the two
+ * failure modes are byte-identical, not just "both errors".
+ */
+describe("service-boundary authorisation — non-owner gets the SAME error as nonexistent (no oracle)", () => {
+	it("updateIntegrationScopes: non-owner vs nonexistent id", async () => {
+		const { integration } = await registerTestIntegration();
+		const outsider = await createTestUser();
+
+		const nonOwner = await updateIntegrationScopes(
+			integration.id,
+			["case:read"],
+			outsider.id
+		);
+		const nonexistent = await updateIntegrationScopes(
+			NOT_FOUND_ID,
+			["case:read"],
+			outsider.id
+		);
+
+		expectError(nonOwner, INTEGRATION_NOT_FOUND);
+		expectSameError(nonOwner, nonexistent);
+	});
+
+	it("suspendIntegration: non-owner vs nonexistent id", async () => {
+		const { integration } = await registerTestIntegration();
+		const outsider = await createTestUser();
+
+		const nonOwner = await suspendIntegration(integration.id, outsider.id);
+		const nonexistent = await suspendIntegration(NOT_FOUND_ID, outsider.id);
+
+		expectError(nonOwner, INTEGRATION_NOT_FOUND);
+		expectSameError(nonOwner, nonexistent);
+	});
+
+	it("reactivateIntegration: non-owner vs nonexistent id", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		await suspendIntegration(integration.id, owner.id);
+		const outsider = await createTestUser();
+
+		const nonOwner = await reactivateIntegration(integration.id, outsider.id);
+		const nonexistent = await reactivateIntegration(NOT_FOUND_ID, outsider.id);
+
+		expectError(nonOwner, INTEGRATION_NOT_FOUND);
+		expectSameError(nonOwner, nonexistent);
+	});
+
+	it("revokeIntegration: non-owner vs nonexistent id", async () => {
+		const { integration } = await registerTestIntegration();
+		const outsider = await createTestUser();
+
+		const nonOwner = await revokeIntegration(integration.id, outsider.id);
+		const nonexistent = await revokeIntegration(NOT_FOUND_ID, outsider.id);
+
+		expectError(nonOwner, INTEGRATION_NOT_FOUND);
+		expectSameError(nonOwner, nonexistent);
+	});
+
+	it("reassignIntegrationOwner: non-owner vs nonexistent id", async () => {
+		const { integration } = await registerTestIntegration();
+		const outsider = await createTestUser();
+		const newOwner = await createTestUser();
+
+		const nonOwner = await reassignIntegrationOwner(
+			integration.id,
+			newOwner.id,
+			outsider.id
+		);
+		const nonexistent = await reassignIntegrationOwner(
+			NOT_FOUND_ID,
+			newOwner.id,
+			outsider.id
+		);
+
+		expectError(nonOwner, INTEGRATION_NOT_FOUND);
+		expectSameError(nonOwner, nonexistent);
+	});
+
+	it("deleteIntegrationRegistration: non-owner vs nonexistent id", async () => {
+		const { integration } = await registerTestIntegration();
+		const outsider = await createTestUser();
+
+		const nonOwner = await deleteIntegrationRegistration(
+			integration.id,
+			outsider.id
+		);
+		const nonexistent = await deleteIntegrationRegistration(
+			NOT_FOUND_ID,
+			outsider.id
+		);
+
+		expectError(nonOwner, INTEGRATION_NOT_FOUND);
+		expectSameError(nonOwner, nonexistent);
+
+		// Must NOT have been deleted — the outsider's call had no effect.
+		const stillThere = await prisma.integration.findUnique({
+			where: { id: integration.id },
+		});
+		expect(stillThere).not.toBeNull();
+	});
+
+	it("issueToken: non-owner vs nonexistent integration id", async () => {
+		const { integration } = await registerTestIntegration();
+		const outsider = await createTestUser();
+
+		const nonOwner = await issueToken(integration.id, outsider.id);
+		const nonexistent = await issueToken(NOT_FOUND_ID, outsider.id);
+
+		expectError(nonOwner, INTEGRATION_NOT_FOUND);
+		expectSameError(nonOwner, nonexistent);
+
+		// No token was actually issued for the non-owned integration.
+		const tokens = await prisma.apiToken.findMany({
+			where: { integrationId: integration.id },
+		});
+		expect(tokens).toHaveLength(0);
+	});
+
+	it("rotateToken: non-owner vs nonexistent token id", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const { apiToken } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+		const outsider = await createTestUser();
+
+		const nonOwner = await rotateToken(apiToken.id, outsider.id);
+		const nonexistent = await rotateToken(NOT_FOUND_ID, outsider.id);
+
+		expectError(nonOwner, TOKEN_NOT_FOUND);
+		expectSameError(nonOwner, nonexistent);
+
+		// The token was not rotated — still exactly one token on the integration.
+		const tokens = await prisma.apiToken.findMany({
+			where: { integrationId: integration.id },
+		});
+		expect(tokens).toHaveLength(1);
+	});
+
+	it("revokeToken: non-owner vs nonexistent token id", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		const { apiToken } = expectSuccess(
+			await issueToken(integration.id, owner.id)
+		);
+		const outsider = await createTestUser();
+
+		const nonOwner = await revokeToken(apiToken.id, outsider.id);
+		const nonexistent = await revokeToken(NOT_FOUND_ID, outsider.id);
+
+		expectError(nonOwner, TOKEN_NOT_FOUND);
+		expectSameError(nonOwner, nonexistent);
+
+		// The token was not revoked by the outsider's call.
+		const stillActive = await prisma.apiToken.findUniqueOrThrow({
+			where: { id: apiToken.id },
+		});
+		expect(stillActive.revokedAt).toBeNull();
+	});
+
+	it("registerIntegration binds ownership to the session actor regardless of body content — there is no ownerId field to spoof", async () => {
+		const actor = await createTestUser();
+		const result = expectSuccess(
+			await registerIntegration(
+				{ name: `no-spoof-${actor.id}`, scopes: ["case:read"] },
+				actor.id
+			)
+		);
+		expect(result.integration.ownerId).toBe(actor.id);
+	});
+});
+
+describe("reactivateIntegration — lifecycle (barret deviation 6, 2026-07-03: suspend was a one-way door)", () => {
+	it("reactivates a SUSPENDED integration back to ACTIVE", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		expectSuccess(await suspendIntegration(integration.id, owner.id));
+
+		const reactivated = expectSuccess(
+			await reactivateIntegration(integration.id, owner.id)
+		);
+		expect(reactivated.status).toBe("ACTIVE");
+	});
+
+	it("suspend → reactivate → suspend cycles cleanly", async () => {
+		const { integration, owner } = await registerTestIntegration();
+
+		expectSuccess(await suspendIntegration(integration.id, owner.id));
+		expectSuccess(await reactivateIntegration(integration.id, owner.id));
+		const suspendedAgain = expectSuccess(
+			await suspendIntegration(integration.id, owner.id)
+		);
+
+		expect(suspendedAgain.status).toBe("SUSPENDED");
+	});
+
+	it("refuses to reactivate a REVOKED integration — terminal, not a resurrection", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		expectSuccess(await revokeIntegration(integration.id, owner.id));
+
+		const result = await reactivateIntegration(integration.id, owner.id);
+		expectError(result, CANNOT_REVOKED_PATTERN);
+
+		const unchanged = await prisma.integration.findUniqueOrThrow({
+			where: { id: integration.id },
+		});
+		expect(unchanged.status).toBe("REVOKED");
+	});
+
+	it("refuses to reactivate an already-ACTIVE integration", async () => {
+		const { integration, owner } = await registerTestIntegration();
+
+		const result = await reactivateIntegration(integration.id, owner.id);
+		expectError(result, ALREADY_ACTIVE_PATTERN);
+	});
+
+	it("refuses to SUSPEND a REVOKED integration — suspend must not un-revoke it", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		expectSuccess(await revokeIntegration(integration.id, owner.id));
+
+		const result = await suspendIntegration(integration.id, owner.id);
+		expectError(result, CANNOT_REVOKED_PATTERN);
+
+		const unchanged = await prisma.integration.findUniqueOrThrow({
+			where: { id: integration.id },
+		});
+		expect(unchanged.status).toBe("REVOKED");
+	});
+
+	it("writes a SecurityAuditLog row for reactivation", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		await suspendIntegration(integration.id, owner.id);
+		await reactivateIntegration(integration.id, owner.id);
+
+		const event = await prisma.securityAuditLog.findFirst({
+			where: { userId: owner.id, eventType: "integration_reactivated" },
+		});
+		expect(event).not.toBeNull();
+	});
+});
+
+describe("updateIntegration — description and scopes, partial updates", () => {
+	it("updates description only, leaving scopes untouched", async () => {
+		const { integration, owner } = await registerTestIntegration(["case:read"]);
+
+		const result = expectSuccess(
+			await updateIntegration(
+				integration.id,
+				{ description: "a new description" },
+				owner.id
+			)
+		);
+
+		expect(result.description).toBe("a new description");
+		expect(result.scopes).toEqual(["case:read"]);
+	});
+
+	it("updates scopes only, leaving description untouched", async () => {
+		const { integration, owner } = await registerTestIntegration(["case:read"]);
+
+		const result = expectSuccess(
+			await updateIntegration(
+				integration.id,
+				{ scopes: ["case:read", "health:evidence:read"] },
+				owner.id
+			)
+		);
+
+		expect(result.scopes).toEqual(["case:read", "health:evidence:read"]);
+	});
+
+	it("rejects an unknown scope without persisting anything", async () => {
+		const { integration, owner } = await registerTestIntegration();
+
+		const result = await updateIntegration(
+			integration.id,
+			{ scopes: ["case:read", "not-a-real-scope"] },
+			owner.id
+		);
+		expectError(result, UNKNOWN_SCOPE_PATTERN);
+	});
+
+	it("writes a SecurityAuditLog row for an update", async () => {
+		const { integration, owner } = await registerTestIntegration();
+		await updateIntegration(
+			integration.id,
+			{ description: "updated" },
+			owner.id
+		);
+
+		const event = await prisma.securityAuditLog.findFirst({
+			where: { userId: owner.id, eventType: "integration_updated" },
+		});
+		expect(event).not.toBeNull();
+	});
+});
 
 /** Creates a raw ApiToken row with a known plaintext secret (for edge cases the service's own issueToken doesn't cover, e.g. a past expiresAt). */
 async function createRawToken(
@@ -57,7 +367,7 @@ async function registerTestIntegration(
 	const owner = await createTestUser();
 	const result = expectSuccess(
 		await registerIntegration(
-			{ name: `test-integration-${owner.id}`, ownerId: owner.id, scopes },
+			{ name: `test-integration-${owner.id}`, scopes },
 			owner.id
 		)
 	);
@@ -87,7 +397,6 @@ describe("integration-registry-service — registration & lifecycle", () => {
 		const result = await registerIntegration(
 			{
 				name: "bad-scope-integration",
-				ownerId: owner.id,
 				scopes: ["case:read", "not-a-real-scope"],
 			},
 			owner.id
@@ -119,12 +428,12 @@ describe("integration-registry-service — registration & lifecycle", () => {
 		const owner = await createTestUser();
 		expectSuccess(
 			await registerIntegration(
-				{ name: "dup-name", ownerId: owner.id, scopes: ["case:read"] },
+				{ name: "dup-name", scopes: ["case:read"] },
 				owner.id
 			)
 		);
 		const second = await registerIntegration(
-			{ name: "dup-name", ownerId: owner.id, scopes: ["case:read"] },
+			{ name: "dup-name", scopes: ["case:read"] },
 			owner.id
 		);
 		expectError(second, ALREADY_EXISTS_PATTERN);

--- a/src/__tests__/integration/user-management-service.test.ts
+++ b/src/__tests__/integration/user-management-service.test.ts
@@ -22,9 +22,9 @@ import {
  */
 const SYSTEM_USER_EMAIL = "system@tea-platform.internal";
 const SINGLE_INTEGRATION_BLOCK_PATTERN =
-	/reassign or remove your 1 integration/i;
+	/Remove your 1 integration before deleting your account/;
 const MULTIPLE_INTEGRATIONS_BLOCK_PATTERN =
-	/reassign or remove your 2 integrations/i;
+	/Remove your 2 integrations before deleting your account/;
 
 describe("getOrCreateSystemUser (via deleteAccount) — R2 regression", () => {
 	it("reassigns a deleted user's case to the generic fallback account, not an unrelated system user created first", async () => {
@@ -89,7 +89,7 @@ describe("getOrCreateSystemUser (via deleteAccount) — R2 regression", () => {
  * `ON DELETE RESTRICT` on `Integration.ownerId` (ADR 0002 v2 §2.4) whenever
  * the deleting user owned any integration — that error was caught by the
  * function's catch-all and flattened into an unhelpful "Failed to delete
- * account". `deleteAccount` now checks `getIntegrationsOwnedBy` FIRST and
+ * account". `deleteAccount` now checks `countIntegrationsOwnedBy` FIRST and
  * returns a clean, typed, actionable error instead of ever reaching the
  * transaction.
  */

--- a/src/__tests__/integration/user-management-service.test.ts
+++ b/src/__tests__/integration/user-management-service.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "vitest";
 import prisma from "@/lib/prisma";
+import { reassignIntegrationOwner } from "@/lib/services/integration-registry-service";
 import { deleteAccount } from "@/lib/services/user-management-service";
-import { expectSuccess } from "../utils/assertion-helpers";
-import { createTestCase, createTestUser } from "../utils/prisma-factories";
+import { expectError, expectSuccess } from "../utils/assertion-helpers";
+import {
+	createTestCase,
+	createTestIntegrationWithSystemUser,
+	createTestUser,
+} from "../utils/prisma-factories";
 
 /**
  * Regression test for feasibility review R2 (ADR 0002 v2 §2.4):
@@ -16,6 +21,10 @@ import { createTestCase, createTestUser } from "../utils/prisma-factories";
  * `system@tea-platform.internal` email identifier instead.
  */
 const SYSTEM_USER_EMAIL = "system@tea-platform.internal";
+const SINGLE_INTEGRATION_BLOCK_PATTERN =
+	/reassign or remove your 1 integration/i;
+const MULTIPLE_INTEGRATIONS_BLOCK_PATTERN =
+	/reassign or remove your 2 integrations/i;
 
 describe("getOrCreateSystemUser (via deleteAccount) — R2 regression", () => {
 	it("reassigns a deleted user's case to the generic fallback account, not an unrelated system user created first", async () => {
@@ -72,5 +81,75 @@ describe("getOrCreateSystemUser (via deleteAccount) — R2 regression", () => {
 		]);
 		expect(updatedCaseA.createdById).toBe(fallbackUsers[0]?.id);
 		expect(updatedCaseB.createdById).toBe(fallbackUsers[0]?.id);
+	});
+});
+
+/**
+ * `deleteAccount` used to hit a raw P2003 from the DB's unconditional
+ * `ON DELETE RESTRICT` on `Integration.ownerId` (ADR 0002 v2 §2.4) whenever
+ * the deleting user owned any integration — that error was caught by the
+ * function's catch-all and flattened into an unhelpful "Failed to delete
+ * account". `deleteAccount` now checks `getIntegrationsOwnedBy` FIRST and
+ * returns a clean, typed, actionable error instead of ever reaching the
+ * transaction.
+ */
+describe("deleteAccount — owned-integrations block (ADR 0002 v2 §2.4)", () => {
+	it("refuses with a clean typed error (not a raw P2003) when the user owns an integration", async () => {
+		const owner = await createTestUser({ authProvider: "GITHUB" });
+		await createTestIntegrationWithSystemUser(owner.id);
+
+		const result = await deleteAccount(owner.id);
+
+		expectError(result, SINGLE_INTEGRATION_BLOCK_PATTERN);
+
+		// The user must still exist — the transaction was never attempted.
+		const stillThere = await prisma.user.findUnique({
+			where: { id: owner.id },
+		});
+		expect(stillThere).not.toBeNull();
+	});
+
+	it("pluralises the count for more than one owned integration", async () => {
+		const owner = await createTestUser({ authProvider: "GITHUB" });
+		await createTestIntegrationWithSystemUser(owner.id);
+		await createTestIntegrationWithSystemUser(owner.id);
+
+		const result = await deleteAccount(owner.id);
+
+		expectError(result, MULTIPLE_INTEGRATIONS_BLOCK_PATTERN);
+	});
+
+	it("succeeds once the owned integration is reassigned away", async () => {
+		const owner = await createTestUser({ authProvider: "GITHUB" });
+		const newOwner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+
+		expectSuccess(
+			await reassignIntegrationOwner(integration.id, newOwner.id, owner.id)
+		);
+
+		expectSuccess(await deleteAccount(owner.id));
+
+		const deletedUser = await prisma.user.findUnique({
+			where: { id: owner.id },
+		});
+		expect(deletedUser).toBeNull();
+	});
+
+	it("succeeds once the owned integration is deleted outright", async () => {
+		const owner = await createTestUser({ authProvider: "GITHUB" });
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+
+		await prisma.integration.delete({ where: { id: integration.id } });
+
+		expectSuccess(await deleteAccount(owner.id));
+	});
+
+	it("is unaffected by an integration owned by a DIFFERENT user", async () => {
+		const owner = await createTestUser({ authProvider: "GITHUB" });
+		const otherOwner = await createTestUser();
+		await createTestIntegrationWithSystemUser(otherOwner.id);
+
+		expectSuccess(await deleteAccount(owner.id));
 	});
 });


### PR DESCRIPTION
## Summary

- Enforces ownership at the integration registry service boundary (the standing security-review precondition for exposing it over HTTP): every mutating operation verifies the actor owns the integration through one of two symmetrical choke points (integration-keyed and token-keyed); registration binds ownership to the session user structurally — no owner field exists on the wire.
- Management API under `/api/integrations`: list (token summaries only — prefixes and timestamps, never secrets or hashes), register, update, delete, suspend/reactivate/revoke, and token issue/rotate/revoke. Plaintext token secrets are returned exactly once, at issuance and rotation.
- Non-owner responses are byte-identical to nonexistent-id responses throughout (no enumeration oracle), pinned by regression pairs at both service and route level, including same-owner cross-integration token paths.
- Suspend is now reversible (new reactivate); revoke stays terminal; suspending a revoked integration is refused (closes an un-revoke path).
- Deleting an account that owns integrations now returns a clean 409 with an actionable message instead of a raw database error, and the new DELETE route provides the removal path the message names.

## Review chain

- QA: PASS-WITH-FINDINGS — gate independently re-measured to the digit; all findings dispositioned in the follow-up commit (permission matrix extended to all four id-keyed mutation routes, token-rotation audit row pinned, four route-level 409 proofs, boundary caps pinned, revoked/expired token rendering pinned).
- Code review: APPROVE-WITH-COMMENTS — ownership enforcement verified closed, including two token operations that previously had no ownership check at all; token-keyed choke point extracted; path/token cross-validation added; error mappings anchored.
- Reviewed-to-final delta read in full by the lead; fail-to-pass proof run for the path-validation fix (pre-fix code restored, tests fail 200-vs-404, fix restored, tests pass).

## Test evidence

- Lint 685 files clean · typecheck clean · unit 991/991 · integration 691/691 (35 files, 5 shards) · OpenAPI regeneration diff-clean against the committed artifact.