### PR TITLE
Pin the staging-reseed workflow to staging's tree (main copy — cures the automatic path)

### DIFF
--- a/.github/workflows/seed-staging.yml
+++ b/.github/workflows/seed-staging.yml
@@ -13,8 +13,16 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
 
     steps:
+      # This workflow exists solely to reseed the STAGING database (its
+      # DATABASE_URL is the staging secret). An unpinned checkout runs the
+      # default branch's migrations+seed against staging's DB, which both
+      # strips staging-only schema and seeds the wrong content — found 2026-07-05.
+      # After this pin, the manual dispatch's branch selector is cosmetic —
+      # every run seeds from staging's tree by design.
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: staging
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -53,4 +61,7 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
           SEED_USER_PASSWORD: ${{ secrets.SEED_USER_PASSWORD }}
-        run: npx tsx prisma/seed/dev-seed.ts
+        run: npx tsx prisma/seed/dev-seed.ts | tee seed.log
+
+      - name: Verify expected seed content ran
+        run: grep -q "claim C1 id=" seed.log || { echo "::error::seed log missing the demo-case line — wrong seed script/tree ran"; exit 1; }


### PR DESCRIPTION
## Why this PR targets main

The automatic post-staging-Build reseed executes the copy of this workflow file that lives on the DEFAULT branch — main. Verified against this repo's run history: every automatic seed run to date checked out main's tree, applying main's migrations and main's (fully diverged) seed content to the staging database. This PR is what actually cures that path; its staging counterpart covers manual dispatches and keeps the two copies aligned.

## The change (workflow file only — zero production-behaviour impact)

- `ref: staging` pinned on the checkout (this workflow's only purpose is reseeding the STAGING database; its connection string is the staging secret). Forward-safe: a literal ref, immune to any future default-branch change.
- A self-verifying step: the seed's output is captured and the run FAILS unless the expected demo-content line is present — a wrong-tree reseed can never again pass green silently.
- Rationale comments inline. Existing action versions on this branch deliberately untouched.

**Merge order: this PR first, then its staging counterpart** — the staging PR's own merge triggers a reseed that runs THIS copy, making that reseed the fix's first live proof.

## Review chain

Code review APPROVE (semantics confirmed from GitHub's docs and this repo's own run logs; forward-safety and low-risk-to-main verified) · QA PASS-WITH-FINDINGS (trigger-to-run correlation data; the self-verifying step was QA's prescription, adopted) · both deltas read in full by the lead · YAML parse-verified.