### PR TITLE
Integrations settings page — registration, lifecycle, and token management UI

### DIFF
--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
@@ -19,6 +19,8 @@ const DELETE_CONFIRM_REGEX = /delete integration/i;
 const ISSUE_TOKEN_BUTTON_REGEX = /issue new token/i;
 const PERMANENT_TEXT_REGEX = /permanent/i;
 const CANNOT_BE_UNDONE_TEXT_REGEX = /cannot be undone/i;
+const DONE_BUTTON_REGEX = /done.*stored it/i;
+const TOKEN_ROW_TEST_ID_REGEX = /^token-row-/;
 
 function makeIntegration(
 	overrides: Partial<IntegrationListItem> = {}
@@ -219,6 +221,29 @@ describe("IntegrationCard", () => {
 
 			expect(onRevokeToken).toHaveBeenCalledWith("integration-1", "token-1");
 		});
+
+		it("does not call onRevokeToken when the token revoke confirm dialog is cancelled", async () => {
+			const onRevokeToken = vi.fn();
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration()}
+					onRevokeToken={onRevokeToken}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: REVOKE_TOKEN_TRIGGER_REGEX })
+			);
+			await screen.findByRole("dialog");
+			await user.click(
+				screen.getByRole("button", { name: CANCEL_BUTTON_REGEX })
+			);
+
+			expect(onRevokeToken).not.toHaveBeenCalled();
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		});
 	});
 
 	describe("tokens", () => {
@@ -261,6 +286,59 @@ describe("IntegrationCard", () => {
 			expect(await screen.findByTestId("token-secret-value")).toHaveTextContent(
 				"tea_live_freshsecret"
 			);
+		});
+
+		it("clears the revealed secret from the DOM once Done is clicked — IntegrationCard's own onClose wiring, not just the modal's isolated behaviour", async () => {
+			const onIssueToken = vi.fn().mockResolvedValue({
+				secret: "tea_live_freshsecret",
+				token: {
+					id: "token-2",
+					tokenPrefix: "tea_live_cd34",
+					createdAt: "2026-07-05T00:00:00.000Z",
+					expiresAt: null,
+				},
+			});
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration()}
+					onIssueToken={onIssueToken}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: ISSUE_TOKEN_BUTTON_REGEX })
+			);
+			expect(await screen.findByTestId("token-secret-value")).toHaveTextContent(
+				"tea_live_freshsecret"
+			);
+
+			await user.click(screen.getByRole("button", { name: DONE_BUTTON_REGEX }));
+
+			// A regression to `onClose={() => {}}` (a no-op) would leave this
+			// element in the DOM — `IntegrationTokenSecretModal`'s own isolated
+			// test cannot catch that, since it only ever rerenders with a
+			// directly-supplied `reveal` prop rather than exercising
+			// `IntegrationCard`'s `setTokenReveal(null)` handler.
+			expect(
+				screen.queryByTestId("token-secret-value")
+			).not.toBeInTheDocument();
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		});
+
+		it("shows an empty-tokens message and no token rows when the integration has none issued", () => {
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({ tokens: [] })}
+				/>
+			);
+
+			expect(screen.getByText("No tokens issued yet.")).toBeInTheDocument();
+			expect(
+				screen.queryByTestId(TOKEN_ROW_TEST_ID_REGEX)
+			).not.toBeInTheDocument();
 		});
 	});
 });

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
@@ -1,0 +1,266 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { IntegrationListItem } from "@/lib/schemas/integration";
+import {
+	renderWithoutProviders,
+	screen,
+} from "@/src/__tests__/utils/test-utils";
+import { IntegrationCard } from "../integration-card";
+
+const SUSPEND_BUTTON_REGEX = /suspend/i;
+const REACTIVATE_BUTTON_REGEX = /reactivate/i;
+const REVOKE_INTEGRATION_TRIGGER_REGEX = /revoke this integration/i;
+const REVOKE_INTEGRATION_CONFIRM_REGEX = /revoke integration/i;
+const REVOKE_TOKEN_TRIGGER_REGEX = /revoke this token/i;
+const REVOKE_TOKEN_CONFIRM_REGEX = /revoke token/i;
+const CANCEL_BUTTON_REGEX = /cancel/i;
+const DELETE_TRIGGER_REGEX = /^delete$/i;
+const DELETE_CONFIRM_REGEX = /delete integration/i;
+const ISSUE_TOKEN_BUTTON_REGEX = /issue new token/i;
+const PERMANENT_TEXT_REGEX = /permanent/i;
+const CANNOT_BE_UNDONE_TEXT_REGEX = /cannot be undone/i;
+
+function makeIntegration(
+	overrides: Partial<IntegrationListItem> = {}
+): IntegrationListItem {
+	return {
+		id: "integration-1",
+		name: "darter-evidence-pipeline",
+		description: "Evidence collection pipeline",
+		scopes: ["case:read"],
+		status: "ACTIVE",
+		createdAt: "2026-06-01T00:00:00.000Z",
+		updatedAt: "2026-06-01T00:00:00.000Z",
+		lastSeenAt: null,
+		tokens: [
+			{
+				id: "token-1",
+				tokenPrefix: "tea_live_ab12",
+				createdAt: "2026-06-01T00:00:00.000Z",
+				lastUsedAt: null,
+				expiresAt: null,
+				revokedAt: null,
+			},
+		],
+		...overrides,
+	};
+}
+
+const baseProps = {
+	deleting: false,
+	onDelete: vi.fn(),
+	onIssueToken: vi.fn().mockResolvedValue(null),
+	onReactivate: vi.fn(),
+	onRevoke: vi.fn(),
+	onRevokeToken: vi.fn(),
+	onRotateToken: vi.fn().mockResolvedValue(null),
+	onSuspend: vi.fn(),
+	pending: false,
+	pendingTokenKey: null,
+};
+
+describe("IntegrationCard", () => {
+	describe("status-gated lifecycle actions", () => {
+		it("shows Suspend and Revoke (not Reactivate) for an ACTIVE integration", () => {
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({ status: "ACTIVE" })}
+				/>
+			);
+
+			expect(
+				screen.getByRole("button", { name: SUSPEND_BUTTON_REGEX })
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole("button", { name: REVOKE_INTEGRATION_TRIGGER_REGEX })
+			).toBeInTheDocument();
+			expect(
+				screen.queryByRole("button", { name: REACTIVATE_BUTTON_REGEX })
+			).not.toBeInTheDocument();
+		});
+
+		it("shows Reactivate and Revoke (not Suspend) for a SUSPENDED integration", () => {
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({ status: "SUSPENDED" })}
+				/>
+			);
+
+			expect(
+				screen.getByRole("button", { name: REACTIVATE_BUTTON_REGEX })
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole("button", { name: REVOKE_INTEGRATION_TRIGGER_REGEX })
+			).toBeInTheDocument();
+			expect(
+				screen.queryByRole("button", { name: SUSPEND_BUTTON_REGEX })
+			).not.toBeInTheDocument();
+		});
+
+		it("shows neither Suspend, Reactivate, nor Revoke for a REVOKED integration — only Delete remains", () => {
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({ status: "REVOKED" })}
+				/>
+			);
+
+			expect(
+				screen.queryByRole("button", { name: SUSPEND_BUTTON_REGEX })
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole("button", { name: REACTIVATE_BUTTON_REGEX })
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole("button", { name: REVOKE_INTEGRATION_TRIGGER_REGEX })
+			).not.toBeInTheDocument();
+			expect(
+				screen.getByRole("button", { name: DELETE_TRIGGER_REGEX })
+			).toBeInTheDocument();
+		});
+	});
+
+	describe("confirm dialogs gate destructive actions", () => {
+		it("does not call onRevoke until the confirm dialog is accepted", async () => {
+			const onRevoke = vi.fn();
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration()}
+					onRevoke={onRevoke}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: REVOKE_INTEGRATION_TRIGGER_REGEX })
+			);
+			expect(onRevoke).not.toHaveBeenCalled();
+
+			const dialog = await screen.findByRole("dialog");
+			expect(dialog).toHaveTextContent(PERMANENT_TEXT_REGEX);
+
+			await user.click(
+				screen.getByRole("button", { name: REVOKE_INTEGRATION_CONFIRM_REGEX })
+			);
+			expect(onRevoke).toHaveBeenCalledWith("integration-1");
+		});
+
+		it("does not revoke when the confirm dialog is cancelled", async () => {
+			const onRevoke = vi.fn();
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration()}
+					onRevoke={onRevoke}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: REVOKE_INTEGRATION_TRIGGER_REGEX })
+			);
+			await screen.findByRole("dialog");
+			await user.click(
+				screen.getByRole("button", { name: CANCEL_BUTTON_REGEX })
+			);
+
+			expect(onRevoke).not.toHaveBeenCalled();
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		});
+
+		it("does not call onDelete until the delete confirm dialog is accepted", async () => {
+			const onDelete = vi.fn();
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration()}
+					onDelete={onDelete}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: DELETE_TRIGGER_REGEX })
+			);
+			expect(onDelete).not.toHaveBeenCalled();
+
+			const dialog = await screen.findByRole("dialog");
+			expect(dialog).toHaveTextContent(CANNOT_BE_UNDONE_TEXT_REGEX);
+
+			await user.click(
+				screen.getByRole("button", { name: DELETE_CONFIRM_REGEX })
+			);
+			expect(onDelete).toHaveBeenCalledWith("integration-1");
+		});
+
+		it("does not call onRevokeToken until the token revoke confirm dialog is accepted", async () => {
+			const onRevokeToken = vi.fn();
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration()}
+					onRevokeToken={onRevokeToken}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: REVOKE_TOKEN_TRIGGER_REGEX })
+			);
+			expect(onRevokeToken).not.toHaveBeenCalled();
+
+			await screen.findByRole("dialog");
+			await user.click(
+				screen.getByRole("button", { name: REVOKE_TOKEN_CONFIRM_REGEX })
+			);
+
+			expect(onRevokeToken).toHaveBeenCalledWith("integration-1", "token-1");
+		});
+	});
+
+	describe("tokens", () => {
+		it("disables Issue new token when the integration isn't ACTIVE", () => {
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({ status: "SUSPENDED" })}
+				/>
+			);
+
+			expect(
+				screen.getByRole("button", { name: ISSUE_TOKEN_BUTTON_REGEX })
+			).toBeDisabled();
+		});
+
+		it("shows a token-shown-once modal after issuing succeeds", async () => {
+			const onIssueToken = vi.fn().mockResolvedValue({
+				secret: "tea_live_freshsecret",
+				token: {
+					id: "token-2",
+					tokenPrefix: "tea_live_cd34",
+					createdAt: "2026-07-05T00:00:00.000Z",
+					expiresAt: null,
+				},
+			});
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration()}
+					onIssueToken={onIssueToken}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: ISSUE_TOKEN_BUTTON_REGEX })
+			);
+
+			expect(await screen.findByTestId("token-secret-value")).toHaveTextContent(
+				"tea_live_freshsecret"
+			);
+		});
+	});
+});

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-register-dialog.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-register-dialog.test.tsx
@@ -1,0 +1,149 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import {
+	renderWithoutProviders,
+	screen,
+} from "@/src/__tests__/utils/test-utils";
+import { IntegrationRegisterDialog } from "../integration-register-dialog";
+
+const NAME_LABEL_REGEX = /^name$/i;
+const DESCRIPTION_LABEL_REGEX = /description/i;
+const READ_CASES_CHECKBOX_REGEX = /read cases/i;
+const SUBMIT_BUTTON_REGEX = /register integration/i;
+const CANCEL_BUTTON_REGEX = /cancel/i;
+const NAME_REQUIRED_REGEX = /name is required/i;
+const SCOPE_REQUIRED_REGEX = /at least one scope is required/i;
+
+describe("IntegrationRegisterDialog", () => {
+	it("renders nothing when closed", () => {
+		renderWithoutProviders(
+			<IntegrationRegisterDialog
+				onOpenChange={vi.fn()}
+				onSubmit={vi.fn()}
+				open={false}
+				submitting={false}
+			/>
+		);
+
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+	});
+
+	it("renders the name, description, and every closed-vocabulary scope as a checkbox when open", () => {
+		renderWithoutProviders(
+			<IntegrationRegisterDialog
+				onOpenChange={vi.fn()}
+				onSubmit={vi.fn()}
+				open
+				submitting={false}
+			/>
+		);
+
+		expect(screen.getByLabelText(NAME_LABEL_REGEX)).toBeInTheDocument();
+		expect(screen.getByLabelText(DESCRIPTION_LABEL_REGEX)).toBeInTheDocument();
+		expect(screen.getAllByRole("checkbox")).toHaveLength(3);
+		expect(screen.getByText("case:read")).toBeInTheDocument();
+		expect(screen.getByText("health:evidence:read")).toBeInTheDocument();
+		expect(screen.getByText("health:evidence:write")).toBeInTheDocument();
+	});
+
+	it("blocks submission and shows inline errors when name is empty and no scope is selected", async () => {
+		const onSubmit = vi.fn();
+		const user = userEvent.setup();
+
+		renderWithoutProviders(
+			<IntegrationRegisterDialog
+				onOpenChange={vi.fn()}
+				onSubmit={onSubmit}
+				open
+				submitting={false}
+			/>
+		);
+
+		await user.click(screen.getByRole("button", { name: SUBMIT_BUTTON_REGEX }));
+
+		expect(await screen.findByText(NAME_REQUIRED_REGEX)).toBeInTheDocument();
+		expect(screen.getByText(SCOPE_REQUIRED_REGEX)).toBeInTheDocument();
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("submits the parsed values (name, description, scopes) and closes on success", async () => {
+		const onSubmit = vi.fn().mockResolvedValue(true);
+		const onOpenChange = vi.fn();
+		const user = userEvent.setup();
+
+		renderWithoutProviders(
+			<IntegrationRegisterDialog
+				onOpenChange={onOpenChange}
+				onSubmit={onSubmit}
+				open
+				submitting={false}
+			/>
+		);
+
+		await user.type(
+			screen.getByLabelText(NAME_LABEL_REGEX),
+			"darter-evidence-pipeline"
+		);
+		await user.type(
+			screen.getByLabelText(DESCRIPTION_LABEL_REGEX),
+			"Evidence collection pipeline"
+		);
+		await user.click(
+			screen.getByRole("checkbox", { name: READ_CASES_CHECKBOX_REGEX })
+		);
+
+		await user.click(screen.getByRole("button", { name: SUBMIT_BUTTON_REGEX }));
+
+		await vi.waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+		expect(onSubmit).toHaveBeenCalledWith({
+			name: "darter-evidence-pipeline",
+			description: "Evidence collection pipeline",
+			scopes: ["case:read"],
+		});
+		await vi.waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+	});
+
+	it("does not close the dialog when the submission fails", async () => {
+		const onSubmit = vi.fn().mockResolvedValue(false);
+		const onOpenChange = vi.fn();
+		const user = userEvent.setup();
+
+		renderWithoutProviders(
+			<IntegrationRegisterDialog
+				onOpenChange={onOpenChange}
+				onSubmit={onSubmit}
+				open
+				submitting={false}
+			/>
+		);
+
+		await user.type(screen.getByLabelText(NAME_LABEL_REGEX), "already-exists");
+		await user.click(
+			screen.getByRole("checkbox", { name: READ_CASES_CHECKBOX_REGEX })
+		);
+		await user.click(screen.getByRole("button", { name: SUBMIT_BUTTON_REGEX }));
+
+		await vi.waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+		expect(onOpenChange).not.toHaveBeenCalled();
+	});
+
+	it("calls onOpenChange(false) from Cancel without submitting", async () => {
+		const onSubmit = vi.fn();
+		const onOpenChange = vi.fn();
+		const user = userEvent.setup();
+
+		renderWithoutProviders(
+			<IntegrationRegisterDialog
+				onOpenChange={onOpenChange}
+				onSubmit={onSubmit}
+				open
+				submitting={false}
+			/>
+		);
+
+		await user.click(screen.getByRole("button", { name: CANCEL_BUTTON_REGEX }));
+
+		expect(onOpenChange).toHaveBeenCalledWith(false);
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+});

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-register-dialog.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-register-dialog.test.tsx
@@ -13,6 +13,10 @@ const SUBMIT_BUTTON_REGEX = /register integration/i;
 const CANCEL_BUTTON_REGEX = /cancel/i;
 const NAME_REQUIRED_REGEX = /name is required/i;
 const SCOPE_REQUIRED_REGEX = /at least one scope is required/i;
+const NAME_TOO_LONG_REGEX = /name must be less than 100 characters/i;
+const DESCRIPTION_TOO_LONG_REGEX = /must be less than 1000 characters/i;
+const NAME_OVER_CAP = "n".repeat(101);
+const DESCRIPTION_OVER_CAP = "d".repeat(1001);
 
 describe("IntegrationRegisterDialog", () => {
 	it("renders nothing when closed", () => {
@@ -63,6 +67,34 @@ describe("IntegrationRegisterDialog", () => {
 
 		expect(await screen.findByText(NAME_REQUIRED_REGEX)).toBeInTheDocument();
 		expect(screen.getByText(SCOPE_REQUIRED_REGEX)).toBeInTheDocument();
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("blocks submission and shows inline errors when name or description exceed the schema's caps (mirrors registerIntegrationSchema's 100/1000 limits)", async () => {
+		const onSubmit = vi.fn();
+		const user = userEvent.setup();
+
+		renderWithoutProviders(
+			<IntegrationRegisterDialog
+				onOpenChange={vi.fn()}
+				onSubmit={onSubmit}
+				open
+				submitting={false}
+			/>
+		);
+
+		await user.click(screen.getByLabelText(NAME_LABEL_REGEX));
+		await user.paste(NAME_OVER_CAP);
+		await user.click(screen.getByLabelText(DESCRIPTION_LABEL_REGEX));
+		await user.paste(DESCRIPTION_OVER_CAP);
+		await user.click(
+			screen.getByRole("checkbox", { name: READ_CASES_CHECKBOX_REGEX })
+		);
+
+		await user.click(screen.getByRole("button", { name: SUBMIT_BUTTON_REGEX }));
+
+		expect(await screen.findByText(NAME_TOO_LONG_REGEX)).toBeInTheDocument();
+		expect(screen.getByText(DESCRIPTION_TOO_LONG_REGEX)).toBeInTheDocument();
 		expect(onSubmit).not.toHaveBeenCalled();
 	});
 

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-token-row.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-token-row.test.tsx
@@ -1,0 +1,141 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { IntegrationTokenSummary } from "@/lib/schemas/integration";
+import {
+	renderWithoutProviders,
+	screen,
+} from "@/src/__tests__/utils/test-utils";
+import { IntegrationTokenRow } from "../integration-token-row";
+
+const ROTATE_REGEX = /rotate/i;
+const ROTATING_REGEX = /rotating/i;
+const REVOKE_REGEX = /revoke/i;
+
+function makeToken(
+	overrides: Partial<IntegrationTokenSummary> = {}
+): IntegrationTokenSummary {
+	return {
+		id: "token-1",
+		tokenPrefix: "tea_live_ab12",
+		createdAt: "2026-06-01T00:00:00.000Z",
+		lastUsedAt: null,
+		expiresAt: null,
+		revokedAt: null,
+		...overrides,
+	};
+}
+
+describe("IntegrationTokenRow", () => {
+	it("renders a live token with a Live badge and rotate/revoke actions", () => {
+		renderWithoutProviders(
+			<IntegrationTokenRow
+				canRotate
+				onRevoke={vi.fn()}
+				onRotate={vi.fn()}
+				pending={false}
+				token={makeToken()}
+			/>
+		);
+
+		expect(screen.getByText("Live")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: ROTATE_REGEX })
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: REVOKE_REGEX })
+		).toBeInTheDocument();
+	});
+
+	it("renders a revoked token distinctly, with no rotate/revoke actions", () => {
+		renderWithoutProviders(
+			<IntegrationTokenRow
+				canRotate
+				onRevoke={vi.fn()}
+				onRotate={vi.fn()}
+				pending={false}
+				token={makeToken({ revokedAt: "2026-06-15T00:00:00.000Z" })}
+			/>
+		);
+
+		expect(screen.getByText("Revoked")).toBeInTheDocument();
+		expect(screen.queryByText("Live")).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: ROTATE_REGEX })
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: REVOKE_REGEX })
+		).not.toBeInTheDocument();
+	});
+
+	it("renders an expired-but-unrevoked token distinctly from both live and revoked", () => {
+		renderWithoutProviders(
+			<IntegrationTokenRow
+				canRotate
+				onRevoke={vi.fn()}
+				onRotate={vi.fn()}
+				pending={false}
+				token={makeToken({ expiresAt: "2020-01-01T00:00:00.000Z" })}
+			/>
+		);
+
+		expect(screen.getByText("Expired")).toBeInTheDocument();
+		expect(screen.queryByText("Live")).not.toBeInTheDocument();
+		expect(screen.queryByText("Revoked")).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: ROTATE_REGEX })
+		).not.toBeInTheDocument();
+	});
+
+	it("disables rotate (but not revoke) when the parent integration isn't ACTIVE", () => {
+		renderWithoutProviders(
+			<IntegrationTokenRow
+				canRotate={false}
+				onRevoke={vi.fn()}
+				onRotate={vi.fn()}
+				pending={false}
+				token={makeToken()}
+			/>
+		);
+
+		expect(screen.getByRole("button", { name: ROTATE_REGEX })).toBeDisabled();
+		expect(
+			screen.getByRole("button", { name: REVOKE_REGEX })
+		).not.toBeDisabled();
+	});
+
+	it("calls onRotate/onRevoke with the token id", async () => {
+		const user = userEvent.setup();
+		const onRotate = vi.fn();
+		const onRevoke = vi.fn();
+		renderWithoutProviders(
+			<IntegrationTokenRow
+				canRotate
+				onRevoke={onRevoke}
+				onRotate={onRotate}
+				pending={false}
+				token={makeToken({ id: "token-abc" })}
+			/>
+		);
+
+		await user.click(screen.getByRole("button", { name: ROTATE_REGEX }));
+		expect(onRotate).toHaveBeenCalledWith("token-abc");
+
+		await user.click(screen.getByRole("button", { name: REVOKE_REGEX }));
+		expect(onRevoke).toHaveBeenCalledWith("token-abc");
+	});
+
+	it("disables both actions and shows a pending label while a request for this token is in flight", () => {
+		renderWithoutProviders(
+			<IntegrationTokenRow
+				canRotate
+				onRevoke={vi.fn()}
+				onRotate={vi.fn()}
+				pending
+				token={makeToken()}
+			/>
+		);
+
+		expect(screen.getByRole("button", { name: ROTATING_REGEX })).toBeDisabled();
+		expect(screen.getByRole("button", { name: REVOKE_REGEX })).toBeDisabled();
+	});
+});

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-token-secret-modal.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-token-secret-modal.test.tsx
@@ -1,0 +1,120 @@
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	renderWithoutProviders,
+	screen,
+} from "@/src/__tests__/utils/test-utils";
+import { IntegrationTokenSecretModal } from "../integration-token-secret-modal";
+
+const SECRET = "tea_live_ab12cd34ef56";
+const SHOWN_ONCE_WARNING_REGEX = /only time this token is displayed/i;
+const COPY_BUTTON_REGEX = /copy token/i;
+const COPIED_BUTTON_REGEX = /copied/i;
+const DONE_BUTTON_REGEX = /done.*stored it/i;
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("IntegrationTokenSecretModal", () => {
+	it("renders nothing when reveal is null", () => {
+		renderWithoutProviders(
+			<IntegrationTokenSecretModal onClose={vi.fn()} reveal={null} />
+		);
+
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+	});
+
+	it("renders the plaintext secret from the reveal prop, plus the shown-once warning", () => {
+		renderWithoutProviders(
+			<IntegrationTokenSecretModal
+				onClose={vi.fn()}
+				reveal={{ secret: SECRET }}
+			/>
+		);
+
+		expect(screen.getByTestId("token-secret-value")).toHaveTextContent(SECRET);
+		expect(screen.getByText(SHOWN_ONCE_WARNING_REGEX)).toBeInTheDocument();
+	});
+
+	it("renders an optional notice (e.g. a rotation's overlap window)", () => {
+		renderWithoutProviders(
+			<IntegrationTokenSecretModal
+				onClose={vi.fn()}
+				reveal={{
+					secret: SECRET,
+					notice: "The previous token stays valid until 14:32.",
+				}}
+			/>
+		);
+
+		expect(
+			screen.getByText("The previous token stays valid until 14:32.")
+		).toBeInTheDocument();
+	});
+
+	it("copies the secret to the clipboard and shows a Copied confirmation", async () => {
+		// `userEvent.setup()` unconditionally installs its OWN
+		// `navigator.clipboard` stub (`attachClipboardStubToView`, called
+		// directly from its `setup()`), overwriting anything already there —
+		// so the override below has to happen AFTER `setup()`, not before, or
+		// `setup()` clobbers it. That stub is otherwise a good citizen (Real
+		// EventTarget-backed Clipboard implementation used by `user.copy()`/
+		// `user.paste()`), so we still redefine only `writeText` for this
+		// assertion, not the whole clipboard object.
+		const user = userEvent.setup();
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		Object.defineProperty(navigator, "clipboard", {
+			value: { writeText },
+			configurable: true,
+		});
+
+		renderWithoutProviders(
+			<IntegrationTokenSecretModal
+				onClose={vi.fn()}
+				reveal={{ secret: SECRET }}
+			/>
+		);
+
+		await user.click(screen.getByRole("button", { name: COPY_BUTTON_REGEX }));
+
+		expect(writeText).toHaveBeenCalledWith(SECRET);
+		expect(
+			await screen.findByRole("button", { name: COPIED_BUTTON_REGEX })
+		).toBeInTheDocument();
+	});
+
+	it("calls onClose when Done is clicked", async () => {
+		const onClose = vi.fn();
+		const user = userEvent.setup();
+
+		renderWithoutProviders(
+			<IntegrationTokenSecretModal
+				onClose={onClose}
+				reveal={{ secret: SECRET }}
+			/>
+		);
+
+		await user.click(screen.getByRole("button", { name: DONE_BUTTON_REGEX }));
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it("no longer renders the secret once the caller clears reveal to null — the only place the secret lives is this prop", () => {
+		const { rerender } = renderWithoutProviders(
+			<IntegrationTokenSecretModal
+				onClose={vi.fn()}
+				reveal={{ secret: SECRET }}
+			/>
+		);
+
+		expect(screen.getByTestId("token-secret-value")).toHaveTextContent(SECRET);
+
+		// Simulates the parent's tokenReveal state being cleared on close —
+		// exactly what `IntegrationCard`'s onClose handler does.
+		rerender(<IntegrationTokenSecretModal onClose={vi.fn()} reveal={null} />);
+
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		expect(screen.queryByText(SECRET)).not.toBeInTheDocument();
+	});
+});

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integrations-section.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integrations-section.test.tsx
@@ -1,0 +1,134 @@
+import { waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { server } from "@/src/__tests__/mocks/server";
+import {
+	renderWithoutProviders,
+	screen,
+} from "@/src/__tests__/utils/test-utils";
+import { IntegrationsSection } from "../integrations-section";
+
+const REGISTER_BUTTON_REGEX = /register integration/i;
+const NAME_LABEL_REGEX = /^name$/i;
+const READ_CASES_CHECKBOX_REGEX = /read cases/i;
+
+const INTEGRATION = {
+	id: "integration-1",
+	name: "darter-evidence-pipeline",
+	description: "Evidence collection pipeline",
+	scopes: ["case:read"],
+	status: "ACTIVE",
+	createdAt: "2026-06-01T00:00:00.000Z",
+	updatedAt: "2026-06-01T00:00:00.000Z",
+	lastSeenAt: null,
+	tokens: [],
+};
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("IntegrationsSection", () => {
+	it("shows a loading state before the list resolves, then renders the integration", async () => {
+		server.use(
+			http.get("/api/integrations", () =>
+				HttpResponse.json({ integrations: [INTEGRATION] })
+			)
+		);
+
+		renderWithoutProviders(<IntegrationsSection />);
+
+		expect(
+			screen.getByTestId("integrations-section-loading")
+		).toBeInTheDocument();
+
+		await waitFor(() =>
+			expect(screen.getByText("darter-evidence-pipeline")).toBeInTheDocument()
+		);
+		expect(
+			screen.queryByTestId("integrations-section-loading")
+		).not.toBeInTheDocument();
+	});
+
+	it("shows an error message when the GET route fails", async () => {
+		server.use(
+			http.get("/api/integrations", () =>
+				HttpResponse.json(
+					{ error: "Failed to list integrations" },
+					{ status: 500 }
+				)
+			)
+		);
+
+		renderWithoutProviders(<IntegrationsSection />);
+
+		await waitFor(() =>
+			expect(
+				screen.getByText("Failed to list integrations")
+			).toBeInTheDocument()
+		);
+	});
+
+	it("shows an empty message when the caller has no integrations registered", async () => {
+		server.use(
+			http.get("/api/integrations", () =>
+				HttpResponse.json({ integrations: [] })
+			)
+		);
+
+		renderWithoutProviders(<IntegrationsSection />);
+
+		await waitFor(() =>
+			expect(
+				screen.getByText("You haven't registered any integrations yet.")
+			).toBeInTheDocument()
+		);
+	});
+
+	it("opens the register dialog from the header button and registers through the full round trip", async () => {
+		let integrations: (typeof INTEGRATION)[] = [];
+		server.use(
+			http.get("/api/integrations", () => HttpResponse.json({ integrations })),
+			http.post("/api/integrations", async ({ request }) => {
+				const body = (await request.json()) as {
+					name: string;
+					scopes: string[];
+				};
+				integrations = [
+					{ ...INTEGRATION, name: body.name, scopes: body.scopes },
+				];
+				return HttpResponse.json(
+					{ integration: integrations[0] },
+					{ status: 201 }
+				);
+			})
+		);
+
+		const user = userEvent.setup();
+		renderWithoutProviders(<IntegrationsSection />);
+
+		await waitFor(() =>
+			expect(
+				screen.getByText("You haven't registered any integrations yet.")
+			).toBeInTheDocument()
+		);
+
+		await user.click(
+			screen.getByRole("button", { name: REGISTER_BUTTON_REGEX })
+		);
+		const dialog = await screen.findByRole("dialog");
+		await user.type(screen.getByLabelText(NAME_LABEL_REGEX), "new-pipeline");
+		await user.click(
+			screen.getByRole("checkbox", { name: READ_CASES_CHECKBOX_REGEX })
+		);
+		await user.click(
+			within(dialog).getByRole("button", { name: REGISTER_BUTTON_REGEX })
+		);
+
+		await waitFor(() =>
+			expect(screen.getByText("new-pipeline")).toBeInTheDocument()
+		);
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+	});
+});

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integrations-section.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integrations-section.test.tsx
@@ -12,6 +12,7 @@ import { IntegrationsSection } from "../integrations-section";
 const REGISTER_BUTTON_REGEX = /register integration/i;
 const NAME_LABEL_REGEX = /^name$/i;
 const READ_CASES_CHECKBOX_REGEX = /read cases/i;
+const CANCEL_BUTTON_REGEX = /cancel/i;
 
 const INTEGRATION = {
 	id: "integration-1",
@@ -130,5 +131,56 @@ describe("IntegrationsSection", () => {
 			expect(screen.getByText("new-pipeline")).toBeInTheDocument()
 		);
 		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+	});
+
+	it("does not leak stale form field values into a freshly reopened register dialog (pins the react-doctor remount fix, f324045e)", async () => {
+		server.use(
+			http.get("/api/integrations", () =>
+				HttpResponse.json({ integrations: [] })
+			)
+		);
+
+		const user = userEvent.setup();
+		renderWithoutProviders(<IntegrationsSection />);
+
+		await waitFor(() =>
+			expect(
+				screen.getByText("You haven't registered any integrations yet.")
+			).toBeInTheDocument()
+		);
+
+		await user.click(
+			screen.getByRole("button", { name: REGISTER_BUTTON_REGEX })
+		);
+		let dialog = await screen.findByRole("dialog");
+		await user.type(
+			within(dialog).getByLabelText(NAME_LABEL_REGEX),
+			"stale-value"
+		);
+		await user.click(
+			within(dialog).getByRole("checkbox", { name: READ_CASES_CHECKBOX_REGEX })
+		);
+		await user.click(
+			within(dialog).getByRole("button", { name: CANCEL_BUTTON_REGEX })
+		);
+
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+		// Reopening is the exact click that bumps `registerDialogInstance` and
+		// remounts `IntegrationRegisterDialog` under a fresh `key`. Before
+		// f324045e this form state lived in a `useForm` instance kept alive
+		// across opens and reset imperatively from a `useEffect` watching
+		// `open` — a regression back to that pattern, or dropping the `key`
+		// bump on the register button's click handler, would leave
+		// "stale-value" and the checked checkbox showing here.
+		await user.click(
+			screen.getByRole("button", { name: REGISTER_BUTTON_REGEX })
+		);
+		dialog = await screen.findByRole("dialog");
+
+		expect(within(dialog).getByLabelText(NAME_LABEL_REGEX)).toHaveValue("");
+		expect(
+			within(dialog).getByRole("checkbox", { name: READ_CASES_CHECKBOX_REGEX })
+		).not.toBeChecked();
 	});
 });

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { Ban, KeyRound, PauseCircle, PlayCircle, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { AlertModal } from "@/components/modals/alert-modal";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	formatFullDate,
+	formatRelativeToNow,
+	formatShortDate,
+} from "@/lib/date";
+import type {
+	IntegrationListItem,
+	IssuedTokenResult,
+	RotatedTokenResult,
+} from "@/lib/schemas/integration";
+import { scopeLabel } from "./integration-scope-labels";
+import { IntegrationStatusBadge } from "./integration-status-badge";
+import { IntegrationTokenRow } from "./integration-token-row";
+import {
+	IntegrationTokenSecretModal,
+	type TokenReveal,
+} from "./integration-token-secret-modal";
+
+export interface IntegrationCardProps {
+	/** True while THIS integration's registration delete request is in flight. */
+	deleting: boolean;
+	integration: IntegrationListItem;
+	onDelete: (id: string) => void;
+	onIssueToken: (id: string) => Promise<IssuedTokenResult | null>;
+	onReactivate: (id: string) => void;
+	onRevoke: (id: string) => void;
+	onRevokeToken: (integrationId: string, tokenId: string) => void;
+	onRotateToken: (
+		integrationId: string,
+		tokenId: string
+	) => Promise<RotatedTokenResult | null>;
+	onSuspend: (id: string) => void;
+	/** True while THIS integration's own lifecycle action (suspend/reactivate/revoke) is in flight. */
+	pending: boolean;
+	/** `${integrationId}:${tokenId}` or `${integrationId}` (issuing) currently in flight, shared across every card. */
+	pendingTokenKey: string | null;
+}
+
+/**
+ * One integration's management card: identity + status + scopes (functional
+ * scope item 1), lifecycle actions (item 3), and its tokens with issue/
+ * rotate/revoke (item 4). Presentational — every mutation is a callback prop
+ * so this component (and its tests) never touch `useIntegrations` directly.
+ */
+export function IntegrationCard({
+	deleting,
+	integration,
+	onDelete,
+	onIssueToken,
+	onReactivate,
+	onRevoke,
+	onRevokeToken,
+	onRotateToken,
+	onSuspend,
+	pending,
+	pendingTokenKey,
+}: IntegrationCardProps) {
+	const [tokenReveal, setTokenReveal] = useState<TokenReveal | null>(null);
+	const [confirmRevokeOpen, setConfirmRevokeOpen] = useState(false);
+	const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+	const [confirmRevokeTokenId, setConfirmRevokeTokenId] = useState<
+		string | null
+	>(null);
+
+	const isIssuing = pendingTokenKey === integration.id;
+	const integrationActive = integration.status === "ACTIVE";
+
+	async function handleIssueToken() {
+		const result = await onIssueToken(integration.id);
+		if (result) {
+			setTokenReveal({ secret: result.secret });
+		}
+	}
+
+	async function handleRotateToken(tokenId: string) {
+		const result = await onRotateToken(integration.id, tokenId);
+		if (result) {
+			setTokenReveal({
+				secret: result.secret,
+				notice: `The previous token stays valid until ${formatFullDate(
+					result.overlapUntil
+				)}, so callers mid-flight have time to pick up the new one.`,
+			});
+		}
+	}
+
+	function handleConfirmRevokeToken() {
+		const tokenId = confirmRevokeTokenId;
+		setConfirmRevokeTokenId(null);
+		if (tokenId) {
+			onRevokeToken(integration.id, tokenId);
+		}
+	}
+
+	return (
+		<div
+			className="space-y-4 rounded-lg border border-border bg-card p-4"
+			data-testid={`integration-card-${integration.id}`}
+		>
+			<div className="flex flex-wrap items-start justify-between gap-3">
+				<div className="space-y-1">
+					<div className="flex items-center gap-2">
+						<span className="font-medium text-foreground text-sm">
+							{integration.name}
+						</span>
+						<IntegrationStatusBadge status={integration.status} />
+					</div>
+					{integration.description && (
+						<p className="text-muted-foreground text-sm">
+							{integration.description}
+						</p>
+					)}
+					<p className="text-muted-foreground text-xs">
+						{`Registered ${formatShortDate(integration.createdAt)}`}
+						{integration.lastSeenAt
+							? ` · last seen ${formatRelativeToNow(integration.lastSeenAt)}`
+							: " · never used"}
+					</p>
+					<div className="flex flex-wrap gap-1.5 pt-1">
+						{integration.scopes.map((scope) => (
+							<Badge key={scope} variant="outline">
+								{scopeLabel(scope)}
+							</Badge>
+						))}
+					</div>
+				</div>
+
+				<div className="flex flex-wrap items-center gap-2">
+					{integrationActive && (
+						<Button
+							disabled={pending}
+							onClick={() => onSuspend(integration.id)}
+							size="sm"
+							type="button"
+							variant="outline"
+						>
+							<PauseCircle aria-hidden="true" className="h-3.5 w-3.5" />
+							{pending ? "Suspending…" : "Suspend"}
+						</Button>
+					)}
+					{integration.status === "SUSPENDED" && (
+						<Button
+							disabled={pending}
+							onClick={() => onReactivate(integration.id)}
+							size="sm"
+							type="button"
+							variant="outline"
+						>
+							<PlayCircle aria-hidden="true" className="h-3.5 w-3.5" />
+							{pending ? "Reactivating…" : "Reactivate"}
+						</Button>
+					)}
+					{integration.status !== "REVOKED" && (
+						<Button
+							aria-label="Revoke this integration"
+							className="text-destructive hover:text-destructive"
+							disabled={pending}
+							onClick={() => setConfirmRevokeOpen(true)}
+							size="sm"
+							type="button"
+							variant="outline"
+						>
+							<Ban aria-hidden="true" className="h-3.5 w-3.5" />
+							Revoke
+						</Button>
+					)}
+					<Button
+						disabled={deleting}
+						onClick={() => setConfirmDeleteOpen(true)}
+						size="sm"
+						type="button"
+						variant="destructive"
+					>
+						<Trash2 aria-hidden="true" className="h-3.5 w-3.5" />
+						{deleting ? "Deleting…" : "Delete"}
+					</Button>
+				</div>
+			</div>
+
+			<div className="space-y-2 border-border border-t pt-3">
+				<div className="flex items-center justify-between gap-2">
+					<h4 className="font-medium text-foreground text-xs uppercase tracking-wide">
+						Tokens
+					</h4>
+					<Button
+						disabled={!integrationActive || isIssuing}
+						onClick={handleIssueToken}
+						size="sm"
+						title={
+							integrationActive
+								? undefined
+								: "Only an ACTIVE integration can issue a token"
+						}
+						type="button"
+						variant="outline"
+					>
+						<KeyRound aria-hidden="true" className="h-3.5 w-3.5" />
+						{isIssuing ? "Issuing…" : "Issue new token"}
+					</Button>
+				</div>
+
+				{integration.tokens.length === 0 ? (
+					<p className="text-muted-foreground text-xs">No tokens issued yet.</p>
+				) : (
+					<div className="space-y-2">
+						{integration.tokens.map((token) => (
+							<IntegrationTokenRow
+								canRotate={integrationActive}
+								key={token.id}
+								onRevoke={(tokenId) => setConfirmRevokeTokenId(tokenId)}
+								onRotate={handleRotateToken}
+								pending={pendingTokenKey === `${integration.id}:${token.id}`}
+								token={token}
+							/>
+						))}
+					</div>
+				)}
+			</div>
+
+			<IntegrationTokenSecretModal
+				onClose={() => setTokenReveal(null)}
+				reveal={tokenReveal}
+			/>
+
+			<AlertModal
+				cancelButtonText="Cancel"
+				confirmButtonText="Revoke integration"
+				isOpen={confirmRevokeOpen}
+				loading={pending}
+				message={`Revoking "${integration.name}" is permanent — every token it has issued stops authenticating immediately, and a revoked integration cannot be reactivated.`}
+				onClose={() => setConfirmRevokeOpen(false)}
+				onConfirm={() => {
+					setConfirmRevokeOpen(false);
+					onRevoke(integration.id);
+				}}
+			/>
+
+			<AlertModal
+				cancelButtonText="Cancel"
+				confirmButtonText="Delete integration"
+				isOpen={confirmDeleteOpen}
+				loading={deleting}
+				message={`Deleting "${integration.name}" permanently removes its registration and every one of its tokens. This cannot be undone.`}
+				onClose={() => setConfirmDeleteOpen(false)}
+				onConfirm={() => {
+					setConfirmDeleteOpen(false);
+					onDelete(integration.id);
+				}}
+			/>
+
+			<AlertModal
+				cancelButtonText="Cancel"
+				confirmButtonText="Revoke token"
+				isOpen={confirmRevokeTokenId !== null}
+				loading={
+					confirmRevokeTokenId !== null &&
+					pendingTokenKey === `${integration.id}:${confirmRevokeTokenId}`
+				}
+				message="Revoking this token takes effect immediately and cannot be undone — any caller still using it will start failing to authenticate right away."
+				onClose={() => setConfirmRevokeTokenId(null)}
+				onConfirm={handleConfirmRevokeToken}
+			/>
+		</div>
+	);
+}

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-register-dialog.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-register-dialog.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import {
+	Form,
+	FormControl,
+	FormDescription,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { SCOPES } from "@/lib/auth/scopes";
+import {
+	type RegisterIntegrationBody,
+	type RegisterIntegrationFormInput,
+	registerIntegrationSchema,
+} from "@/lib/schemas/integration";
+import { scopeLabel } from "./integration-scope-labels";
+
+export interface IntegrationRegisterDialogProps {
+	onOpenChange: (open: boolean) => void;
+	onSubmit: (input: RegisterIntegrationBody) => Promise<boolean>;
+	open: boolean;
+	submitting: boolean;
+}
+
+const DEFAULT_VALUES: RegisterIntegrationFormInput = {
+	name: "",
+	description: "",
+	scopes: [],
+};
+
+/**
+ * The register-integration form (functional scope item 2): name, optional
+ * description, scopes as checkboxes against the closed vocabulary in
+ * `lib/auth/scopes.ts` (never free text). Validated with
+ * `registerIntegrationSchema` — the exact schema `POST /api/integrations`
+ * validates server-side, imported and reused rather than re-declared, so the
+ * two can never quietly drift apart.
+ *
+ * `useForm`'s field-values generic is the schema's pre-transform INPUT shape
+ * (`RegisterIntegrationFormInput` — `description` still allows `null`); its
+ * third (transformed-values) generic is the parsed OUTPUT shape
+ * (`RegisterIntegrationBody`), which is what `handleSubmit` hands to
+ * `onSubmit` below. Two different types because `optionalString`'s
+ * `.transform()` folds `null`/empty into `undefined` — using the output type
+ * for both, as a same-shaped schema elsewhere in the app might get away
+ * with, fails `zodResolver`'s own typing here.
+ */
+export function IntegrationRegisterDialog({
+	onOpenChange,
+	onSubmit,
+	open,
+	submitting,
+}: IntegrationRegisterDialogProps) {
+	const form = useForm<
+		RegisterIntegrationFormInput,
+		unknown,
+		RegisterIntegrationBody
+	>({
+		resolver: zodResolver(registerIntegrationSchema),
+		defaultValues: DEFAULT_VALUES,
+	});
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: form is a stable react-hook-form handle; including it would re-run on every keystroke
+	useEffect(() => {
+		if (open) {
+			form.reset(DEFAULT_VALUES);
+		}
+	}, [open]);
+
+	async function handleSubmit(values: RegisterIntegrationBody) {
+		const success = await onSubmit(values);
+		if (success) {
+			onOpenChange(false);
+		}
+	}
+
+	return (
+		<Dialog onOpenChange={onOpenChange} open={open}>
+			<DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+				<DialogHeader>
+					<DialogTitle>Register an integration</DialogTitle>
+					<DialogDescription>
+						Register an external machine client and choose which scopes it may
+						authorise for. You will issue its first token afterwards.
+					</DialogDescription>
+				</DialogHeader>
+
+				<Form {...form}>
+					<form
+						className="space-y-6"
+						onSubmit={form.handleSubmit(handleSubmit)}
+					>
+						<FormField
+							control={form.control}
+							name="name"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Name</FormLabel>
+									<FormControl>
+										<Input placeholder="darter-evidence-pipeline" {...field} />
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+
+						<FormField
+							control={form.control}
+							name="description"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Description</FormLabel>
+									<FormControl>
+										<Textarea
+											placeholder="What does this integration do?"
+											rows={3}
+											{...field}
+											value={field.value ?? ""}
+										/>
+									</FormControl>
+									<FormDescription className="text-xs">
+										Optional — helps you tell integrations apart later.
+									</FormDescription>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+
+						<FormField
+							control={form.control}
+							name="scopes"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Scopes</FormLabel>
+									<FormDescription className="text-xs">
+										Choose at least one. Scopes gate which verbs this
+										integration's tokens may call, not which cases it can see —
+										that still rides its system user's own permissions.
+									</FormDescription>
+									<div className="space-y-2 pt-1">
+										{SCOPES.map((scope) => {
+											const checked = field.value?.includes(scope) ?? false;
+											const checkboxId = `integration-scope-${scope}`;
+											return (
+												<div className="flex items-start gap-2" key={scope}>
+													<FormControl>
+														<Checkbox
+															checked={checked}
+															id={checkboxId}
+															onCheckedChange={(next) => {
+																const current = field.value ?? [];
+																field.onChange(
+																	next
+																		? [...current, scope]
+																		: current.filter((s) => s !== scope)
+																);
+															}}
+														/>
+													</FormControl>
+													<Label
+														className="font-normal text-sm leading-tight"
+														htmlFor={checkboxId}
+													>
+														<span className="block">{scopeLabel(scope)}</span>
+														<span className="block text-muted-foreground text-xs">
+															{scope}
+														</span>
+													</Label>
+												</div>
+											);
+										})}
+									</div>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+
+						<DialogFooter>
+							<Button
+								disabled={submitting}
+								onClick={() => onOpenChange(false)}
+								type="button"
+								variant="outline"
+							>
+								Cancel
+							</Button>
+							<Button disabled={submitting} type="submit">
+								{submitting ? "Registering…" : "Register integration"}
+							</Button>
+						</DialogFooter>
+					</form>
+				</Form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-register-dialog.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-register-dialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -62,6 +61,13 @@ const DEFAULT_VALUES: RegisterIntegrationFormInput = {
  * `.transform()` folds `null`/empty into `undefined` — using the output type
  * for both, as a same-shaped schema elsewhere in the app might get away
  * with, fails `zodResolver`'s own typing here.
+ *
+ * Fresh fields on every open ride the parent's `key={registerDialogInstance}`
+ * (`IntegrationsSection`), which remounts this whole component on each
+ * "open" click — React's own recommended fix for "resetting state when a
+ * prop changes" — rather than a `useEffect` watching `open` to imperatively
+ * call `form.reset()` (flagged by react-doctor as event logic misplaced in
+ * an effect, plus a stale-closure risk on `form.reset` as a missing dep).
  */
 export function IntegrationRegisterDialog({
 	onOpenChange,
@@ -77,13 +83,6 @@ export function IntegrationRegisterDialog({
 		resolver: zodResolver(registerIntegrationSchema),
 		defaultValues: DEFAULT_VALUES,
 	});
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: form is a stable react-hook-form handle; including it would re-run on every keystroke
-	useEffect(() => {
-		if (open) {
-			form.reset(DEFAULT_VALUES);
-		}
-	}, [open]);
 
 	async function handleSubmit(values: RegisterIntegrationBody) {
 		const success = await onSubmit(values);

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-scope-labels.ts
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-scope-labels.ts
@@ -1,0 +1,20 @@
+import type { Scope } from "@/lib/auth/scopes";
+
+/**
+ * Human-readable labels for the closed scope vocabulary (`lib/auth/
+ * scopes.ts`). A `Partial` record, not a full one, so adding a new scope to
+ * `SCOPES` (an ADR amendment, per that file's own doc comment) can't fail to
+ * compile here — `scopeLabel` below falls back to the raw scope string for
+ * anything this map hasn't caught up with yet, rather than the settings UI
+ * breaking on an unrecognised-but-valid scope.
+ */
+const SCOPE_LABELS: Partial<Record<Scope, string>> = {
+	"case:read": "Read cases",
+	"health:evidence:read": "Read claim/evidence health data",
+	"health:evidence:write": "Write claim/evidence health data",
+};
+
+/** A short, human-readable label for a scope string, falling back to the raw value. */
+export function scopeLabel(scope: string): string {
+	return SCOPE_LABELS[scope as Scope] ?? scope;
+}

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-status-badge.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-status-badge.tsx
@@ -1,0 +1,26 @@
+import { Badge, type BadgeProps } from "@/components/ui/badge";
+import type { IntegrationStatus } from "@/lib/schemas/integration";
+
+const STATUS_VARIANT: Record<IntegrationStatus, BadgeProps["variant"]> = {
+	ACTIVE: "default",
+	SUSPENDED: "secondary",
+	REVOKED: "destructive",
+};
+
+const STATUS_LABEL: Record<IntegrationStatus, string> = {
+	ACTIVE: "Active",
+	SUSPENDED: "Suspended",
+	REVOKED: "Revoked",
+};
+
+/**
+ * An integration's lifecycle status — label text carries the meaning (not
+ * colour alone), the badge variant reinforces it.
+ */
+export function IntegrationStatusBadge({
+	status,
+}: {
+	status: IntegrationStatus;
+}) {
+	return <Badge variant={STATUS_VARIANT[status]}>{STATUS_LABEL[status]}</Badge>;
+}

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-token-row.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-token-row.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { RotateCw, ShieldOff } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { formatRelativeToNow, formatShortDate } from "@/lib/date";
+import type { IntegrationTokenSummary } from "@/lib/schemas/integration";
+import { cn } from "@/lib/utils";
+
+export interface IntegrationTokenRowProps {
+	/** False when the parent integration isn't ACTIVE — rotation is refused server-side for a non-active integration, even for an otherwise-live token. */
+	canRotate: boolean;
+	onRevoke: (tokenId: string) => void;
+	onRotate: (tokenId: string) => void;
+	/** True while THIS token's rotate/revoke request is in flight. */
+	pending: boolean;
+	token: IntegrationTokenSummary;
+}
+
+type TokenState = "expired" | "live" | "revoked";
+
+function tokenState(token: IntegrationTokenSummary): TokenState {
+	if (token.revokedAt) {
+		return "revoked";
+	}
+	if (token.expiresAt && new Date(token.expiresAt).getTime() <= Date.now()) {
+		return "expired";
+	}
+	return "live";
+}
+
+/**
+ * One issued token's row: prefix, timestamps, and its revoked/expired/live
+ * state rendered distinctly (functional scope item 1) — never the plaintext
+ * secret, which this row never receives (`IntegrationListItem`'s tokens are
+ * `IntegrationTokenSummary`, prefix only). Rotate/revoke actions render only
+ * for a live token; a revoked or expired token is read-only history here.
+ */
+export function IntegrationTokenRow({
+	canRotate,
+	onRevoke,
+	onRotate,
+	pending,
+	token,
+}: IntegrationTokenRowProps) {
+	const state = tokenState(token);
+	const isLive = state === "live";
+
+	return (
+		<div
+			className={cn(
+				"flex flex-wrap items-center justify-between gap-3 rounded-md border border-border px-3 py-2 text-sm",
+				!isLive && "bg-muted/40"
+			)}
+			data-testid={`token-row-${token.id}`}
+		>
+			<div className="space-y-0.5">
+				<div className="flex items-center gap-2">
+					<code className="font-mono text-xs">{token.tokenPrefix}…</code>
+					{state === "revoked" && <Badge variant="destructive">Revoked</Badge>}
+					{state === "expired" && <Badge variant="outline">Expired</Badge>}
+					{state === "live" && <Badge variant="secondary">Live</Badge>}
+				</div>
+				<p className="text-muted-foreground text-xs">
+					{`Issued ${formatShortDate(token.createdAt)}`}
+					{token.lastUsedAt
+						? ` · last used ${formatRelativeToNow(token.lastUsedAt)}`
+						: " · never used"}
+					{token.expiresAt
+						? ` · expires ${formatShortDate(token.expiresAt)}`
+						: ""}
+					{token.revokedAt
+						? ` · revoked ${formatShortDate(token.revokedAt)}`
+						: ""}
+				</p>
+			</div>
+
+			{isLive && (
+				<div className="flex shrink-0 items-center gap-2">
+					<Button
+						disabled={pending || !canRotate}
+						onClick={() => onRotate(token.id)}
+						size="sm"
+						title={
+							canRotate
+								? undefined
+								: "Only an ACTIVE integration's tokens can be rotated"
+						}
+						type="button"
+						variant="outline"
+					>
+						<RotateCw aria-hidden="true" className="h-3.5 w-3.5" />
+						{pending ? "Rotating…" : "Rotate"}
+					</Button>
+					<Button
+						aria-label="Revoke this token"
+						className="text-destructive hover:text-destructive"
+						disabled={pending}
+						onClick={() => onRevoke(token.id)}
+						size="sm"
+						type="button"
+						variant="ghost"
+					>
+						<ShieldOff aria-hidden="true" className="h-3.5 w-3.5" />
+						Revoke
+					</Button>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-token-secret-modal.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-token-secret-modal.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { AlertTriangle, Check, Copy } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Modal } from "@/components/ui/modal";
+import { toast } from "@/lib/toast";
+
+/**
+ * The data a token-shown-once reveal needs — deliberately narrow (just the
+ * plaintext secret plus enough context to label it), never the full
+ * `IssuedTokenResult`/`RotatedTokenResult` response, so nothing beyond what
+ * this modal renders can accidentally be threaded through to a longer-lived
+ * piece of state by a future edit.
+ */
+export interface TokenReveal {
+	/** e.g. "Rotated token — the previous one stays valid until 14:32." */
+	notice?: string;
+	secret: string;
+}
+
+export interface IntegrationTokenSecretModalProps {
+	onClose: () => void;
+	reveal: TokenReveal | null;
+}
+
+/**
+ * The token-shown-once modal (functional scope item 4). The plaintext secret
+ * is rendered ONLY from the `reveal` prop the caller passes in for as long as
+ * the modal is open — this component holds no state of its own that outlives
+ * a render, and the caller (`IntegrationCard`'s `tokenReveal` state) clears
+ * that prop to `null` on close, so the secret cannot be re-shown by
+ * reopening the dialog.
+ */
+export function IntegrationTokenSecretModal({
+	onClose,
+	reveal,
+}: IntegrationTokenSecretModalProps) {
+	const [copied, setCopied] = useState(false);
+
+	if (!reveal) {
+		return null;
+	}
+
+	const handleClose = () => {
+		setCopied(false);
+		onClose();
+	};
+
+	const handleCopy = async () => {
+		try {
+			await navigator.clipboard.writeText(reveal.secret);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		} catch {
+			toast({
+				variant: "destructive",
+				title: "Copy failed",
+				description:
+					"Could not copy to the clipboard — copy the token manually.",
+			});
+		}
+	};
+
+	return (
+		<Modal
+			description="Copy it now — for security, it will not be shown again."
+			isOpen
+			onClose={handleClose}
+			title="Token secret"
+		>
+			<div className="space-y-4">
+				<div className="flex items-center gap-2 rounded-lg border border-warning/30 bg-warning/10 p-3 text-sm text-warning-foreground">
+					<AlertTriangle aria-hidden="true" className="h-4 w-4 shrink-0" />
+					<span>
+						This is the only time this token is displayed — store it somewhere
+						safe before closing this dialog.
+					</span>
+				</div>
+
+				<div className="flex items-stretch gap-2">
+					<code
+						className="flex-1 overflow-x-auto rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm"
+						data-testid="token-secret-value"
+					>
+						{reveal.secret}
+					</code>
+					<Button
+						aria-label={
+							copied ? "Copied to clipboard" : "Copy token to clipboard"
+						}
+						onClick={handleCopy}
+						type="button"
+						variant="outline"
+					>
+						{copied ? (
+							<Check aria-hidden="true" className="h-4 w-4" />
+						) : (
+							<Copy aria-hidden="true" className="h-4 w-4" />
+						)}
+						{copied ? "Copied" : "Copy"}
+					</Button>
+				</div>
+
+				{reveal.notice && (
+					<p className="text-muted-foreground text-sm">{reveal.notice}</p>
+				)}
+
+				<div className="flex justify-end pt-2">
+					<Button onClick={handleClose} type="button">
+						Done — I have stored it
+					</Button>
+				</div>
+			</div>
+		</Modal>
+	);
+}

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integrations-section.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integrations-section.tsx
@@ -36,6 +36,11 @@ export function IntegrationsSection() {
 	} = useIntegrations();
 
 	const [registerOpen, setRegisterOpen] = useState(false);
+	// Bumped on every "open" click and used as the dialog's `key` — remounting
+	// it is how it gets a fresh `useForm` state each time it opens (React's
+	// own recommended fix for "resetting state when a prop changes", rather
+	// than a `useEffect` watching `open` to imperatively call `form.reset()`).
+	const [registerDialogInstance, setRegisterDialogInstance] = useState(0);
 
 	return (
 		<div className="grid max-w-7xl grid-cols-1 gap-x-8 gap-y-10 px-4 py-16 sm:px-6 md:grid-cols-3 lg:px-8">
@@ -53,7 +58,13 @@ export function IntegrationsSection() {
 
 			<div className="space-y-4 md:col-span-2">
 				<div className="flex justify-end">
-					<Button onClick={() => setRegisterOpen(true)} type="button">
+					<Button
+						onClick={() => {
+							setRegisterDialogInstance((instance) => instance + 1);
+							setRegisterOpen(true);
+						}}
+						type="button"
+					>
 						<Plus aria-hidden="true" className="h-4 w-4" />
 						Register integration
 					</Button>
@@ -99,6 +110,7 @@ export function IntegrationsSection() {
 			</div>
 
 			<IntegrationRegisterDialog
+				key={registerDialogInstance}
 				onOpenChange={setRegisterOpen}
 				onSubmit={registerIntegration}
 				open={registerOpen}

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integrations-section.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integrations-section.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { AlertCircle, Plus } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useIntegrations } from "@/hooks/use-integrations";
+import { IntegrationCard } from "./integration-card";
+import { IntegrationRegisterDialog } from "./integration-register-dialog";
+
+/**
+ * The Integrations settings pane — lists the caller's registered machine
+ * clients (`GET /api/integrations`) with register/lifecycle/token actions
+ * (ADR 0002 v2 §2.4, work item 7's settings-page half). Fetches and mutates
+ * entirely through `useIntegrations` — no other data source, no direct
+ * service/Prisma import, per the house rule for this pane (mirrors
+ * `PluginsSection`'s relationship to `usePluginSettings`).
+ */
+export function IntegrationsSection() {
+	const {
+		integrations,
+		loading,
+		error,
+		registering,
+		registerIntegration,
+		pendingIntegrationId,
+		deletingId,
+		pendingTokenKey,
+		suspendIntegration,
+		reactivateIntegration,
+		revokeIntegration,
+		deleteIntegration,
+		issueToken,
+		rotateToken,
+		revokeToken,
+	} = useIntegrations();
+
+	const [registerOpen, setRegisterOpen] = useState(false);
+
+	return (
+		<div className="grid max-w-7xl grid-cols-1 gap-x-8 gap-y-10 px-4 py-16 sm:px-6 md:grid-cols-3 lg:px-8">
+			<div>
+				<h2 className="font-semibold text-base text-foreground leading-7">
+					Integrations
+				</h2>
+				<p className="mt-1 text-muted-foreground text-sm leading-6">
+					Manage external machine clients that authenticate against the
+					platform's API on your behalf — pipelines, evidence collectors, and
+					other automated callers. Each integration authenticates with its own
+					bearer tokens, scoped to the verbs it's allowed to call.
+				</p>
+			</div>
+
+			<div className="space-y-4 md:col-span-2">
+				<div className="flex justify-end">
+					<Button onClick={() => setRegisterOpen(true)} type="button">
+						<Plus aria-hidden="true" className="h-4 w-4" />
+						Register integration
+					</Button>
+				</div>
+
+				{loading && (
+					<div className="space-y-3" data-testid="integrations-section-loading">
+						<Skeleton className="h-32 w-full rounded-lg" />
+						<Skeleton className="h-32 w-full rounded-lg" />
+					</div>
+				)}
+
+				{!loading && error && (
+					<div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-destructive text-sm">
+						<AlertCircle aria-hidden="true" className="h-4 w-4 shrink-0" />
+						<span>{error}</span>
+					</div>
+				)}
+
+				{!(loading || error) && integrations.length === 0 && (
+					<p className="text-muted-foreground text-sm">
+						You haven't registered any integrations yet.
+					</p>
+				)}
+
+				{!(loading || error) &&
+					integrations.map((integration) => (
+						<IntegrationCard
+							deleting={deletingId === integration.id}
+							integration={integration}
+							key={integration.id}
+							onDelete={deleteIntegration}
+							onIssueToken={issueToken}
+							onReactivate={reactivateIntegration}
+							onRevoke={revokeIntegration}
+							onRevokeToken={revokeToken}
+							onRotateToken={rotateToken}
+							onSuspend={suspendIntegration}
+							pending={pendingIntegrationId === integration.id}
+							pendingTokenKey={pendingTokenKey}
+						/>
+					))}
+			</div>
+
+			<IntegrationRegisterDialog
+				onOpenChange={setRegisterOpen}
+				onSubmit={registerIntegration}
+				open={registerOpen}
+				submitting={registering}
+			/>
+		</div>
+	);
+}

--- a/app/(authenticated)/dashboard/settings/integrations/page.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/page.tsx
@@ -1,0 +1,19 @@
+import SettingsNav from "../_components/settings-nav";
+import { IntegrationsSection } from "./_components/integrations-section";
+
+const IntegrationsSettings = () => {
+	return (
+		<main>
+			<h1 className="sr-only">Integrations</h1>
+
+			<header className="border-white/5 border-b">
+				{/* Secondary navigation */}
+				<SettingsNav />
+			</header>
+
+			<IntegrationsSection />
+		</main>
+	);
+};
+
+export default IntegrationsSettings;

--- a/hooks/__tests__/use-integrations.test.ts
+++ b/hooks/__tests__/use-integrations.test.ts
@@ -1,0 +1,309 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+	IntegrationListItem,
+	IssuedTokenResult,
+	RotatedTokenResult,
+} from "@/lib/schemas/integration";
+import { server } from "@/src/__tests__/mocks/server";
+import { useIntegrations } from "../use-integrations";
+
+const SECRET_KEY_REGEX = /secret/i;
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function makeIntegration(
+	overrides: Partial<IntegrationListItem> = {}
+): IntegrationListItem {
+	return {
+		id: "integration-1",
+		name: "darter-evidence-pipeline",
+		description: null,
+		scopes: ["case:read"],
+		status: "ACTIVE",
+		createdAt: "2026-06-01T00:00:00.000Z",
+		updatedAt: "2026-06-01T00:00:00.000Z",
+		lastSeenAt: null,
+		tokens: [],
+		...overrides,
+	};
+}
+
+describe("useIntegrations", () => {
+	it("starts loading, then resolves to the fetched integrations list", async () => {
+		server.use(
+			http.get("/api/integrations", () =>
+				HttpResponse.json({ integrations: [makeIntegration()] })
+			)
+		);
+
+		const { result } = renderHook(() => useIntegrations());
+
+		expect(result.current.loading).toBe(true);
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.integrations).toHaveLength(1);
+		expect(result.current.integrations[0]?.name).toBe(
+			"darter-evidence-pipeline"
+		);
+		expect(result.current.error).toBeNull();
+	});
+
+	it("surfaces the envelope error message when the GET fails", async () => {
+		server.use(
+			http.get("/api/integrations", () =>
+				HttpResponse.json(
+					{ error: "Failed to list integrations" },
+					{ status: 500 }
+				)
+			)
+		);
+
+		const { result } = renderHook(() => useIntegrations());
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.error).toBe("Failed to list integrations");
+		expect(result.current.integrations).toEqual([]);
+	});
+
+	describe("registerIntegration", () => {
+		it("posts the input, refetches, and resolves true on success", async () => {
+			let registered = false;
+			server.use(
+				http.get("/api/integrations", () =>
+					HttpResponse.json({
+						integrations: registered ? [makeIntegration()] : [],
+					})
+				),
+				http.post("/api/integrations", async ({ request }) => {
+					const body = (await request.json()) as { name: string };
+					expect(body.name).toBe("darter-evidence-pipeline");
+					registered = true;
+					return HttpResponse.json(
+						{ integration: makeIntegration() },
+						{
+							status: 201,
+						}
+					);
+				})
+			);
+
+			const { result } = renderHook(() => useIntegrations());
+			await waitFor(() => expect(result.current.loading).toBe(false));
+			expect(result.current.integrations).toHaveLength(0);
+
+			let success: boolean | undefined;
+			await act(async () => {
+				success = await result.current.registerIntegration({
+					name: "darter-evidence-pipeline",
+					scopes: ["case:read"],
+				});
+			});
+
+			expect(success).toBe(true);
+			expect(result.current.integrations).toHaveLength(1);
+		});
+
+		it("resolves false and leaves the list unchanged on a 409 name conflict", async () => {
+			server.use(
+				http.get("/api/integrations", () =>
+					HttpResponse.json({ integrations: [] })
+				),
+				http.post("/api/integrations", () =>
+					HttpResponse.json(
+						{ error: "An integration with this name already exists" },
+						{ status: 409 }
+					)
+				)
+			);
+
+			const { result } = renderHook(() => useIntegrations());
+			await waitFor(() => expect(result.current.loading).toBe(false));
+
+			let success: boolean | undefined;
+			await act(async () => {
+				success = await result.current.registerIntegration({
+					name: "darter-evidence-pipeline",
+					scopes: ["case:read"],
+				});
+			});
+
+			expect(success).toBe(false);
+			expect(result.current.integrations).toHaveLength(0);
+		});
+	});
+
+	describe("lifecycle actions", () => {
+		it("marks pendingIntegrationId during suspend and clears it after refetch", async () => {
+			let status: "ACTIVE" | "SUSPENDED" = "ACTIVE";
+			server.use(
+				http.get("/api/integrations", () =>
+					HttpResponse.json({ integrations: [makeIntegration({ status })] })
+				),
+				http.post("/api/integrations/integration-1/suspend", () => {
+					status = "SUSPENDED";
+					return HttpResponse.json({
+						integration: makeIntegration({ status }),
+					});
+				})
+			);
+
+			const { result } = renderHook(() => useIntegrations());
+			await waitFor(() => expect(result.current.loading).toBe(false));
+
+			expect(result.current.pendingIntegrationId).toBeNull();
+
+			let settled!: Promise<void>;
+			act(() => {
+				settled = result.current.suspendIntegration("integration-1");
+			});
+
+			// The state update from `setPendingIntegrationId` inside the async
+			// action only reaches `result.current` once React commits a render —
+			// not synchronously on the line after calling it — so this has to be
+			// polled rather than read immediately.
+			await waitFor(() =>
+				expect(result.current.pendingIntegrationId).toBe("integration-1")
+			);
+
+			await act(() => settled);
+
+			expect(result.current.pendingIntegrationId).toBeNull();
+			expect(result.current.integrations[0]?.status).toBe("SUSPENDED");
+		});
+	});
+
+	describe("token actions", () => {
+		it("issueToken resolves the secret and refetches, without ever storing the secret on the hook's own state", async () => {
+			server.use(
+				http.get("/api/integrations", () =>
+					HttpResponse.json({ integrations: [makeIntegration()] })
+				),
+				http.post("/api/integrations/integration-1/tokens", () =>
+					HttpResponse.json(
+						{
+							secret: "tea_live_secretvalue",
+							token: {
+								id: "token-1",
+								tokenPrefix: "tea_live_",
+								createdAt: "2026-07-05T00:00:00.000Z",
+								expiresAt: null,
+							},
+						},
+						{ status: 201 }
+					)
+				)
+			);
+
+			const { result } = renderHook(() => useIntegrations());
+			await waitFor(() => expect(result.current.loading).toBe(false));
+
+			let issued!: IssuedTokenResult | null;
+			await act(async () => {
+				issued = await result.current.issueToken("integration-1");
+			});
+
+			expect(issued).not.toBeNull();
+			expect(issued?.secret).toBe("tea_live_secretvalue");
+			// The hook's own public surface has no field that could hold the
+			// secret across renders — it is handed back through the resolved
+			// promise only, never assigned to hook state.
+			expect(result.current).not.toHaveProperty("secret");
+			expect(JSON.stringify(Object.keys(result.current))).not.toMatch(
+				SECRET_KEY_REGEX
+			);
+		});
+
+		it("rotateToken resolves the new secret plus the old token's overlap window", async () => {
+			server.use(
+				http.get("/api/integrations", () =>
+					HttpResponse.json({
+						integrations: [
+							makeIntegration({
+								tokens: [
+									{
+										id: "token-1",
+										tokenPrefix: "tea_live_",
+										createdAt: "2026-06-01T00:00:00.000Z",
+										lastUsedAt: null,
+										expiresAt: null,
+										revokedAt: null,
+									},
+								],
+							}),
+						],
+					})
+				),
+				http.post("/api/integrations/integration-1/tokens/token-1/rotate", () =>
+					HttpResponse.json({
+						secret: "tea_live_newsecret",
+						token: {
+							id: "token-2",
+							tokenPrefix: "tea_live_",
+							createdAt: "2026-07-05T00:00:00.000Z",
+							expiresAt: null,
+						},
+						oldTokenId: "token-1",
+						overlapUntil: "2026-07-05T01:00:00.000Z",
+					})
+				)
+			);
+
+			const { result } = renderHook(() => useIntegrations());
+			await waitFor(() => expect(result.current.loading).toBe(false));
+
+			let rotated!: RotatedTokenResult | null;
+			await act(async () => {
+				rotated = await result.current.rotateToken("integration-1", "token-1");
+			});
+
+			expect(rotated?.oldTokenId).toBe("token-1");
+			expect(rotated?.overlapUntil).toBe("2026-07-05T01:00:00.000Z");
+			expect(rotated?.secret).toBe("tea_live_newsecret");
+		});
+
+		it("revokeToken issues the DELETE and refetches", async () => {
+			let revokedAt: string | null = null;
+			server.use(
+				http.get("/api/integrations", () =>
+					HttpResponse.json({
+						integrations: [
+							makeIntegration({
+								tokens: [
+									{
+										id: "token-1",
+										tokenPrefix: "tea_live_",
+										createdAt: "2026-06-01T00:00:00.000Z",
+										lastUsedAt: null,
+										expiresAt: null,
+										revokedAt,
+									},
+								],
+							}),
+						],
+					})
+				),
+				http.delete("/api/integrations/integration-1/tokens/token-1", () => {
+					revokedAt = "2026-07-05T00:00:00.000Z";
+					return HttpResponse.json({ success: true });
+				})
+			);
+
+			const { result } = renderHook(() => useIntegrations());
+			await waitFor(() => expect(result.current.loading).toBe(false));
+
+			await act(async () => {
+				await result.current.revokeToken("integration-1", "token-1");
+			});
+
+			expect(result.current.integrations[0]?.tokens[0]?.revokedAt).toBe(
+				"2026-07-05T00:00:00.000Z"
+			);
+		});
+	});
+});

--- a/hooks/__tests__/use-integrations.test.ts
+++ b/hooks/__tests__/use-integrations.test.ts
@@ -217,6 +217,12 @@ describe("useIntegrations", () => {
 			expect(JSON.stringify(Object.keys(result.current))).not.toMatch(
 				SECRET_KEY_REGEX
 			);
+			// The key-name checks above would miss a regression that stashed the
+			// secret under an innocuously-named field (e.g. `lastIssuedToken:
+			// { secret }`), since they only ever inspect top-level key names.
+			// Serialising the whole hook result and searching for the literal
+			// secret value catches that shape of leak too, nested or not.
+			expect(JSON.stringify(result.current)).not.toContain(issued?.secret);
 		});
 
 		it("rotateToken resolves the new secret plus the old token's overlap window", async () => {
@@ -265,6 +271,8 @@ describe("useIntegrations", () => {
 			expect(rotated?.oldTokenId).toBe("token-1");
 			expect(rotated?.overlapUntil).toBe("2026-07-05T01:00:00.000Z");
 			expect(rotated?.secret).toBe("tea_live_newsecret");
+			// Same non-persistence invariant as issueToken, for the rotate path.
+			expect(JSON.stringify(result.current)).not.toContain(rotated?.secret);
 		});
 
 		it("revokeToken issues the DELETE and refetches", async () => {

--- a/hooks/use-integrations.ts
+++ b/hooks/use-integrations.ts
@@ -9,17 +9,6 @@ import type {
 } from "@/lib/schemas/integration";
 import { toast } from "@/lib/toast";
 
-// Re-exported so consumers (`IntegrationsSection`, its tests, etc.) import
-// the settings pane's item shape from this hook, same convention as
-// `use-plugin-settings.ts` re-exporting `PluginSettingsListItem` — one
-// definition, in `lib/schemas/integration.ts`.
-export type {
-	IntegrationListItem,
-	IntegrationTokenSummary,
-	IssuedTokenResult,
-	RotatedTokenResult,
-} from "@/lib/schemas/integration";
-
 interface ApiErrorBody {
 	error?: string;
 }

--- a/hooks/use-integrations.ts
+++ b/hooks/use-integrations.ts
@@ -1,0 +1,330 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type {
+	IntegrationListItem,
+	IssuedTokenResult,
+	RegisterIntegrationBody,
+	RotatedTokenResult,
+} from "@/lib/schemas/integration";
+import { toast } from "@/lib/toast";
+
+// Re-exported so consumers (`IntegrationsSection`, its tests, etc.) import
+// the settings pane's item shape from this hook, same convention as
+// `use-plugin-settings.ts` re-exporting `PluginSettingsListItem` — one
+// definition, in `lib/schemas/integration.ts`.
+export type {
+	IntegrationListItem,
+	IntegrationTokenSummary,
+	IssuedTokenResult,
+	RotatedTokenResult,
+} from "@/lib/schemas/integration";
+
+interface ApiErrorBody {
+	error?: string;
+}
+
+async function parseErrorMessage(response: Response): Promise<string> {
+	const body = (await response.json().catch(() => null)) as ApiErrorBody | null;
+	return body?.error ?? "Something went wrong";
+}
+
+async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
+	const response = await fetch(url, {
+		...init,
+		headers: { "Content-Type": "application/json", ...init?.headers },
+	});
+	if (!response.ok) {
+		throw new Error(await parseErrorMessage(response));
+	}
+	return (await response.json()) as T;
+}
+
+async function requestIntegrations(): Promise<IntegrationListItem[]> {
+	const body = await requestJson<{ integrations: IntegrationListItem[] }>(
+		"/api/integrations"
+	);
+	return body.integrations;
+}
+
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : "Something went wrong";
+}
+
+export interface UseIntegrationsResult {
+	deleteIntegration: (id: string) => Promise<void>;
+	/** The integrationId currently being deleted, or `null`. */
+	deletingId: string | null;
+	error: string | null;
+	integrations: IntegrationListItem[];
+
+	issueToken: (integrationId: string) => Promise<IssuedTokenResult | null>;
+	loading: boolean;
+	/** The integrationId currently mid lifecycle-action (suspend/reactivate/revoke), or `null`. */
+	pendingIntegrationId: string | null;
+	/** `${integrationId}:${tokenId}` currently mid rotate/revoke, or `${integrationId}` while issuing a fresh token, or `null`. */
+	pendingTokenKey: string | null;
+	reactivateIntegration: (id: string) => Promise<void>;
+	refetch: () => Promise<void>;
+
+	registerIntegration: (input: RegisterIntegrationBody) => Promise<boolean>;
+	registering: boolean;
+	revokeIntegration: (id: string) => Promise<void>;
+	revokeToken: (integrationId: string, tokenId: string) => Promise<void>;
+	rotateToken: (
+		integrationId: string,
+		tokenId: string
+	) => Promise<RotatedTokenResult | null>;
+	suspendIntegration: (id: string) => Promise<void>;
+}
+
+/**
+ * Fetches and manages the session user's integrations via `/api/
+ * integrations/**` — the Integrations settings pane's only data source
+ * (house rule: data via the new routes only, no service/Prisma imports here).
+ *
+ * Every mutation re-fetches the full list on success rather than patching
+ * local state from the mutation's response, same rationale as
+ * `usePluginSettings`: a token action changes a nested `tokens[]` entry
+ * whose derived state (e.g. which token is now the "current" one after a
+ * rotation) is cheaper to re-resolve through the same GET the pane renders
+ * from than to hand-reconcile locally.
+ *
+ * The plaintext token `secret` returned by `issueToken`/`rotateToken` is
+ * handed straight back to the caller and never written to this hook's own
+ * state — this hook has no `secret` field anywhere in `UseIntegrationsResult`.
+ * The token-shown-once modal is responsible for holding it only as long as
+ * it stays open (see `IntegrationCard`'s `tokenReveal` state).
+ */
+export function useIntegrations(): UseIntegrationsResult {
+	const [integrations, setIntegrations] = useState<IntegrationListItem[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [registering, setRegistering] = useState(false);
+	const [pendingIntegrationId, setPendingIntegrationId] = useState<
+		string | null
+	>(null);
+	const [deletingId, setDeletingId] = useState<string | null>(null);
+	const [pendingTokenKey, setPendingTokenKey] = useState<string | null>(null);
+
+	const load = useCallback(async () => {
+		try {
+			const data = await requestIntegrations();
+			setIntegrations(data);
+			setError(null);
+		} catch (err) {
+			setError(errorMessage(err));
+		}
+	}, []);
+
+	useEffect(() => {
+		setLoading(true);
+		load().finally(() => setLoading(false));
+	}, [load]);
+
+	const registerIntegration = useCallback(
+		async (input: RegisterIntegrationBody) => {
+			setRegistering(true);
+			try {
+				await requestJson("/api/integrations", {
+					method: "POST",
+					body: JSON.stringify(input),
+				});
+				await load();
+				toast({
+					variant: "success",
+					title: "Integration registered",
+					description: `"${input.name}" is ready to issue tokens for.`,
+				});
+				return true;
+			} catch (err) {
+				toast({
+					variant: "destructive",
+					title: "Couldn't register integration",
+					description: errorMessage(err),
+				});
+				return false;
+			} finally {
+				setRegistering(false);
+			}
+		},
+		[load]
+	);
+
+	const runLifecycleAction = useCallback(
+		async (
+			id: string,
+			path: "" | "/suspend" | "/reactivate" | "/revoke",
+			method: "POST" | "DELETE",
+			successTitle: string,
+			errorTitle: string
+		) => {
+			setPendingIntegrationId(id);
+			try {
+				await requestJson(`/api/integrations/${id}${path}`, { method });
+				await load();
+				toast({ variant: "success", title: successTitle });
+			} catch (err) {
+				toast({
+					variant: "destructive",
+					title: errorTitle,
+					description: errorMessage(err),
+				});
+			} finally {
+				setPendingIntegrationId(null);
+			}
+		},
+		[load]
+	);
+
+	const suspendIntegration = useCallback(
+		(id: string) =>
+			runLifecycleAction(
+				id,
+				"/suspend",
+				"POST",
+				"Integration suspended",
+				"Couldn't suspend integration"
+			),
+		[runLifecycleAction]
+	);
+
+	const reactivateIntegration = useCallback(
+		(id: string) =>
+			runLifecycleAction(
+				id,
+				"/reactivate",
+				"POST",
+				"Integration reactivated",
+				"Couldn't reactivate integration"
+			),
+		[runLifecycleAction]
+	);
+
+	const revokeIntegration = useCallback(
+		(id: string) =>
+			runLifecycleAction(
+				id,
+				"/revoke",
+				"POST",
+				"Integration revoked",
+				"Couldn't revoke integration"
+			),
+		[runLifecycleAction]
+	);
+
+	const deleteIntegration = useCallback(
+		async (id: string) => {
+			setDeletingId(id);
+			try {
+				await requestJson(`/api/integrations/${id}`, { method: "DELETE" });
+				await load();
+				toast({ variant: "success", title: "Integration deleted" });
+			} catch (err) {
+				toast({
+					variant: "destructive",
+					title: "Couldn't delete integration",
+					description: errorMessage(err),
+				});
+			} finally {
+				setDeletingId(null);
+			}
+		},
+		[load]
+	);
+
+	const issueToken = useCallback(
+		async (integrationId: string): Promise<IssuedTokenResult | null> => {
+			setPendingTokenKey(integrationId);
+			try {
+				const result = await requestJson<IssuedTokenResult>(
+					`/api/integrations/${integrationId}/tokens`,
+					{ method: "POST", body: JSON.stringify({}) }
+				);
+				await load();
+				return result;
+			} catch (err) {
+				toast({
+					variant: "destructive",
+					title: "Couldn't issue token",
+					description: errorMessage(err),
+				});
+				return null;
+			} finally {
+				setPendingTokenKey(null);
+			}
+		},
+		[load]
+	);
+
+	const rotateToken = useCallback(
+		async (
+			integrationId: string,
+			tokenId: string
+		): Promise<RotatedTokenResult | null> => {
+			const key = `${integrationId}:${tokenId}`;
+			setPendingTokenKey(key);
+			try {
+				const result = await requestJson<RotatedTokenResult>(
+					`/api/integrations/${integrationId}/tokens/${tokenId}/rotate`,
+					{ method: "POST" }
+				);
+				await load();
+				return result;
+			} catch (err) {
+				toast({
+					variant: "destructive",
+					title: "Couldn't rotate token",
+					description: errorMessage(err),
+				});
+				return null;
+			} finally {
+				setPendingTokenKey(null);
+			}
+		},
+		[load]
+	);
+
+	const revokeToken = useCallback(
+		async (integrationId: string, tokenId: string) => {
+			const key = `${integrationId}:${tokenId}`;
+			setPendingTokenKey(key);
+			try {
+				await requestJson(
+					`/api/integrations/${integrationId}/tokens/${tokenId}`,
+					{ method: "DELETE" }
+				);
+				await load();
+				toast({ variant: "success", title: "Token revoked" });
+			} catch (err) {
+				toast({
+					variant: "destructive",
+					title: "Couldn't revoke token",
+					description: errorMessage(err),
+				});
+			} finally {
+				setPendingTokenKey(null);
+			}
+		},
+		[load]
+	);
+
+	return {
+		integrations,
+		loading,
+		error,
+		refetch: load,
+		registering,
+		pendingIntegrationId,
+		deletingId,
+		pendingTokenKey,
+		registerIntegration,
+		suspendIntegration,
+		reactivateIntegration,
+		revokeIntegration,
+		deleteIntegration,
+		issueToken,
+		rotateToken,
+		revokeToken,
+	};
+}

--- a/lib/schemas/integration.ts
+++ b/lib/schemas/integration.ts
@@ -77,6 +77,9 @@ export type RegisterIntegrationFormInput = z.input<
  * Both fields optional, but at least one must be present — an empty PATCH
  * is a caller bug, not a no-op success.
  */
+// No `z.infer` alias here — nothing currently consumes an updateIntegrationSchema
+// type outside the route's own `.safeParse` call. Add one back when an edit UI
+// lands and a caller needs the parsed shape by name.
 export const updateIntegrationSchema = z
 	.object({
 		description: optionalString(1000),
@@ -86,8 +89,6 @@ export const updateIntegrationSchema = z
 		(data) => data.description !== undefined || data.scopes !== undefined,
 		{ message: "At least one field to update must be provided" }
 	);
-
-export type UpdateIntegrationBody = z.infer<typeof updateIntegrationSchema>;
 
 // ============================================
 // POST /api/integrations/[id]/tokens
@@ -102,6 +103,9 @@ export type UpdateIntegrationBody = z.infer<typeof updateIntegrationSchema>;
  * asking for an already-dead token is always a mistake worth rejecting at
  * the boundary rather than silently honouring.
  */
+// No `z.infer` alias here — nothing currently consumes an issueTokenSchema
+// type outside the route's own `.safeParse` call. Add one back when an
+// expiry-picker UI lands and a caller needs the parsed shape by name.
 export const issueTokenSchema = z.object({
 	expiresAt: z.coerce
 		.date()
@@ -110,8 +114,6 @@ export const issueTokenSchema = z.object({
 		})
 		.optional(),
 });
-
-export type IssueTokenBody = z.infer<typeof issueTokenSchema>;
 
 // ============================================
 // Response wire shapes — settings UI

--- a/lib/schemas/integration.ts
+++ b/lib/schemas/integration.ts
@@ -55,6 +55,19 @@ export const registerIntegrationSchema = z.object({
 
 export type RegisterIntegrationBody = z.infer<typeof registerIntegrationSchema>;
 
+/**
+ * The register form's raw field-values shape — react-hook-form +
+ * `zodResolver` work with this PRE-transform shape (`description` still
+ * allows `null`, `optionalString`'s own input type before its
+ * `.transform()` folds `null`/empty into `undefined`), not the parsed
+ * `RegisterIntegrationBody` output the resolver hands to `onSubmit`. Same
+ * input/output split as `PersonalInfoFormInput`/`Output` in
+ * `lib/schemas/user.ts`.
+ */
+export type RegisterIntegrationFormInput = z.input<
+	typeof registerIntegrationSchema
+>;
+
 // ============================================
 // PATCH /api/integrations/[id]
 // ============================================
@@ -99,3 +112,78 @@ export const issueTokenSchema = z.object({
 });
 
 export type IssueTokenBody = z.infer<typeof issueTokenSchema>;
+
+// ============================================
+// Response wire shapes — settings UI
+// ============================================
+//
+// These mirror the JSON `GET`/`POST` response bodies from `app/api/
+// integrations/**`, not `lib/services/integration-registry-service.ts`'s
+// `IntegrationListItem`/`IntegrationTokenSummary` — deliberately hand-written
+// here rather than imported from the service, for the same reason
+// `PluginSettingsListItem` lives in `lib/schemas/plugin.ts` rather than being
+// imported from a service: components/hooks must never import from
+// `lib/services/` (house rule — Prisma-touching modules), and the shapes
+// actually differ anyway once JSON is in the picture — every `Date` on the
+// service type crosses the wire as an ISO string, not a `Date` instance.
+
+/** An integration's lifecycle state (mirrors the Prisma `IntegrationStatus` enum without importing it). */
+export type IntegrationStatus = "ACTIVE" | "SUSPENDED" | "REVOKED";
+
+/**
+ * One issued token's summary as returned by `GET /api/integrations` — never
+ * the plaintext secret or hash, only what's needed to identify and manage it.
+ * `revokedAt`/`expiresAt` are both nullable and independent: a token can be
+ * expired but not revoked, or revoked before its expiry ever arrives.
+ */
+export interface IntegrationTokenSummary {
+	createdAt: string;
+	expiresAt: string | null;
+	id: string;
+	lastUsedAt: string | null;
+	revokedAt: string | null;
+	tokenPrefix: string;
+}
+
+/** A single integration as returned by `GET /api/integrations` — the settings pane's only data source. */
+export interface IntegrationListItem {
+	createdAt: string;
+	description: string | null;
+	id: string;
+	lastSeenAt: string | null;
+	name: string;
+	scopes: string[];
+	status: IntegrationStatus;
+	tokens: IntegrationTokenSummary[];
+	updatedAt: string;
+}
+
+/** The token summary embedded in an issue/rotate response — a narrower shape than `IntegrationTokenSummary` (no `revokedAt`: a token just issued or rotated in is never revoked). */
+export interface IssuedTokenSummary {
+	createdAt: string;
+	expiresAt: string | null;
+	id: string;
+	tokenPrefix: string;
+}
+
+/**
+ * `POST /api/integrations/[id]/tokens` response — the plaintext `secret` is
+ * present here and ONLY here. Callers must not persist it in any state that
+ * outlives the token-shown-once modal.
+ */
+export interface IssuedTokenResult {
+	secret: string;
+	token: IssuedTokenSummary;
+}
+
+/**
+ * `POST /api/integrations/[id]/tokens/[tokenId]/rotate` response — like
+ * `IssuedTokenResult` but also names the token it replaced and the overlap
+ * window during which both the old and new secrets still authenticate.
+ */
+export interface RotatedTokenResult {
+	oldTokenId: string;
+	overlapUntil: string;
+	secret: string;
+	token: IssuedTokenSummary;
+}

--- a/src/__tests__/setup/dom-polyfills.ts
+++ b/src/__tests__/setup/dom-polyfills.ts
@@ -1,11 +1,25 @@
 import { vi } from "vitest";
 
 // ResizeObserver
-global.ResizeObserver = vi.fn().mockImplementation(() => ({
-	observe: vi.fn(),
-	unobserve: vi.fn(),
-	disconnect: vi.fn(),
-}));
+//
+// The mock implementation MUST be a `function`/`class`, never an arrow
+// function: some components (e.g. Radix `Checkbox`'s hidden bubble input,
+// via `@radix-ui/react-use-size`) call `new ResizeObserver(...)` directly,
+// and vitest's spy implementation calls `Reflect.construct` on whatever's
+// configured here — which throws "is not a constructor" for an arrow
+// function (arrow functions have no `[[Construct]]`). Every prior consumer
+// of this mock only ever called `.observe`/`.disconnect` on an
+// already-constructed instance, so this never surfaced until a real
+// `new ResizeObserver()` call exercised it.
+global.ResizeObserver = vi
+	.fn()
+	.mockImplementation(function ResizeObserverMock() {
+		return {
+			observe: vi.fn(),
+			unobserve: vi.fn(),
+			disconnect: vi.fn(),
+		};
+	});
 
 // window.matchMedia
 Object.defineProperty(window, "matchMedia", {


### PR DESCRIPTION
## Summary

- The Integrations section in Settings (fills the pre-existing nav entry that pointed at a dead route): list your registered integrations with status, scopes, token prefixes, and last-used times; register new ones with scopes picked from the catalogue; suspend / reactivate / revoke / delete with confirm dialogs; issue, rotate, and revoke tokens.
- **The plaintext token secret appears exactly once** — in a modal with a copy button and an explicit not-shown-again warning. It never enters shared state, is cleared explicitly on close, and cannot reappear on reopen; the whole-state leak-scan and close-wiring tests pin this behaviourally, not just by naming convention.
- All data flows through the merged `/api/integrations` routes — no service or database imports client-side; wire types verified field-by-field against the route serialisers.
- Fixes a pre-existing test-infrastructure bug (a non-constructible ResizeObserver mock that crashed on first genuine use) and drops a handful of dead type exports.

## Review chain

- QA: PASS-WITH-FINDINGS — all gates independently reproduced; two genuine test-tautology gaps found in the secret-handling coverage and closed; the dialog-remount fix now carries a regression pin.
- Code review: APPROVE-WITH-COMMENTS — secret handling traced end-to-end with no leak path (state, logs, toasts, clipboard fallback all clean); auth posture, boundary discipline, and accessibility of the destructive-action patterns verified; British English swept.
- Reviewed-to-final delta read in full by the lead.

## Test evidence

- Lint 700 files clean · typecheck clean · unit 1035/1035 · integration 691/691 (35 files, 5 shards) · react-doctor clean on the changed scope.