### PR TITLE
Bake the DARTER demo case + integration into the staging seed

### DIFF
--- a/lib/services/darter-integration-service.ts
+++ b/lib/services/darter-integration-service.ts
@@ -1,0 +1,115 @@
+import { sameScopes } from "@/lib/auth/scopes";
+import { prisma } from "@/lib/prisma";
+import {
+	registerIntegration,
+	updateIntegrationScopes,
+} from "@/lib/services/integration-registry-service";
+import type { PermissionLevel } from "@/src/generated/prisma";
+import type { ServiceResult } from "@/types/service";
+
+/**
+ * Shared find-or-register-and-grant logic for the `darter-pipeline`
+ * integration (ADR 0002 v2 §2.4), reused by two entry points that must stay
+ * in lockstep on name/scopes but diverge on what happens next:
+ *   - `scripts/seed-darter-integration.ts` — the ad-hoc/manual CLI path,
+ *     which additionally issues a token and prints it.
+ *   - `prisma/seed/dev-seed.ts` — the demo-seed path, which deliberately
+ *     issues NO token (shown-once semantics; the token is issued through
+ *     the management UI at demo time, PR #849).
+ *
+ * Idempotent: reuses the existing integration/system user if one already
+ * exists, reconciling its scopes to `DARTER_EXPECTED_SCOPES` if they've
+ * drifted; upserts the case permission grant either way.
+ */
+
+export const DARTER_INTEGRATION_NAME = "darter-pipeline";
+export const DARTER_EXPECTED_SCOPES = [
+	"case:read",
+	"health:evidence:write",
+] as const;
+const DARTER_DESCRIPTION =
+	"DARTER evidence pipeline — machine client for the health plugin";
+
+export interface DarterIntegrationRef {
+	integrationId: string;
+	status: "created" | "existing" | "reconciled";
+	systemUserId: string;
+}
+
+/**
+ * Finds or registers the `darter-pipeline` integration, reconciling its
+ * scopes if they've drifted from `DARTER_EXPECTED_SCOPES`. Does NOT grant
+ * case access or touch tokens — see `ensureDarterCaseGrant` and each
+ * caller's own token handling.
+ */
+export async function ensureDarterIntegration(
+	actorUserId: string
+): ServiceResult<DarterIntegrationRef> {
+	const existing = await prisma.integration.findUnique({
+		where: { name: DARTER_INTEGRATION_NAME },
+	});
+
+	if (existing) {
+		if (sameScopes(existing.scopes, DARTER_EXPECTED_SCOPES)) {
+			return {
+				data: {
+					integrationId: existing.id,
+					systemUserId: existing.systemUserId,
+					status: "existing",
+				},
+			};
+		}
+
+		const reconciled = await updateIntegrationScopes(
+			existing.id,
+			[...DARTER_EXPECTED_SCOPES],
+			actorUserId
+		);
+		if ("error" in reconciled) {
+			return reconciled;
+		}
+		return {
+			data: {
+				integrationId: existing.id,
+				systemUserId: existing.systemUserId,
+				status: "reconciled",
+			},
+		};
+	}
+
+	const registered = await registerIntegration(
+		{
+			name: DARTER_INTEGRATION_NAME,
+			description: DARTER_DESCRIPTION,
+			scopes: [...DARTER_EXPECTED_SCOPES],
+		},
+		actorUserId
+	);
+	if ("error" in registered) {
+		return registered;
+	}
+	return {
+		data: {
+			integrationId: registered.data.integration.id,
+			systemUserId: registered.data.systemUserId,
+			status: "created",
+		},
+	};
+}
+
+/**
+ * Upserts the DARTER system user's case permission grant — safe to call on
+ * every run (re-running with the same `permission` is a no-op update).
+ */
+export async function ensureDarterCaseGrant(
+	caseId: string,
+	systemUserId: string,
+	permission: PermissionLevel,
+	grantedById: string
+): Promise<void> {
+	await prisma.casePermission.upsert({
+		where: { caseId_userId: { caseId, userId: systemUserId } },
+		create: { caseId, userId: systemUserId, permission, grantedById },
+		update: { permission, grantedById },
+	});
+}

