### PR TITLE
Add reachable link to the Integrations settings page

### DIFF
--- a/app/(authenticated)/dashboard/settings/__tests__/page.test.tsx
+++ b/app/(authenticated)/dashboard/settings/__tests__/page.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// The settings landing page is an async server component that fetches the
+// current user + connected accounts and composes six settings sections.
+// Those sections have their own dedicated tests (and their own data
+// dependencies — session, plugin API, etc.) so they're stubbed here: this
+// suite exists only to pin the page's *wiring*, which is exactly what
+// regressed in the source issue (the Integrations page existed and worked,
+// but nothing on this page linked to it).
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue({
+		userId: "1",
+		username: "chris",
+		email: "chris@example.com",
+	}),
+}));
+vi.mock("@/actions/users", () => ({
+	fetchCurrentUser: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("@/actions/connected-accounts", () => ({
+	fetchConnectedAccounts: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("../_components/appearance-form", () => ({
+	AppearanceForm: () => <div data-testid="appearance-form" />,
+}));
+vi.mock("../_components/personal-info-form", () => ({
+	PersonalInfoForm: () => <div data-testid="personal-info-form" />,
+}));
+vi.mock("../_components/connected-accounts-form", () => ({
+	ConnectedAccountsForm: () => <div data-testid="connected-accounts-form" />,
+}));
+vi.mock("../_components/plugins-section", () => ({
+	PluginsSection: () => <div data-testid="plugins-section" />,
+}));
+vi.mock("../_components/password-form", () => ({
+	PasswordForm: () => <div data-testid="password-form" />,
+}));
+vi.mock("../_components/delete-form", () => ({
+	DeleteForm: () => <div data-testid="delete-form" />,
+}));
+
+import SettingsPage from "../page";
+
+describe("SettingsPage", () => {
+	it("renders a link to the Integrations settings page (regression: page existed but was unreachable)", async () => {
+		render(await SettingsPage());
+
+		const link = screen.getByRole("link", { name: /integrations/i });
+		expect(link).toHaveAttribute("href", "/dashboard/settings/integrations");
+	});
+
+	it("places the Integrations link section after Plugins and before the password form", async () => {
+		const { container } = render(await SettingsPage());
+
+		const testIds = Array.from(
+			container.querySelectorAll("[data-testid]")
+		).map((el) => el.getAttribute("data-testid"));
+
+		const pluginsIndex = testIds.indexOf("plugins-section");
+		const integrationsIndex = testIds.indexOf("integrations-link-section");
+		const passwordIndex = testIds.indexOf("password-form");
+
+		expect(pluginsIndex).toBeGreaterThanOrEqual(0);
+		expect(integrationsIndex).toBeGreaterThan(pluginsIndex);
+		expect(passwordIndex).toBeGreaterThan(integrationsIndex);
+	});
+});

--- a/app/(authenticated)/dashboard/settings/__tests__/page.test.tsx
+++ b/app/(authenticated)/dashboard/settings/__tests__/page.test.tsx
@@ -42,20 +42,24 @@ vi.mock("../_components/delete-form", () => ({
 
 import SettingsPage from "../page";
 
+const INTEGRATIONS_LINK_NAME_REGEX = /integrations/i;
+
 describe("SettingsPage", () => {
 	it("renders a link to the Integrations settings page (regression: page existed but was unreachable)", async () => {
 		render(await SettingsPage());
 
-		const link = screen.getByRole("link", { name: /integrations/i });
+		const link = screen.getByRole("link", {
+			name: INTEGRATIONS_LINK_NAME_REGEX,
+		});
 		expect(link).toHaveAttribute("href", "/dashboard/settings/integrations");
 	});
 
 	it("places the Integrations link section after Plugins and before the password form", async () => {
 		const { container } = render(await SettingsPage());
 
-		const testIds = Array.from(
-			container.querySelectorAll("[data-testid]")
-		).map((el) => el.getAttribute("data-testid"));
+		const testIds = Array.from(container.querySelectorAll("[data-testid]")).map(
+			(el) => el.getAttribute("data-testid")
+		);
 
 		const pluginsIndex = testIds.indexOf("plugins-section");
 		const integrationsIndex = testIds.indexOf("integrations-link-section");

--- a/app/(authenticated)/dashboard/settings/_components/__tests__/integrations-link-section.test.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/__tests__/integrations-link-section.test.tsx
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { renderWithoutProviders, screen } from "@/src/__tests__/utils/test-utils";
+import {
+	renderWithoutProviders,
+	screen,
+} from "@/src/__tests__/utils/test-utils";
 import { IntegrationsLinkSection } from "../integrations-link-section";
 
 describe("IntegrationsLinkSection", () => {

--- a/app/(authenticated)/dashboard/settings/_components/__tests__/integrations-link-section.test.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/__tests__/integrations-link-section.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { renderWithoutProviders, screen } from "@/src/__tests__/utils/test-utils";
+import { IntegrationsLinkSection } from "../integrations-link-section";
+
+describe("IntegrationsLinkSection", () => {
+	it("renders the Integrations heading and description", () => {
+		renderWithoutProviders(<IntegrationsLinkSection />);
+
+		expect(
+			screen.getByRole("heading", { name: "Integrations" })
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"Manage machine clients and API tokens for this account."
+			)
+		).toBeInTheDocument();
+	});
+
+	it("links to the Integrations settings page", () => {
+		renderWithoutProviders(<IntegrationsLinkSection />);
+
+		const link = screen.getByRole("link", { name: "Manage integrations" });
+		expect(link).toHaveAttribute("href", "/dashboard/settings/integrations");
+	});
+});

--- a/app/(authenticated)/dashboard/settings/_components/integrations-link-section.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/integrations-link-section.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Settings-landing link-out to the Integrations page (`/dashboard/settings/
+ * integrations`, shipped in PR #851). That page has no other entry point —
+ * this section is the fix for users only being able to reach it by typing
+ * the URL. Scope is deliberately a link-out only (Chris's G1 ruling): the
+ * full integrations manager stays on its own page, and this does not add a
+ * dashboard-nav entry.
+ */
+export function IntegrationsLinkSection() {
+	return (
+		<div
+			className="grid max-w-7xl grid-cols-1 gap-x-8 gap-y-10 px-4 py-16 sm:px-6 md:grid-cols-3 lg:px-8"
+			data-testid="integrations-link-section"
+		>
+			<div>
+				<h2 className="font-semibold text-base text-foreground leading-7">
+					Integrations
+				</h2>
+				<p className="mt-1 text-muted-foreground text-sm leading-6">
+					Manage machine clients and API tokens for this account.
+				</p>
+			</div>
+
+			<div className="md:col-span-2">
+				<Button asChild variant="outline">
+					<Link href="/dashboard/settings/integrations">
+						Manage integrations
+					</Link>
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/app/(authenticated)/dashboard/settings/page.tsx
+++ b/app/(authenticated)/dashboard/settings/page.tsx
@@ -5,6 +5,7 @@ import { validateSession } from "@/lib/auth/validate-session";
 import { AppearanceForm } from "./_components/appearance-form";
 import { ConnectedAccountsForm } from "./_components/connected-accounts-form";
 import { DeleteForm } from "./_components/delete-form";
+import { IntegrationsLinkSection } from "./_components/integrations-link-section";
 import { PasswordForm } from "./_components/password-form";
 import { PersonalInfoForm } from "./_components/personal-info-form";
 import { PluginsSection } from "./_components/plugins-section";
@@ -28,6 +29,7 @@ const SettingsPage = async () => {
 				<PersonalInfoForm data={currentUser} />
 				<ConnectedAccountsForm data={connectedAccounts} />
 				<PluginsSection />
+				<IntegrationsLinkSection />
 				<PasswordForm data={currentUser} />
 				<DeleteForm user={currentUser} />
 			</div>


### PR DESCRIPTION
## Summary

The Integrations settings page (#851) had no entry point in the UI — it was reachable only by typing the URL directly. This adds a compact link-out section to the Settings landing page, positioned after Plugins and before Password, with a button navigating to `/dashboard/settings/integrations`.

Scope is deliberately a link-out only: the full integrations manager stays on its own page, and no dashboard-nav entry is added.

## Changes

- New `IntegrationsLinkSection` — static presentational component matching the sibling settings sections' layout and typography
- Wired into the settings landing page at the agreed position
- Component test: heading, description, and link name + href
- Page-level wiring test pinning reachability from the real settings page composition — it fails if the section is ever removed from the page, which is exactly the regression class this PR fixes

## Testing

- Lint: 705 files clean · typecheck clean · unit suite 1039/1039
- The wiring test was proven to bite: removing the section from the page makes both page tests fail; restored and re-verified
- react-doctor 100/100 on the changed scope
- Structural audit vs base: no new dead code, complexity, or duplication introduced