### PR TITLE
Fix flaky dialog-close assertion in the integrations settings test

### DIFF
--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integrations-section.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integrations-section.test.tsx
@@ -130,7 +130,9 @@ describe("IntegrationsSection", () => {
 		await waitFor(() =>
 			expect(screen.getByText("new-pipeline")).toBeInTheDocument()
 		);
-		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+		await waitFor(() =>
+			expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+		);
 	});
 
 	it("does not leak stale form field values into a freshly reopened register dialog (pins the react-doctor remount fix, f324045e)", async () => {


### PR DESCRIPTION
## Summary

The integrations settings-page test "registers through the full round trip" asserted the register dialog was gone **synchronously**, immediately after waiting for the new integration to appear in the list. But the dialog's close is a separate async effect (the register hook awaits a refetch that renders the list, *then* closes the dialog) — so under CI contention the dialog was sometimes still present when the assertion ran. Green at #851's own Build and 7+ local runs; tripped once on the #853 Build and blocked staging's deploy.

Fix: wrap that one assertion in `waitFor` — await the close rather than assert it instantaneously. No component change; the component was always correct, the test was racing it.

## Audit

The implementer verified structurally (against the hook's source) that this is the *only* synchronous-after-async disappearance assertion across the five integrations test files — every other dialog/modal close is triggered synchronously inside its click handler, with no async gap. QA independently spot-checked that claim (loading/list gate, three Cancel flows, the token-modal Done flow) and confirmed no second racing assertion is hiding.

## Review chain

QA (nanaki): PASS — 10× foreground loop all green; confirmed the wrapped assertion still fails loudly if the dialog never closes (not vacuous); audited and confirmed the implementer's structural audit. Reviewer scoped to QA alone — test-only one-line change, no security or pattern surface. Delta read by the lead (no post-review changes).

## Test evidence

- 10× loop on the target file: all green · lint 702 files clean · typecheck clean · unit 1035/1035 · react-doctor 100/100 on the changed scope.