--- a/prisma/seed/dev-seed.ts
+++ b/prisma/seed/dev-seed.ts
@@ -13,6 +13,12 @@ import { fileURLToPath } from "node:url";
 import { PrismaPg } from "@prisma/adapter-pg";
 import argon2 from "argon2";
 import { Pool } from "pg";
+import { prisma as appPrisma } from "../../lib/prisma";
+import {
+	DARTER_INTEGRATION_NAME,
+	ensureDarterCaseGrant,
+	ensureDarterIntegration,
+} from "../../lib/services/darter-integration-service";
 import { PrismaClient } from "../../src/generated/prisma";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -112,7 +118,7 @@ async function main() {
 		hashPassword(charliePw),
 	]);
 
-	await prisma.$transaction(
+	const seeded = await prisma.$transaction(
 		async (tx) => {
 			// ============================================
 			// 1. CREATE USERS
@@ -607,6 +613,171 @@ async function main() {
 
 			console.log(`Created: Bob's Case (Draft, bob, shared with charlie)`);
 
+			// 3e. DARTER Demo Case (chris) - Draft, keystone demo target.
+			// Deterministic name/description so the demo documentation and the
+			// DARTER integration registration (below, after this transaction
+			// commits) can point at this case and its C1 claim by name. C1 is
+			// deliberately left WITHOUT a static EvidenceLink — it's the
+			// keystone claim whose badge flips live when the DARTER pipeline
+			// posts its first evidence-format-v0.1 item through the health
+			// plugin's machine endpoint. Do not seed PluginHealthEvidence or
+			// PluginData for it; that would pre-empt the live demo.
+			const demoCase = await tx.assuranceCase.create({
+				data: {
+					name: "DARTER Demo — Ship Detection Assurance",
+					description:
+						"Assurance case for the DARTER ship-detection pipeline, demonstrating runtime evidence flowing from the health plugin into a claim's assurance score.",
+					createdById: chris.id,
+					mode: "ADVANCED",
+					publishStatus: "DRAFT",
+				},
+			});
+
+			const demoGoal = await tx.assuranceElement.create({
+				data: {
+					caseId: demoCase.id,
+					elementType: "GOAL",
+					role: "TOP_LEVEL",
+					name: "G1",
+					description:
+						"The ship-detection system performs reliably enough for operational deployment",
+					context: [
+						"DARTER ship-detection pipeline",
+						"Runtime health-plugin monitoring",
+					],
+					createdById: chris.id,
+				},
+			});
+
+			const demoStrategy1 = await tx.assuranceElement.create({
+				data: {
+					caseId: demoCase.id,
+					elementType: "STRATEGY",
+					role: "SUPPORTING",
+					parentId: demoGoal.id,
+					name: "S1",
+					description: "Argue over runtime detection-performance monitoring",
+					justification:
+						"Continuous runtime health evidence is the primary signal for detection reliability once deployed",
+					createdById: chris.id,
+				},
+			});
+
+			const demoStrategy2 = await tx.assuranceElement.create({
+				data: {
+					caseId: demoCase.id,
+					elementType: "STRATEGY",
+					role: "SUPPORTING",
+					parentId: demoGoal.id,
+					name: "S2",
+					description:
+						"Argue over human oversight and escalation for automated detections",
+					justification:
+						"Human oversight bounds the risk of undetected model drift between health-evidence checks",
+					createdById: chris.id,
+				},
+			});
+
+			// C1 is the keystone evidence target for the DARTER integration —
+			// intentionally created with NO EvidenceLink below.
+			const demoClaim1 = await tx.assuranceElement.create({
+				data: {
+					caseId: demoCase.id,
+					elementType: "PROPERTY_CLAIM",
+					role: "SUPPORTING",
+					parentId: demoStrategy1.id,
+					name: "C1",
+					description:
+						"Ship detection recall remains above the operational threshold in production monitoring",
+					createdById: chris.id,
+				},
+			});
+
+			const demoClaim2 = await tx.assuranceElement.create({
+				data: {
+					caseId: demoCase.id,
+					elementType: "PROPERTY_CLAIM",
+					role: "SUPPORTING",
+					parentId: demoStrategy1.id,
+					name: "C2",
+					description: "False-positive rate remains within acceptable bounds",
+					createdById: chris.id,
+				},
+			});
+
+			const demoClaim3 = await tx.assuranceElement.create({
+				data: {
+					caseId: demoCase.id,
+					elementType: "PROPERTY_CLAIM",
+					role: "SUPPORTING",
+					parentId: demoStrategy2.id,
+					name: "C3",
+					description:
+						"Low-confidence detections are escalated to human review",
+					createdById: chris.id,
+				},
+			});
+
+			const demoClaim4 = await tx.assuranceElement.create({
+				data: {
+					caseId: demoCase.id,
+					elementType: "PROPERTY_CLAIM",
+					role: "SUPPORTING",
+					parentId: demoStrategy2.id,
+					name: "C4",
+					description: "Operators can override automated detections",
+					createdById: chris.id,
+				},
+			});
+
+			const demoEvidence1 = await tx.assuranceElement.create({
+				data: {
+					caseId: demoCase.id,
+					elementType: "EVIDENCE",
+					role: "SUPPORTING",
+					name: "E1",
+					description: "False-positive rate analysis report",
+					url: "https://example.com/reports/darter-false-positive-rate.pdf",
+					createdById: chris.id,
+				},
+			});
+
+			const demoEvidence2 = await tx.assuranceElement.create({
+				data: {
+					caseId: demoCase.id,
+					elementType: "EVIDENCE",
+					role: "SUPPORTING",
+					name: "E2",
+					description: "Escalation workflow test report",
+					url: "https://example.com/reports/darter-escalation-workflow.pdf",
+					createdById: chris.id,
+				},
+			});
+
+			const demoEvidence3 = await tx.assuranceElement.create({
+				data: {
+					caseId: demoCase.id,
+					elementType: "EVIDENCE",
+					role: "SUPPORTING",
+					name: "E3",
+					description: "Operator override audit log",
+					url: "https://example.com/reports/darter-operator-override.pdf",
+					createdById: chris.id,
+				},
+			});
+
+			await tx.evidenceLink.createMany({
+				data: [
+					{ evidenceId: demoEvidence1.id, claimId: demoClaim2.id },
+					{ evidenceId: demoEvidence2.id, claimId: demoClaim3.id },
+					{ evidenceId: demoEvidence3.id, claimId: demoClaim4.id },
+				],
+			});
+
+			console.log(
+				"Created: DARTER Demo — Ship Detection Assurance (Draft, chris, C1 reserved for live health-plugin evidence)"
+			);
+
 			// ============================================
 			// 4. CREATE COMMENTS (for collaboration testing)
 			// ============================================
@@ -632,9 +803,46 @@ async function main() {
 			});
 
 			console.log("Created: 2 comments on Medium Case from alice");
+
+			return {
+				chrisId: chris.id,
+				demoCaseId: demoCase.id,
+				demoClaim1Id: demoClaim1.id,
+			};
 		},
 		{ timeout: 30_000 }
 	); // end $transaction
+
+	const { chrisId, demoCaseId, demoClaim1Id } = seeded;
+
+	// ============================================
+	// 5. REGISTER THE DARTER INTEGRATION (keystone demo)
+	// ============================================
+	// Runs OUTSIDE the transaction above and through the app's own `prisma`
+	// client (`@/lib/prisma`, a separate connection/pool from this script's
+	// adapter-bound client) because `registerIntegration` and
+	// `ensureDarterCaseGrant` live in `lib/services/` and import that client
+	// directly — they need the demo case + chris user already committed and
+	// visible, which they are by this point. Reuses the exact registration
+	// logic `scripts/seed-darter-integration.ts` uses (shared via
+	// `lib/services/darter-integration-service.ts`), actor = the chris seed
+	// user, scopes = case:read + health:evidence:write. Deliberately issues
+	// NO token — shown-once semantics mean the token is issued through the
+	// management UI (PR #849) at demo time, never baked into the seed.
+	console.log("\nRegistering DARTER integration...");
+	const darter = await ensureDarterIntegration(chrisId);
+	if ("error" in darter) {
+		throw new Error(`Failed to register DARTER integration: ${darter.error}`);
+	}
+	await ensureDarterCaseGrant(
+		demoCaseId,
+		darter.data.systemUserId,
+		"EDIT",
+		chrisId
+	);
+	console.log(
+		`Registered "${DARTER_INTEGRATION_NAME}" integration (${darter.data.status}) and granted EDIT on the DARTER demo case to its system user. No token issued — issue one via the management UI at demo time.`
+	);
 
 	// ============================================
 	// SUMMARY
@@ -645,12 +853,18 @@ async function main() {
 	console.log("\nCreated:");
 	console.log("  - 4 users: chris, alice, bob, charlie");
 	console.log("  - 1 team: Test Team (alice=ADMIN, bob=MEMBER)");
-	console.log("  - 4 assurance cases:");
+	console.log("  - 5 assurance cases:");
 	console.log("    - Simple Case (chris, Draft)");
 	console.log("    - Medium Case (chris, Published, shared with alice)");
 	console.log("    - Alice's Case (alice, Draft, team shared)");
 	console.log("    - Bob's Case (bob, Draft, shared with charlie)");
+	console.log(
+		`    - DARTER Demo — Ship Detection Assurance (chris, Draft, id=${demoCaseId}, claim C1 id=${demoClaim1Id} is the live evidence target)`
+	);
 	console.log("  - 2 comments on Medium Case");
+	console.log(
+		`  - 1 machine integration: ${DARTER_INTEGRATION_NAME} (case:read + health:evidence:write, EDIT on the demo case, no token issued)`
+	);
 	console.log("\nLogin with any test user using the SEED_USER_PASSWORD");
 }
 
@@ -660,6 +874,19 @@ main()
 		process.exit(1);
 	})
 	.finally(async () => {
+		// Two Prisma clients are live in this process: this script's own
+		// (`prisma`, backed by its own `pg.Pool`, ended explicitly below) and
+		// the app's shared singleton (`appPrisma`, imported transitively via
+		// `lib/services/darter-integration-service.ts` for the DARTER
+		// registration step, backed by ITS OWN separate `pg.Pool` created
+		// inside `lib/prisma.ts`). `PrismaPg`'s `disposeExternalPool` option
+		// defaults to `false`, so neither client's `$disconnect()` closes its
+		// underlying pool — only `pool.end()` does that, and this script has
+		// no handle on the second, internal one. `process.exit(0)` below
+		// guarantees the process still terminates promptly either way,
+		// rather than hanging on that dangling pool's open sockets.
+		await appPrisma.$disconnect();
 		await prisma.$disconnect();
 		await pool.end();
+		process.exit(0);
 	});

