### PR TITLE
Integration case-access grants — service + API (backend half)

### DIFF
--- a/app/api/integrations/[id]/case-grants/[caseId]/route.ts
+++ b/app/api/integrations/[id]/case-grants/[caseId]/route.ts
@@ -1,0 +1,56 @@
+import {
+	apiError,
+	apiErrorFromUnknown,
+	apiSuccess,
+	requireAuth,
+	serviceErrorToAppError,
+} from "@/lib/api-response";
+import { validationError } from "@/lib/errors";
+import { uuidSchema } from "@/lib/schemas/base";
+import { revokeIntegrationCaseAccess } from "@/lib/services/integration-registry-service";
+
+/**
+ * DELETE /api/integrations/[id]/case-grants/[caseId]
+ *
+ * Revokes the integration's system user's access to a case, if any is
+ * currently granted. Idempotent — revoking a case that was never granted
+ * (or already revoked) is a 200 success, not an error. Requires the caller
+ * both own the integration and hold ADMIN on the case.
+ *
+ * @pathParam id - Integration ID (UUID)
+ * @pathParam caseId - Case ID (UUID)
+ * @response 200 - `{ success: true }`
+ * @response 400 - Validation error
+ * @response 401 - Unauthorised
+ * @response 404 - Integration not found, OR case not found, OR caller lacks case ADMIN (identical message/status for all three — no enumeration oracle)
+ * @auth SessionAuth
+ * @tag Integrations
+ */
+export async function DELETE(
+	_request: Request,
+	{ params }: { params: Promise<{ caseId: string; id: string }> }
+) {
+	try {
+		const userId = await requireAuth();
+		const { id, caseId } = await params;
+
+		const parsedId = uuidSchema.safeParse(id);
+		const parsedCaseId = uuidSchema.safeParse(caseId);
+		if (!(parsedId.success && parsedCaseId.success)) {
+			return apiError(validationError("Invalid id"));
+		}
+
+		const result = await revokeIntegrationCaseAccess(
+			parsedId.data,
+			parsedCaseId.data,
+			userId
+		);
+		if ("error" in result) {
+			return apiError(serviceErrorToAppError(result.error));
+		}
+
+		return apiSuccess({ success: true });
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}

--- a/app/api/integrations/[id]/case-grants/[caseId]/route.ts
+++ b/app/api/integrations/[id]/case-grants/[caseId]/route.ts
@@ -15,7 +15,11 @@ import { revokeIntegrationCaseAccess } from "@/lib/services/integration-registry
  * Revokes the integration's system user's access to a case, if any is
  * currently granted. Idempotent — revoking a case that was never granted
  * (or already revoked) is a 200 success, not an error. Requires the caller
- * both own the integration and hold ADMIN on the case.
+ * both own the integration and hold ADMIN on the case. Deliberately NOT
+ * gated on integration status — revoking a suspended or revoked
+ * integration's case access must keep working, since it is the operator's
+ * cleanup path (see `revokeIntegrationCaseAccess`'s doc comment in
+ * `integration-registry-service.ts`).
  *
  * @pathParam id - Integration ID (UUID)
  * @pathParam caseId - Case ID (UUID)

--- a/app/api/integrations/[id]/case-grants/route.ts
+++ b/app/api/integrations/[id]/case-grants/route.ts
@@ -1,0 +1,117 @@
+import {
+	apiError,
+	apiErrorFromUnknown,
+	apiSuccess,
+	requireAuth,
+	serviceErrorToAppError,
+} from "@/lib/api-response";
+import { validationError } from "@/lib/errors";
+import { uuidSchema } from "@/lib/schemas/base";
+import { grantCaseAccessSchema } from "@/lib/schemas/integration";
+import {
+	grantIntegrationCaseAccess,
+	listIntegrationCaseGrants,
+} from "@/lib/services/integration-registry-service";
+
+/**
+ * GET /api/integrations/[id]/case-grants
+ *
+ * Lists the cases the integration's system user currently has access to.
+ * Owner-only.
+ *
+ * @pathParam id - Integration ID (UUID)
+ * @response 200 - `{ grants: Array<{ caseId, caseName, permission, grantedAt }> }`
+ * @response 400 - Validation error
+ * @response 401 - Unauthorised
+ * @response 404 - Integration not found (covers non-existent and not-owned — same message)
+ * @auth SessionAuth
+ * @tag Integrations
+ */
+export async function GET(
+	_request: Request,
+	{ params }: { params: Promise<{ id: string }> }
+) {
+	try {
+		const userId = await requireAuth();
+		const { id } = await params;
+
+		const parsedId = uuidSchema.safeParse(id);
+		if (!parsedId.success) {
+			return apiError(validationError("Invalid integration id"));
+		}
+
+		const result = await listIntegrationCaseGrants(parsedId.data, userId);
+		if ("error" in result) {
+			return apiError(serviceErrorToAppError(result.error));
+		}
+
+		return apiSuccess({ grants: result.data });
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}
+
+/**
+ * POST /api/integrations/[id]/case-grants
+ *
+ * Grants the integration's system user access to a case. The target user
+ * is ALWAYS the integration's own system user — the request body has no
+ * `userId` field, so a caller can never name a different user to grant.
+ * Requires the caller both own the integration and hold ADMIN on the case.
+ *
+ * @description Never errors on a repeat call for a case the system user
+ * already has SOME access to (upsert, not create) — see
+ * `grantIntegrationCaseAccess`'s doc comment. Re-granting the EXACT SAME
+ * permission level is idempotent success (`alreadyGranted: true`, 200). A
+ * fresh grant, OR a repeat call that changes the permission level, is a
+ * real write and returns 201 with `alreadyGranted: false`.
+ * @pathParam id - Integration ID (UUID)
+ * @body { caseId: string, permission: "VIEW" | "COMMENT" | "EDIT" | "ADMIN" }
+ * @response 201 - `{ grant: { caseId, caseName, permission, grantedAt, alreadyGranted: false } }` — new grant, or an existing grant's permission level changed
+ * @response 200 - `{ grant: { ..., alreadyGranted: true } }` — already had EXACTLY this permission level
+ * @response 400 - Validation error
+ * @response 401 - Unauthorised
+ * @response 404 - Integration not found, OR case not found, OR caller lacks case ADMIN (identical message/status for all three — no enumeration oracle)
+ * @auth SessionAuth
+ * @tag Integrations
+ */
+export async function POST(
+	request: Request,
+	{ params }: { params: Promise<{ id: string }> }
+) {
+	try {
+		const userId = await requireAuth();
+		const { id } = await params;
+
+		const parsedId = uuidSchema.safeParse(id);
+		if (!parsedId.success) {
+			return apiError(validationError("Invalid integration id"));
+		}
+
+		const parsed = grantCaseAccessSchema.safeParse(
+			await request.json().catch(() => ({}))
+		);
+		if (!parsed.success) {
+			return apiError(
+				validationError(parsed.error.issues[0]?.message ?? "Invalid input")
+			);
+		}
+
+		const result = await grantIntegrationCaseAccess(
+			parsedId.data,
+			parsed.data.caseId,
+			parsed.data.permission,
+			userId
+		);
+		if ("error" in result) {
+			return apiError(serviceErrorToAppError(result.error));
+		}
+
+		return apiSuccess(
+			{ grant: result.data },
+			result.data.alreadyGranted ? 200 : 201
+		);
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}

--- a/app/api/integrations/[id]/case-grants/route.ts
+++ b/app/api/integrations/[id]/case-grants/route.ts
@@ -17,7 +17,12 @@ import {
  * GET /api/integrations/[id]/case-grants
  *
  * Lists the cases the integration's system user currently has access to.
- * Owner-only.
+ * Owner-only at the integration level, and additionally filtered per-row to
+ * cases the CALLER themselves can currently view — a reassigned integration
+ * owner does not learn the id/name of a case they cannot access just by
+ * having been handed the integration (see `listIntegrationCaseGrants`'s doc
+ * comment). Not gated on integration status — listing a suspended or
+ * revoked integration's grants still works (operator cleanup path).
  *
  * @pathParam id - Integration ID (UUID)
  * @response 200 - `{ grants: Array<{ caseId, caseName, permission, grantedAt }> }`
@@ -57,7 +62,18 @@ export async function GET(
  * Grants the integration's system user access to a case. The target user
  * is ALWAYS the integration's own system user — the request body has no
  * `userId` field, so a caller can never name a different user to grant.
- * Requires the caller both own the integration and hold ADMIN on the case.
+ * Requires the caller both own the integration and hold ADMIN on the case,
+ * AND requires the integration be ACTIVE (mirrors `POST .../tokens`'s own
+ * ACTIVE gate) — granting MORE case access through an integration that
+ * can't currently authenticate (SUSPENDED) or never will again (REVOKED)
+ * makes no sense. `GET`/`DELETE` on this same resource are deliberately NOT
+ * gated on integration status — see `grantIntegrationCaseAccess`'s doc
+ * comment in `integration-registry-service.ts`.
+ *
+ * `permission` accepts VIEW/COMMENT/EDIT only, never ADMIN — a machine
+ * principal has no use for case-ADMIN today, and requesting it is a 400,
+ * not a silent downgrade (see `grantCaseAccessSchema`'s doc comment in
+ * `lib/schemas/integration.ts`).
  *
  * @description Never errors on a repeat call for a case the system user
  * already has SOME access to (upsert, not create) — see
@@ -66,12 +82,13 @@ export async function GET(
  * fresh grant, OR a repeat call that changes the permission level, is a
  * real write and returns 201 with `alreadyGranted: false`.
  * @pathParam id - Integration ID (UUID)
- * @body { caseId: string, permission: "VIEW" | "COMMENT" | "EDIT" | "ADMIN" }
+ * @body { caseId: string, permission: "VIEW" | "COMMENT" | "EDIT" }
  * @response 201 - `{ grant: { caseId, caseName, permission, grantedAt, alreadyGranted: false } }` — new grant, or an existing grant's permission level changed
  * @response 200 - `{ grant: { ..., alreadyGranted: true } }` — already had EXACTLY this permission level
- * @response 400 - Validation error
+ * @response 400 - Validation error (including `permission: "ADMIN"`, which this endpoint never accepts)
  * @response 401 - Unauthorised
- * @response 404 - Integration not found, OR case not found, OR caller lacks case ADMIN (identical message/status for all three — no enumeration oracle)
+ * @response 404 - Integration not found, OR case not found (incl. soft-deleted/trashed), OR caller lacks case ADMIN (identical message/status for all — no enumeration oracle)
+ * @response 409 - The integration is not ACTIVE
  * @auth SessionAuth
  * @tag Integrations
  */

--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -133,12 +133,13 @@ const ERROR_MAPPINGS: Array<{
 	// the integration or token exists and is owned by the caller, but its
 	// current status makes the requested action a no-op or a terminal-state
 	// violation (e.g. reactivating a REVOKED integration, or issuing/
-	// rotating a token against one that isn't ACTIVE). None of these contain
-	// "already" or "not found", so without this entry they'd fall through to
-	// INTERNAL (500) the first time an HTTP route ever surfaced them.
+	// rotating a token against one that isn't ACTIVE, or granting case access
+	// through one that isn't ACTIVE). None of these contain "already" or
+	// "not found", so without this entry they'd fall through to INTERNAL
+	// (500) the first time an HTTP route ever surfaced them.
 	{
 		pattern:
-			/^Cannot (suspend|reactivate) a revoked integration$|^Cannot (issue|rotate) a token for a non-active integration$|^Cannot rotate a revoked token$/,
+			/^Cannot (suspend|reactivate) a revoked integration$|^Cannot (issue|rotate) a token for a non-active integration$|^Cannot grant case access for a non-active integration$|^Cannot rotate a revoked token$/,
 		factory: conflict,
 	},
 	// `user-management-service.ts`'s `deleteAccount` — owned integrations

--- a/lib/schemas/integration.ts
+++ b/lib/schemas/integration.ts
@@ -1,11 +1,6 @@
 import { z } from "zod";
 import { SCOPES } from "@/lib/auth/scopes";
-import {
-	optionalString,
-	permissionLevelSchema,
-	requiredString,
-	uuidSchema,
-} from "@/lib/schemas/base";
+import { optionalString, requiredString, uuidSchema } from "@/lib/schemas/base";
 
 /**
  * Zod schemas for the integration management API (ADR 0002 v2 §2.4, work
@@ -125,19 +120,39 @@ export const issueTokenSchema = z.object({
 // ============================================
 
 /**
- * Body schema for granting an integration's system user access to a case.
- * `permission` is restricted to the closed `PermissionLevel` enum
- * (`permissionLevelSchema` — VIEW/COMMENT/EDIT/ADMIN); there is no `userId`
- * field — the grant always targets the integration's OWN system user,
- * derived server-side in `grantIntegrationCaseAccess`, never a
- * caller-supplied one.
+ * Permission levels grantable to an integration's system user —
+ * VIEW/COMMENT/EDIT only, deliberately narrower than the full
+ * `permissionLevelSchema` (which also allows ADMIN for human case-sharing).
+ * Least privilege: no machine-facing surface in this codebase does anything
+ * with case-ADMIN today (team/collaborator management, deletion) that a
+ * machine principal has any business doing unattended, so there is nothing
+ * for machine-ADMIN to be USED for right now — granting it would be inert
+ * capability sitting on a system user, which is a standing risk with no
+ * offsetting benefit. A request naming ADMIN is rejected here with a 400
+ * validation error, never silently downgraded to EDIT — if machine-ADMIN is
+ * ever wanted, that should arrive as its own deliberate, reviewed change,
+ * not as a value this schema quietly lets through.
  */
-export const grantCaseAccessSchema = z.object({
-	caseId: uuidSchema,
-	permission: permissionLevelSchema,
+const grantableCasePermissionSchema = z.enum(["VIEW", "COMMENT", "EDIT"], {
+	message: "Invalid permission level",
 });
 
-export type GrantCaseAccessBody = z.infer<typeof grantCaseAccessSchema>;
+/**
+ * Body schema for granting an integration's system user access to a case.
+ * `permission` is restricted to `grantableCasePermissionSchema`
+ * (VIEW/COMMENT/EDIT — see its doc comment for why ADMIN is excluded); there
+ * is no `userId` field — the grant always targets the integration's OWN
+ * system user, derived server-side in `grantIntegrationCaseAccess`, never a
+ * caller-supplied one.
+ */
+// No `z.infer` alias here — nothing currently consumes a GrantCaseAccessBody
+// type outside the route's own `.safeParse` call (file convention — see
+// `updateIntegrationSchema`/`issueTokenSchema` above). Add one back when a
+// caller needs the parsed shape by name.
+export const grantCaseAccessSchema = z.object({
+	caseId: uuidSchema,
+	permission: grantableCasePermissionSchema,
+});
 
 // ============================================
 // Response wire shapes — settings UI

--- a/lib/schemas/integration.ts
+++ b/lib/schemas/integration.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import { SCOPES } from "@/lib/auth/scopes";
-import { optionalString, requiredString } from "@/lib/schemas/base";
+import {
+	optionalString,
+	permissionLevelSchema,
+	requiredString,
+	uuidSchema,
+} from "@/lib/schemas/base";
 
 /**
  * Zod schemas for the integration management API (ADR 0002 v2 §2.4, work
@@ -114,6 +119,25 @@ export const issueTokenSchema = z.object({
 		})
 		.optional(),
 });
+
+// ============================================
+// POST /api/integrations/[id]/case-grants
+// ============================================
+
+/**
+ * Body schema for granting an integration's system user access to a case.
+ * `permission` is restricted to the closed `PermissionLevel` enum
+ * (`permissionLevelSchema` — VIEW/COMMENT/EDIT/ADMIN); there is no `userId`
+ * field — the grant always targets the integration's OWN system user,
+ * derived server-side in `grantIntegrationCaseAccess`, never a
+ * caller-supplied one.
+ */
+export const grantCaseAccessSchema = z.object({
+	caseId: uuidSchema,
+	permission: permissionLevelSchema,
+});
+
+export type GrantCaseAccessBody = z.infer<typeof grantCaseAccessSchema>;
 
 // ============================================
 // Response wire shapes — settings UI

--- a/lib/services/integration-registry-service.ts
+++ b/lib/services/integration-registry-service.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/auth/api-token-service";
 import { findUnknownScopes, type Scope } from "@/lib/auth/scopes";
 import { addTimingNoise, isTimestampValid } from "@/lib/auth/timing-safe";
+import { canAccessCase } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import {
 	checkRateLimit,
@@ -16,6 +17,7 @@ import {
 import {
 	type ApiToken,
 	type Integration,
+	type PermissionLevel,
 	Prisma,
 } from "@/src/generated/prisma";
 import type { ServiceResult } from "@/types/service";
@@ -40,8 +42,9 @@ import type { ServiceResult } from "@/types/service";
  *   - INTEGRATION-keyed ops — `suspendIntegration`, `reactivateIntegration`,
  *     `revokeIntegration`, `issueToken`, `updateIntegration`/
  *     `updateIntegrationScopes`, `reassignIntegrationOwner`,
- *     `deleteIntegrationRegistration` — go through
- *     `getOwnedIntegrationOrError`.
+ *     `deleteIntegrationRegistration`, `listIntegrationCaseGrants`,
+ *     `grantIntegrationCaseAccess`, `revokeIntegrationCaseAccess` — go
+ *     through `getOwnedIntegrationOrError`.
  *   - TOKEN-keyed ops — `rotateToken`, `revokeToken` — go through
  *     `getOwnedApiTokenOrError`, its symmetrical twin. Ownership rides the
  *     token's OWN integration, not a path-supplied integration id; a caller
@@ -1055,4 +1058,237 @@ export async function validateApiToken(
 			tokenPrefix: record.tokenPrefix,
 		},
 	};
+}
+
+// ============================================
+// Case-access grants (ADR 0002 v2 — machine-access pillar; TEA — Integration
+// case-access grants need a product surface)
+// ============================================
+//
+// A registered integration authenticates fine on its own, but its system
+// user starts with ZERO case permissions — nothing granted here means an
+// integration that can present a valid bearer token yet touch no case at
+// all, with no in-product way to fix that (the gap this section closes).
+//
+// These three ops sit on a SECOND authorisation axis on top of every other
+// function in this file: `getOwnedIntegrationOrError` still gates who may
+// act on the INTEGRATION (unchanged), but granting/revoking access to a
+// CASE additionally requires the actor hold ADMIN on THAT case. That check
+// reuses `canAccessCase` from `lib/permissions.ts` directly rather than
+// `case-permission-service.ts`'s own `validateCaseAdmin` — that helper
+// isn't exported, and, more importantly, its "Permission denied" error maps
+// to a 403 (`lib/api-response.ts`'s `ERROR_MAPPINGS`), which here would
+// itself BE an enumeration oracle: a caller could distinguish "case doesn't
+// exist" (404) from "case exists but you're not its admin" (403).
+// `canAccessCase` already collapses both into a single `false` —
+// `getCasePermission` returns `hasAccess: false` for a nonexistent case
+// exactly like it does for "exists but no permission" (`lib/permissions.ts`)
+// — so every failure here is reported as "Case not found", the same
+// substring-matched 404 `serviceErrorToAppError` already gives
+// "Integration not found". A caller therefore cannot tell wrong integration
+// owner, no case-admin, or a nonexistent case apart from one another.
+
+export interface IntegrationCaseGrant {
+	caseId: string;
+	caseName: string;
+	grantedAt: Date;
+	permission: PermissionLevel;
+}
+
+/**
+ * Lists the integration's system user's current case permissions — the
+ * `GET /api/integrations/[id]/case-grants` data source. Owner-only
+ * (`getOwnedIntegrationOrError`); does not itself require case admin, since
+ * this only reads grants already made through this same authorised path.
+ */
+export async function listIntegrationCaseGrants(
+	integrationId: string,
+	actorUserId: string
+): ServiceResult<IntegrationCaseGrant[]> {
+	try {
+		const integration = await getOwnedIntegrationOrError(
+			integrationId,
+			actorUserId,
+			{ systemUserId: true }
+		);
+		if ("error" in integration) {
+			return integration;
+		}
+
+		const grants = await prisma.casePermission.findMany({
+			where: { userId: integration.data.systemUserId },
+			orderBy: { grantedAt: "desc" },
+			include: { case: { select: { id: true, name: true } } },
+		});
+
+		return {
+			data: grants.map((grant) => ({
+				caseId: grant.case.id,
+				caseName: grant.case.name,
+				permission: grant.permission,
+				grantedAt: grant.grantedAt,
+			})),
+		};
+	} catch {
+		return { error: "Failed to list case grants" };
+	}
+}
+
+export interface IntegrationCaseGrantResult {
+	alreadyGranted: boolean;
+	caseId: string;
+	caseName: string;
+	grantedAt: Date;
+	permission: PermissionLevel;
+}
+
+/**
+ * Upserts a `CasePermission` for the integration's system user — the target
+ * userId is NEVER caller-supplied, it is derived server-side from the
+ * integration (`integration.data.systemUserId`), so nothing in the request
+ * body can ever grant access to an arbitrary user. Requires the actor OWN
+ * the integration AND hold ADMIN on `caseId` (see the section doc comment
+ * above for why both collapse to the same "Case not found" / "Integration
+ * not found" 404 shape rather than a 403).
+ *
+ * Granting to a case the system user's integration already has access to
+ * never throws a unique-constraint error — it always goes through
+ * `upsert`, mirroring `shareByEmail`'s already-shared path. Re-granting the
+ * EXACT SAME permission level is idempotent success (`alreadyGranted:
+ * true`); re-granting a DIFFERENT level is a real write (the permission is
+ * updated) and reports `alreadyGranted: false` — either way it is a normal
+ * successful result, never an error. Granting when the system user is somehow already
+ * the case's owner (never expected in practice — integrations don't create
+ * cases — but checked defensively, same as `shareByEmail`'s owner check) is
+ * also idempotent success: the owner already has implicit ADMIN, and
+ * writing a `CasePermission` row for them would be a redundant, confusing
+ * state.
+ */
+export async function grantIntegrationCaseAccess(
+	integrationId: string,
+	caseId: string,
+	permission: PermissionLevel,
+	actorUserId: string
+): ServiceResult<IntegrationCaseGrantResult> {
+	try {
+		const integration = await getOwnedIntegrationOrError(
+			integrationId,
+			actorUserId,
+			{ systemUserId: true }
+		);
+		if ("error" in integration) {
+			return integration;
+		}
+
+		const hasCaseAdmin = await canAccessCase(
+			{ userId: actorUserId, caseId },
+			"ADMIN"
+		);
+		if (!hasCaseAdmin) {
+			return { error: "Case not found" };
+		}
+
+		const assuranceCase = await prisma.assuranceCase.findUnique({
+			where: { id: caseId },
+			select: { id: true, name: true, createdById: true },
+		});
+		if (!assuranceCase) {
+			return { error: "Case not found" };
+		}
+
+		const { systemUserId } = integration.data;
+
+		if (assuranceCase.createdById === systemUserId) {
+			return {
+				data: {
+					alreadyGranted: true,
+					caseId,
+					caseName: assuranceCase.name,
+					permission,
+					grantedAt: new Date(),
+				},
+			};
+		}
+
+		const existing = await prisma.casePermission.findUnique({
+			where: { caseId_userId: { caseId, userId: systemUserId } },
+		});
+
+		const grant = await prisma.casePermission.upsert({
+			where: { caseId_userId: { caseId, userId: systemUserId } },
+			create: {
+				caseId,
+				userId: systemUserId,
+				permission,
+				grantedById: actorUserId,
+			},
+			update: { permission, grantedById: actorUserId },
+		});
+
+		await writeAuditLog({
+			userId: actorUserId,
+			eventType: "integration_case_access_granted",
+			metadata: { integrationId, caseId, permission },
+		});
+
+		return {
+			data: {
+				alreadyGranted: Boolean(existing && existing.permission === permission),
+				caseId,
+				caseName: assuranceCase.name,
+				permission: grant.permission,
+				grantedAt: grant.grantedAt,
+			},
+		};
+	} catch {
+		return { error: "Failed to grant case access" };
+	}
+}
+
+/**
+ * Removes the integration's system user's `CasePermission` on `caseId`, if
+ * any. Same dual authorisation as `grantIntegrationCaseAccess`. Uses
+ * `deleteMany` rather than `delete` so revoking an already-absent grant is a
+ * no-op success rather than a Prisma "record not found" throw — revoke is
+ * idempotent by design here (unlike `revokeToken`, which treats a
+ * double-revoke as a 409 conflict: a case grant has no "already revoked"
+ * state worth surfacing, it either exists or it doesn't).
+ */
+export async function revokeIntegrationCaseAccess(
+	integrationId: string,
+	caseId: string,
+	actorUserId: string
+): ServiceResult<true> {
+	try {
+		const integration = await getOwnedIntegrationOrError(
+			integrationId,
+			actorUserId,
+			{ systemUserId: true }
+		);
+		if ("error" in integration) {
+			return integration;
+		}
+
+		const hasCaseAdmin = await canAccessCase(
+			{ userId: actorUserId, caseId },
+			"ADMIN"
+		);
+		if (!hasCaseAdmin) {
+			return { error: "Case not found" };
+		}
+
+		await prisma.casePermission.deleteMany({
+			where: { caseId, userId: integration.data.systemUserId },
+		});
+
+		await writeAuditLog({
+			userId: actorUserId,
+			eventType: "integration_case_access_revoked",
+			metadata: { integrationId, caseId },
+		});
+
+		return { data: true };
+	} catch {
+		return { error: "Failed to revoke case access" };
+	}
 }

--- a/lib/services/integration-registry-service.ts
+++ b/lib/services/integration-registry-service.ts
@@ -1070,23 +1070,44 @@ export async function validateApiToken(
 // integration that can present a valid bearer token yet touch no case at
 // all, with no in-product way to fix that (the gap this section closes).
 //
-// These three ops sit on a SECOND authorisation axis on top of every other
-// function in this file: `getOwnedIntegrationOrError` still gates who may
-// act on the INTEGRATION (unchanged), but granting/revoking access to a
-// CASE additionally requires the actor hold ADMIN on THAT case. That check
-// reuses `canAccessCase` from `lib/permissions.ts` directly rather than
-// `case-permission-service.ts`'s own `validateCaseAdmin` — that helper
-// isn't exported, and, more importantly, its "Permission denied" error maps
-// to a 403 (`lib/api-response.ts`'s `ERROR_MAPPINGS`), which here would
-// itself BE an enumeration oracle: a caller could distinguish "case doesn't
-// exist" (404) from "case exists but you're not its admin" (403).
-// `canAccessCase` already collapses both into a single `false` —
-// `getCasePermission` returns `hasAccess: false` for a nonexistent case
-// exactly like it does for "exists but no permission" (`lib/permissions.ts`)
-// — so every failure here is reported as "Case not found", the same
-// substring-matched 404 `serviceErrorToAppError` already gives
-// "Integration not found". A caller therefore cannot tell wrong integration
-// owner, no case-admin, or a nonexistent case apart from one another.
+// `grantIntegrationCaseAccess` / `revokeIntegrationCaseAccess` sit on a
+// SECOND authorisation axis on top of every other function in this file:
+// `getOwnedIntegrationOrError` still gates who may act on the INTEGRATION
+// (unchanged), but granting/revoking access to a CASE additionally requires
+// the actor hold ADMIN on THAT case. That check reuses `canAccessCase` from
+// `lib/permissions.ts` directly rather than `case-permission-service.ts`'s
+// own `validateCaseAdmin` — that helper isn't exported, and, more
+// importantly, its "Permission denied" error maps to a 403
+// (`lib/api-response.ts`'s `ERROR_MAPPINGS`), which here would itself BE an
+// enumeration oracle: a caller could distinguish "case doesn't exist" (404)
+// from "case exists but you're not its admin" (403). `canAccessCase` already
+// collapses both into a single `false` — `getCasePermission` returns
+// `hasAccess: false` for a nonexistent case exactly like it does for
+// "exists but no permission" (`lib/permissions.ts`) — so every failure here
+// is reported as "Case not found", the same substring-matched 404
+// `serviceErrorToAppError` already gives "Integration not found". A caller
+// therefore cannot tell wrong integration owner, no case-admin, or a
+// nonexistent case apart from one another. `requireIntegrationOwnerAndCaseAdmin`
+// below is the single choke point both ops go through for this check.
+//
+// `listIntegrationCaseGrants` is deliberately NOT gated on case-admin the
+// same way — it is owner-only, but per-row FILTERS its results to cases the
+// ACTOR (not the integration's system user) can currently VIEW, rather than
+// requiring admin on every row before returning any of them. An earlier
+// version of this comment justified skipping any case-level check at all on
+// the theory that a listed grant was "already made through this same
+// authorised path" — that reasoning does not survive
+// `reassignIntegrationOwner`: ownership can move to a user who was never the
+// one who granted any of these permissions and may hold no access at all to
+// some of the cases involved, so trusting integration-ownership alone would
+// let a newly-assigned owner enumerate case ids/names they cannot otherwise
+// see. Filtering by VIEW (not ADMIN) matches what listing actually discloses
+// (id + name), not the higher bar granting/revoking requires.
+//
+// Grant additionally requires the integration be ACTIVE
+// (`grantIntegrationCaseAccess`'s own doc comment) — list and revoke do not
+// carry that gate; see their doc comments for why leaving them ungated is
+// deliberate, not an oversight.
 
 export interface IntegrationCaseGrant {
 	caseId: string;
@@ -1097,9 +1118,19 @@ export interface IntegrationCaseGrant {
 
 /**
  * Lists the integration's system user's current case permissions — the
- * `GET /api/integrations/[id]/case-grants` data source. Owner-only
- * (`getOwnedIntegrationOrError`); does not itself require case admin, since
- * this only reads grants already made through this same authorised path.
+ * `GET /api/integrations/[id]/case-grants` data source. Owner-only at the
+ * INTEGRATION level (`getOwnedIntegrationOrError`), but each row is then
+ * filtered to cases the ACTOR (the calling human, not the integration's
+ * system user) can currently VIEW (`canAccessCase`, per-row) — deliberately
+ * NOT a blanket "owner may see every grant" read. Integration ownership can
+ * move (`reassignIntegrationOwner`) to a user who never made any of these
+ * grants and has no access themselves to some of the cases involved; without
+ * this filter, a newly-reassigned owner could learn case ids/names purely by
+ * having been handed the integration, which is exactly the kind of
+ * enumeration this module otherwise guards against (see the section doc
+ * comment above). Not gated on integration status — see
+ * `grantIntegrationCaseAccess`'s doc comment for why list/revoke stay
+ * ungated while grant does not.
  */
 export async function listIntegrationCaseGrants(
 	integrationId: string,
@@ -1121,13 +1152,21 @@ export async function listIntegrationCaseGrants(
 			include: { case: { select: { id: true, name: true } } },
 		});
 
+		const visibility = await Promise.all(
+			grants.map((grant) =>
+				canAccessCase({ userId: actorUserId, caseId: grant.case.id }, "VIEW")
+			)
+		);
+
 		return {
-			data: grants.map((grant) => ({
-				caseId: grant.case.id,
-				caseName: grant.case.name,
-				permission: grant.permission,
-				grantedAt: grant.grantedAt,
-			})),
+			data: grants
+				.filter((_grant, index) => visibility[index])
+				.map((grant) => ({
+					caseId: grant.case.id,
+					caseName: grant.case.name,
+					permission: grant.permission,
+					grantedAt: grant.grantedAt,
+				})),
 		};
 	} catch {
 		return { error: "Failed to list case grants" };
@@ -1143,13 +1182,84 @@ export interface IntegrationCaseGrantResult {
 }
 
 /**
+ * Shared preamble for the case-grant family (`grantIntegrationCaseAccess`,
+ * `revokeIntegrationCaseAccess`): verifies the actor owns `integrationId`
+ * (`getOwnedIntegrationOrError`) AND holds ADMIN on `caseId`
+ * (`canAccessCase`) — the second authorisation axis the section doc comment
+ * above describes. Both checks collapse to the exact same "Integration not
+ * found" / "Case not found" 404 shape their own call sites already produce
+ * (never a 403 — see the section comment for why). Returns the
+ * integration's `systemUserId` and `status` on success — `status` is
+ * fetched here (not by a second `getOwnedIntegrationOrError` call) purely so
+ * `grantIntegrationCaseAccess`'s own ACTIVE gate doesn't need a THIRD
+ * ownership query; `revokeIntegrationCaseAccess` just ignores it.
+ *
+ * Deduped from what used to be two independently-maintained copies of this
+ * exact block (fallow clone finding) — collapsing them here makes it
+ * structurally impossible for grant and revoke to drift onto two different
+ * error messages for the same failure, the same reasoning
+ * `getOwnedIntegrationOrError`'s own doc comment gives for existing.
+ */
+async function requireIntegrationOwnerAndCaseAdmin(
+	integrationId: string,
+	caseId: string,
+	actorUserId: string
+): ServiceResult<{ status: Integration["status"]; systemUserId: string }> {
+	const integration = await getOwnedIntegrationOrError(
+		integrationId,
+		actorUserId,
+		{ systemUserId: true, status: true }
+	);
+	if ("error" in integration) {
+		return integration;
+	}
+
+	const hasCaseAdmin = await canAccessCase(
+		{ userId: actorUserId, caseId },
+		"ADMIN"
+	);
+	if (!hasCaseAdmin) {
+		return { error: "Case not found" };
+	}
+
+	return { data: integration.data };
+}
+
+/**
  * Upserts a `CasePermission` for the integration's system user — the target
  * userId is NEVER caller-supplied, it is derived server-side from the
  * integration (`integration.data.systemUserId`), so nothing in the request
  * body can ever grant access to an arbitrary user. Requires the actor OWN
- * the integration AND hold ADMIN on `caseId` (see the section doc comment
- * above for why both collapse to the same "Case not found" / "Integration
- * not found" 404 shape rather than a 403).
+ * the integration AND hold ADMIN on `caseId`
+ * (`requireIntegrationOwnerAndCaseAdmin`; see the section doc comment above
+ * for why both collapse to the same "Case not found" / "Integration not
+ * found" 404 shape rather than a 403).
+ *
+ * Additionally requires the integration be ACTIVE — mirrors `issueToken`'s
+ * own guard and error shape ("Cannot grant case access for a non-active
+ * integration", mapped to 409 by `lib/api-response.ts`'s `ERROR_MAPPINGS`):
+ * handing a suspended or revoked integration's system user MORE case access
+ * makes no sense while it can't authenticate (SUSPENDED) or never will again
+ * (REVOKED). This check runs after `requireIntegrationOwnerAndCaseAdmin`
+ * rather than before — the two conditions are independent, so the ordering
+ * doesn't change what any caller can learn: failing case-admin always
+ * reports "Case not found" regardless of integration status, and an
+ * inactive integration always reports this conflict regardless of case
+ * access. `listIntegrationCaseGrants` and `revokeIntegrationCaseAccess`
+ * deliberately do NOT carry this gate — listing or revoking a suspended or
+ * revoked integration's access is exactly the cleanup path an operator
+ * needs after suspending/revoking it, and blocking that would make the
+ * suspend/revoke path harder to recover from, not safer.
+ *
+ * Rejects a soft-deleted (trashed) case identically to a nonexistent one —
+ * `deletedAt` is checked locally, in the query below, rather than inside
+ * `canAccessCase`/`lib/permissions.ts`: that helper ignoring soft-deletion
+ * is a pre-existing, platform-wide gap (tracked separately —
+ * "TEA — canAccessCase ignores soft-deleted cases (platform-wide)") that
+ * affects every caller of `canAccessCase`, not just this one; fixing it here
+ * only would paper over the general problem while leaving every other call
+ * site exposed, so this closes just the local hole (granting NEW machine
+ * access into trash) and leaves the platform-wide fix to that issue.
  *
  * Granting to a case the system user's integration already has access to
  * never throws a unique-constraint error — it always goes through
@@ -1163,6 +1273,14 @@ export interface IntegrationCaseGrantResult {
  * also idempotent success: the owner already has implicit ADMIN, and
  * writing a `CasePermission` row for them would be a redundant, confusing
  * state.
+ *
+ * The `assuranceCase` lookup below is a second query even though
+ * `canAccessCase` (inside `requireIntegrationOwnerAndCaseAdmin`) already
+ * reads the same row internally — folding the two was considered (V6) and
+ * NOT done: `canAccessCase` returns only a boolean, never the row, and
+ * extending its return shape (or `lib/permissions.ts` generally) is exactly
+ * the kind of platform-wide change the soft-delete issue above is already
+ * scoped to weigh, not a trivial fold to make incidentally here.
  */
 export async function grantIntegrationCaseAccess(
 	integrationId: string,
@@ -1171,32 +1289,27 @@ export async function grantIntegrationCaseAccess(
 	actorUserId: string
 ): ServiceResult<IntegrationCaseGrantResult> {
 	try {
-		const integration = await getOwnedIntegrationOrError(
+		const authorised = await requireIntegrationOwnerAndCaseAdmin(
 			integrationId,
-			actorUserId,
-			{ systemUserId: true }
+			caseId,
+			actorUserId
 		);
-		if ("error" in integration) {
-			return integration;
+		if ("error" in authorised) {
+			return authorised;
 		}
-
-		const hasCaseAdmin = await canAccessCase(
-			{ userId: actorUserId, caseId },
-			"ADMIN"
-		);
-		if (!hasCaseAdmin) {
-			return { error: "Case not found" };
+		if (authorised.data.status !== "ACTIVE") {
+			return { error: "Cannot grant case access for a non-active integration" };
 		}
 
 		const assuranceCase = await prisma.assuranceCase.findUnique({
 			where: { id: caseId },
-			select: { id: true, name: true, createdById: true },
+			select: { id: true, name: true, createdById: true, deletedAt: true },
 		});
-		if (!assuranceCase) {
+		if (!assuranceCase || assuranceCase.deletedAt) {
 			return { error: "Case not found" };
 		}
 
-		const { systemUserId } = integration.data;
+		const { systemUserId } = authorised.data;
 
 		if (assuranceCase.createdById === systemUserId) {
 			return {
@@ -1247,12 +1360,20 @@ export async function grantIntegrationCaseAccess(
 
 /**
  * Removes the integration's system user's `CasePermission` on `caseId`, if
- * any. Same dual authorisation as `grantIntegrationCaseAccess`. Uses
- * `deleteMany` rather than `delete` so revoking an already-absent grant is a
- * no-op success rather than a Prisma "record not found" throw — revoke is
- * idempotent by design here (unlike `revokeToken`, which treats a
- * double-revoke as a 409 conflict: a case grant has no "already revoked"
- * state worth surfacing, it either exists or it doesn't).
+ * any. Same dual authorisation as `grantIntegrationCaseAccess`
+ * (`requireIntegrationOwnerAndCaseAdmin`), but deliberately NOT gated on the
+ * integration's status — see `grantIntegrationCaseAccess`'s doc comment for
+ * why revoking (and listing) a suspended or revoked integration's case
+ * access must keep working: it is the operator's cleanup path, not a
+ * privilege grant. Uses `deleteMany` rather than `delete` so revoking an
+ * already-absent grant is a no-op success rather than a Prisma "record not
+ * found" throw — revoke is idempotent by design here (unlike `revokeToken`,
+ * which treats a double-revoke as a 409 conflict: a case grant has no
+ * "already revoked" state worth surfacing, it either exists or it doesn't).
+ * The audit log write is skipped when nothing was actually removed
+ * (`deleteMany`'s count is 0) — a revoke call against a grant that was never
+ * there is a real no-op, not an event worth recording in the security audit
+ * trail.
  */
 export async function revokeIntegrationCaseAccess(
 	integrationId: string,
@@ -1260,32 +1381,26 @@ export async function revokeIntegrationCaseAccess(
 	actorUserId: string
 ): ServiceResult<true> {
 	try {
-		const integration = await getOwnedIntegrationOrError(
+		const authorised = await requireIntegrationOwnerAndCaseAdmin(
 			integrationId,
-			actorUserId,
-			{ systemUserId: true }
+			caseId,
+			actorUserId
 		);
-		if ("error" in integration) {
-			return integration;
+		if ("error" in authorised) {
+			return authorised;
 		}
 
-		const hasCaseAdmin = await canAccessCase(
-			{ userId: actorUserId, caseId },
-			"ADMIN"
-		);
-		if (!hasCaseAdmin) {
-			return { error: "Case not found" };
+		const { count } = await prisma.casePermission.deleteMany({
+			where: { caseId, userId: authorised.data.systemUserId },
+		});
+
+		if (count > 0) {
+			await writeAuditLog({
+				userId: actorUserId,
+				eventType: "integration_case_access_revoked",
+				metadata: { integrationId, caseId },
+			});
 		}
-
-		await prisma.casePermission.deleteMany({
-			where: { caseId, userId: integration.data.systemUserId },
-		});
-
-		await writeAuditLog({
-			userId: actorUserId,
-			eventType: "integration_case_access_revoked",
-			metadata: { integrationId, caseId },
-		});
 
 		return { data: true };
 	} catch {

--- a/src/__tests__/integration/api-integration-case-grants.test.ts
+++ b/src/__tests__/integration/api-integration-case-grants.test.ts
@@ -1,0 +1,672 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { canAccessCase } from "@/lib/permissions";
+import prisma from "@/lib/prisma";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	createTestCase,
+	createTestIntegrationWithSystemUser,
+	createTestPermission,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+/**
+ * `POST/GET /api/integrations/[id]/case-grants` +
+ * `DELETE /api/integrations/[id]/case-grants/[caseId]` — the API surface
+ * that lets a human operator grant/list/revoke an integration's system
+ * user's access to a case (TEA — Integration case-access grants need a
+ * product surface). Mirrors `api-integrations.test.ts`'s conventions:
+ * real Postgres, mocked session auth, byte-identical-404 assertions for
+ * the no-enumeration-oracle guarantee.
+ */
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+beforeEach(async () => {
+	await mockNoAuth();
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+const NOT_FOUND_ID = "00000000-0000-0000-0000-000000000000";
+const INTEGRATION_NOT_FOUND = "Integration not found";
+const CASE_NOT_FOUND = "Case not found";
+
+function jsonRequest(url: string, method: string, body?: unknown): Request {
+	return new Request(`http://localhost:3000${url}`, {
+		method,
+		...(body !== undefined && { body: JSON.stringify(body) }),
+	});
+}
+
+function idParams(id: string) {
+	return { params: Promise.resolve({ id }) };
+}
+
+function caseGrantParams(id: string, caseId: string) {
+	return { params: Promise.resolve({ id, caseId }) };
+}
+
+describe("GET /api/integrations/[id]/case-grants", () => {
+	it("returns 401 when unauthenticated", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const { GET } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+
+		const response = await GET(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "GET"),
+			idParams(integration.id)
+		);
+		expect(response.status).toBe(401);
+	});
+
+	it("lists the integration's current case grants (case id/name + permission)", async () => {
+		const owner = await createTestUser();
+		const { integration, systemUser } =
+			await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(owner.id, { name: "Grant target" });
+		await createTestPermission(testCase.id, systemUser.id, owner.id, "EDIT");
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { GET } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		const response = await GET(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "GET"),
+			idParams(integration.id)
+		);
+		expect(response.status).toBe(200);
+
+		const body = await response.json();
+		expect(body.grants).toHaveLength(1);
+		expect(body.grants[0]).toMatchObject({
+			caseId: testCase.id,
+			caseName: "Grant target",
+			permission: "EDIT",
+		});
+	});
+
+	it("returns BYTE-IDENTICAL 404s for a non-owner vs a nonexistent integration id", async () => {
+		const owner = await createTestUser();
+		const outsider = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		await mockAuth(outsider.id, outsider.username, outsider.email);
+
+		const { GET } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		const nonOwnerResponse = await GET(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "GET"),
+			idParams(integration.id)
+		);
+		const nonexistentResponse = await GET(
+			jsonRequest(`/api/integrations/${NOT_FOUND_ID}/case-grants`, "GET"),
+			idParams(NOT_FOUND_ID)
+		);
+
+		expect(nonOwnerResponse.status).toBe(404);
+		expect(nonOwnerResponse.status).toBe(nonexistentResponse.status);
+		const nonOwnerBody = await nonOwnerResponse.json();
+		const nonexistentBody = await nonexistentResponse.json();
+		expect(nonOwnerBody).toEqual(nonexistentBody);
+		expect(nonOwnerBody.error).toBe(INTEGRATION_NOT_FOUND);
+	});
+});
+
+describe("POST /api/integrations/[id]/case-grants", () => {
+	it("returns 401 when unauthenticated", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(owner.id);
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+
+		const response = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "VIEW",
+			}),
+			idParams(integration.id)
+		);
+		expect(response.status).toBe(401);
+	});
+
+	it("owner+admin: grants access, creating a CasePermission for the integration's system user", async () => {
+		const owner = await createTestUser();
+		const { integration, systemUser } =
+			await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(owner.id, { name: "Owned case" });
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		const response = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "EDIT",
+			}),
+			idParams(integration.id)
+		);
+
+		expect(response.status).toBe(201);
+		const body = await response.json();
+		expect(body.grant).toMatchObject({
+			caseId: testCase.id,
+			caseName: "Owned case",
+			permission: "EDIT",
+			alreadyGranted: false,
+		});
+
+		const permission = await prisma.casePermission.findUnique({
+			where: { caseId_userId: { caseId: testCase.id, userId: systemUser.id } },
+		});
+		expect(permission?.permission).toBe("EDIT");
+
+		// The system user can now access the case at the granted level —
+		// this is the exact check a machine-facing case route would run via
+		// `requireApiToken`'s `systemUserId` (no machine case-read route
+		// exists yet to drive this end-to-end through a bearer token, so
+		// this pins the same access-control primitive that route would use).
+		expect(
+			await canAccessCase(
+				{ userId: systemUser.id, caseId: testCase.id },
+				"EDIT"
+			)
+		).toBe(true);
+	});
+
+	it("owner+admin-via-direct-share (not the case creator): grants access", async () => {
+		const creator = await createTestUser();
+		const admin = await createTestUser();
+		const { integration, systemUser } =
+			await createTestIntegrationWithSystemUser(admin.id);
+		const testCase = await createTestCase(creator.id);
+		await createTestPermission(testCase.id, admin.id, creator.id, "ADMIN");
+		await mockAuth(admin.id, admin.username, admin.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		const response = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "VIEW",
+			}),
+			idParams(integration.id)
+		);
+
+		expect(response.status).toBe(201);
+		expect(
+			await canAccessCase(
+				{ userId: systemUser.id, caseId: testCase.id },
+				"VIEW"
+			)
+		).toBe(true);
+	});
+
+	it("duplicate grant is idempotent success (200, alreadyGranted: true), not an error", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		const first = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "VIEW",
+			}),
+			idParams(integration.id)
+		);
+		expect(first.status).toBe(201);
+
+		const second = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "VIEW",
+			}),
+			idParams(integration.id)
+		);
+		expect(second.status).toBe(200);
+		const body = await second.json();
+		expect(body.grant.alreadyGranted).toBe(true);
+
+		// Still exactly one CasePermission row — the unique (caseId, userId)
+		// constraint is honoured via upsert, never a second row or an error.
+		const permissions = await prisma.casePermission.findMany({
+			where: { caseId: testCase.id },
+		});
+		expect(permissions).toHaveLength(1);
+	});
+
+	it("re-granting with a DIFFERENT permission level updates it (upsert) — a real change, so 201/alreadyGranted:false, never an error", async () => {
+		const owner = await createTestUser();
+		const { integration, systemUser } =
+			await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "VIEW",
+			}),
+			idParams(integration.id)
+		);
+		const response = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "ADMIN",
+			}),
+			idParams(integration.id)
+		);
+
+		expect(response.status).toBe(201);
+		const body = await response.json();
+		expect(body.grant.alreadyGranted).toBe(false);
+		const permission = await prisma.casePermission.findUnique({
+			where: { caseId_userId: { caseId: testCase.id, userId: systemUser.id } },
+		});
+		expect(permission?.permission).toBe("ADMIN");
+
+		// Still exactly one row — upsert on the (caseId, userId) unique
+		// constraint, never a second row for the same grant.
+		const permissions = await prisma.casePermission.findMany({
+			where: { caseId: testCase.id },
+		});
+		expect(permissions).toHaveLength(1);
+	});
+
+	it("returns BYTE-IDENTICAL 404s for a non-owner vs a nonexistent integration id", async () => {
+		const owner = await createTestUser();
+		const outsider = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(outsider.id, outsider.username, outsider.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		const nonOwnerResponse = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "VIEW",
+			}),
+			idParams(integration.id)
+		);
+		const nonexistentResponse = await POST(
+			jsonRequest(`/api/integrations/${NOT_FOUND_ID}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "VIEW",
+			}),
+			idParams(NOT_FOUND_ID)
+		);
+
+		expect(nonOwnerResponse.status).toBe(404);
+		expect(nonOwnerResponse.status).toBe(nonexistentResponse.status);
+		const nonOwnerBody = await nonOwnerResponse.json();
+		const nonexistentBody = await nonexistentResponse.json();
+		expect(nonOwnerBody).toEqual(nonexistentBody);
+		expect(nonOwnerBody.error).toBe(INTEGRATION_NOT_FOUND);
+	});
+
+	/**
+	 * The dispatch's core requirement: an actor who OWNS the integration but
+	 * has no ADMIN permission on the target case must fail exactly like a
+	 * nonexistent case — same status, same message — never a distinct 403
+	 * that would leak "the case exists, you're just not its admin".
+	 */
+	it("owner-but-not-case-admin fails as not-found, BYTE-IDENTICAL to a nonexistent case", async () => {
+		const owner = await createTestUser();
+		const caseCreator = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(caseCreator.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		const notAdminResponse = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "VIEW",
+			}),
+			idParams(integration.id)
+		);
+		const nonexistentCaseResponse = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: NOT_FOUND_ID,
+				permission: "VIEW",
+			}),
+			idParams(integration.id)
+		);
+
+		expect(notAdminResponse.status).toBe(404);
+		expect(notAdminResponse.status).toBe(nonexistentCaseResponse.status);
+		const notAdminBody = await notAdminResponse.json();
+		const nonexistentCaseBody = await nonexistentCaseResponse.json();
+		expect(notAdminBody).toEqual(nonexistentCaseBody);
+		expect(notAdminBody.error).toBe(CASE_NOT_FOUND);
+	});
+
+	it("case admin via VIEW/COMMENT/EDIT (below ADMIN) also fails as not-found", async () => {
+		const owner = await createTestUser();
+		const caseCreator = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(caseCreator.id);
+		await createTestPermission(testCase.id, owner.id, caseCreator.id, "EDIT");
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		const response = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "VIEW",
+			}),
+			idParams(integration.id)
+		);
+
+		expect(response.status).toBe(404);
+		expect((await response.json()).error).toBe(CASE_NOT_FOUND);
+	});
+
+	it("rejects an invalid permission value with 400", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		const response = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "SUPER_ADMIN",
+			}),
+			idParams(integration.id)
+		);
+		expect(response.status).toBe(400);
+	});
+
+	it("rejects a non-UUID caseId with 400", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		const response = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: "not-a-uuid",
+				permission: "VIEW",
+			}),
+			idParams(integration.id)
+		);
+		expect(response.status).toBe(400);
+	});
+
+	it("cannot grant access to an arbitrary userId — the body has no such field", async () => {
+		const owner = await createTestUser();
+		const other = await createTestUser();
+		const { integration, systemUser } =
+			await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "VIEW",
+				userId: other.id,
+			}),
+			idParams(integration.id)
+		);
+
+		// Only the integration's OWN system user ever gets a grant.
+		const grantedForOther = await prisma.casePermission.findUnique({
+			where: { caseId_userId: { caseId: testCase.id, userId: other.id } },
+		});
+		expect(grantedForOther).toBeNull();
+		const grantedForSystemUser = await prisma.casePermission.findUnique({
+			where: {
+				caseId_userId: { caseId: testCase.id, userId: systemUser.id },
+			},
+		});
+		expect(grantedForSystemUser).not.toBeNull();
+	});
+
+	it("writes a SecurityAuditLog row for a grant", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "VIEW",
+			}),
+			idParams(integration.id)
+		);
+
+		const event = await prisma.securityAuditLog.findFirst({
+			where: { userId: owner.id, eventType: "integration_case_access_granted" },
+		});
+		expect(event).not.toBeNull();
+	});
+});
+
+describe("DELETE /api/integrations/[id]/case-grants/[caseId]", () => {
+	it("returns 401 when unauthenticated", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(owner.id);
+		const { DELETE } = await import(
+			"@/app/api/integrations/[id]/case-grants/[caseId]/route"
+		);
+
+		const response = await DELETE(
+			jsonRequest(
+				`/api/integrations/${integration.id}/case-grants/${testCase.id}`,
+				"DELETE"
+			),
+			caseGrantParams(integration.id, testCase.id)
+		);
+		expect(response.status).toBe(401);
+	});
+
+	it("revokes access — a system user that could VIEW the case loses access after revoke", async () => {
+		const owner = await createTestUser();
+		const { integration, systemUser } =
+			await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(owner.id);
+		await createTestPermission(testCase.id, systemUser.id, owner.id, "VIEW");
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		expect(
+			await canAccessCase(
+				{ userId: systemUser.id, caseId: testCase.id },
+				"VIEW"
+			)
+		).toBe(true);
+
+		const { DELETE } = await import(
+			"@/app/api/integrations/[id]/case-grants/[caseId]/route"
+		);
+		const response = await DELETE(
+			jsonRequest(
+				`/api/integrations/${integration.id}/case-grants/${testCase.id}`,
+				"DELETE"
+			),
+			caseGrantParams(integration.id, testCase.id)
+		);
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.success).toBe(true);
+
+		expect(
+			await canAccessCase(
+				{ userId: systemUser.id, caseId: testCase.id },
+				"VIEW"
+			)
+		).toBe(false);
+		const permission = await prisma.casePermission.findUnique({
+			where: {
+				caseId_userId: { caseId: testCase.id, userId: systemUser.id },
+			},
+		});
+		expect(permission).toBeNull();
+	});
+
+	it("revoking a grant that never existed is idempotent success, not an error", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { DELETE } = await import(
+			"@/app/api/integrations/[id]/case-grants/[caseId]/route"
+		);
+		const response = await DELETE(
+			jsonRequest(
+				`/api/integrations/${integration.id}/case-grants/${testCase.id}`,
+				"DELETE"
+			),
+			caseGrantParams(integration.id, testCase.id)
+		);
+		expect(response.status).toBe(200);
+	});
+
+	it("returns BYTE-IDENTICAL 404s for a non-owner vs a nonexistent integration id", async () => {
+		const owner = await createTestUser();
+		const outsider = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(outsider.id, outsider.username, outsider.email);
+
+		const { DELETE } = await import(
+			"@/app/api/integrations/[id]/case-grants/[caseId]/route"
+		);
+		const nonOwnerResponse = await DELETE(
+			jsonRequest(
+				`/api/integrations/${integration.id}/case-grants/${testCase.id}`,
+				"DELETE"
+			),
+			caseGrantParams(integration.id, testCase.id)
+		);
+		const nonexistentResponse = await DELETE(
+			jsonRequest(
+				`/api/integrations/${NOT_FOUND_ID}/case-grants/${testCase.id}`,
+				"DELETE"
+			),
+			caseGrantParams(NOT_FOUND_ID, testCase.id)
+		);
+
+		expect(nonOwnerResponse.status).toBe(404);
+		expect(nonOwnerResponse.status).toBe(nonexistentResponse.status);
+		const nonOwnerBody = await nonOwnerResponse.json();
+		const nonexistentBody = await nonexistentResponse.json();
+		expect(nonOwnerBody).toEqual(nonexistentBody);
+		expect(nonOwnerBody.error).toBe(INTEGRATION_NOT_FOUND);
+	});
+
+	it("owner-but-not-case-admin fails as not-found, BYTE-IDENTICAL to a nonexistent case", async () => {
+		const owner = await createTestUser();
+		const caseCreator = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(caseCreator.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { DELETE } = await import(
+			"@/app/api/integrations/[id]/case-grants/[caseId]/route"
+		);
+		const notAdminResponse = await DELETE(
+			jsonRequest(
+				`/api/integrations/${integration.id}/case-grants/${testCase.id}`,
+				"DELETE"
+			),
+			caseGrantParams(integration.id, testCase.id)
+		);
+		const nonexistentCaseResponse = await DELETE(
+			jsonRequest(
+				`/api/integrations/${integration.id}/case-grants/${NOT_FOUND_ID}`,
+				"DELETE"
+			),
+			caseGrantParams(integration.id, NOT_FOUND_ID)
+		);
+
+		expect(notAdminResponse.status).toBe(404);
+		expect(notAdminResponse.status).toBe(nonexistentCaseResponse.status);
+		const notAdminBody = await notAdminResponse.json();
+		const nonexistentCaseBody = await nonexistentCaseResponse.json();
+		expect(notAdminBody).toEqual(nonexistentCaseBody);
+		expect(notAdminBody.error).toBe(CASE_NOT_FOUND);
+	});
+
+	it("rejects a non-UUID path id with 400", async () => {
+		const owner = await createTestUser();
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { DELETE } = await import(
+			"@/app/api/integrations/[id]/case-grants/[caseId]/route"
+		);
+		const response = await DELETE(
+			jsonRequest(
+				"/api/integrations/not-a-uuid/case-grants/also-not-a-uuid",
+				"DELETE"
+			),
+			caseGrantParams("not-a-uuid", "also-not-a-uuid")
+		);
+		expect(response.status).toBe(400);
+	});
+
+	it("writes a SecurityAuditLog row for a revoke", async () => {
+		const owner = await createTestUser();
+		const { integration, systemUser } =
+			await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(owner.id);
+		await createTestPermission(testCase.id, systemUser.id, owner.id, "VIEW");
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { DELETE } = await import(
+			"@/app/api/integrations/[id]/case-grants/[caseId]/route"
+		);
+		await DELETE(
+			jsonRequest(
+				`/api/integrations/${integration.id}/case-grants/${testCase.id}`,
+				"DELETE"
+			),
+			caseGrantParams(integration.id, testCase.id)
+		);
+
+		const event = await prisma.securityAuditLog.findFirst({
+			where: {
+				userId: owner.id,
+				eventType: "integration_case_access_revoked",
+			},
+		});
+		expect(event).not.toBeNull();
+	});
+});

--- a/src/__tests__/integration/api-integration-case-grants.test.ts
+++ b/src/__tests__/integration/api-integration-case-grants.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { canAccessCase } from "@/lib/permissions";
 import prisma from "@/lib/prisma";
+import { reassignIntegrationOwner } from "@/lib/services/integration-registry-service";
 import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
 import {
 	createTestCase,
@@ -115,6 +116,104 @@ describe("GET /api/integrations/[id]/case-grants", () => {
 		const nonexistentBody = await nonexistentResponse.json();
 		expect(nonOwnerBody).toEqual(nonexistentBody);
 		expect(nonOwnerBody.error).toBe(INTEGRATION_NOT_FOUND);
+	});
+
+	/**
+	 * V1: a reassigned owner must not learn the id/name of a case they
+	 * cannot themselves access, purely by having been handed the
+	 * integration — even though the `CasePermission` row for the
+	 * integration's system user still exists and is untouched.
+	 */
+	it("filters out grants for cases the new owner cannot access after reassignment", async () => {
+		const caseCreator = await createTestUser();
+		const originalOwner = await createTestUser();
+		const newOwner = await createTestUser();
+		const { integration, systemUser } =
+			await createTestIntegrationWithSystemUser(originalOwner.id);
+		const testCase = await createTestCase(caseCreator.id, {
+			name: "Not the new owner's case",
+		});
+		await createTestPermission(
+			testCase.id,
+			originalOwner.id,
+			caseCreator.id,
+			"ADMIN"
+		);
+		await createTestPermission(
+			testCase.id,
+			systemUser.id,
+			originalOwner.id,
+			"VIEW"
+		);
+
+		const reassignResult = await reassignIntegrationOwner(
+			integration.id,
+			newOwner.id,
+			originalOwner.id
+		);
+		expect("data" in reassignResult).toBe(true);
+
+		await mockAuth(newOwner.id, newOwner.username, newOwner.email);
+		const { GET } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		const response = await GET(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "GET"),
+			idParams(integration.id)
+		);
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.grants).toHaveLength(0);
+
+		// The underlying grant is untouched by the filter — only the LIST
+		// response is narrowed for this caller.
+		const permission = await prisma.casePermission.findUnique({
+			where: { caseId_userId: { caseId: testCase.id, userId: systemUser.id } },
+		});
+		expect(permission).not.toBeNull();
+
+		// Once the new owner is ALSO given their own access to the case, the
+		// same grant becomes visible to them.
+		await createTestPermission(
+			testCase.id,
+			newOwner.id,
+			caseCreator.id,
+			"VIEW"
+		);
+		const secondResponse = await GET(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "GET"),
+			idParams(integration.id)
+		);
+		const secondBody = await secondResponse.json();
+		expect(secondBody.grants).toHaveLength(1);
+		expect(secondBody.grants[0].caseId).toBe(testCase.id);
+	});
+
+	/**
+	 * N1: list is deliberately ungated on integration status — a REVOKED
+	 * integration's existing grants must still be readable (the operator's
+	 * cleanup path), unlike granting new access, which N1 blocks.
+	 */
+	it("still lists grants when the integration is REVOKED", async () => {
+		const owner = await createTestUser();
+		const { integration, systemUser } =
+			await createTestIntegrationWithSystemUser(owner.id, {
+				status: "REVOKED",
+			});
+		const testCase = await createTestCase(owner.id, { name: "Revoked target" });
+		await createTestPermission(testCase.id, systemUser.id, owner.id, "VIEW");
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { GET } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		const response = await GET(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "GET"),
+			idParams(integration.id)
+		);
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.grants).toHaveLength(1);
 	});
 });
 
@@ -268,7 +367,7 @@ describe("POST /api/integrations/[id]/case-grants", () => {
 		const response = await POST(
 			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
 				caseId: testCase.id,
-				permission: "ADMIN",
+				permission: "EDIT",
 			}),
 			idParams(integration.id)
 		);
@@ -279,7 +378,7 @@ describe("POST /api/integrations/[id]/case-grants", () => {
 		const permission = await prisma.casePermission.findUnique({
 			where: { caseId_userId: { caseId: testCase.id, userId: systemUser.id } },
 		});
-		expect(permission?.permission).toBe("ADMIN");
+		expect(permission?.permission).toBe("EDIT");
 
 		// Still exactly one row — upsert on the (caseId, userId) unique
 		// constraint, never a second row for the same grant.
@@ -287,6 +386,39 @@ describe("POST /api/integrations/[id]/case-grants", () => {
 			where: { caseId: testCase.id },
 		});
 		expect(permissions).toHaveLength(1);
+	});
+
+	/**
+	 * V2: ADMIN is excluded from the grantable set — a machine principal has
+	 * no use for case-ADMIN today, so requesting it is a 400 validation
+	 * error, never a silent downgrade to a lower level (see
+	 * `grantCaseAccessSchema`'s doc comment, `lib/schemas/integration.ts`).
+	 * This is the inversion of the old "upsert to ADMIN" proof above — that
+	 * proof now uses EDIT instead, since ADMIN is no longer a legal request.
+	 */
+	it("rejects granting permission: ADMIN with 400 — never a silent downgrade", async () => {
+		const owner = await createTestUser();
+		const { integration, systemUser } =
+			await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		const response = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "ADMIN",
+			}),
+			idParams(integration.id)
+		);
+
+		expect(response.status).toBe(400);
+		const permission = await prisma.casePermission.findUnique({
+			where: { caseId_userId: { caseId: testCase.id, userId: systemUser.id } },
+		});
+		expect(permission).toBeNull();
 	});
 
 	it("returns BYTE-IDENTICAL 404s for a non-owner vs a nonexistent integration id", async () => {
@@ -454,7 +586,12 @@ describe("POST /api/integrations/[id]/case-grants", () => {
 		expect(grantedForSystemUser).not.toBeNull();
 	});
 
-	it("writes a SecurityAuditLog row for a grant", async () => {
+	/**
+	 * N3: assert the audit row's METADATA, not just its presence — the
+	 * prior version of this test only checked a matching row existed, which
+	 * would pass even if the metadata were empty or wrong.
+	 */
+	it("writes a SecurityAuditLog row for a grant, with integrationId/caseId/permission in its metadata", async () => {
 		const owner = await createTestUser();
 		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
 		const testCase = await createTestCase(owner.id);
@@ -466,7 +603,7 @@ describe("POST /api/integrations/[id]/case-grants", () => {
 		await POST(
 			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
 				caseId: testCase.id,
-				permission: "VIEW",
+				permission: "EDIT",
 			}),
 			idParams(integration.id)
 		);
@@ -475,6 +612,114 @@ describe("POST /api/integrations/[id]/case-grants", () => {
 			where: { userId: owner.id, eventType: "integration_case_access_granted" },
 		});
 		expect(event).not.toBeNull();
+		expect(event?.metadata).toMatchObject({
+			integrationId: integration.id,
+			caseId: testCase.id,
+			permission: "EDIT",
+		});
+	});
+
+	/**
+	 * N1: granting is gated on the integration being ACTIVE — mirrors
+	 * `issueToken`'s own guard. GET/DELETE deliberately do NOT carry this
+	 * gate (see the "still lists"/"still revokes" tests in their own
+	 * describe blocks).
+	 */
+	it("rejects granting case access via a SUSPENDED integration with 409", async () => {
+		const owner = await createTestUser();
+		const { integration, systemUser } =
+			await createTestIntegrationWithSystemUser(owner.id, {
+				status: "SUSPENDED",
+			});
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		const response = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "VIEW",
+			}),
+			idParams(integration.id)
+		);
+
+		expect(response.status).toBe(409);
+		const permission = await prisma.casePermission.findUnique({
+			where: { caseId_userId: { caseId: testCase.id, userId: systemUser.id } },
+		});
+		expect(permission).toBeNull();
+	});
+
+	it("rejects granting case access via a REVOKED integration with 409", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(
+			owner.id,
+			{
+				status: "REVOKED",
+			}
+		);
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		const response = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "VIEW",
+			}),
+			idParams(integration.id)
+		);
+
+		expect(response.status).toBe(409);
+	});
+
+	/**
+	 * N2: a soft-deleted (trashed) case is rejected identically to a
+	 * nonexistent one — `canAccessCase` itself doesn't know about
+	 * `deletedAt` (a separate, platform-wide gap — see
+	 * `grantIntegrationCaseAccess`'s doc comment), but the owner here IS the
+	 * case's creator, so `canAccessCase` still reports ADMIN regardless of
+	 * trashing; the LOCAL `deletedAt` check in the grant path is what must
+	 * catch this.
+	 */
+	it("rejects granting access into a soft-deleted case, BYTE-IDENTICAL 404 to nonexistent", async () => {
+		const owner = await createTestUser();
+		const { integration } = await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(owner.id);
+		await prisma.assuranceCase.update({
+			where: { id: testCase.id },
+			data: { deletedAt: new Date() },
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		const trashedResponse = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "VIEW",
+			}),
+			idParams(integration.id)
+		);
+		const nonexistentResponse = await POST(
+			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
+				caseId: NOT_FOUND_ID,
+				permission: "VIEW",
+			}),
+			idParams(integration.id)
+		);
+
+		expect(trashedResponse.status).toBe(404);
+		expect(trashedResponse.status).toBe(nonexistentResponse.status);
+		const trashedBody = await trashedResponse.json();
+		const nonexistentBody = await nonexistentResponse.json();
+		expect(trashedBody).toEqual(nonexistentBody);
+		expect(trashedBody.error).toBe(CASE_NOT_FOUND);
 	});
 });
 
@@ -557,6 +802,48 @@ describe("DELETE /api/integrations/[id]/case-grants/[caseId]", () => {
 			caseGrantParams(integration.id, testCase.id)
 		);
 		expect(response.status).toBe(200);
+
+		// V5: a no-op revoke (nothing to delete) writes NO audit row — the
+		// gate is on `deleteMany`'s count, not on the call having been made.
+		const event = await prisma.securityAuditLog.findFirst({
+			where: { userId: owner.id, eventType: "integration_case_access_revoked" },
+		});
+		expect(event).toBeNull();
+	});
+
+	/**
+	 * N1: list/revoke are deliberately NOT gated on integration status —
+	 * revoking a REVOKED integration's case access must still work, since
+	 * it is the operator's cleanup path (contrast with granting, which N1
+	 * blocks for a non-ACTIVE integration).
+	 */
+	it("still revokes access when the integration is REVOKED", async () => {
+		const owner = await createTestUser();
+		const { integration, systemUser } =
+			await createTestIntegrationWithSystemUser(owner.id, {
+				status: "REVOKED",
+			});
+		const testCase = await createTestCase(owner.id);
+		await createTestPermission(testCase.id, systemUser.id, owner.id, "VIEW");
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { DELETE } = await import(
+			"@/app/api/integrations/[id]/case-grants/[caseId]/route"
+		);
+		const response = await DELETE(
+			jsonRequest(
+				`/api/integrations/${integration.id}/case-grants/${testCase.id}`,
+				"DELETE"
+			),
+			caseGrantParams(integration.id, testCase.id)
+		);
+		expect(response.status).toBe(200);
+		const permission = await prisma.casePermission.findUnique({
+			where: {
+				caseId_userId: { caseId: testCase.id, userId: systemUser.id },
+			},
+		});
+		expect(permission).toBeNull();
 	});
 
 	it("returns BYTE-IDENTICAL 404s for a non-owner vs a nonexistent integration id", async () => {
@@ -642,7 +929,11 @@ describe("DELETE /api/integrations/[id]/case-grants/[caseId]", () => {
 		expect(response.status).toBe(400);
 	});
 
-	it("writes a SecurityAuditLog row for a revoke", async () => {
+	/**
+	 * N3: assert the audit row's METADATA, not just its presence (same
+	 * upgrade as the grant-side audit test above).
+	 */
+	it("writes a SecurityAuditLog row for a revoke, with integrationId/caseId in its metadata", async () => {
 		const owner = await createTestUser();
 		const { integration, systemUser } =
 			await createTestIntegrationWithSystemUser(owner.id);
@@ -668,5 +959,9 @@ describe("DELETE /api/integrations/[id]/case-grants/[caseId]", () => {
 			},
 		});
 		expect(event).not.toBeNull();
+		expect(event?.metadata).toMatchObject({
+			integrationId: integration.id,
+			caseId: testCase.id,
+		});
 	});
 });


### PR DESCRIPTION
Closes the gap found in the 2026-07-13 keystone rehearsal: there was no product surface for granting an integration's machine user access to a case — a recreated integration could authenticate but touch nothing, with no in-product recovery.

Adds `listIntegrationCaseGrants` / `grantIntegrationCaseAccess` / `revokeIntegrationCaseAccess` plus `GET/POST /api/integrations/[id]/case-grants` and `DELETE .../case-grants/[caseId]`. The settings-page UI half follows separately.

## Security model
- Actor must own the integration AND hold ADMIN on the target case; every failure collapses to byte-identical 404s (no enumeration oracle — verified against the ERROR_MAPPINGS order).
- Grants always target the integration's own system user, derived server-side — the body has no userId field.
- Grantable levels capped at VIEW/COMMENT/EDIT; ADMIN is a 400, never a silent downgrade (no machine surface consumes case-ADMIN today; escalation trace confirmed it unlocks nothing).
- Granting requires an ACTIVE integration (409 otherwise); list/revoke deliberately stay available on suspended/revoked integrations as the operator cleanup path.
- Grants into soft-deleted cases rejected identically to nonexistent ones.
- List results are filtered per-row to cases the caller can view — a reassigned integration owner cannot enumerate case names they lack access to.

## Review chain
- Code review: approve-with-nits — all nits folded in a reviewed fix batch (shared authorisation preamble, audit write gated on actual deletion, unused export dropped).
- QA: pass-with-gaps — 225/225 across target + 7 adjacent suites; all gap findings adjudicated and either fixed here or tracked (platform-wide soft-delete permission behaviour has its own issue).
- Post-review delta verified line-by-line against the prescriptions before push.