### PR TITLE
Auto-tuck revoked tokens in the integration settings list

### DIFF
--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
@@ -7,6 +7,7 @@ import { server } from "@/src/__tests__/mocks/server";
 import {
 	renderWithoutProviders,
 	screen,
+	within,
 } from "@/src/__tests__/utils/test-utils";
 import { IntegrationCard } from "../integration-card";
 
@@ -32,6 +33,9 @@ const CASE_COMBOBOX_REGEX = /^case$/i;
 const PERMISSION_COMBOBOX_REGEX = /permission level/i;
 const DELETING_LABEL_REGEX = /deleting…/i;
 const REACTIVATE_IT_TEXT_REGEX = /reactivate it/i;
+const REVOKED_SECTION_BUTTON_REGEX = /^revoked/i;
+const ROTATE_BUTTON_REGEX = /^rotate$/i;
+const REVOKE_TOKEN_BUTTON_REGEX = /revoke this token/i;
 
 vi.mock("@/actions/assurance-cases", () => ({
 	fetchAssuranceCases: vi
@@ -934,6 +938,202 @@ describe("IntegrationCard", () => {
 				).toBeInTheDocument()
 			);
 			expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("token list auto-tuck (revoked tokens collapse out of the active list)", () => {
+		function makeToken(
+			id: string,
+			createdAt: string,
+			revokedAt: string | null = null
+		) {
+			return {
+				id,
+				tokenPrefix: `tea_live_${id}`,
+				createdAt,
+				lastUsedAt: null,
+				expiresAt: null,
+				revokedAt,
+			};
+		}
+
+		it("sorts active tokens newest-issued-first, regardless of API order", () => {
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({
+						tokens: [
+							makeToken("a", "2026-06-01T00:00:00.000Z"),
+							makeToken("b", "2026-07-01T00:00:00.000Z"),
+							makeToken("c", "2026-06-15T00:00:00.000Z"),
+						],
+					})}
+				/>
+			);
+
+			const rows = screen
+				.getAllByTestId(TOKEN_ROW_TEST_ID_REGEX)
+				.map((row) => row.getAttribute("data-testid"));
+			expect(rows).toEqual(["token-row-b", "token-row-c", "token-row-a"]);
+		});
+
+		it("never shows a revoked token above an active token — revoked stays collapsed under the disclosure", () => {
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({
+						tokens: [
+							makeToken(
+								"old-revoked",
+								"2026-01-01T00:00:00.000Z",
+								"2026-02-01T00:00:00.000Z"
+							),
+							makeToken("active", "2026-01-15T00:00:00.000Z"),
+						],
+					})}
+				/>
+			);
+
+			// Only the active token renders as a visible row; the revoked one is
+			// tucked behind the still-collapsed disclosure, even though it's
+			// chronologically irrelevant to prove the point either way.
+			expect(screen.getByTestId("token-row-active")).toBeInTheDocument();
+			expect(
+				screen.queryByTestId("token-row-old-revoked")
+			).not.toBeInTheDocument();
+		});
+
+		it("collapses the revoked section by default, with an accurate count", () => {
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({
+						tokens: [
+							makeToken("active", "2026-06-01T00:00:00.000Z"),
+							makeToken(
+								"r1",
+								"2026-05-01T00:00:00.000Z",
+								"2026-05-10T00:00:00.000Z"
+							),
+							makeToken(
+								"r2",
+								"2026-04-01T00:00:00.000Z",
+								"2026-04-10T00:00:00.000Z"
+							),
+							makeToken(
+								"r3",
+								"2026-03-01T00:00:00.000Z",
+								"2026-03-10T00:00:00.000Z"
+							),
+						],
+					})}
+				/>
+			);
+
+			const toggle = screen.getByRole("button", {
+				name: REVOKED_SECTION_BUTTON_REGEX,
+			});
+			expect(toggle).toHaveTextContent("Revoked (3)");
+			expect(toggle).toHaveAttribute("aria-expanded", "false");
+			expect(screen.queryByTestId("token-row-r1")).not.toBeInTheDocument();
+		});
+
+		it("expands the revoked section on click, and collapses again on a second click", async () => {
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({
+						tokens: [
+							makeToken("active", "2026-06-01T00:00:00.000Z"),
+							makeToken(
+								"r1",
+								"2026-05-01T00:00:00.000Z",
+								"2026-05-10T00:00:00.000Z"
+							),
+						],
+					})}
+				/>
+			);
+
+			const toggle = screen.getByRole("button", {
+				name: REVOKED_SECTION_BUTTON_REGEX,
+			});
+
+			await user.click(toggle);
+			expect(screen.getByTestId("token-row-r1")).toBeInTheDocument();
+			expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+			await user.click(toggle);
+			expect(screen.queryByTestId("token-row-r1")).not.toBeInTheDocument();
+			expect(toggle).toHaveAttribute("aria-expanded", "false");
+		});
+
+		it("renders no rotate/revoke actions on an expanded revoked row", async () => {
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({
+						tokens: [
+							makeToken(
+								"r1",
+								"2026-05-01T00:00:00.000Z",
+								"2026-05-10T00:00:00.000Z"
+							),
+						],
+					})}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: REVOKED_SECTION_BUTTON_REGEX })
+			);
+
+			const row = screen.getByTestId("token-row-r1");
+			expect(
+				within(row).queryByRole("button", { name: ROTATE_BUTTON_REGEX })
+			).not.toBeInTheDocument();
+			expect(
+				within(row).queryByRole("button", { name: REVOKE_TOKEN_BUTTON_REGEX })
+			).not.toBeInTheDocument();
+		});
+
+		it("shows no revoked section at all when there are zero revoked tokens", () => {
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({
+						tokens: [makeToken("active", "2026-06-01T00:00:00.000Z")],
+					})}
+				/>
+			);
+
+			expect(
+				screen.queryByRole("button", { name: REVOKED_SECTION_BUTTON_REGEX })
+			).not.toBeInTheDocument();
+		});
+
+		it("shows a 'No active tokens.' message (not 'No tokens issued yet.') when every token has been revoked", () => {
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({
+						tokens: [
+							makeToken(
+								"r1",
+								"2026-05-01T00:00:00.000Z",
+								"2026-05-10T00:00:00.000Z"
+							),
+						],
+					})}
+				/>
+			);
+
+			expect(screen.getByText("No active tokens.")).toBeInTheDocument();
+			expect(
+				screen.queryByText("No tokens issued yet.")
+			).not.toBeInTheDocument();
 		});
 	});
 });

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
@@ -995,12 +995,12 @@ describe("IntegrationCard", () => {
 			);
 
 			// Only the active token renders as a visible row; the revoked one is
-			// tucked behind the still-collapsed disclosure, even though it's
-			// chronologically irrelevant to prove the point either way.
-			expect(screen.getByTestId("token-row-active")).toBeInTheDocument();
-			expect(
-				screen.queryByTestId("token-row-old-revoked")
-			).not.toBeInTheDocument();
+			// mounted (the disclosure panel stays in the DOM so `aria-controls`
+			// always resolves) but hidden behind the still-collapsed disclosure,
+			// even though it's chronologically irrelevant to prove the point
+			// either way.
+			expect(screen.getByTestId("token-row-active")).toBeVisible();
+			expect(screen.getByTestId("token-row-old-revoked")).not.toBeVisible();
 		});
 
 		it("collapses the revoked section by default, with an accurate count", () => {
@@ -1035,7 +1035,7 @@ describe("IntegrationCard", () => {
 			});
 			expect(toggle).toHaveTextContent("Revoked (3)");
 			expect(toggle).toHaveAttribute("aria-expanded", "false");
-			expect(screen.queryByTestId("token-row-r1")).not.toBeInTheDocument();
+			expect(screen.getByTestId("token-row-r1")).not.toBeVisible();
 		});
 
 		it("expands the revoked section on click, and collapses again on a second click", async () => {
@@ -1061,11 +1061,11 @@ describe("IntegrationCard", () => {
 			});
 
 			await user.click(toggle);
-			expect(screen.getByTestId("token-row-r1")).toBeInTheDocument();
+			expect(screen.getByTestId("token-row-r1")).toBeVisible();
 			expect(toggle).toHaveAttribute("aria-expanded", "true");
 
 			await user.click(toggle);
-			expect(screen.queryByTestId("token-row-r1")).not.toBeInTheDocument();
+			expect(screen.getByTestId("token-row-r1")).not.toBeVisible();
 			expect(toggle).toHaveAttribute("aria-expanded", "false");
 		});
 
