### PR TITLE
Pin the staging-reseed workflow to staging's tree (staging copy)

### DIFF
--- a/.github/workflows/seed-staging.yml
+++ b/.github/workflows/seed-staging.yml
@@ -17,6 +17,8 @@ jobs:
       # DATABASE_URL is the staging secret). An unpinned checkout runs the
       # default branch's migrations+seed against staging's DB, which both
       # strips staging-only schema and seeds the wrong content — found 2026-07-05.
+      # After this pin, the manual dispatch's branch selector is cosmetic —
+      # every run seeds from staging's tree by design.
       - name: Checkout code
         uses: actions/checkout@v7
         with:
@@ -59,4 +61,7 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
           SEED_USER_PASSWORD: ${{ secrets.SEED_USER_PASSWORD }}
-        run: npx tsx prisma/seed/dev-seed.ts
+        run: npx tsx prisma/seed/dev-seed.ts | tee seed.log
+
+      - name: Verify expected seed content ran
+        run: grep -q "claim C1 id=" seed.log || { echo "::error::seed log missing the demo-case line — wrong seed script/tree ran"; exit 1; }

--- a/.github/workflows/seed-staging.yml
+++ b/.github/workflows/seed-staging.yml
@@ -13,8 +13,14 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
 
     steps:
+      # This workflow exists solely to reseed the STAGING database (its
+      # DATABASE_URL is the staging secret). An unpinned checkout runs the
+      # default branch's migrations+seed against staging's DB, which both
+      # strips staging-only schema and seeds the wrong content — found 2026-07-05.
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: staging
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Staging counterpart of the main-targeted pin PR (merge that one FIRST — the automatic reseed executes main's copy of this file; this copy governs manual `--ref staging` dispatches and keeps the two aligned).

- `ref: staging` pinned on the checkout + rationale comments (incl.: after the pin, the manual dispatch's branch selector is cosmetic by design).
- Self-verifying seed: output captured, run fails unless the expected demo-content line is present — wrong-tree reseeds become self-detecting instead of silently green.

## Review chain

Code review APPROVE · QA PASS-WITH-FINDINGS (the self-verifying step is QA's prescription, adopted) · reviewed-to-final delta read in full by the lead · YAML parse-verified · lint 702 files / typecheck clean (no-op sanity).