### PR TITLE
Integration case-access UI + delete guard (stacked on #858)

### DIFF
--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/case-access-section.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/case-access-section.test.tsx
@@ -20,6 +20,9 @@ const CANCEL_BUTTON_REGEX = /^cancel$/i;
 const EMPTY_STATE_TEXT_REGEX =
 	/which cases this integration's machine user can touch/i;
 const INTEGRATION_MUST_BE_ACTIVE_REGEX = /integration must be active/i;
+const TRY_AGAIN_BUTTON_REGEX = /^try again$/i;
+const ADMIN_OPTION_REGEX = /admin/i;
+const GRANTING_BUTTON_REGEX = /^granting…$/i;
 
 vi.mock("@/actions/assurance-cases", () => ({
 	fetchAssuranceCases: vi.fn().mockResolvedValue([
@@ -43,10 +46,12 @@ function makeGrant(
 const baseProps = {
 	granting: false,
 	grantError: null,
+	integrationActive: true,
 	loadError: null,
 	loading: false,
 	onGrant: vi.fn().mockResolvedValue(true),
 	onRemove: vi.fn(),
+	onRetry: vi.fn(),
 	removingCaseId: null,
 };
 
@@ -89,6 +94,63 @@ describe("CaseAccessSection", () => {
 			expect(
 				screen.queryByTestId(CASE_ROW_TEST_ID_REGEX)
 			).not.toBeInTheDocument();
+		});
+	});
+
+	describe("activation gating", () => {
+		it("disables the grant trigger with a tooltip when the integration isn't ACTIVE", () => {
+			renderWithoutProviders(
+				<CaseAccessSection
+					{...baseProps}
+					grants={[]}
+					integrationActive={false}
+				/>
+			);
+
+			const trigger = screen.getByRole("button", { name: GRANT_TRIGGER_REGEX });
+			expect(trigger).toBeDisabled();
+			expect(trigger).toHaveAttribute(
+				"title",
+				"Only an ACTIVE integration can be granted access to a case"
+			);
+		});
+
+		it("leaves existing grants' remove action enabled when the integration isn't ACTIVE — only the grant trigger is gated (N1: GET/DELETE deliberately ungated)", () => {
+			renderWithoutProviders(
+				<CaseAccessSection
+					{...baseProps}
+					grants={[makeGrant({ caseId: "case-1", caseName: "Alpha" })]}
+					integrationActive={false}
+				/>
+			);
+
+			expect(
+				screen.getByRole("button", { name: REMOVE_ALPHA_TRIGGER_REGEX })
+			).not.toBeDisabled();
+		});
+	});
+
+	describe("load error", () => {
+		it("shows a Try again button wired to onRetry alongside the error message", async () => {
+			const onRetry = vi.fn();
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<CaseAccessSection
+					{...baseProps}
+					grants={[]}
+					loadError="Failed to list case grants"
+					onRetry={onRetry}
+				/>
+			);
+
+			expect(
+				screen.getByText("Failed to list case grants")
+			).toBeInTheDocument();
+
+			await user.click(
+				screen.getByRole("button", { name: TRY_AGAIN_BUTTON_REGEX })
+			);
+			expect(onRetry).toHaveBeenCalledTimes(1);
 		});
 	});
 
@@ -190,6 +252,78 @@ describe("CaseAccessSection", () => {
 				screen.getByRole("button", { name: GRANT_SUBMIT_REGEX })
 			).toBeInTheDocument();
 		});
+
+		it("never offers ADMIN as a permission option — only VIEW/COMMENT/EDIT (a machine principal can never hold case-ADMIN)", async () => {
+			const user = userEvent.setup();
+			renderWithoutProviders(<CaseAccessSection {...baseProps} grants={[]} />);
+
+			await user.click(
+				screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+			);
+			await waitFor(() =>
+				expect(
+					screen.getByRole("combobox", { name: CASE_COMBOBOX_REGEX })
+				).toBeInTheDocument()
+			);
+			await user.click(
+				screen.getByRole("combobox", { name: PERMISSION_COMBOBOX_REGEX })
+			);
+
+			const options = screen.getAllByRole("option");
+			expect(options.map((option) => option.textContent)).toEqual([
+				"Can view",
+				"Can comment",
+				"Can edit",
+			]);
+			expect(
+				screen.queryByRole("option", { name: ADMIN_OPTION_REGEX })
+			).not.toBeInTheDocument();
+		});
+
+		it("disables the submit button while a grant is in flight, so a further click fires nothing", async () => {
+			const onGrant = vi.fn().mockResolvedValue(true);
+			const user = userEvent.setup();
+			const { rerender } = renderWithoutProviders(
+				<CaseAccessSection {...baseProps} grants={[]} onGrant={onGrant} />
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+			);
+			await waitFor(() =>
+				expect(
+					screen.getByRole("combobox", { name: CASE_COMBOBOX_REGEX })
+				).toBeInTheDocument()
+			);
+			await user.click(
+				screen.getByRole("combobox", { name: CASE_COMBOBOX_REGEX })
+			);
+			await user.click(screen.getByRole("option", { name: "Assurance" }));
+
+			// Mirrors the real sequence: the instant `onGrant` (backed by the
+			// real hook's `grantAccess`) goes in flight, `IntegrationCard` passes
+			// down `granting: true` from `useIntegrationCaseGrants` a render
+			// later — this rerender is that update, same convention as the 409
+			// test above.
+			rerender(
+				<CaseAccessSection
+					{...baseProps}
+					granting={true}
+					grants={[]}
+					onGrant={onGrant}
+				/>
+			);
+
+			// Its label switches to "Granting…" the instant `granting` flips —
+			// same busy-label convention as the Issue-Token button.
+			const submitButton = screen.getByRole("button", {
+				name: GRANTING_BUTTON_REGEX,
+			});
+			expect(submitButton).toBeDisabled();
+
+			await user.click(submitButton);
+			expect(onGrant).not.toHaveBeenCalled();
+		});
 	});
 
 	describe("remove flow", () => {
@@ -238,6 +372,49 @@ describe("CaseAccessSection", () => {
 			expect(
 				screen.queryByText(REMOVE_CONFIRM_TEXT_REGEX)
 			).not.toBeInTheDocument();
+		});
+
+		it("moves focus to the Confirm button the moment the inline confirm appears", async () => {
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<CaseAccessSection
+					{...baseProps}
+					grants={[makeGrant({ caseId: "case-1", caseName: "Alpha" })]}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: REMOVE_ALPHA_TRIGGER_REGEX })
+			);
+
+			await waitFor(() =>
+				expect(
+					screen.getByRole("button", { name: CONFIRM_BUTTON_REGEX })
+				).toHaveFocus()
+			);
+		});
+
+		it("returns focus to the Remove trigger when the inline confirm is cancelled", async () => {
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<CaseAccessSection
+					{...baseProps}
+					grants={[makeGrant({ caseId: "case-1", caseName: "Alpha" })]}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: REMOVE_ALPHA_TRIGGER_REGEX })
+			);
+			await user.click(
+				screen.getByRole("button", { name: CANCEL_BUTTON_REGEX })
+			);
+
+			await waitFor(() =>
+				expect(
+					screen.getByRole("button", { name: REMOVE_ALPHA_TRIGGER_REGEX })
+				).toHaveFocus()
+			);
 		});
 	});
 });

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/case-access-section.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/case-access-section.test.tsx
@@ -1,0 +1,243 @@
+import { waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { IntegrationCaseGrant } from "@/lib/schemas/integration";
+import {
+	renderWithoutProviders,
+	screen,
+} from "@/src/__tests__/utils/test-utils";
+import { CaseAccessSection } from "../case-access-section";
+
+const GRANT_TRIGGER_REGEX = /grant access to a case/i;
+const GRANT_SUBMIT_REGEX = /^grant access$/i;
+const CASE_ROW_TEST_ID_REGEX = /^case-access-row-/;
+const CASE_COMBOBOX_REGEX = /^case$/i;
+const PERMISSION_COMBOBOX_REGEX = /permission level/i;
+const REMOVE_ALPHA_TRIGGER_REGEX = /remove access to alpha/i;
+const REMOVE_CONFIRM_TEXT_REGEX = /remove access\?/i;
+const CONFIRM_BUTTON_REGEX = /^confirm$/i;
+const CANCEL_BUTTON_REGEX = /^cancel$/i;
+const EMPTY_STATE_TEXT_REGEX =
+	/which cases this integration's machine user can touch/i;
+const INTEGRATION_MUST_BE_ACTIVE_REGEX = /integration must be active/i;
+
+vi.mock("@/actions/assurance-cases", () => ({
+	fetchAssuranceCases: vi.fn().mockResolvedValue([
+		{ id: "case-9", name: "Assurance" },
+		{ id: "case-10", name: "DARTER Demo — Automated Inspection" },
+	]),
+}));
+
+function makeGrant(
+	overrides: Partial<IntegrationCaseGrant> = {}
+): IntegrationCaseGrant {
+	return {
+		caseId: "case-1",
+		caseName: "DARTER Demo — Automated Inspection",
+		permission: "EDIT",
+		grantedAt: "2026-07-10T00:00:00.000Z",
+		...overrides,
+	};
+}
+
+const baseProps = {
+	granting: false,
+	grantError: null,
+	loadError: null,
+	loading: false,
+	onGrant: vi.fn().mockResolvedValue(true),
+	onRemove: vi.fn(),
+	removingCaseId: null,
+};
+
+describe("CaseAccessSection", () => {
+	describe("ordering and empty state", () => {
+		it("renders grants in the order given, each with its permission badge", () => {
+			renderWithoutProviders(
+				<CaseAccessSection
+					{...baseProps}
+					grants={[
+						makeGrant({
+							caseId: "case-1",
+							caseName: "Alpha",
+							permission: "VIEW",
+						}),
+						makeGrant({
+							caseId: "case-2",
+							caseName: "Beta",
+							permission: "EDIT",
+						}),
+					]}
+				/>
+			);
+
+			const rows = screen.getAllByTestId(CASE_ROW_TEST_ID_REGEX);
+			expect(rows).toHaveLength(2);
+			expect(rows[0]).toHaveAttribute("data-testid", "case-access-row-case-1");
+			expect(rows[1]).toHaveAttribute("data-testid", "case-access-row-case-2");
+			expect(rows[0]).toHaveTextContent("VIEW");
+			expect(rows[1]).toHaveTextContent("EDIT");
+		});
+
+		it("shows the empty-state explanation and the grant button when there are no grants", () => {
+			renderWithoutProviders(<CaseAccessSection {...baseProps} grants={[]} />);
+
+			expect(screen.getByText(EMPTY_STATE_TEXT_REGEX)).toBeInTheDocument();
+			expect(
+				screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+			).toBeInTheDocument();
+			expect(
+				screen.queryByTestId(CASE_ROW_TEST_ID_REGEX)
+			).not.toBeInTheDocument();
+		});
+	});
+
+	describe("grant flow", () => {
+		it("happy path: opens the form, picks a case and permission, and calls onGrant — then closes the form", async () => {
+			const onGrant = vi.fn().mockResolvedValue(true);
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<CaseAccessSection {...baseProps} grants={[]} onGrant={onGrant} />
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+			);
+
+			await waitFor(() =>
+				expect(
+					screen.getByRole("combobox", { name: CASE_COMBOBOX_REGEX })
+				).toBeInTheDocument()
+			);
+
+			await user.click(
+				screen.getByRole("combobox", { name: CASE_COMBOBOX_REGEX })
+			);
+			await user.click(screen.getByRole("option", { name: "Assurance" }));
+
+			await user.click(
+				screen.getByRole("combobox", { name: PERMISSION_COMBOBOX_REGEX })
+			);
+			await user.click(screen.getByRole("option", { name: "Can edit" }));
+
+			await user.click(
+				screen.getByRole("button", { name: GRANT_SUBMIT_REGEX })
+			);
+
+			expect(onGrant).toHaveBeenCalledWith("case-9", "EDIT");
+
+			// A successful grant closes the form back to its trigger button.
+			await waitFor(() =>
+				expect(
+					screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+				).toBeInTheDocument()
+			);
+			expect(
+				screen.queryByRole("button", { name: GRANT_SUBMIT_REGEX })
+			).not.toBeInTheDocument();
+		});
+
+		it("keeps the form open and surfaces the mapped 409 message without swallowing the error", async () => {
+			const onGrant = vi.fn().mockResolvedValue(false);
+			const user = userEvent.setup();
+			const { rerender } = renderWithoutProviders(
+				<CaseAccessSection
+					{...baseProps}
+					grantError={null}
+					grants={[]}
+					onGrant={onGrant}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+			);
+			await waitFor(() =>
+				expect(
+					screen.getByRole("combobox", { name: CASE_COMBOBOX_REGEX })
+				).toBeInTheDocument()
+			);
+			await user.click(
+				screen.getByRole("combobox", { name: CASE_COMBOBOX_REGEX })
+			);
+			await user.click(screen.getByRole("option", { name: "Assurance" }));
+
+			await user.click(
+				screen.getByRole("button", { name: GRANT_SUBMIT_REGEX })
+			);
+
+			expect(onGrant).toHaveBeenCalledWith("case-9", "VIEW");
+
+			// The real hook (`useIntegrationCaseGrants`) sets `grantError` only
+			// once the rejected promise's `.catch` runs, which lands as a prop
+			// update from `IntegrationCard` a render after the failed attempt —
+			// this rerender is that update, not a contrived shortcut.
+			rerender(
+				<CaseAccessSection
+					{...baseProps}
+					grantError="This integration must be ACTIVE before it can be granted access to a case. Reactivate it, then try again."
+					grants={[]}
+					onGrant={onGrant}
+				/>
+			);
+
+			expect(screen.getByRole("alert")).toHaveTextContent(
+				INTEGRATION_MUST_BE_ACTIVE_REGEX
+			);
+			// Not swallowed, and the form stays open for a retry — never silently
+			// reverts to the collapsed trigger button on failure.
+			expect(
+				screen.getByRole("button", { name: GRANT_SUBMIT_REGEX })
+			).toBeInTheDocument();
+		});
+	});
+
+	describe("remove flow", () => {
+		it("requires an inline confirm click before calling onRemove", async () => {
+			const onRemove = vi.fn();
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<CaseAccessSection
+					{...baseProps}
+					grants={[makeGrant({ caseId: "case-1", caseName: "Alpha" })]}
+					onRemove={onRemove}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: REMOVE_ALPHA_TRIGGER_REGEX })
+			);
+			expect(onRemove).not.toHaveBeenCalled();
+			expect(screen.getByText(REMOVE_CONFIRM_TEXT_REGEX)).toBeInTheDocument();
+
+			await user.click(
+				screen.getByRole("button", { name: CONFIRM_BUTTON_REGEX })
+			);
+			expect(onRemove).toHaveBeenCalledWith("case-1");
+		});
+
+		it("does not call onRemove when the inline confirm is cancelled", async () => {
+			const onRemove = vi.fn();
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<CaseAccessSection
+					{...baseProps}
+					grants={[makeGrant({ caseId: "case-1", caseName: "Alpha" })]}
+					onRemove={onRemove}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: REMOVE_ALPHA_TRIGGER_REGEX })
+			);
+			await user.click(
+				screen.getByRole("button", { name: CANCEL_BUTTON_REGEX })
+			);
+
+			expect(onRemove).not.toHaveBeenCalled();
+			expect(
+				screen.queryByText(REMOVE_CONFIRM_TEXT_REGEX)
+			).not.toBeInTheDocument();
+		});
+	});
+});

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
@@ -19,6 +19,8 @@ const REVOKE_TOKEN_CONFIRM_REGEX = /revoke token/i;
 const CANCEL_BUTTON_REGEX = /cancel/i;
 const DELETE_TRIGGER_REGEX = /^delete$/i;
 const DELETE_CONFIRM_REGEX = /delete integration/i;