@@ -1134,6 +1134,139 @@ describe("IntegrationCard", () => {
 			expect(
 				screen.queryByText("No tokens issued yet.")
 			).not.toBeInTheDocument();
+		});
+
+		it("keeps input order among active tokens that share the same createdAt (stable sort)", () => {
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({
+						tokens: [
+							makeToken("x", "2026-06-01T00:00:00.000Z"),
+							makeToken("y", "2026-06-01T00:00:00.000Z"),
+							makeToken("z", "2026-06-01T00:00:00.000Z"),
+						],
+					})}
+				/>
+			);
+
+			const rows = screen
+				.getAllByTestId(TOKEN_ROW_TEST_ID_REGEX)
+				.map((row) => row.getAttribute("data-testid"));
+			expect(rows).toEqual(["token-row-x", "token-row-y", "token-row-z"]);
+		});
+
+		it("keeps the disclosure expanded across a parent re-render that adds a newly-revoked token", async () => {
+			const user = userEvent.setup();
+			const integration = makeIntegration({
+				tokens: [
+					makeToken("active", "2026-06-01T00:00:00.000Z"),
+					makeToken(
+						"r1",
+						"2026-05-01T00:00:00.000Z",
+						"2026-05-10T00:00:00.000Z"
+					),
+				],
+			});
+			const { rerender } = renderWithoutProviders(
+				<IntegrationCard {...baseProps} integration={integration} />
+			);
+
+			const toggle = screen.getByRole("button", {
+				name: REVOKED_SECTION_BUTTON_REGEX,
+			});
+			await user.click(toggle);
+			expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+			rerender(
+				<IntegrationCard
+					{...baseProps}
+					integration={{
+						...integration,
+						tokens: [
+							...integration.tokens,
+							makeToken(
+								"r2",
+								"2026-05-02T00:00:00.000Z",
+								"2026-05-11T00:00:00.000Z"
+							),
+						],
+					}}
+				/>
+			);
+
+			const toggleAfterRerender = screen.getByRole("button", {
+				name: REVOKED_SECTION_BUTTON_REGEX,
+			});
+			expect(toggleAfterRerender).toHaveTextContent("Revoked (2)");
+			expect(toggleAfterRerender).toHaveAttribute("aria-expanded", "true");
+			expect(screen.getByTestId("token-row-r1")).toBeVisible();
+			expect(screen.getByTestId("token-row-r2")).toBeVisible();
+		});
+
+		it("wires aria-controls to the id of the real, always-mounted disclosure region", () => {
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({
+						tokens: [
+							makeToken(
+								"r1",
+								"2026-05-01T00:00:00.000Z",
+								"2026-05-10T00:00:00.000Z"
+							),
+						],
+					})}
+				/>
+			);
+
+			const toggle = screen.getByRole("button", {
+				name: REVOKED_SECTION_BUTTON_REGEX,
+			});
+			const controlsId = toggle.getAttribute("aria-controls");
+			expect(controlsId).toBeTruthy();
+			if (!controlsId) {
+				throw new Error("expected aria-controls to be set");
+			}
+
+			const region = document.getElementById(controlsId);
+			expect(region).not.toBeNull();
+			if (!region) {
+				throw new Error("expected the disclosure region to be mounted");
+			}
+			expect(within(region).getByTestId("token-row-r1")).toBeInTheDocument();
+		});
+
+		it("toggles via keyboard — Enter opens, Space closes", async () => {
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({
+						tokens: [
+							makeToken(
+								"r1",
+								"2026-05-01T00:00:00.000Z",
+								"2026-05-10T00:00:00.000Z"
+							),
+						],
+					})}
+				/>
+			);
+
+			const toggle = screen.getByRole("button", {
+				name: REVOKED_SECTION_BUTTON_REGEX,
+			});
+			toggle.focus();
+			expect(toggle).toHaveFocus();
+
+			await user.keyboard("{Enter}");
+			expect(toggle).toHaveAttribute("aria-expanded", "true");
+			expect(screen.getByTestId("token-row-r1")).toBeVisible();
+
+			await user.keyboard(" ");
+			expect(toggle).toHaveAttribute("aria-expanded", "false");
+			expect(screen.getByTestId("token-row-r1")).not.toBeVisible();
 		});
 	});
 });

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
@@ -28,28 +28,39 @@ import {
 	type TokenReveal,
 } from "./integration-token-secret-modal";
 