--- a/prisma/seed/dev-seed.ts
+++ b/prisma/seed/dev-seed.ts
@@ -630,6 +630,7 @@ async function main() {
 					createdById: chris.id,
 					mode: "ADVANCED",
 					publishStatus: "DRAFT",
+					// isDemo must stay false (the schema default) — the onboarding-tour feature keys on `isDemo && name` matches (G1/S1/E1…) unrelated to this case, so `true` here would misfire tour highlights on this case AND suppress the real tutorial case.
 				},
 			});
 
@@ -882,11 +883,16 @@ main()
 		// inside `lib/prisma.ts`). `PrismaPg`'s `disposeExternalPool` option
 		// defaults to `false`, so neither client's `$disconnect()` closes its
 		// underlying pool — only `pool.end()` does that, and this script has
-		// no handle on the second, internal one. `process.exit(0)` below
-		// guarantees the process still terminates promptly either way,
-		// rather than hanging on that dangling pool's open sockets.
-		await appPrisma.$disconnect();
-		await prisma.$disconnect();
-		await pool.end();
-		process.exit(0);
+		// no handle on the second, internal one. The `try`/`finally` below
+		// guarantees `process.exit(0)` runs — and the process still
+		// terminates promptly — either way: whether or not those
+		// disconnects fully close every socket, AND even if one of them
+		// throws.
+		try {
+			await appPrisma.$disconnect();
+			await prisma.$disconnect();
+			await pool.end();
+		} finally {
+			process.exit(0);
+		}
 	});