+const DELETE_TOOLTIP_TEXT = "Revoke first — delete is permanent";
+const TYPE_NAME_LABEL_REGEX = /type.*to confirm/i;
 const ISSUE_TOKEN_BUTTON_REGEX = /issue new token/i;
 const PERMANENT_TEXT_REGEX = /permanent/i;
 const CANNOT_BE_UNDONE_TEXT_REGEX = /cannot be undone/i;
@@ -151,6 +153,111 @@ describe("IntegrationCard", () => {
 		});
 	});
 
+	describe("delete needs a guard — revoke first", () => {
+		it("disables Delete with an explanatory tooltip for an ACTIVE integration", () => {
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({ status: "ACTIVE" })}
+				/>
+			);
+
+			const deleteButton = screen.getByRole("button", {
+				name: DELETE_TRIGGER_REGEX,
+			});
+			expect(deleteButton).toBeDisabled();
+			expect(deleteButton).toHaveAttribute("title", DELETE_TOOLTIP_TEXT);
+		});
+
+		it("disables Delete with an explanatory tooltip for a SUSPENDED integration", () => {
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({ status: "SUSPENDED" })}
+				/>
+			);
+
+			const deleteButton = screen.getByRole("button", {
+				name: DELETE_TRIGGER_REGEX,
+			});
+			expect(deleteButton).toBeDisabled();
+			expect(deleteButton).toHaveAttribute("title", DELETE_TOOLTIP_TEXT);
+		});
+
+		it("enables Delete with no tooltip for a REVOKED integration", () => {
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({ status: "REVOKED" })}
+				/>
+			);
+
+			const deleteButton = screen.getByRole("button", {
+				name: DELETE_TRIGGER_REGEX,
+			});
+			expect(deleteButton).toBeEnabled();
+			expect(deleteButton).not.toHaveAttribute("title");
+		});
+
+		it("keeps the destructive confirm button disabled when the typed text doesn't exactly match the integration's name", async () => {
+			const onDelete = vi.fn();
+			const user = userEvent.setup();
+			const integration = makeIntegration({ status: "REVOKED" });
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={integration}
+					onDelete={onDelete}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: DELETE_TRIGGER_REGEX })
+			);
+			await screen.findByRole("alertdialog");
+
+			const confirmButton = screen.getByRole("button", {
+				name: DELETE_CONFIRM_REGEX,
+			});
+			await user.type(
+				screen.getByLabelText(TYPE_NAME_LABEL_REGEX),
+				`${integration.name}-typo`
+			);
+			expect(confirmButton).toBeDisabled();
+
+			await user.click(confirmButton);
+			expect(onDelete).not.toHaveBeenCalled();
+		});
+
+		it("calls onDelete neither on cancel, nor before the dialog is confirmed, and closes the dialog", async () => {
+			const onDelete = vi.fn();
+			const user = userEvent.setup();
+			const integration = makeIntegration({ status: "REVOKED" });
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={integration}
+					onDelete={onDelete}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: DELETE_TRIGGER_REGEX })
+			);
+			await screen.findByRole("alertdialog");
+			await user.type(
+				screen.getByLabelText(TYPE_NAME_LABEL_REGEX),
+				integration.name
+			);
+			await user.click(
+				screen.getByRole("button", { name: CANCEL_BUTTON_REGEX })
+			);
+
+			expect(onDelete).not.toHaveBeenCalled();
+			expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+		});
+	});
+
 	describe("confirm dialogs gate destructive actions", () => {
 		it("does not call onRevoke until the confirm dialog is accepted", async () => {
 			const onRevoke = vi.fn();
@@ -200,13 +307,14 @@ describe("IntegrationCard", () => {
 			expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 		});
 
-		it("does not call onDelete until the delete confirm dialog is accepted", async () => {
+		it("does not call onDelete until the delete confirm dialog is accepted with the exact name typed", async () => {
 			const onDelete = vi.fn();
 			const user = userEvent.setup();
+			const integration = makeIntegration({ status: "REVOKED" });
 			renderWithoutProviders(
 				<IntegrationCard
 					{...baseProps}
-					integration={makeIntegration()}
+					integration={integration}
 					onDelete={onDelete}
 				/>
 			);
@@ -216,12 +324,22 @@ describe("IntegrationCard", () => {
 			);
 			expect(onDelete).not.toHaveBeenCalled();
 
-			const dialog = await screen.findByRole("dialog");
+			const dialog = await screen.findByRole("alertdialog");
 			expect(dialog).toHaveTextContent(CANNOT_BE_UNDONE_TEXT_REGEX);
 
-			await user.click(
-				screen.getByRole("button", { name: DELETE_CONFIRM_REGEX })
+			const confirmButton = screen.getByRole("button", {
+				name: DELETE_CONFIRM_REGEX,
+			});
+			expect(confirmButton).toBeDisabled();
+
+			await user.type(
+				screen.getByLabelText(TYPE_NAME_LABEL_REGEX),
+				integration.name
 			);
+			expect(confirmButton).toBeEnabled();
+
+			await user.click(confirmButton);
+			expect(onDelete).toHaveBeenCalledTimes(1);
 			expect(onDelete).toHaveBeenCalledWith("integration-1");
 		});
 

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -23,6 +24,16 @@ const PERMANENT_TEXT_REGEX = /permanent/i;
 const CANNOT_BE_UNDONE_TEXT_REGEX = /cannot be undone/i;
 const DONE_BUTTON_REGEX = /done.*stored it/i;
 const TOKEN_ROW_TEST_ID_REGEX = /^token-row-/;
+const GRANT_TRIGGER_REGEX = /grant access to a case/i;
+const GRANT_SUBMIT_REGEX = /^grant access$/i;
+const CASE_COMBOBOX_REGEX = /^case$/i;
+const PERMISSION_COMBOBOX_REGEX = /permission level/i;
+
+vi.mock("@/actions/assurance-cases", () => ({
+	fetchAssuranceCases: vi
+		.fn()
+		.mockResolvedValue([{ id: "case-9", name: "Assurance" }]),
+}));
 
 function makeIntegration(
 	overrides: Partial<IntegrationListItem> = {}
@@ -354,6 +365,88 @@ describe("IntegrationCard", () => {
 			expect(screen.getByText("No tokens issued yet.")).toBeInTheDocument();
 			expect(
 				screen.queryByTestId(TOKEN_ROW_TEST_ID_REGEX)
+			).not.toBeInTheDocument();
+		});
+	});
+
+	describe("case access (wired to the real hook)", () => {
+		it("full grant round trip through the actual UI: card, real useIntegrationCaseGrants, and MSW — the row appears and the form closes (card↔hook wiring seam, nanaki G3 probe)", async () => {
+			let grants: Array<{
+				caseId: string;
+				caseName: string;
+				permission: string;
+				grantedAt: string;
+			}> = [];
+			server.use(
+				http.get("/api/integrations/:id/case-grants", () =>
+					HttpResponse.json({ grants })
+				),
+				http.post("/api/integrations/:id/case-grants", async ({ request }) => {
+					const body = (await request.json()) as {
+						caseId: string;
+						permission: string;
+					};
+					const grant = {
+						caseId: body.caseId,
+						caseName: "Assurance",
+						permission: body.permission,
+						grantedAt: "2026-07-13T00:00:00.000Z",
+					};
+					grants = [...grants, grant];
+					return HttpResponse.json({ grant }, { status: 201 });
+				})
+			);
+
+			const user = userEvent.setup();
+			// No `onGrant`/`grants` props here — this test does NOT stub
+			// `useIntegrationCaseGrants` or pass case-access state down by
+			// hand. `IntegrationCard` calls the real hook itself, exactly as
+			// it does in production; a swapped/miswired prop between the card
+			// and the hook would pass every OTHER test in this file (they
+			// never touch case access) but fail here.
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({ status: "ACTIVE" })}
+				/>
+			);
+
+			await waitFor(() =>
+				expect(
+					screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+				).toBeInTheDocument()
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+			);
+			await waitFor(() =>
+				expect(
+					screen.getByRole("combobox", { name: CASE_COMBOBOX_REGEX })
+				).toBeInTheDocument()
+			);
+			await user.click(
+				screen.getByRole("combobox", { name: CASE_COMBOBOX_REGEX })
+			);
+			await user.click(screen.getByRole("option", { name: "Assurance" }));
+			await user.click(
+				screen.getByRole("combobox", { name: PERMISSION_COMBOBOX_REGEX })
+			);
+			await user.click(screen.getByRole("option", { name: "Can edit" }));
+			await user.click(
+				screen.getByRole("button", { name: GRANT_SUBMIT_REGEX })
+			);
+
+			expect(
+				await screen.findByTestId("case-access-row-case-9")
+			).toBeInTheDocument();
+			await waitFor(() =>
+				expect(
+					screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+				).toBeInTheDocument()
+			);
+			expect(
+				screen.queryByRole("button", { name: GRANT_SUBMIT_REGEX })
 			).not.toBeInTheDocument();
 		});
 	});

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
@@ -1,6 +1,8 @@
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { IntegrationListItem } from "@/lib/schemas/integration";
+import { server } from "@/src/__tests__/mocks/server";
 import {
 	renderWithoutProviders,
 	screen,
@@ -60,6 +62,20 @@ const baseProps = {
 	pending: false,
 	pendingTokenKey: null,
 };
+
+// Every render of `IntegrationCard` now fires its own
+// `GET .../case-grants` (see `useIntegrationCaseGrants`, called directly
+// from `IntegrationCard` — one hook per card instance, not per list). None
+// of the pre-existing tests below care about case access, so this default
+// keeps them exercising exactly what they did before that section existed;
+// the dedicated case-access describe block overrides it per scenario.
+beforeEach(() => {
+	server.use(
+		http.get("/api/integrations/:id/case-grants", () =>
+			HttpResponse.json({ grants: [] })
+		)
+	);
+});
 
 describe("IntegrationCard", () => {
 	describe("status-gated lifecycle actions", () => {

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
@@ -30,6 +30,7 @@ const GRANT_TRIGGER_REGEX = /grant access to a case/i;
 const GRANT_SUBMIT_REGEX = /^grant access$/i;
 const CASE_COMBOBOX_REGEX = /^case$/i;
 const PERMISSION_COMBOBOX_REGEX = /permission level/i;
+const DELETING_LABEL_REGEX = /deleting…/i;
 
 vi.mock("@/actions/assurance-cases", () => ({
 	fetchAssuranceCases: vi
@@ -255,6 +256,196 @@ describe("IntegrationCard", () => {
 
 			expect(onDelete).not.toHaveBeenCalled();
 			expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("delete dialog — QA probe regressions", () => {
+		it("disables both Cancel and the destructive confirm, and relabels the confirm button, while a delete is in flight", async () => {
+			const user = userEvent.setup();
+			const integration = makeIntegration({ status: "REVOKED" });
+			const { rerender } = renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					deleting={false}
+					integration={integration}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: DELETE_TRIGGER_REGEX })
+			);
+			await screen.findByRole("alertdialog");
+
+			const cancelButton = screen.getByRole("button", {
+				name: CANCEL_BUTTON_REGEX,
+			});
+			const confirmButton = screen.getByRole("button", {
+				name: DELETE_CONFIRM_REGEX,
+			});
+
+			rerender(
+				<IntegrationCard
+					{...baseProps}
+					deleting={true}
+					integration={integration}
+				/>
+			);
+
+			expect(cancelButton).toBeDisabled();
+			expect(confirmButton).toBeDisabled();
+			expect(confirmButton).toHaveTextContent(DELETING_LABEL_REGEX);
+		});
+
+		it("resets the typed name when the dialog is cancelled and reopened — a remembered name must never pre-enable delete", async () => {
+			const user = userEvent.setup();
+			const integration = makeIntegration({ status: "REVOKED" });
+			renderWithoutProviders(
+				<IntegrationCard {...baseProps} integration={integration} />
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: DELETE_TRIGGER_REGEX })
+			);
+			await screen.findByRole("alertdialog");
+			await user.type(
+				screen.getByLabelText(TYPE_NAME_LABEL_REGEX),
+				integration.name
+			);
+			expect(
+				screen.getByRole("button", { name: DELETE_CONFIRM_REGEX })
+			).toBeEnabled();
+
+			await user.click(
+				screen.getByRole("button", { name: CANCEL_BUTTON_REGEX })
+			);
+			expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+
+			await user.click(
+				screen.getByRole("button", { name: DELETE_TRIGGER_REGEX })
+			);
+			await screen.findByRole("alertdialog");
+
+			expect(screen.getByLabelText(TYPE_NAME_LABEL_REGEX)).toHaveValue("");
+			expect(
+				screen.getByRole("button", { name: DELETE_CONFIRM_REGEX })
+			).toBeDisabled();
+		});
+
+		it("keeps the confirm button disabled when the typed name has trailing whitespace the real name doesn't have", async () => {
+			const user = userEvent.setup();
+			const integration = makeIntegration({ status: "REVOKED" });
+			renderWithoutProviders(
+				<IntegrationCard {...baseProps} integration={integration} />
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: DELETE_TRIGGER_REGEX })
+			);
+			await screen.findByRole("alertdialog");
+			await user.type(
+				screen.getByLabelText(TYPE_NAME_LABEL_REGEX),
+				`${integration.name}  `
+			);
+
+			expect(
+				screen.getByRole("button", { name: DELETE_CONFIRM_REGEX })
+			).toBeDisabled();
+		});
+
+		it("keeps the confirm button disabled when the typed name differs only in case", async () => {
+			const user = userEvent.setup();
+			const integration = makeIntegration({ status: "REVOKED" });
+			renderWithoutProviders(
+				<IntegrationCard {...baseProps} integration={integration} />
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: DELETE_TRIGGER_REGEX })
+			);
+			await screen.findByRole("alertdialog");
+			await user.type(
+				screen.getByLabelText(TYPE_NAME_LABEL_REGEX),
+				integration.name.toUpperCase()
+			);
+
+			expect(
+				screen.getByRole("button", { name: DELETE_CONFIRM_REGEX })
+			).toBeDisabled();
+		});
+
+		it("keeps the confirm button disabled when the typed text is a proper prefix of the name", async () => {
+			const user = userEvent.setup();
+			const integration = makeIntegration({ status: "REVOKED" });
+			renderWithoutProviders(
+				<IntegrationCard {...baseProps} integration={integration} />
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: DELETE_TRIGGER_REGEX })
+			);
+			await screen.findByRole("alertdialog");
+			await user.type(
+				screen.getByLabelText(TYPE_NAME_LABEL_REGEX),
+				integration.name.slice(0, -1)
+			);
+
+			expect(
+				screen.getByRole("button", { name: DELETE_CONFIRM_REGEX })
+			).toBeDisabled();
+		});
+
+		it("matches an integration name containing regex metacharacters only by exact literal equality", async () => {
+			const user = userEvent.setup();
+			const integration = makeIntegration({
+				status: "REVOKED",
+				name: "pipe.line(v2)+",
+			});
+			renderWithoutProviders(
+				<IntegrationCard {...baseProps} integration={integration} />
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: DELETE_TRIGGER_REGEX })
+			);
+			await screen.findByRole("alertdialog");
+
+			const confirmButton = screen.getByRole("button", {
+				name: DELETE_CONFIRM_REGEX,
+			});
+			const input = screen.getByLabelText(TYPE_NAME_LABEL_REGEX);
+
+			// If the comparison were ever refactored into a regex test instead of
+			// `===`, the "." here would match any character and this string
+			// would wrongly enable the button.
+			await user.type(input, "pipeXline(v2)+");
+			expect(confirmButton).toBeDisabled();
+
+			await user.clear(input);
+			await user.type(input, integration.name);
+			expect(confirmButton).toBeEnabled();
+		});
+
+		it("closes the dialog on Escape without calling onDelete", async () => {
+			const onDelete = vi.fn();
+			const user = userEvent.setup();
+			const integration = makeIntegration({ status: "REVOKED" });
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={integration}
+					onDelete={onDelete}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: DELETE_TRIGGER_REGEX })
+			);
+			await screen.findByRole("alertdialog");
+
+			await user.keyboard("{Escape}");
+
+			expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+			expect(onDelete).not.toHaveBeenCalled();
 		});
 	});
 

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integrations-section.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integrations-section.test.tsx
@@ -1,7 +1,7 @@
 import { waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { server } from "@/src/__tests__/mocks/server";
 import {
 	renderWithoutProviders,
@@ -28,6 +28,18 @@ const INTEGRATION = {
 
 afterEach(() => {
 	vi.restoreAllMocks();
+});
+
+// Every rendered `IntegrationCard` fires its own `GET .../case-grants` (see
+// `useIntegrationCaseGrants`) — none of the tests below exercise case
+// access, so this default keeps them green without each one needing its
+// own handler for a resource they don't care about.
+beforeEach(() => {
+	server.use(
+		http.get("/api/integrations/:id/case-grants", () =>
+			HttpResponse.json({ grants: [] })
+		)
+	);
 });
 
 describe("IntegrationsSection", () => {

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integrations-section.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integrations-section.test.tsx
@@ -13,6 +13,7 @@ const REGISTER_BUTTON_REGEX = /register integration/i;
 const NAME_LABEL_REGEX = /^name$/i;
 const READ_CASES_CHECKBOX_REGEX = /read cases/i;
 const CANCEL_BUTTON_REGEX = /cancel/i;
+const FAILED_CASE_GRANTS_TEXT_REGEX = /failed to list case grants/i;
 
 const INTEGRATION = {
 	id: "integration-1",
@@ -196,5 +197,79 @@ describe("IntegrationsSection", () => {
 		expect(
 			within(dialog).getByRole("checkbox", { name: READ_CASES_CHECKBOX_REGEX })
 		).not.toBeChecked();
+	});
+
+	it("isolates a case-access load failure to the one card whose GET 500s — the sibling card renders fine, with exactly one case-grants GET per card (nanaki G3 fault-isolation probe)", async () => {
+		const failingIntegration = {
+			...INTEGRATION,
+			id: "integration-fails",
+			name: "flaky-pipeline",
+		};
+		const healthyIntegration = {
+			...INTEGRATION,
+			id: "integration-ok",
+			name: "steady-pipeline",
+		};
+		const callsById: Record<string, number> = {};
+
+		server.use(
+			http.get("/api/integrations", () =>
+				HttpResponse.json({
+					integrations: [failingIntegration, healthyIntegration],
+				})
+			),
+			http.get("/api/integrations/:id/case-grants", ({ params }) => {
+				const id = params.id as string;
+				callsById[id] = (callsById[id] ?? 0) + 1;
+				if (id === failingIntegration.id) {
+					return HttpResponse.json(
+						{ error: "Failed to list case grants" },
+						{ status: 500 }
+					);
+				}
+				return HttpResponse.json({
+					grants: [
+						{
+							caseId: "case-1",
+							caseName: "Assurance",
+							permission: "EDIT",
+							grantedAt: "2026-07-10T00:00:00.000Z",
+						},
+					],
+				});
+			})
+		);
+
+		renderWithoutProviders(<IntegrationsSection />);
+
+		await waitFor(() =>
+			expect(screen.getByText("flaky-pipeline")).toBeInTheDocument()
+		);
+		expect(screen.getByText("steady-pipeline")).toBeInTheDocument();
+
+		const failingCard = screen.getByTestId(
+			`integration-card-${failingIntegration.id}`
+		);
+		const healthyCard = screen.getByTestId(
+			`integration-card-${healthyIntegration.id}`
+		);
+
+		await waitFor(() =>
+			expect(
+				within(failingCard).getByText("Failed to list case grants")
+			).toBeInTheDocument()
+		);
+		// The sibling card's own GET succeeded independently — one card's
+		// 500 never poisons the other's case-access state.
+		expect(
+			within(healthyCard).getByTestId("case-access-row-case-1")
+		).toBeInTheDocument();
+		expect(
+			within(healthyCard).queryByText(FAILED_CASE_GRANTS_TEXT_REGEX)
+		).not.toBeInTheDocument();
+
+		await waitFor(() => expect(callsById[failingIntegration.id]).toBe(1));
+		expect(callsById[healthyIntegration.id]).toBe(1);
+		expect(Object.keys(callsById)).toHaveLength(2);
 	});
 });

--- a/app/(authenticated)/dashboard/settings/integrations/_components/case-access-row.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/case-access-row.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { X } from "lucide-react";
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { formatShortDate } from "@/lib/date";
+import type { IntegrationCaseGrant } from "@/lib/schemas/integration";
+
+const PERMISSION_LABEL: Record<IntegrationCaseGrant["permission"], string> = {
+	VIEW: "VIEW",
+	COMMENT: "COMMENT",
+	EDIT: "EDIT",
+};
+
+export interface CaseAccessRowProps {
+	grant: IntegrationCaseGrant;
+	onRemove: (caseId: string) => void;
+	/** True while THIS row's removal request is in flight. */
+	removing: boolean;
+}
+
+/**
+ * One case the integration's system user currently has access to. Removal
+ * is a lightweight, reversible action (re-granting restores it), so unlike
+ * the integration/token lifecycle actions in `IntegrationCard` this confirms
+ * inline — a second click on the row itself — rather than opening a full
+ * `AlertModal`, which this codebase reserves for genuinely irreversible
+ * actions (revoke integration, delete integration, revoke token).
+ */
+export function CaseAccessRow({
+	grant,
+	onRemove,
+	removing,
+}: CaseAccessRowProps) {
+	const [confirming, setConfirming] = useState(false);
+
+	return (
+		<div
+			className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border px-3 py-2 text-sm"
+			data-testid={`case-access-row-${grant.caseId}`}
+		>
+			<div className="space-y-0.5">
+				<p className="font-medium text-foreground">{grant.caseName}</p>
+				<p className="text-muted-foreground text-xs">
+					{`Granted ${formatShortDate(grant.grantedAt)}`}
+				</p>
+			</div>
+
+			<div className="flex shrink-0 items-center gap-2">
+				<Badge variant="outline">{PERMISSION_LABEL[grant.permission]}</Badge>
+
+				{confirming ? (
+					<>
+						<span className="text-muted-foreground text-xs">
+							Remove access?
+						</span>
+						<Button
+							disabled={removing}
+							onClick={() => setConfirming(false)}
+							size="sm"
+							type="button"
+							variant="outline"
+						>
+							Cancel
+						</Button>
+						<Button
+							disabled={removing}
+							onClick={() => onRemove(grant.caseId)}
+							size="sm"
+							type="button"
+							variant="destructive"
+						>
+							{removing ? "Removing…" : "Confirm"}
+						</Button>
+					</>
+				) : (
+					<Button
+						aria-label={`Remove access to ${grant.caseName}`}
+						className="text-destructive hover:text-destructive"
+						onClick={() => setConfirming(true)}
+						size="sm"
+						type="button"
+						variant="ghost"
+					>
+						<X aria-hidden="true" className="h-3.5 w-3.5" />
+						Remove
+					</Button>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/app/(authenticated)/dashboard/settings/integrations/_components/case-access-row.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/case-access-row.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { X } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { formatShortDate } from "@/lib/date";
@@ -34,6 +34,33 @@ export function CaseAccessRow({
 	removing,
 }: CaseAccessRowProps) {
 	const [confirming, setConfirming] = useState(false);
+	const confirmButtonRef = useRef<HTMLButtonElement>(null);
+	const removeTriggerRef = useRef<HTMLButtonElement>(null);
+	// Set only by `handleCancel`, never by the initial mount or the
+	// entry-into-confirm transition — this is what stops the effect below
+	// from stealing focus onto the Remove trigger the first time the row
+	// ever renders (when `confirming` is already `false` and nothing has
+	// been focused yet).
+	const returnFocusOnCancel = useRef(false);
+
+	// Moves focus to the Confirm button the moment the inline confirm
+	// appears (so a keyboard user lands straight on it rather than the DOM
+	// default of nowhere-in-particular), and back to the Remove trigger
+	// when a cancel collapses it — never on removal success/failure, which
+	// leaves the row's confirm state exactly where the click left it.
+	useEffect(() => {
+		if (confirming) {
+			confirmButtonRef.current?.focus();
+		} else if (returnFocusOnCancel.current) {
+			removeTriggerRef.current?.focus();
+			returnFocusOnCancel.current = false;
+		}
+	}, [confirming]);
+
+	function handleCancel() {
+		returnFocusOnCancel.current = true;
+		setConfirming(false);
+	}
 
 	return (
 		<div
@@ -57,7 +84,7 @@ export function CaseAccessRow({
 						</span>
 						<Button
 							disabled={removing}
-							onClick={() => setConfirming(false)}
+							onClick={handleCancel}
 							size="sm"
 							type="button"
 							variant="outline"
@@ -67,6 +94,7 @@ export function CaseAccessRow({
 						<Button
 							disabled={removing}
 							onClick={() => onRemove(grant.caseId)}
+							ref={confirmButtonRef}
 							size="sm"
 							type="button"
 							variant="destructive"
@@ -79,6 +107,7 @@ export function CaseAccessRow({
 						aria-label={`Remove access to ${grant.caseName}`}
 						className="text-destructive hover:text-destructive"
 						onClick={() => setConfirming(true)}
+						ref={removeTriggerRef}
 						size="sm"
 						type="button"
 						variant="ghost"

--- a/app/(authenticated)/dashboard/settings/integrations/_components/case-access-section.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/case-access-section.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { AlertCircle, Plus } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import type {
+	CaseGrantPermission,
+	IntegrationCaseGrant,
+} from "@/lib/schemas/integration";
+import { CaseAccessRow } from "./case-access-row";
+import { GrantCaseAccessForm } from "./grant-case-access-form";
+
+export interface CaseAccessSectionProps {
+	/** The faithfully-mapped message from the most recent failed grant attempt, or `null`. */
+	grantError: string | null;
+	/** True while a grant request is in flight (disables the form's submit/cancel). */
+	granting: boolean;
+	grants: IntegrationCaseGrant[];
+	loadError: string | null;
+	/** True while the initial list fetch is in flight. */
+	loading: boolean;
+	onGrant: (
+		caseId: string,
+		permission: CaseGrantPermission
+	) => Promise<boolean>;
+	onRemove: (caseId: string) => void;
+	/** The caseId currently mid-removal, or `null`. */
+	removingCaseId: string | null;
+}
+
+/**
+ * The "Case access" section of an integration's card — which cases the
+ * integration's machine user can currently touch, with grant/remove actions
+ * (ADR 0002 v2 §2.4, work item 7's settings-page half). Presentational, like
+ * its `Tokens` sibling section in `IntegrationCard`: every mutation is a
+ * callback prop, and this component (and its tests) never call
+ * `useIntegrationCaseGrants` directly — `IntegrationCard` owns that hook and
+ * threads its state down here.
+ */
+export function CaseAccessSection({
+	granting,
+	grantError,
+	grants,
+	loading,
+	loadError,
+	onGrant,
+	onRemove,
+	removingCaseId,
+}: CaseAccessSectionProps) {
+	const [addOpen, setAddOpen] = useState(false);
+
+	async function handleGrant(caseId: string, permission: CaseGrantPermission) {
+		const granted = await onGrant(caseId, permission);
+		if (granted) {
+			setAddOpen(false);
+		}
+		return granted;
+	}
+
+	return (
+		<div className="space-y-2 border-border border-t pt-3">
+			<h4 className="font-medium text-foreground text-xs uppercase tracking-wide">
+				Case access
+			</h4>
+
+			{loading && (
+				<p className="text-muted-foreground text-xs">Loading case access…</p>
+			)}
+
+			{!loading && loadError && (
+				<div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-destructive text-xs">
+					<AlertCircle aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />
+					<span>{loadError}</span>
+				</div>
+			)}
+
+			{!(loading || loadError) && grants.length === 0 && (
+				<p className="text-muted-foreground text-xs">
+					Which cases this integration&apos;s machine user can touch — none
+					granted yet.
+				</p>
+			)}
+
+			{!(loading || loadError) && grants.length > 0 && (
+				<div className="space-y-2">
+					{grants.map((grant) => (
+						<CaseAccessRow
+							grant={grant}
+							key={grant.caseId}
+							onRemove={onRemove}
+							removing={removingCaseId === grant.caseId}
+						/>
+					))}
+				</div>
+			)}
+
+			{!(loading || loadError) &&
+				(addOpen ? (
+					<GrantCaseAccessForm
+						existingCaseIds={grants.map((grant) => grant.caseId)}
+						grantError={grantError}
+						granting={granting}
+						onCancel={() => setAddOpen(false)}
+						onGrant={handleGrant}
+					/>
+				) : (
+					<Button
+						onClick={() => setAddOpen(true)}
+						size="sm"
+						type="button"
+						variant="outline"
+					>
+						<Plus aria-hidden="true" className="h-3.5 w-3.5" />
+						Grant access to a case…
+					</Button>
+				))}
+		</div>
+	);
+}

--- a/app/(authenticated)/dashboard/settings/integrations/_components/case-access-section.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/case-access-section.tsx
@@ -16,6 +16,8 @@ export interface CaseAccessSectionProps {
 	/** True while a grant request is in flight (disables the form's submit/cancel). */
 	granting: boolean;
 	grants: IntegrationCaseGrant[];
+	/** True when the integration is ACTIVE — gates opening the grant form (existing grants stay listable/removable regardless, per N1: GET/DELETE deliberately ungated). */
+	integrationActive: boolean;
 	loadError: string | null;
 	/** True while the initial list fetch is in flight. */
 	loading: boolean;
@@ -24,6 +26,8 @@ export interface CaseAccessSectionProps {
 		permission: CaseGrantPermission
 	) => Promise<boolean>;
 	onRemove: (caseId: string) => void;
+	/** Retries the initial list fetch — wired to the hook's own `refetch`. Only rendered alongside `loadError`. */
+	onRetry: () => void;
 	/** The caseId currently mid-removal, or `null`. */
 	removingCaseId: string | null;
 }
@@ -41,10 +45,12 @@ export function CaseAccessSection({
 	granting,
 	grantError,
 	grants,
+	integrationActive,
 	loading,
 	loadError,
 	onGrant,
 	onRemove,
+	onRetry,
 	removingCaseId,
 }: CaseAccessSectionProps) {
 	const [addOpen, setAddOpen] = useState(false);
@@ -70,7 +76,10 @@ export function CaseAccessSection({
 			{!loading && loadError && (
 				<div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-destructive text-xs">
 					<AlertCircle aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />
-					<span>{loadError}</span>
+					<span className="flex-1">{loadError}</span>
+					<Button onClick={onRetry} size="sm" type="button" variant="outline">
+						Try again
+					</Button>
 				</div>
 			)}
 
@@ -105,8 +114,14 @@ export function CaseAccessSection({
 					/>
 				) : (
 					<Button
+						disabled={!integrationActive}
 						onClick={() => setAddOpen(true)}
 						size="sm"
+						title={
+							integrationActive
+								? undefined
+								: "Only an ACTIVE integration can be granted access to a case"
+						}
 						type="button"
 						variant="outline"
 					>

--- a/app/(authenticated)/dashboard/settings/integrations/_components/grant-case-access-form.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/grant-case-access-form.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useEffect, useState } from "react";
+import { fetchAssuranceCases } from "@/actions/assurance-cases";
+import { Button } from "@/components/ui/button";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import type { CaseGrantPermission } from "@/lib/schemas/integration";
+
+interface CaseOption {
+	id: string;
+	name: string;
+}
+
+const PERMISSION_OPTIONS: Array<{
+	label: string;
+	value: CaseGrantPermission;
+}> = [
+	{ value: "VIEW", label: "Can view" },
+	{ value: "COMMENT", label: "Can comment" },
+	{ value: "EDIT", label: "Can edit" },
+];
+
+export interface GrantCaseAccessFormProps {
+	/** caseIds the integration already has access to — excluded from the picker so re-granting the same case is never offered as a "fresh" option. */
+	existingCaseIds: string[];
+	/** The faithfully-mapped 409/404/network message from the most recent failed attempt, or `null`. */
+	grantError: string | null;
+	/** True while the parent's grant request is in flight. */
+	granting: boolean;
+	onCancel: () => void;
+	onGrant: (
+		caseId: string,
+		permission: CaseGrantPermission
+	) => Promise<boolean>;
+}
+
+/**
+ * The inline "grant access to a case" form — rendered by `CaseAccessSection`
+ * once "+ Grant access to a case…" is clicked. Sources its case options from
+ * `fetchAssuranceCases`, the same server action the main dashboard list
+ * uses, fetched lazily here on mount rather than eagerly whenever the
+ * settings page loads — nobody needs the full cases list until they
+ * actually open this form.
+ *
+ * Deliberately restricted to the caller's OWNED cases, not
+ * `fetchAssuranceCases`'s shared-cases sibling: a case a user owns always
+ * carries implicit case-ADMIN (the creator short-circuit in
+ * `getCasePermissionFromPrisma`, `lib/permissions.ts`), so every option
+ * offered here is guaranteed to pass the API's own ADMIN check. Cases
+ * merely SHARED to the user (even at ADMIN level) are left out on purpose:
+ * `listUserCases`'s `permissions` field labels every non-owner row "view"
+ * regardless of its real level (a pre-existing gap in
+ * `case-fetch-service.ts` — not this ticket's to fix), so this component
+ * cannot reliably tell a shared-ADMIN case apart from a shared-VIEW one from
+ * that data. Showing only owned cases keeps every option correct-by-
+ * construction instead of leaning on that unreliable label; the API's own
+ * 404 (surfaced via `grantError`) remains the backstop for any case this
+ * picker still gets wrong.
+ */
+export function GrantCaseAccessForm({
+	existingCaseIds,
+	granting,
+	grantError,
+	onCancel,
+	onGrant,
+}: GrantCaseAccessFormProps) {
+	const [cases, setCases] = useState<CaseOption[]>([]);
+	const [casesLoading, setCasesLoading] = useState(true);
+	const [selectedCaseId, setSelectedCaseId] = useState("");
+	const [selectedPermission, setSelectedPermission] =
+		useState<CaseGrantPermission>("VIEW");
+
+	useEffect(() => {
+		let cancelled = false;
+		setCasesLoading(true);
+		fetchAssuranceCases()
+			.then((result) => {
+				if (!cancelled) {
+					setCases(
+						(result ?? []).map((c) => ({ id: String(c.id), name: c.name }))
+					);
+				}
+			})
+			.finally(() => {
+				if (!cancelled) {
+					setCasesLoading(false);
+				}
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	const availableCases = cases.filter((c) => !existingCaseIds.includes(c.id));
+
+	async function handleSubmit(event: FormEvent) {
+		event.preventDefault();
+		if (!selectedCaseId) {
+			return;
+		}
+		await onGrant(selectedCaseId, selectedPermission);
+	}
+
+	return (
+		<form
+			className="space-y-3 rounded-md border border-border border-dashed p-3"
+			onSubmit={handleSubmit}
+		>
+			{grantError && (
+				<p className="text-destructive text-xs" role="alert">
+					{grantError}
+				</p>
+			)}
+
+			{casesLoading && (
+				<p className="text-muted-foreground text-xs">Loading your cases…</p>
+			)}
+
+			{!casesLoading && availableCases.length === 0 && (
+				<p className="text-muted-foreground text-xs">
+					Every case you administer already has this integration granted.
+				</p>
+			)}
+
+			{!casesLoading && availableCases.length > 0 && (
+				<div className="flex flex-wrap items-center gap-2">
+					<Select onValueChange={setSelectedCaseId} value={selectedCaseId}>
+						<SelectTrigger aria-label="Case" className="h-8 w-56 text-xs">
+							<SelectValue placeholder="Choose a case…" />
+						</SelectTrigger>
+						<SelectContent>
+							{availableCases.map((c) => (
+								<SelectItem key={c.id} value={c.id}>
+									{c.name}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+
+					<Select
+						onValueChange={(value) =>
+							setSelectedPermission(value as CaseGrantPermission)
+						}
+						value={selectedPermission}
+					>
+						<SelectTrigger
+							aria-label="Permission level"
+							className="h-8 w-32 text-xs"
+						>
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{PERMISSION_OPTIONS.map((option) => (
+								<SelectItem key={option.value} value={option.value}>
+									{option.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+			)}
+
+			<div className="flex items-center gap-2">
+				<Button
+					disabled={granting}
+					onClick={onCancel}
+					size="sm"
+					type="button"
+					variant="outline"
+				>
+					Cancel
+				</Button>
+				<Button
+					disabled={granting || !selectedCaseId || availableCases.length === 0}
+					size="sm"
+					type="submit"
+				>
+					{granting ? "Granting…" : "Grant access"}
+				</Button>
+			</div>
+		</form>
+	);
+}

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { AlertModal } from "@/components/modals/alert-modal";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useIntegrationCaseGrants } from "@/hooks/use-integration-case-grants";
 import {
 	formatFullDate,
 	formatRelativeToNow,
@@ -15,6 +16,7 @@ import type {
 	IssuedTokenResult,
 	RotatedTokenResult,
 } from "@/lib/schemas/integration";
+import { CaseAccessSection } from "./case-access-section";
 import { scopeLabel } from "./integration-scope-labels";
 import { IntegrationStatusBadge } from "./integration-status-badge";
 import { IntegrationTokenRow } from "./integration-token-row";
@@ -45,9 +47,17 @@ export interface IntegrationCardProps {
 
 /**
  * One integration's management card: identity + status + scopes (functional
- * scope item 1), lifecycle actions (item 3), and its tokens with issue/
- * rotate/revoke (item 4). Presentational — every mutation is a callback prop
- * so this component (and its tests) never touch `useIntegrations` directly.
+ * scope item 1), lifecycle actions (item 3), its tokens with issue/rotate/
+ * revoke (item 4), and its case-access grants (the settings-page half of
+ * "TEA — Integration case-access grants need a product surface"). Mostly
+ * presentational — every LIST-level mutation (suspend/revoke/delete/tokens)
+ * is still a callback prop from `IntegrationsSection`/`useIntegrations`, so
+ * this component's own tests never touch that hook directly. The one
+ * exception is case-access grants: unlike tokens, they are NOT embedded in
+ * `IntegrationListItem` (a deliberate separate-resource choice on the API
+ * side), so this component calls `useIntegrationCaseGrants(integration.id)`
+ * itself — one hook call per card instance, not a hook-in-a-loop — and
+ * threads its state down into the presentational `CaseAccessSection`.
  */
 export function IntegrationCard({
 	deleting,
@@ -68,6 +78,17 @@ export function IntegrationCard({
 	const [confirmRevokeTokenId, setConfirmRevokeTokenId] = useState<
 		string | null
 	>(null);
+
+	const {
+		grants: caseGrants,
+		loading: caseGrantsLoading,
+		loadError: caseGrantsLoadError,
+		granting: grantingCaseAccess,
+		grantError,
+		grantAccess,
+		removingCaseId,
+		removeAccess,
+	} = useIntegrationCaseGrants(integration.id);
 
 	const isIssuing = pendingTokenKey === integration.id;
 	const integrationActive = integration.status === "ACTIVE";
@@ -223,6 +244,17 @@ export function IntegrationCard({
 					</div>
 				)}
 			</div>
+
+			<CaseAccessSection
+				grantError={grantError}
+				granting={grantingCaseAccess}
+				grants={caseGrants}
+				loadError={caseGrantsLoadError}
+				loading={caseGrantsLoading}
+				onGrant={grantAccess}
+				onRemove={removeAccess}
+				removingCaseId={removingCaseId}
+			/>
 
 			<IntegrationTokenSecretModal
 				onClose={() => setTokenReveal(null)}

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
@@ -88,6 +88,7 @@ export function IntegrationCard({
 		grantAccess,
 		removingCaseId,
 		removeAccess,
+		refetch: refetchCaseGrants,
 	} = useIntegrationCaseGrants(integration.id);
 
 	const isIssuing = pendingTokenKey === integration.id;
@@ -249,10 +250,12 @@ export function IntegrationCard({
 				grantError={grantError}
 				granting={grantingCaseAccess}
 				grants={caseGrants}
+				integrationActive={integrationActive}
 				loadError={caseGrantsLoadError}
 				loading={caseGrantsLoading}
 				onGrant={grantAccess}
 				onRemove={removeAccess}
+				onRetry={refetchCaseGrants}
 				removingCaseId={removingCaseId}
 			/>
 

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
@@ -17,6 +17,7 @@ import type {
 	RotatedTokenResult,
 } from "@/lib/schemas/integration";
 import { CaseAccessSection } from "./case-access-section";
+import { IntegrationDeleteDialog } from "./integration-delete-dialog";
 import { scopeLabel } from "./integration-scope-labels";
 import { IntegrationStatusBadge } from "./integration-status-badge";
 import { IntegrationTokenRow } from "./integration-token-row";
@@ -93,6 +94,7 @@ export function IntegrationCard({
 
 	const isIssuing = pendingTokenKey === integration.id;
 	const integrationActive = integration.status === "ACTIVE";
+	const integrationRevoked = integration.status === "REVOKED";
 
 	async function handleIssueToken() {
 		const result = await onIssueToken(integration.id);
@@ -194,9 +196,14 @@ export function IntegrationCard({
 						</Button>
 					)}
 					<Button
-						disabled={deleting}
+						disabled={deleting || !integrationRevoked}
 						onClick={() => setConfirmDeleteOpen(true)}
 						size="sm"
+						title={
+							integrationRevoked
+								? undefined
+								: "Revoke first — delete is permanent"
+						}
 						type="button"
 						variant="destructive"
 					>
@@ -277,17 +284,15 @@ export function IntegrationCard({
 				}}
 			/>
 
-			<AlertModal
-				cancelButtonText="Cancel"
-				confirmButtonText="Delete integration"
-				isOpen={confirmDeleteOpen}
-				loading={deleting}
-				message={`Deleting "${integration.name}" permanently removes its registration and every one of its tokens. This cannot be undone.`}
-				onClose={() => setConfirmDeleteOpen(false)}
+			<IntegrationDeleteDialog
+				deleting={deleting}
+				integrationName={integration.name}
 				onConfirm={() => {
 					setConfirmDeleteOpen(false);
 					onDelete(integration.id);
 				}}
+				onOpenChange={setConfirmDeleteOpen}
+				open={confirmDeleteOpen}
 			/>
 
 			<AlertModal

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-delete-dialog.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-delete-dialog.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useId, useState } from "react";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export interface IntegrationDeleteDialogProps {
+	/** True while THIS integration's delete request is in flight. */
+	deleting: boolean;
+	integrationName: string;
+	onConfirm: () => void;
+	onOpenChange: (open: boolean) => void;
+	open: boolean;
+}
+
+/**
+ * The type-the-name confirm dialog gating an integration's permanent delete
+ * (TEA — "Integration delete needs a guard": a one-click hard delete sat
+ * right next to reversible revoke and ate a demo integration by accident).
+ * `IntegrationCard` only ever opens this once the integration is REVOKED —
+ * the Delete trigger is disabled with an explanatory tooltip for
+ * ACTIVE/SUSPENDED integrations, so this dialog never opens for those. Its
+ * own component (mirroring `IntegrationRegisterDialog`) so the typed-name
+ * state resets cleanly on close without leaking into `IntegrationCard`.
+ */
+export function IntegrationDeleteDialog({
+	deleting,
+	integrationName,
+	onConfirm,
+	onOpenChange,
+	open,
+}: IntegrationDeleteDialogProps) {
+	const [confirmText, setConfirmText] = useState("");
+	const inputId = useId();
+	const nameMatches = confirmText === integrationName;
+
+	function handleOpenChange(next: boolean) {
+		if (!next) {
+			setConfirmText("");
+		}
+		onOpenChange(next);
+	}
+
+	function handleConfirm() {
+		setConfirmText("");
+		onConfirm();
+	}
+
+	return (
+		<AlertDialog onOpenChange={handleOpenChange} open={open}>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Delete {integrationName}?</AlertDialogTitle>
+					<AlertDialogDescription>
+						This permanently removes the integration, its case-access grants,
+						and its audit trail. This cannot be undone.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+
+				<div className="space-y-2 py-2">
+					<Label htmlFor={inputId}>
+						Type{" "}
+						<span className="font-medium text-foreground">
+							{integrationName}
+						</span>{" "}
+						to confirm
+					</Label>
+					<Input
+						autoComplete="off"
+						id={inputId}
+						onChange={(event) => setConfirmText(event.target.value)}
+						value={confirmText}
+					/>
+				</div>
+
+				<AlertDialogFooter>
+					<AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+					<AlertDialogAction
+						className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						disabled={deleting || !nameMatches}
+						onClick={handleConfirm}
+					>
+						{deleting ? "Deleting…" : "Delete integration"}
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/hooks/__tests__/use-integration-case-grants.test.ts
+++ b/hooks/__tests__/use-integration-case-grants.test.ts
@@ -216,5 +216,37 @@ describe("useIntegrationCaseGrants", () => {
 			expect(result.current.grants).toHaveLength(0);
 			expect(result.current.removingCaseId).toBeNull();
 		});
+
+		it("leaves the grant in place when the DELETE fails — the row persists through a failed removal cycle (nanaki G3 probe)", async () => {
+			server.use(
+				http.get(CASE_GRANTS_PATH, () =>
+					HttpResponse.json({ grants: [makeGrant()] })
+				),
+				http.delete(`${CASE_GRANTS_PATH}/case-1`, () =>
+					HttpResponse.json(
+						{ error: "Failed to remove case access" },
+						{ status: 500 }
+					)
+				)
+			);
+
+			const { result } = renderHook(() =>
+				useIntegrationCaseGrants(INTEGRATION_ID)
+			);
+			await waitFor(() => expect(result.current.loading).toBe(false));
+			expect(result.current.grants).toHaveLength(1);
+
+			await act(async () => {
+				await result.current.removeAccess("case-1");
+			});
+
+			// No refetch was ever triggered by the failed DELETE (`load()` only
+			// runs in the `try` block, on success), so the grant that was never
+			// actually removed server-side stays visible rather than vanishing
+			// from a state the client never confirmed.
+			expect(result.current.grants).toHaveLength(1);
+			expect(result.current.grants[0]?.caseId).toBe("case-1");
+			expect(result.current.removingCaseId).toBeNull();
+		});
 	});
 });

--- a/hooks/__tests__/use-integration-case-grants.test.ts
+++ b/hooks/__tests__/use-integration-case-grants.test.ts
@@ -1,0 +1,220 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { IntegrationCaseGrant } from "@/lib/schemas/integration";
+import { server } from "@/src/__tests__/mocks/server";
+import { useIntegrationCaseGrants } from "../use-integration-case-grants";
+
+const INTEGRATION_ID = "integration-1";
+const CASE_GRANTS_PATH = `/api/integrations/${INTEGRATION_ID}/case-grants`;
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function makeGrant(
+	overrides: Partial<IntegrationCaseGrant> = {}
+): IntegrationCaseGrant {
+	return {
+		caseId: "case-1",
+		caseName: "DARTER Demo — Automated Inspection",
+		permission: "EDIT",
+		grantedAt: "2026-07-10T00:00:00.000Z",
+		...overrides,
+	};
+}
+
+describe("useIntegrationCaseGrants", () => {
+	it("starts loading, then resolves to the fetched grants list", async () => {
+		server.use(
+			http.get(CASE_GRANTS_PATH, () =>
+				HttpResponse.json({ grants: [makeGrant()] })
+			)
+		);
+
+		const { result } = renderHook(() =>
+			useIntegrationCaseGrants(INTEGRATION_ID)
+		);
+
+		expect(result.current.loading).toBe(true);
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.grants).toHaveLength(1);
+		expect(result.current.grants[0]?.caseName).toBe(
+			"DARTER Demo — Automated Inspection"
+		);
+		expect(result.current.loadError).toBeNull();
+	});
+
+	it("surfaces the envelope error message when the GET fails", async () => {
+		server.use(
+			http.get(CASE_GRANTS_PATH, () =>
+				HttpResponse.json(
+					{ error: "Failed to list case grants" },
+					{ status: 500 }
+				)
+			)
+		);
+
+		const { result } = renderHook(() =>
+			useIntegrationCaseGrants(INTEGRATION_ID)
+		);
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.loadError).toBe("Failed to list case grants");
+		expect(result.current.grants).toEqual([]);
+	});
+
+	describe("grantAccess", () => {
+		it("posts the grant, refetches, and resolves true on success", async () => {
+			let granted = false;
+			server.use(
+				http.get(CASE_GRANTS_PATH, () =>
+					HttpResponse.json({ grants: granted ? [makeGrant()] : [] })
+				),
+				http.post(CASE_GRANTS_PATH, async ({ request }) => {
+					const body = (await request.json()) as {
+						caseId: string;
+						permission: string;
+					};
+					expect(body).toEqual({ caseId: "case-1", permission: "EDIT" });
+					granted = true;
+					return HttpResponse.json(
+						{ grant: { ...makeGrant(), alreadyGranted: false } },
+						{ status: 201 }
+					);
+				})
+			);
+
+			const { result } = renderHook(() =>
+				useIntegrationCaseGrants(INTEGRATION_ID)
+			);
+			await waitFor(() => expect(result.current.loading).toBe(false));
+			expect(result.current.grants).toHaveLength(0);
+
+			let success: boolean | undefined;
+			await act(async () => {
+				success = await result.current.grantAccess("case-1", "EDIT");
+			});
+
+			expect(success).toBe(true);
+			expect(result.current.grants).toHaveLength(1);
+			expect(result.current.grantError).toBeNull();
+		});
+
+		it("maps a 409 to a fixed, faithful 'integration must be ACTIVE' message", async () => {
+			server.use(
+				http.get(CASE_GRANTS_PATH, () => HttpResponse.json({ grants: [] })),
+				http.post(CASE_GRANTS_PATH, () =>
+					HttpResponse.json(
+						{ error: "Cannot grant case access for a non-active integration" },
+						{ status: 409 }
+					)
+				)
+			);
+
+			const { result } = renderHook(() =>
+				useIntegrationCaseGrants(INTEGRATION_ID)
+			);
+			await waitFor(() => expect(result.current.loading).toBe(false));
+
+			let success: boolean | undefined;
+			await act(async () => {
+				success = await result.current.grantAccess("case-1", "EDIT");
+			});
+
+			expect(success).toBe(false);
+			expect(result.current.grantError).toBe(
+				"This integration must be ACTIVE before it can be granted access to a case. Reactivate it, then try again."
+			);
+			expect(result.current.grants).toHaveLength(0);
+		});
+
+		it("maps a 404 to a generic 'case not found' message, whatever the server's own wording", async () => {
+			server.use(
+				http.get(CASE_GRANTS_PATH, () => HttpResponse.json({ grants: [] })),
+				http.post(CASE_GRANTS_PATH, () =>
+					HttpResponse.json({ error: "Case not found" }, { status: 404 })
+				)
+			);
+
+			const { result } = renderHook(() =>
+				useIntegrationCaseGrants(INTEGRATION_ID)
+			);
+			await waitFor(() => expect(result.current.loading).toBe(false));
+
+			let success: boolean | undefined;
+			await act(async () => {
+				success = await result.current.grantAccess("case-1", "EDIT");
+			});
+
+			expect(success).toBe(false);
+			expect(result.current.grantError).toBe(
+				"Case not found. Check that the case still exists and that you hold admin access to it."
+			);
+		});
+
+		it("clears a previous grantError at the start of the next attempt", async () => {
+			let attempt = 0;
+			server.use(
+				http.get(CASE_GRANTS_PATH, () => HttpResponse.json({ grants: [] })),
+				http.post(CASE_GRANTS_PATH, () => {
+					attempt += 1;
+					if (attempt === 1) {
+						return HttpResponse.json(
+							{ error: "Case not found" },
+							{ status: 404 }
+						);
+					}
+					return HttpResponse.json(
+						{ grant: { ...makeGrant(), alreadyGranted: false } },
+						{ status: 201 }
+					);
+				})
+			);
+
+			const { result } = renderHook(() =>
+				useIntegrationCaseGrants(INTEGRATION_ID)
+			);
+			await waitFor(() => expect(result.current.loading).toBe(false));
+
+			await act(async () => {
+				await result.current.grantAccess("case-1", "EDIT");
+			});
+			expect(result.current.grantError).not.toBeNull();
+
+			await act(async () => {
+				await result.current.grantAccess("case-1", "EDIT");
+			});
+			expect(result.current.grantError).toBeNull();
+		});
+	});
+
+	describe("removeAccess", () => {
+		it("issues the DELETE and refetches", async () => {
+			let grants = [makeGrant()];
+			server.use(
+				http.get(CASE_GRANTS_PATH, () => HttpResponse.json({ grants })),
+				http.delete(`${CASE_GRANTS_PATH}/case-1`, () => {
+					grants = [];
+					return HttpResponse.json({ success: true });
+				})
+			);
+
+			const { result } = renderHook(() =>
+				useIntegrationCaseGrants(INTEGRATION_ID)
+			);
+			await waitFor(() => expect(result.current.loading).toBe(false));
+			expect(result.current.grants).toHaveLength(1);
+
+			await act(async () => {
+				await result.current.removeAccess("case-1");
+			});
+
+			expect(result.current.grants).toHaveLength(0);
+			expect(result.current.removingCaseId).toBeNull();
+		});
+	});
+});

--- a/hooks/use-integration-case-grants.ts
+++ b/hooks/use-integration-case-grants.ts
@@ -1,51 +1,12 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { RequestJsonError, requestJson } from "@/lib/request-json";
 import type {
 	CaseGrantPermission,
 	IntegrationCaseGrant,
 } from "@/lib/schemas/integration";
 import { toast } from "@/lib/toast";
-
-interface ApiErrorBody {
-	error?: string;
-}
-
-/**
- * A failed `fetch` against the case-grants routes, carrying the HTTP status
- * alongside the envelope's `error` message — `useIntegrations`' own
- * `requestJson` discards the status code, which is fine for its callers
- * (every failure there gets the same generic toast treatment) but not for
- * this hook: the grant flow needs to tell a 409 (integration not ACTIVE)
- * from a 404 (case not found / not admin) apart, faithfully, per the
- * settings-page dispatch brief.
- */
-class CaseGrantRequestError extends Error {
-	readonly status: number;
-
-	constructor(message: string, status: number) {
-		super(message);
-		this.name = "CaseGrantRequestError";
-		this.status = status;
-	}
-}
-
-async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
-	const response = await fetch(url, {
-		...init,
-		headers: { "Content-Type": "application/json", ...init?.headers },
-	});
-	if (!response.ok) {
-		const body = (await response
-			.json()
-			.catch(() => null)) as ApiErrorBody | null;
-		throw new CaseGrantRequestError(
-			body?.error ?? "Something went wrong",
-			response.status
-		);
-	}
-	return (await response.json()) as T;
-}
 
 function errorMessage(err: unknown): string {
 	return err instanceof Error ? err.message : "Something went wrong";
@@ -61,7 +22,7 @@ function errorMessage(err: unknown): string {
  * try to tell those apart either, on purpose.
  */
 function grantErrorMessage(err: unknown): string {
-	if (err instanceof CaseGrantRequestError) {
+	if (err instanceof RequestJsonError) {
 		if (err.status === 409) {
 			return "This integration must be ACTIVE before it can be granted access to a case. Reactivate it, then try again.";
 		}
@@ -114,6 +75,19 @@ export function useIntegrationCaseGrants(
 	const [grantError, setGrantError] = useState<string | null>(null);
 	const [removingCaseId, setRemovingCaseId] = useState<string | null>(null);
 
+	// No `cancelled`/AbortController guard here, unlike `GrantCaseAccessForm`'s
+	// mount effect — deliberate, not an oversight (fix-batch item 6, G3
+	// review 2026-07-13). That form's fetch is called from exactly one
+	// effect, so a single `cancelled` flag cleanly scopes to "this mount is
+	// gone." `load` here is shared across three call sites (the mount
+	// effect AND both `grantAccess`/`removeAccess`), where a flag flipped by
+	// the mount effect's cleanup would wrongly suppress a mutation's own
+	// post-request refetch if the component happened to unmount in between.
+	// A correct version needs a second, call-site-scoped guard, not a
+	// straight port of the form's pattern — real added complexity for a
+	// race that's a non-issue under React 19 (setState after unmount is a
+	// silent no-op, confirmed by nanaki's unmount-during-flight probe,
+	// G3 review UI test half).
 	const load = useCallback(async () => {
 		try {
 			const body = await requestJson<{ grants: IntegrationCaseGrant[] }>(

--- a/hooks/use-integration-case-grants.ts
+++ b/hooks/use-integration-case-grants.ts
@@ -1,0 +1,188 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type {
+	CaseGrantPermission,
+	IntegrationCaseGrant,
+} from "@/lib/schemas/integration";
+import { toast } from "@/lib/toast";
+
+interface ApiErrorBody {
+	error?: string;
+}
+
+/**
+ * A failed `fetch` against the case-grants routes, carrying the HTTP status
+ * alongside the envelope's `error` message — `useIntegrations`' own
+ * `requestJson` discards the status code, which is fine for its callers
+ * (every failure there gets the same generic toast treatment) but not for
+ * this hook: the grant flow needs to tell a 409 (integration not ACTIVE)
+ * from a 404 (case not found / not admin) apart, faithfully, per the
+ * settings-page dispatch brief.
+ */
+class CaseGrantRequestError extends Error {
+	readonly status: number;
+
+	constructor(message: string, status: number) {
+		super(message);
+		this.name = "CaseGrantRequestError";
+		this.status = status;
+	}
+}
+
+async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
+	const response = await fetch(url, {
+		...init,
+		headers: { "Content-Type": "application/json", ...init?.headers },
+	});
+	if (!response.ok) {
+		const body = (await response
+			.json()
+			.catch(() => null)) as ApiErrorBody | null;
+		throw new CaseGrantRequestError(
+			body?.error ?? "Something went wrong",
+			response.status
+		);
+	}
+	return (await response.json()) as T;
+}
+
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : "Something went wrong";
+}
+
+/**
+ * Maps a failed grant attempt to the fixed, faithful message the settings
+ * UI should show — 409 always means "the integration isn't ACTIVE" (the
+ * only conflict `POST .../case-grants` ever returns, per its own doc
+ * comment), and 404 is deliberately generic: it covers a nonexistent case,
+ * a soft-deleted one, AND the caller lacking case-ADMIN, all with the exact
+ * same message server-side (no enumeration oracle) — this hook does not
+ * try to tell those apart either, on purpose.
+ */
+function grantErrorMessage(err: unknown): string {
+	if (err instanceof CaseGrantRequestError) {
+		if (err.status === 409) {
+			return "This integration must be ACTIVE before it can be granted access to a case. Reactivate it, then try again.";
+		}
+		if (err.status === 404) {
+			return "Case not found. Check that the case still exists and that you hold admin access to it.";
+		}
+	}
+	return errorMessage(err);
+}
+
+export interface UseIntegrationCaseGrantsResult {
+	grantAccess: (
+		caseId: string,
+		permission: CaseGrantPermission
+	) => Promise<boolean>;
+	/** The faithfully-mapped message from the most recent failed grant attempt, or `null`. */
+	grantError: string | null;
+	/** True while a `POST` grant request is in flight. */
+	granting: boolean;
+	grants: IntegrationCaseGrant[];
+	loadError: string | null;
+	/** True while the initial (or a manually triggered) list fetch is in flight. */
+	loading: boolean;
+	refetch: () => Promise<void>;
+	removeAccess: (caseId: string) => Promise<void>;
+	/** The caseId currently mid-`DELETE`, or `null`. */
+	removingCaseId: string | null;
+}
+
+/**
+ * Fetches and manages one integration's case-access grants via
+ * `/api/integrations/[id]/case-grants` — the "Case access" section's only
+ * data source (house rule: data via the new routes only, no service/Prisma
+ * import here). One instance of this hook is scoped to a single
+ * integrationId, called directly from `IntegrationCard` (which already owns
+ * exactly one integration per render, so this is one hook call per card
+ * instance, not a hook-in-a-loop).
+ *
+ * Every mutation re-fetches the full list on success, same rationale as
+ * `useIntegrations`: cheaper to re-resolve through the same GET the section
+ * renders from than to hand-reconcile a nested array locally.
+ */
+export function useIntegrationCaseGrants(
+	integrationId: string
+): UseIntegrationCaseGrantsResult {
+	const [grants, setGrants] = useState<IntegrationCaseGrant[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [loadError, setLoadError] = useState<string | null>(null);
+	const [granting, setGranting] = useState(false);
+	const [grantError, setGrantError] = useState<string | null>(null);
+	const [removingCaseId, setRemovingCaseId] = useState<string | null>(null);
+
+	const load = useCallback(async () => {
+		try {
+			const body = await requestJson<{ grants: IntegrationCaseGrant[] }>(
+				`/api/integrations/${integrationId}/case-grants`
+			);
+			setGrants(body.grants);
+			setLoadError(null);
+		} catch (err) {
+			setLoadError(errorMessage(err));
+		}
+	}, [integrationId]);
+
+	useEffect(() => {
+		setLoading(true);
+		load().finally(() => setLoading(false));
+	}, [load]);
+
+	const grantAccess = useCallback(
+		async (caseId: string, permission: CaseGrantPermission) => {
+			setGranting(true);
+			setGrantError(null);
+			try {
+				await requestJson(`/api/integrations/${integrationId}/case-grants`, {
+					method: "POST",
+					body: JSON.stringify({ caseId, permission }),
+				});
+				await load();
+				return true;
+			} catch (err) {
+				setGrantError(grantErrorMessage(err));
+				return false;
+			} finally {
+				setGranting(false);
+			}
+		},
+		[integrationId, load]
+	);
+
+	const removeAccess = useCallback(
+		async (caseId: string) => {
+			setRemovingCaseId(caseId);
+			try {
+				await requestJson(
+					`/api/integrations/${integrationId}/case-grants/${caseId}`,
+					{ method: "DELETE" }
+				);
+				await load();
+			} catch (err) {
+				toast({
+					variant: "destructive",
+					title: "Couldn't remove case access",
+					description: errorMessage(err),
+				});
+			} finally {
+				setRemovingCaseId(null);
+			}
+		},
+		[integrationId, load]
+	);
+
+	return {
+		grants,
+		loading,
+		loadError,
+		refetch: load,
+		granting,
+		grantError,
+		grantAccess,
+		removingCaseId,
+		removeAccess,
+	};
+}

--- a/hooks/use-integrations.ts
+++ b/hooks/use-integrations.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { requestJson } from "@/lib/request-json";
 import type {
 	IntegrationListItem,
 	IssuedTokenResult,
@@ -8,26 +9,6 @@ import type {
 	RotatedTokenResult,
 } from "@/lib/schemas/integration";
 import { toast } from "@/lib/toast";
-
-interface ApiErrorBody {
-	error?: string;
-}
-
-async function parseErrorMessage(response: Response): Promise<string> {
-	const body = (await response.json().catch(() => null)) as ApiErrorBody | null;
-	return body?.error ?? "Something went wrong";
-}
-
-async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
-	const response = await fetch(url, {
-		...init,
-		headers: { "Content-Type": "application/json", ...init?.headers },
-	});
-	if (!response.ok) {
-		throw new Error(await parseErrorMessage(response));
-	}
-	return (await response.json()) as T;
-}
 
 async function requestIntegrations(): Promise<IntegrationListItem[]> {
 	const body = await requestJson<{ integrations: IntegrationListItem[] }>(

--- a/lib/__tests__/request-json.test.ts
+++ b/lib/__tests__/request-json.test.ts
@@ -1,0 +1,65 @@
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+import { server } from "@/src/__tests__/mocks/server";
+import { RequestJsonError, requestJson } from "../request-json";
+
+const PATH = "/api/__test__/request-json";
+
+describe("requestJson", () => {
+	it("resolves with the parsed JSON body on a 2xx response", async () => {
+		server.use(
+			http.get(PATH, () => HttpResponse.json({ ok: true, value: 42 }))
+		);
+
+		const body = await requestJson<{ ok: boolean; value: number }>(PATH);
+
+		expect(body).toEqual({ ok: true, value: 42 });
+	});
+
+	it("always sends Content-Type: application/json, merged with any caller-supplied headers", async () => {
+		let seenContentType: string | null = null;
+		let seenCustomHeader: string | null = null;
+		server.use(
+			http.post(PATH, ({ request }) => {
+				seenContentType = request.headers.get("Content-Type");
+				seenCustomHeader = request.headers.get("X-Custom");
+				return HttpResponse.json({ ok: true });
+			})
+		);
+
+		await requestJson(PATH, {
+			method: "POST",
+			headers: { "X-Custom": "value" },
+			body: JSON.stringify({}),
+		});
+
+		expect(seenContentType).toBe("application/json");
+		expect(seenCustomHeader).toBe("value");
+	});
+
+	it("throws a RequestJsonError carrying the envelope's message and the status code on a non-2xx response", async () => {
+		server.use(
+			http.get(PATH, () =>
+				HttpResponse.json({ error: "Case not found" }, { status: 404 })
+			)
+		);
+
+		await expect(requestJson(PATH)).rejects.toMatchObject({
+			name: "RequestJsonError",
+			message: "Case not found",
+			status: 404,
+		});
+		await expect(requestJson(PATH)).rejects.toBeInstanceOf(RequestJsonError);
+	});
+
+	it("falls back to a generic message when the failure body isn't JSON or has no `error` field", async () => {
+		server.use(
+			http.get(PATH, () => new HttpResponse("<html/>", { status: 500 }))
+		);
+
+		await expect(requestJson(PATH)).rejects.toMatchObject({
+			message: "Something went wrong",
+			status: 500,
+		});
+	});
+});

--- a/lib/request-json.ts
+++ b/lib/request-json.ts
@@ -1,0 +1,51 @@
+interface ApiErrorBody {
+	error?: string;
+}
+
+/**
+ * A failed `requestJson` call, carrying the HTTP status alongside the
+ * envelope's `error` message. Most callers (`useIntegrations`) only need
+ * `message` — every failure there gets the same generic toast treatment —
+ * but a caller that must tell status codes apart (`useIntegrationCaseGrants`,
+ * which maps 409 vs 404 to two different faithful messages) reads `status`
+ * off the caught error via `instanceof RequestJsonError`.
+ */
+export class RequestJsonError extends Error {
+	readonly status: number;
+
+	constructor(message: string, status: number) {
+		super(message);
+		this.name = "RequestJsonError";
+		this.status = status;
+	}
+}
+
+/**
+ * Shared client-side `fetch` + JSON wrapper for hooks under `hooks/` — always
+ * sends `Content-Type: application/json`, and on a non-2xx response throws a
+ * `RequestJsonError` carrying both the envelope's `error` message (falling
+ * back to a generic one if the body isn't JSON or has no `error` field) and
+ * the response's status code. Extracted from `useIntegrations` and
+ * `useIntegrationCaseGrants`, which each carried a near-identical copy
+ * (fallow-flagged clone, G3 review 2026-07-13) — this is the one definition
+ * both import.
+ */
+export async function requestJson<T>(
+	url: string,
+	init?: RequestInit
+): Promise<T> {
+	const response = await fetch(url, {
+		...init,
+		headers: { "Content-Type": "application/json", ...init?.headers },
+	});
+	if (!response.ok) {
+		const body = (await response
+			.json()
+			.catch(() => null)) as ApiErrorBody | null;
+		throw new RequestJsonError(
+			body?.error ?? "Something went wrong",
+			response.status
+		);
+	}
+	return (await response.json()) as T;
+}

--- a/lib/schemas/integration.ts
+++ b/lib/schemas/integration.ts
@@ -228,3 +228,29 @@ export interface RotatedTokenResult {
 	secret: string;
 	token: IssuedTokenSummary;
 }
+
+/**
+ * Case-grant permission levels a machine principal may hold — mirrors
+ * `grantableCasePermissionSchema` above (VIEW/COMMENT/EDIT only, never
+ * ADMIN). Kept as its own wire-shape type rather than reusing a
+ * `z.infer<typeof grantableCasePermissionSchema>` alias, for the same reason
+ * `IntegrationStatus` above doesn't import the Prisma enum: this crosses the
+ * wire as a JSON string, and components/hooks must never import from
+ * `lib/services/` or reach for a Prisma-derived type.
+ */
+export type CaseGrantPermission = "COMMENT" | "EDIT" | "VIEW";
+
+/**
+ * One case an integration's system user currently has access to, as
+ * returned by `GET /api/integrations/[id]/case-grants` and (on success) by
+ * `POST .../case-grants`'s `grant` field — mirrors
+ * `IntegrationCaseGrant`/`IntegrationCaseGrantResult` in
+ * `lib/services/integration-registry-service.ts`, JSON-shaped (`grantedAt`
+ * a string, never a `Date`).
+ */
+export interface IntegrationCaseGrant {
+	caseId: string;
+	caseName: string;
+	grantedAt: string;
+	permission: CaseGrantPermission;
+}


### PR DESCRIPTION
Stacked on #858 (the case-grants API) — this PR shows only the UI delta and will retarget to staging automatically when #858 merges. Merge order: #858 first, then this.

## What's here (5 reviewed commits)

**Case access section** on each integration card: lists the machine user's case grants, grants new access (case picker offers only cases you own — guaranteed valid; permission levels VIEW/COMMENT/EDIT, ADMIN never offered), removes grants with an inline confirm. Errors surface faithfully — a 409 explains the integration must be active; 404s stay deliberately generic per the API's no-enumeration guarantee. Load failures get a retry button; the grant button is disabled with an explanation on non-active integrations.

**Delete guard** (revoke-first): Delete is disabled with an explanatory tooltip until an integration is revoked; on a revoked integration it opens a confirm dialog that names what is permanently lost (case access, audit trail) and requires typing the integration's exact name. One-click hard delete is now impossible in every state.

**Shared request helper** extracted (`lib/request-json.ts`) with status-code passthrough — removes the duplication between the integrations hooks.

## Review chain
- Both halves through QA + code review; every finding dispositioned. 27 regression tests adopted from the QA probe rounds — including the card-to-hook wiring seam, per-card fault isolation, double-submit guards, and seven pins on the delete dialog's strict name-matching (whitespace/case/prefix/regex-literal) so a future refactor can't silently loosen a destructive-action guard.
- Final state: settings suite 89/89, full unit project green, lint + typecheck clean, zero introduced static-analysis findings.

## Known follow-ups (filed, not blocking)
- Disabled-button tooltips aren't perceivable to keyboard/screen-reader users — pre-existing pattern across three buttons, tracked as its own issue for one consistent fix.
- Per-card grants fetch is fine at current integration counts; scaling note recorded if counts grow past ~10–20.