-/** Active tokens sort newest-issued-first — the auto-tuck UX (issue TEA —
- * Token list UX): a revoked token never needs a manual archive step because
- * revoking already removes it from this list. */
-function sortTokensByCreatedDesc(
-	tokens: IntegrationTokenSummary[]
-): IntegrationTokenSummary[] {
-	return [...tokens].sort(
-		(a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-	);
-}
-
-/** Revoked tokens (within the collapsed section) sort most-recently-revoked
- * first — every entry here has a non-null `revokedAt` by construction
- * (filtered below), so the fallback to 0 never fires in practice. */
-function sortTokensByRevokedDesc(
-	tokens: IntegrationTokenSummary[]
+/** Shared newest-first sort for both token lists — active tokens sort by
+ * `createdAt` (the auto-tuck UX, issue TEA — Token list UX: a revoked token
+ * never needs a manual archive step because revoking already removes it from
+ * the active list); revoked tokens (within the collapsed section) sort by
+ * `revokedAt`, most-recently-revoked first. The null fallback only matters
+ * for `revokedAt` in principle — every entry passed for that field has a
+ * non-null value by construction (partitioned below), so it never fires in
+ * practice. */
+function sortTokensByDateDesc(
+	tokens: IntegrationTokenSummary[],
+	field: "createdAt" | "revokedAt"
 ): IntegrationTokenSummary[] {
 	return [...tokens].sort((a, b) => {
-		const aTime = a.revokedAt ? new Date(a.revokedAt).getTime() : 0;
-		const bTime = b.revokedAt ? new Date(b.revokedAt).getTime() : 0;
+		const aValue = a[field];
+		const bValue = b[field];
+		const aTime = aValue ? new Date(aValue).getTime() : 0;
+		const bTime = bValue ? new Date(bValue).getTime() : 0;
 		return bTime - aTime;
 	});
+}
+
+/** Splits an integration's tokens into active/revoked in one pass rather than
+ * filtering the array twice. */
+function partitionTokensByRevoked(tokens: IntegrationTokenSummary[]): {
+	active: IntegrationTokenSummary[];
+	revoked: IntegrationTokenSummary[];
+} {
+	const active: IntegrationTokenSummary[] = [];
+	const revoked: IntegrationTokenSummary[] = [];
+	for (const token of tokens) {
+		(token.revokedAt ? revoked : active).push(token);
+	}
+	return { active, revoked };
 }
 
 export interface IntegrationCardProps {
@@ -127,12 +138,10 @@ export function IntegrationCard({
 	const integrationActive = integration.status === "ACTIVE";
 	const integrationRevoked = integration.status === "REVOKED";
 
-	const activeTokens = sortTokensByCreatedDesc(
-		integration.tokens.filter((token) => !token.revokedAt)
-	);
-	const revokedTokens = sortTokensByRevokedDesc(
-		integration.tokens.filter((token) => Boolean(token.revokedAt))
-	);
+	const { active: activeTokensRaw, revoked: revokedTokensRaw } =
+		partitionTokensByRevoked(integration.tokens);
+	const activeTokens = sortTokensByDateDesc(activeTokensRaw, "createdAt");
+	const revokedTokens = sortTokensByDateDesc(revokedTokensRaw, "revokedAt");
 
 	async function handleIssueToken() {
 		const result = await onIssueToken(integration.id);

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
@@ -13,11 +13,13 @@ import {
 } from "@/lib/date";
 import type {
 	IntegrationListItem,
+	IntegrationTokenSummary,
 	IssuedTokenResult,
 	RotatedTokenResult,
 } from "@/lib/schemas/integration";
 import { CaseAccessSection } from "./case-access-section";
 import { IntegrationDeleteDialog } from "./integration-delete-dialog";
+import { IntegrationRevokedTokens } from "./integration-revoked-tokens";
 import { scopeLabel } from "./integration-scope-labels";
 import { IntegrationStatusBadge } from "./integration-status-badge";
 import { IntegrationTokenRow } from "./integration-token-row";
@@ -25,6 +27,30 @@ import {
 	IntegrationTokenSecretModal,
 	type TokenReveal,
 } from "./integration-token-secret-modal";
+
+/** Active tokens sort newest-issued-first — the auto-tuck UX (issue TEA —
+ * Token list UX): a revoked token never needs a manual archive step because
+ * revoking already removes it from this list. */
+function sortTokensByCreatedDesc(
+	tokens: IntegrationTokenSummary[]
+): IntegrationTokenSummary[] {
+	return [...tokens].sort(
+		(a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+	);
+}
+
+/** Revoked tokens (within the collapsed section) sort most-recently-revoked
+ * first — every entry here has a non-null `revokedAt` by construction
+ * (filtered below), so the fallback to 0 never fires in practice. */
+function sortTokensByRevokedDesc(
+	tokens: IntegrationTokenSummary[]
+): IntegrationTokenSummary[] {
+	return [...tokens].sort((a, b) => {
+		const aTime = a.revokedAt ? new Date(a.revokedAt).getTime() : 0;
+		const bTime = b.revokedAt ? new Date(b.revokedAt).getTime() : 0;
+		return bTime - aTime;
+	});
+}
 
 export interface IntegrationCardProps {
 	/** True while THIS integration's registration delete request is in flight. */
@@ -100,6 +126,13 @@ export function IntegrationCard({
 	const isIssuing = pendingTokenKey === integration.id;
 	const integrationActive = integration.status === "ACTIVE";
 	const integrationRevoked = integration.status === "REVOKED";
+
+	const activeTokens = sortTokensByCreatedDesc(
+		integration.tokens.filter((token) => !token.revokedAt)
+	);
+	const revokedTokens = sortTokensByRevokedDesc(
+		integration.tokens.filter((token) => Boolean(token.revokedAt))
+	);
 
 	async function handleIssueToken() {
 		const result = await onIssueToken(integration.id);
@@ -240,11 +273,15 @@ export function IntegrationCard({
 					</Button>
 				</div>
 
-				{integration.tokens.length === 0 ? (
-					<p className="text-muted-foreground text-xs">No tokens issued yet.</p>
+				{activeTokens.length === 0 ? (
+					<p className="text-muted-foreground text-xs">
+						{revokedTokens.length > 0
+							? "No active tokens."
+							: "No tokens issued yet."}
+					</p>
 				) : (
 					<div className="space-y-2">
-						{integration.tokens.map((token) => (
+						{activeTokens.map((token) => (
 							<IntegrationTokenRow
 								canRotate={integrationActive}
 								key={token.id}
@@ -256,6 +293,8 @@ export function IntegrationCard({
 						))}
 					</div>
 				)}
+
+				<IntegrationRevokedTokens tokens={revokedTokens} />
 			</div>
 
 			<CaseAccessSection

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-revoked-tokens.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-revoked-tokens.tsx
@@ -46,27 +46,30 @@ export function IntegrationRevokedTokens({
 				{`Revoked (${tokens.length})`}
 			</button>
 
-			{open && (
-				<div className="space-y-2" id={listId}>
-					{tokens.map((token) => (
-						<IntegrationTokenRow
-							canRotate={false}
-							key={token.id}
-							onRevoke={() => {
-								// Revoked rows never render an action to trigger this —
-								// `IntegrationTokenRow` only wires rotate/revoke for a
-								// live token. Kept as a no-op rather than threading a
-								// real handler through for a callback that can't fire.
-							}}
-							onRotate={() => {
-								// See onRevoke above — unreachable for a revoked row.
-							}}
-							pending={false}
-							token={token}
-						/>
-					))}
-				</div>
-			)}
+			{/* Always mounted, visibility toggled via `hidden` (not conditional
+			 * rendering) — so `aria-controls` above always resolves to a real
+			 * element, collapsed or not. A conditionally-rendered panel points
+			 * `aria-controls` at an id that doesn't exist in the DOM while
+			 * closed, which assistive tech reports as broken. */}
+			<div className="space-y-2" hidden={!open} id={listId}>
+				{tokens.map((token) => (
+					<IntegrationTokenRow
+						canRotate={false}
+						key={token.id}
+						onRevoke={() => {
+							// Revoked rows never render an action to trigger this —
+							// `IntegrationTokenRow` only wires rotate/revoke for a
+							// live token. Kept as a no-op rather than threading a
+							// real handler through for a callback that can't fire.
+						}}
+						onRotate={() => {
+							// See onRevoke above — unreachable for a revoked row.
+						}}
+						pending={false}
+						token={token}
+					/>
+				))}
+			</div>
 		</div>
 	);
 }

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-revoked-tokens.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-revoked-tokens.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useId, useState } from "react";
+import type { IntegrationTokenSummary } from "@/lib/schemas/integration";
+import { IntegrationTokenRow } from "./integration-token-row";
+
+export interface IntegrationRevokedTokensProps {
+	tokens: IntegrationTokenSummary[];
+}
+
+/**
+ * Revoking a token IS the archive action here (no separate archive flag, no
+ * API change) — this component is the purely presentational other half:
+ * it tucks already-revoked tokens out of the active list and behind a
+ * collapsed-by-default disclosure, so a long-lived integration's dead tokens
+ * don't crowd out the ones that still authenticate. Renders nothing at all
+ * when there are no revoked tokens — never a "Revoked (0)" section.
+ * Reuses `IntegrationTokenRow` for the expanded rows: its `state === "revoked"`
+ * branch already renders prefix + revoked date with no rotate/revoke actions.
+ */
+export function IntegrationRevokedTokens({
+	tokens,
+}: IntegrationRevokedTokensProps) {
+	const [open, setOpen] = useState(false);
+	const listId = useId();
+
+	if (tokens.length === 0) {
+		return null;
+	}
+
+	return (
+		<div className="space-y-2">
+			<button
+				aria-controls={listId}
+				aria-expanded={open}
+				className="flex items-center gap-1.5 text-muted-foreground text-xs hover:text-foreground"
+				onClick={() => setOpen((value) => !value)}
+				type="button"
+			>
+				{open ? (
+					<ChevronDown aria-hidden="true" className="h-3.5 w-3.5" />
+				) : (
+					<ChevronRight aria-hidden="true" className="h-3.5 w-3.5" />
+				)}
+				{`Revoked (${tokens.length})`}
+			</button>
+
+			{open && (
+				<div className="space-y-2" id={listId}>
+					{tokens.map((token) => (
+						<IntegrationTokenRow
+							canRotate={false}
+							key={token.id}
+							onRevoke={() => {
+								// Revoked rows never render an action to trigger this —
+								// `IntegrationTokenRow` only wires rotate/revoke for a
+								// live token. Kept as a no-op rather than threading a
+								// real handler through for a callback that can't fire.
+							}}
+							onRotate={() => {
+								// See onRevoke above — unreachable for a revoked row.
+							}}
+							pending={false}
+							token={token}
+						/>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}


### PR DESCRIPTION
Active tokens now sort newest-issued-first; revoked tokens drop into a collapsed "Revoked (n)" disclosure at the bottom of the list (absent when none). Revoking is the archive action — no manual step, no new stored state, no API change.

## Review chain
- QA: pass — 7 acceptance-mapped tests plus 4 adopted gap probes (stable sort, disclosure state retention across re-renders, aria-controls wiring, keyboard toggle); full unit project green (1050 tests).
- Code review: approve — no blockers; revoked rows render no actions (gated behind isLive, not merely disabled); token list carries prefixes only, never secrets; zero new static-analysis findings introduced.
- Post-review fix batch: WAI-ARIA disclosure pattern (panel stays mounted, hidden-toggled, so aria-controls always resolves), consolidated sort helper, single-pass partition.

## Notes
Display-layer only. The disclosure is a plain button + hidden-toggled region; if disclosure UI recurs elsewhere, consider adopting the shadcn Collapsible primitive at that point.