--- a/prisma/seed/dev-seed.ts
+++ b/prisma/seed/dev-seed.ts
@@ -624,9 +624,9 @@ async function main() {
 			// PluginData for it; that would pre-empt the live demo.
 			const demoCase = await tx.assuranceCase.create({
 				data: {
-					name: "DARTER Demo — Ship Detection Assurance",
+					name: "DARTER Demo — Automated Inspection Assurance",
 					description:
-						"Assurance case for the DARTER ship-detection pipeline, demonstrating runtime evidence flowing from the health plugin into a claim's assurance score.",
+						"Assurance case for an automated visual-inspection pipeline, demonstrating runtime evidence flowing from the health plugin into a claim's assurance score.",
 					createdById: chris.id,
 					mode: "ADVANCED",
 					publishStatus: "DRAFT",
@@ -641,9 +641,9 @@ async function main() {
 					role: "TOP_LEVEL",
 					name: "G1",
 					description:
-						"The ship-detection system performs reliably enough for operational deployment",
+						"The automated inspection system performs reliably enough for operational deployment",
 					context: [
-						"DARTER ship-detection pipeline",
+						"automated visual-inspection pipeline",
 						"Runtime health-plugin monitoring",
 					],
 					createdById: chris.id,
@@ -689,7 +689,7 @@ async function main() {
 					parentId: demoStrategy1.id,
 					name: "C1",
 					description:
-						"Ship detection recall remains above the operational threshold in production monitoring",
+						"Defect detection recall remains above the operational threshold in production monitoring",
 					createdById: chris.id,
 				},
 			});
@@ -776,7 +776,7 @@ async function main() {
 			});
 
 			console.log(
-				"Created: DARTER Demo — Ship Detection Assurance (Draft, chris, C1 reserved for live health-plugin evidence)"
+				"Created: DARTER Demo — Automated Inspection Assurance (Draft, chris, C1 reserved for live health-plugin evidence)"
 			);
 
 			// ============================================
@@ -860,7 +860,7 @@ async function main() {
 	console.log("    - Alice's Case (alice, Draft, team shared)");
 	console.log("    - Bob's Case (bob, Draft, shared with charlie)");
 	console.log(
-		`    - DARTER Demo — Ship Detection Assurance (chris, Draft, id=${demoCaseId}, claim C1 id=${demoClaim1Id} is the live evidence target)`
+		`    - DARTER Demo — Automated Inspection Assurance (chris, Draft, id=${demoCaseId}, claim C1 id=${demoClaim1Id} is the live evidence target)`
 	);
 	console.log("  - 2 comments on Medium Case");
 	console.log(

--- a/scripts/seed-darter-integration.ts
+++ b/scripts/seed-darter-integration.ts
@@ -17,17 +17,16 @@
  * accountable owner, so this script never invents one.
  */
 
-import { sameScopes } from "../lib/auth/scopes";
 import { prisma } from "../lib/prisma";
 import {
-	issueToken,
-	registerIntegration,
-	updateIntegrationScopes,
-} from "../lib/services/integration-registry-service";
+	DARTER_EXPECTED_SCOPES,
+	DARTER_INTEGRATION_NAME,
+	ensureDarterCaseGrant,
+	ensureDarterIntegration,
+} from "../lib/services/darter-integration-service";
+import { issueToken } from "../lib/services/integration-registry-service";
 import type { PermissionLevel } from "../src/generated/prisma";
 
-const INTEGRATION_NAME = "darter-pipeline";
-const EXPECTED_SCOPES = ["case:read", "health:evidence:write"] as const;
 const VALID_PERMISSIONS: PermissionLevel[] = [
 	"VIEW",
 	"COMMENT",
@@ -97,59 +96,30 @@ async function main() {
 		return;
 	}
 
-	let integrationId: string;
-	let systemUserId: string;
+	const ensured = await ensureDarterIntegration(owner.id);
+	if ("error" in ensured) {
+		console.error(`Failed to register/reconcile integration: ${ensured.error}`);
+		process.exit(1);
+		return;
+	}
+	const { integrationId, systemUserId, status } = ensured.data;
 
-	const existing = await prisma.integration.findUnique({
-		where: { name: INTEGRATION_NAME },
-	});
-
-	if (existing) {
-		integrationId = existing.id;
-		systemUserId = existing.systemUserId;
+	if (status === "existing") {
 		console.log(
-			`Integration "${INTEGRATION_NAME}" already registered (${existing.id}).`
+			`Integration "${DARTER_INTEGRATION_NAME}" already registered (${integrationId}).`
 		);
-
-		if (!sameScopes(existing.scopes, EXPECTED_SCOPES)) {
-			const result = await updateIntegrationScopes(
-				existing.id,
-				[...EXPECTED_SCOPES],
-				owner.id
-			);
-			if ("error" in result) {
-				console.error(`Failed to reconcile scopes: ${result.error}`);
-				process.exit(1);
-			}
-			console.log(`Reconciled scopes to: ${EXPECTED_SCOPES.join(", ")}`);
-		}
+	} else if (status === "reconciled") {
+		console.log(
+			`Integration "${DARTER_INTEGRATION_NAME}" already registered (${integrationId}).`
+		);
+		console.log(`Reconciled scopes to: ${DARTER_EXPECTED_SCOPES.join(", ")}`);
 	} else {
-		const result = await registerIntegration(
-			{
-				name: INTEGRATION_NAME,
-				description:
-					"DARTER evidence pipeline — machine client for the health plugin",
-				scopes: [...EXPECTED_SCOPES],
-			},
-			owner.id
-		);
-		if ("error" in result) {
-			console.error(`Failed to register integration: ${result.error}`);
-			process.exit(1);
-			return;
-		}
-		integrationId = result.data.integration.id;
-		systemUserId = result.data.systemUserId;
 		console.log(
-			`Registered integration "${INTEGRATION_NAME}" (${integrationId}).`
+			`Registered integration "${DARTER_INTEGRATION_NAME}" (${integrationId}).`
 		);
 	}
 
-	await prisma.casePermission.upsert({
-		where: { caseId_userId: { caseId, userId: systemUserId } },
-		create: { caseId, userId: systemUserId, permission, grantedById: owner.id },
-		update: { permission, grantedById: owner.id },
-	});
+	await ensureDarterCaseGrant(caseId, systemUserId, permission, owner.id);
 	console.log(
 		`Granted ${permission} on case "${targetCase.name}" (${caseId}) to the DARTER system user.`
 	);

--- a/src/__tests__/integration/darter-integration-service.test.ts
+++ b/src/__tests__/integration/darter-integration-service.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import prisma from "@/lib/prisma";
+import {
+	DARTER_EXPECTED_SCOPES,
+	DARTER_INTEGRATION_NAME,
+	ensureDarterCaseGrant,
+	ensureDarterIntegration,
+} from "@/lib/services/darter-integration-service";
+import { expectSuccess } from "../utils/assertion-helpers";
+import { createTestCase, createTestUser } from "../utils/prisma-factories";
+
+/**
+ * `ensureDarterIntegration` / `ensureDarterCaseGrant` are the shared
+ * find-or-register-and-grant logic behind two callers that must stay in
+ * lockstep on name/scopes — `scripts/seed-darter-integration.ts` and the
+ * demo-seed path (`prisma/seed/dev-seed.ts`) — see the module doc comment on
+ * `lib/services/darter-integration-service.ts`. Neither caller, nor
+ * `machine-auth.test.ts` (which tests `integration-registry-service.ts`
+ * directly, not this wrapper), exercises the `"reconciled"` branch: nothing
+ * mutates a persisted integration's scopes out from under the service to
+ * force drift detection on a re-run. This file closes that gap.
+ */
+describe("ensureDarterIntegration", () => {
+	it("creates the integration on first call — status 'created', scopes match DARTER_EXPECTED_SCOPES", async () => {
+		const actor = await createTestUser();
+
+		const result = expectSuccess(await ensureDarterIntegration(actor.id));
+
+		expect(result.status).toBe("created");
+		const persisted = await prisma.integration.findUniqueOrThrow({
+			where: { id: result.integrationId },
+		});
+		expect(persisted.name).toBe(DARTER_INTEGRATION_NAME);
+		expect(persisted.scopes).toEqual([...DARTER_EXPECTED_SCOPES]);
+		expect(persisted.systemUserId).toBe(result.systemUserId);
+	});
+
+	it("returns 'existing' on a second call by the same actor — no duplicate integration row, scopes unchanged", async () => {
+		const actor = await createTestUser();
+
+		const first = expectSuccess(await ensureDarterIntegration(actor.id));
+		const second = expectSuccess(await ensureDarterIntegration(actor.id));
+
+		expect(second.status).toBe("existing");
+		expect(second.integrationId).toBe(first.integrationId);
+		expect(second.systemUserId).toBe(first.systemUserId);
+
+		const rows = await prisma.integration.findMany({
+			where: { name: DARTER_INTEGRATION_NAME },
+		});
+		expect(rows).toHaveLength(1);
+		const persisted = await prisma.integration.findUniqueOrThrow({
+			where: { name: DARTER_INTEGRATION_NAME },
+		});
+		expect(persisted.scopes).toEqual([...DARTER_EXPECTED_SCOPES]);
+	});
+
+	it("reconciles drifted scopes back to DARTER_EXPECTED_SCOPES — status 'reconciled'", async () => {
+		const actor = await createTestUser();
+		const created = expectSuccess(await ensureDarterIntegration(actor.id));
+
+		// Simulate drift directly against the DB, bypassing the service — the
+		// way a manual hotfix, a bad migration, or a bug elsewhere might leave
+		// the persisted scopes out of sync with DARTER_EXPECTED_SCOPES.
+		await prisma.integration.update({
+			where: { id: created.integrationId },
+			data: { scopes: ["case:read"] },
+		});
+
+		const reconciled = expectSuccess(await ensureDarterIntegration(actor.id));
+
+		expect(reconciled.status).toBe("reconciled");
+		expect(reconciled.integrationId).toBe(created.integrationId);
+		expect(reconciled.systemUserId).toBe(created.systemUserId);
+
+		const persisted = await prisma.integration.findUniqueOrThrow({
+			where: { id: created.integrationId },
+		});
+		expect(persisted.scopes).toEqual([...DARTER_EXPECTED_SCOPES]);
+
+		// Reconciliation must update the existing row, never create a second one.
+		const rows = await prisma.integration.findMany({
+			where: { name: DARTER_INTEGRATION_NAME },
+		});
+		expect(rows).toHaveLength(1);
+	});
+});
+
+describe("ensureDarterCaseGrant", () => {
+	it("upserts the case permission grant — a second call with a different permission value updates it to the latest, not a second row", async () => {
+		const actor = await createTestUser();
+		const testCase = await createTestCase(actor.id);
+		const { systemUserId } = expectSuccess(
+			await ensureDarterIntegration(actor.id)
+		);
+
+		await ensureDarterCaseGrant(testCase.id, systemUserId, "VIEW", actor.id);
+		await ensureDarterCaseGrant(testCase.id, systemUserId, "EDIT", actor.id);
+
+		const grant = await prisma.casePermission.findUniqueOrThrow({
+			where: {
+				caseId_userId: { caseId: testCase.id, userId: systemUserId },
+			},
+		});
+		expect(grant.permission).toBe("EDIT");
+		expect(grant.grantedById).toBe(actor.id);
+
+		const grants = await prisma.casePermission.findMany({
+			where: { caseId: testCase.id, userId: systemUserId },
+		});
+		expect(grants).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## Summary

- Every staging reset now recreates the keystone-demo state automatically: a realistic ten-element demo assurance case ("DARTER Demo — Automated Inspection Assurance") owned by the chris seed user, with the darter-pipeline integration registered against it (scopes `case:read` + `health:evidence:write`, EDIT grant via its system user).
- Claim C1 is deliberately evidence-free — the pre-demo state. The live evidence POST at demo time is what flips its badge; nothing is pre-seeded into the health-plugin tables.
- **No token is ever issued by the seed** (shown-once semantics; zero ApiToken rows proven by query). The token is issued at demo time through the integrations settings page.
- Shared find-or-register/reconcile logic extracted to `lib/services/darter-integration-service.ts`, composing the unchanged registry-service primitives; the ad-hoc CLI script now rides the same code (happy-path output byte-identical).
- Fixed a latent hang: dev-seed transitively imports the app's Prisma singleton, whose second connection pool kept the process alive after completion — the exact command the seed workflow runs. Failure exits are proven unaffected (empirical probe: broken DB URL exits 1; success exits 0 in half a second).

## Review chain

- QA: PASS-WITH-FINDINGS — all six seeding proofs re-verified by direct query; the exit-code question settled empirically; findings dispositioned in a follow-up commit (reconciliation-branch test coverage, a cross-feature guard comment, unconditional success-exit).
- Code review: APPROVE-WITH-COMMENTS — placement, dual-client analysis, and scope-reconciliation semantics verified; fallow clean gate.
- Reviewed-to-final deltas read in full by the lead (fix batch + a follow-up naming commit switching the demo to a neutral inspection domain).

## Test evidence

- Lint 687 files clean · typecheck clean · unit 991/991 · dedicated service test file 4/4 · seed verified against a scratch database with verbatim query proofs.