### PR TITLE
Delete an integration's system user with the integration

### DIFF
--- a/app/api/integrations/[id]/case-grants/route.ts
+++ b/app/api/integrations/[id]/case-grants/route.ts
@@ -88,7 +88,7 @@ export async function GET(
  * @response 400 - Validation error (including `permission: "ADMIN"`, which this endpoint never accepts)
  * @response 401 - Unauthorised
  * @response 404 - Integration not found, OR case not found (incl. soft-deleted/trashed), OR caller lacks case ADMIN (identical message/status for all — no enumeration oracle)
- * @response 409 - The integration is not ACTIVE
+ * @response 409 - The integration is not ACTIVE — `error` is one of two distinct, status-specific strings, not a uniform message: "Cannot grant case access for a suspended integration" or "Cannot grant case access for a revoked integration" (safe to disclose — this only fires after the owner + case-admin checks above already pass)
  * @auth SessionAuth
  * @tag Integrations
  */

--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -143,10 +143,15 @@ const ERROR_MAPPINGS: Array<{
 	// "...for a revoked integration"), not one uniform "non-active" string
 	// (QA, 2026-07-14 — a client that keys its own copy off a held prop can
 	// go stale cross-tab; the uniform message gave it nothing to recover
-	// with). Both still collapse to the same 409 CONFLICT here.
+	// with). The service's own gate still fails closed on `!== "ACTIVE"`
+	// rather than allowlisting just these two statuses, so the original
+	// uniform "...for a non-active integration" string remains a live
+	// (if unreachable while `IntegrationStatus` stays a 3-value enum)
+	// fallback — kept here too, or that fallback would 500 as INTERNAL
+	// instead of 409. All three collapse to the same 409 CONFLICT here.
 	{
 		pattern:
-			/^Cannot (suspend|reactivate) a revoked integration$|^Cannot (issue|rotate) a token for a non-active integration$|^Cannot grant case access for a (suspended|revoked) integration$|^Cannot rotate a revoked token$/,
+			/^Cannot (suspend|reactivate) a revoked integration$|^Cannot (issue|rotate) a token for a non-active integration$|^Cannot grant case access for a (suspended|revoked|non-active) integration$|^Cannot rotate a revoked token$/,
 		factory: conflict,
 	},
 	// `user-management-service.ts`'s `deleteAccount` — owned integrations

--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -137,9 +137,16 @@ const ERROR_MAPPINGS: Array<{
 	// through one that isn't ACTIVE). None of these contain "already" or
 	// "not found", so without this entry they'd fall through to INTERNAL
 	// (500) the first time an HTTP route ever surfaced them.
+	//
+	// `grantIntegrationCaseAccess` reports its non-ACTIVE guard as two
+	// DISTINCT status-specific messages ("...for a suspended integration" /
+	// "...for a revoked integration"), not one uniform "non-active" string
+	// (QA, 2026-07-14 — a client that keys its own copy off a held prop can
+	// go stale cross-tab; the uniform message gave it nothing to recover
+	// with). Both still collapse to the same 409 CONFLICT here.
 	{
 		pattern:
-			/^Cannot (suspend|reactivate) a revoked integration$|^Cannot (issue|rotate) a token for a non-active integration$|^Cannot grant case access for a non-active integration$|^Cannot rotate a revoked token$/,
+			/^Cannot (suspend|reactivate) a revoked integration$|^Cannot (issue|rotate) a token for a non-active integration$|^Cannot grant case access for a (suspended|revoked) integration$|^Cannot rotate a revoked token$/,
 		factory: conflict,
 	},
 	// `user-management-service.ts`'s `deleteAccount` — owned integrations

--- a/lib/services/integration-registry-service.ts
+++ b/lib/services/integration-registry-service.ts
@@ -1282,8 +1282,15 @@ async function requireIntegrationOwnerAndCaseAdmin(
  * nothing about which of the two terminal states it was looking at). Two
  * distinct, `^...$`-anchored messages — "Cannot grant case access for a
  * suspended integration" / "...for a revoked integration" — both map to 409
- * via `lib/api-response.ts`'s `ERROR_MAPPINGS`. Revealing which status it is
- * leaks nothing: this check runs strictly AFTER
+ * via `lib/api-response.ts`'s `ERROR_MAPPINGS`. The gate itself stays a
+ * single `!== "ACTIVE"` check (fail-closed) rather than an allowlist of
+ * `SUSPENDED`/`REVOKED` — `IntegrationStatus` is a closed 3-value enum
+ * today, so the two are behaviourally identical, but `!== "ACTIVE"` also
+ * rejects any status this enum might grow in future, where an allowlist
+ * would silently fall through and grant. The unreachable-today fallback
+ * message ("...for a non-active integration") is also still matched by
+ * `ERROR_MAPPINGS`, so that future status would 409 rather than 500.
+ * Revealing which status it is leaks nothing: this check runs strictly AFTER
  * `requireIntegrationOwnerAndCaseAdmin`, so it only fires once the caller
  * has already proven they own the integration and hold case-ADMIN — status
  * is not something to hide from someone who could just call `GET
@@ -1345,11 +1352,17 @@ export async function grantIntegrationCaseAccess(
 		if ("error" in authorised) {
 			return authorised;
 		}
-		if (authorised.data.status === "SUSPENDED") {
-			return { error: "Cannot grant case access for a suspended integration" };
-		}
-		if (authorised.data.status === "REVOKED") {
-			return { error: "Cannot grant case access for a revoked integration" };
+		// Fail closed: gate on `!== "ACTIVE"`, not an allowlist of the two
+		// known-bad statuses — a future IntegrationStatus variant is rejected
+		// by default instead of silently falling through to a grant.
+		if (authorised.data.status !== "ACTIVE") {
+			let message = "Cannot grant case access for a non-active integration";
+			if (authorised.data.status === "SUSPENDED") {
+				message = "Cannot grant case access for a suspended integration";
+			} else if (authorised.data.status === "REVOKED") {
+				message = "Cannot grant case access for a revoked integration";
+			}
+			return { error: message };
 		}
 
 		const assuranceCase = await prisma.assuranceCase.findUnique({

--- a/lib/services/integration-registry-service.ts
+++ b/lib/services/integration-registry-service.ts
@@ -693,11 +693,35 @@ export async function reassignIntegrationOwner(
 }
 
 /**
- * Hard-deletes an integration's registration (cascades its tokens). Use
- * when reassignment isn't wanted — deleting the row, not just revoking,
- * gives up the integration's own accountability trail, so prefer
- * `revokeIntegration` when that trail matters and this only when a human
- * owner needs the RESTRICT cleared without a new owner to hand off to.
+ * Hard-deletes an integration's registration AND its dedicated system user
+ * (cascades the integration's tokens via `ApiToken`'s `onDelete: Cascade`,
+ * and the system user's `CasePermission` grants via that relation's own
+ * `onDelete: Cascade` — see `prisma/schema.prisma`). Use when reassignment
+ * isn't wanted — deleting the row, not just revoking, gives up the
+ * integration's own accountability trail, so prefer `revokeIntegration`
+ * when that trail matters and this only when a human owner needs the
+ * RESTRICT cleared without a new owner to hand off to.
+ *
+ * Deletion order inside the transaction is load-bearing, not incidental:
+ * `Integration.systemUserId`/`ownerId` are BOTH `onDelete: Restrict` FKs
+ * onto `User` (migration `20260703000000_extension_foundations`), so the
+ * `Integration` row must be gone before its system user can be deleted —
+ * deleting the user first would hit the RESTRICT constraint and roll back.
+ * `$transaction([...])` (array form) runs its statements sequentially in
+ * the order given, so `integration.delete` always precedes `user.delete`.
+ *
+ * Previously this deleted only the `Integration` row, orphaning the system
+ * user: its unique `username`/`email` stuck around forever, permanently
+ * blocking same-name re-registration (a fresh `registerIntegration` call
+ * collides with the orphan's constraints, and the generic unique-violation
+ * catch there misreports it as "An integration with this name already
+ * exists"), and its `CasePermission` grants never cascaded away (the
+ * cascade is keyed on the USER's delete, which never fired) — the delete
+ * dialog's "removes ... its case-access grants" promise wasn't kept for a
+ * grant list that referenced no case; the row itself just sat there,
+ * masked from `listIntegrationCaseGrants` by "the integration no longer
+ * exists" but never actually gone. Both are fixed by deleting the system
+ * user in the same transaction (found + fixed 2026-07-14, staging repro).
  */
 export async function deleteIntegrationRegistration(
 	integrationId: string,
@@ -707,13 +731,16 @@ export async function deleteIntegrationRegistration(
 		const existing = await getOwnedIntegrationOrError(
 			integrationId,
 			actorUserId,
-			{ id: true, name: true }
+			{ id: true, name: true, systemUserId: true }
 		);
 		if ("error" in existing) {
 			return existing;
 		}
 
-		await prisma.integration.delete({ where: { id: integrationId } });
+		await prisma.$transaction([
+			prisma.integration.delete({ where: { id: integrationId } }),
+			prisma.user.delete({ where: { id: existing.data.systemUserId } }),
+		]);
 
 		await writeAuditLog({
 			userId: actorUserId,

--- a/lib/services/integration-registry-service.ts
+++ b/lib/services/integration-registry-service.ts
@@ -722,6 +722,19 @@ export async function reassignIntegrationOwner(
  * masked from `listIntegrationCaseGrants` by "the integration no longer
  * exists" but never actually gone. Both are fixed by deleting the system
  * user in the same transaction (found + fixed 2026-07-14, staging repro).
+ *
+ * One trail this does NOT preserve: `PluginHealthEvidence.createdById`
+ * (`prisma/schema.prisma`) records the machine principal that appended each
+ * evidence row, but that column carries no FK — it is a bare string, not a
+ * `@relation` onto `User` (deliberately: tier-2 plugin tables are one-way,
+ * core never references a plugin table back — see the model's own doc
+ * comment). Deleting this integration's system user here does not cascade
+ * or restrict against those rows; they simply survive with a `createdById`
+ * that no longer resolves to any user, an unattributable actor in an
+ * otherwise tamper-evident, hash-chained evidence log. `revokeIntegration`
+ * — not this function — is the trail-preserving path when that
+ * attribution matters: it never deletes the system user, so its evidence
+ * rows stay resolvable.
  */
 export async function deleteIntegrationRegistration(
 	integrationId: string,
@@ -1263,16 +1276,24 @@ async function requireIntegrationOwnerAndCaseAdmin(
  * found" 404 shape rather than a 403).
  *
  * Additionally requires the integration be ACTIVE — mirrors `issueToken`'s
- * own guard and error shape ("Cannot grant case access for a non-active
- * integration", mapped to 409 by `lib/api-response.ts`'s `ERROR_MAPPINGS`):
- * handing a suspended or revoked integration's system user MORE case access
- * makes no sense while it can't authenticate (SUSPENDED) or never will again
- * (REVOKED). This check runs after `requireIntegrationOwnerAndCaseAdmin`
- * rather than before — the two conditions are independent, so the ordering
- * doesn't change what any caller can learn: failing case-admin always
- * reports "Case not found" regardless of integration status, and an
- * inactive integration always reports this conflict regardless of case
- * access. `listIntegrationCaseGrants` and `revokeIntegrationCaseAccess`
+ * own guard, but reports the integration's ACTUAL status rather than a
+ * uniform "non-active" (QA, 2026-07-14: a client that keys its own copy off
+ * a prop it already held could go stale cross-tab — "non-active" told it
+ * nothing about which of the two terminal states it was looking at). Two
+ * distinct, `^...$`-anchored messages — "Cannot grant case access for a
+ * suspended integration" / "...for a revoked integration" — both map to 409
+ * via `lib/api-response.ts`'s `ERROR_MAPPINGS`. Revealing which status it is
+ * leaks nothing: this check runs strictly AFTER
+ * `requireIntegrationOwnerAndCaseAdmin`, so it only fires once the caller
+ * has already proven they own the integration and hold case-ADMIN — status
+ * is not something to hide from someone who could just call `GET
+ * /api/integrations/[id]` and read it directly. This check runs after
+ * `requireIntegrationOwnerAndCaseAdmin` rather than before — the two
+ * conditions are independent, so the ordering doesn't change what any
+ * caller can learn: failing case-admin always reports "Case not found"
+ * regardless of integration status, and an inactive integration always
+ * reports one of these two conflicts regardless of case access.
+ * `listIntegrationCaseGrants` and `revokeIntegrationCaseAccess`
  * deliberately do NOT carry this gate — listing or revoking a suspended or
  * revoked integration's access is exactly the cleanup path an operator
  * needs after suspending/revoking it, and blocking that would make the
@@ -1324,8 +1345,11 @@ export async function grantIntegrationCaseAccess(
 		if ("error" in authorised) {
 			return authorised;
 		}
-		if (authorised.data.status !== "ACTIVE") {
-			return { error: "Cannot grant case access for a non-active integration" };
+		if (authorised.data.status === "SUSPENDED") {
+			return { error: "Cannot grant case access for a suspended integration" };
+		}
+		if (authorised.data.status === "REVOKED") {
+			return { error: "Cannot grant case access for a revoked integration" };
 		}
 
 		const assuranceCase = await prisma.assuranceCase.findUnique({

--- a/prisma/migrations/20260714000000_backfill_delete_orphaned_integration_system_users/migration.sql
+++ b/prisma/migrations/20260714000000_backfill_delete_orphaned_integration_system_users/migration.sql
@@ -1,0 +1,37 @@
+-- Backfill: delete integration system users orphaned by the OLD
+-- `deleteIntegrationRegistration` bug (fixed in
+-- `lib/services/integration-registry-service.ts`, 2026-07-14 — that fix
+-- only stops NEW orphans; it does nothing for ones the old code already
+-- left behind). An orphaned system user's unique `username`/`email` blocks
+-- same-name re-registration forever (staging carries exactly this case:
+-- `integration-darter-pipeline`). This is data-only — no schema change.
+--
+-- Scope is deliberately narrow, requiring ALL of:
+--   1. `is_system_user = true`
+--   2. `username LIKE 'integration-%'`   (registerIntegration's own shape:
+--      `integration-${slug}`)
+--   3. `email LIKE 'integration+%@tea-platform.internal'` (same call's
+--      `integration+${slug}@tea-platform.internal`)
+--   4. no `integrations` row references it via `system_user_id` (i.e. it is
+--      actually orphaned, not a live integration's principal)
+--
+-- CRITICAL EXCLUSION: the generic fallback system account created by
+-- `getOrCreateSystemUser` (`lib/services/user-management-service.ts`,
+-- ~line 290) is a deliberately separate account used for ownership
+-- transfer when a human user is deleted. Its username/email are the fixed
+-- literals `system` / `system@tea-platform.internal` — neither matches the
+-- `integration-%` / `integration+%@...` shapes above, so condition 2+3
+-- alone already excludes it; it is also never referenced by
+-- `integrations.system_user_id` (condition 4 would exclude it a second way
+-- even if its naming ever changed to something that collided with 2/3).
+--
+-- `case_permissions` rows held by a deleted orphan cascade automatically
+-- (`case_permissions.user_id` is `ON DELETE CASCADE` onto `users` — see
+-- `prisma/schema.prisma`); no separate cleanup statement is needed here.
+DELETE FROM users
+WHERE is_system_user = true
+  AND username LIKE 'integration-%'
+  AND email LIKE 'integration+%@tea-platform.internal'
+  AND NOT EXISTS (
+    SELECT 1 FROM integrations WHERE integrations.system_user_id = users.id
+  );

--- a/src/__tests__/integration/api-integration-case-grants.test.ts
+++ b/src/__tests__/integration/api-integration-case-grants.test.ts
@@ -624,8 +624,14 @@ describe("POST /api/integrations/[id]/case-grants", () => {
 	 * `issueToken`'s own guard. GET/DELETE deliberately do NOT carry this
 	 * gate (see the "still lists"/"still revokes" tests in their own
 	 * describe blocks).
+	 *
+	 * V2 (QA, 2026-07-14): the 409 body must carry the integration's ACTUAL
+	 * status, not a uniform "non-active" message — a client keying its own
+	 * copy off a held prop can go stale cross-tab, and only the real status
+	 * lets it recover. Pinned as two distinct, status-specific strings
+	 * rather than one shared message.
 	 */
-	it("rejects granting case access via a SUSPENDED integration with 409", async () => {
+	it("rejects granting case access via a SUSPENDED integration with 409 and the SUSPENDED-specific message", async () => {
 		const owner = await createTestUser();
 		const { integration, systemUser } =
 			await createTestIntegrationWithSystemUser(owner.id, {
@@ -646,13 +652,17 @@ describe("POST /api/integrations/[id]/case-grants", () => {
 		);
 
 		expect(response.status).toBe(409);
+		const body = await response.json();
+		expect(body.error).toBe(
+			"Cannot grant case access for a suspended integration"
+		);
 		const permission = await prisma.casePermission.findUnique({
 			where: { caseId_userId: { caseId: testCase.id, userId: systemUser.id } },
 		});
 		expect(permission).toBeNull();
 	});
 
-	it("rejects granting case access via a REVOKED integration with 409", async () => {
+	it("rejects granting case access via a REVOKED integration with 409 and the REVOKED-specific message", async () => {
 		const owner = await createTestUser();
 		const { integration } = await createTestIntegrationWithSystemUser(
 			owner.id,
@@ -675,6 +685,10 @@ describe("POST /api/integrations/[id]/case-grants", () => {
 		);
 
 		expect(response.status).toBe(409);
+		const body = await response.json();
+		expect(body.error).toBe(
+			"Cannot grant case access for a revoked integration"
+		);
 	});
 
 	/**

--- a/src/__tests__/integration/api-integrations.test.ts
+++ b/src/__tests__/integration/api-integrations.test.ts
@@ -4,7 +4,9 @@ import prisma from "@/lib/prisma";
 import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
 import {
 	createTestApiToken,
+	createTestCase,
 	createTestIntegrationWithSystemUser,
+	createTestPermission,
 	createTestUser,
 } from "../utils/prisma-factories";
 
@@ -528,6 +530,256 @@ describe("DELETE /api/integrations/[id]", () => {
 		);
 		expect(ids).not.toContain(toDelete.id);
 		expect(ids).toContain(toKeep.id);
+	});
+});
+
+// ============================================
+// DELETE /api/integrations/[id] — system user orphan cleanup
+// (TEA — Integration delete leaves the machine user behind, blocks
+// same-name re-registration; found + fixed 2026-07-14, staging repro)
+// ============================================
+
+describe("DELETE /api/integrations/[id] — system user orphan cleanup", () => {
+	it("full journey: register, grant case access, revoke it, delete, then re-register the same name succeeds — the system user and its CasePermission grants are actually gone, not just unreachable through the deleted integration", async () => {
+		const owner = await createTestUser();
+		await mockAuth(owner.id, owner.username, owner.email);
+		const testCase = await createTestCase(owner.id, {
+			name: "orphan-journey-case",
+		});
+
+		const name = `orphan-journey-${owner.id}`;
+		const { POST: registerPost } = await import("@/app/api/integrations/route");
+		const registerResponse = await registerPost(
+			jsonRequest("/api/integrations", "POST", {
+				name,
+				scopes: ["case:read"],
+			})
+		);
+		expect(registerResponse.status).toBe(201);
+		const { integration } = await registerResponse.json();
+		const integrationId: string = integration.id;
+		const systemUserId: string = integration.systemUserId;
+		expect(systemUserId).toEqual(expect.any(String));
+
+		// The system user exists and carries the exact username/email the
+		// unique-constraint collision used to be keyed on.
+		const systemUserBeforeDelete = await prisma.user.findUnique({
+			where: { id: systemUserId },
+		});
+		expect(systemUserBeforeDelete).toMatchObject({
+			email: `integration+${name}@tea-platform.internal`,
+			isSystemUser: true,
+			username: `integration-${name}`,
+		});
+
+		// Grant the system user access to a case.
+		const { POST: grantPost } = await import(
+			"@/app/api/integrations/[id]/case-grants/route"
+		);
+		const grantResponse = await grantPost(
+			jsonRequest(`/api/integrations/${integrationId}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "EDIT",
+			}),
+			idParams(integrationId)
+		);
+		expect(grantResponse.status).toBe(201);
+		expect(
+			await prisma.casePermission.findUnique({
+				where: {
+					caseId_userId: { caseId: testCase.id, userId: systemUserId },
+				},
+			})
+		).not.toBeNull();
+
+		// Revoke that grant explicitly, then grant it again — proving the
+		// orphan assertions below exercise the DELETE-time cascade, not just
+		// the outcome of this explicit revoke.
+		const { DELETE: revokeCaseAccessDelete } = await import(
+			"@/app/api/integrations/[id]/case-grants/[caseId]/route"
+		);
+		const revokeResponse = await revokeCaseAccessDelete(
+			jsonRequest(
+				`/api/integrations/${integrationId}/case-grants/${testCase.id}`,
+				"DELETE"
+			),
+			{ params: Promise.resolve({ id: integrationId, caseId: testCase.id }) }
+		);
+		expect(revokeResponse.status).toBe(200);
+		expect(
+			await prisma.casePermission.findUnique({
+				where: {
+					caseId_userId: { caseId: testCase.id, userId: systemUserId },
+				},
+			})
+		).toBeNull();
+
+		const regrantResponse = await grantPost(
+			jsonRequest(`/api/integrations/${integrationId}/case-grants`, "POST", {
+				caseId: testCase.id,
+				permission: "VIEW",
+			}),
+			idParams(integrationId)
+		);
+		expect(regrantResponse.status).toBe(201);
+		expect(
+			await prisma.casePermission.findUnique({
+				where: {
+					caseId_userId: { caseId: testCase.id, userId: systemUserId },
+				},
+			})
+		).not.toBeNull();
+
+		// Delete the integration's registration.
+		const { DELETE: deleteIntegrationDelete } = await import(
+			"@/app/api/integrations/[id]/route"
+		);
+		const deleteResponse = await deleteIntegrationDelete(
+			jsonRequest(`/api/integrations/${integrationId}`, "DELETE"),
+			idParams(integrationId)
+		);
+		expect(deleteResponse.status).toBe(200);
+
+		// Orphan assertions: the system user itself is gone...
+		const orphanUser = await prisma.user.findUnique({
+			where: { id: systemUserId },
+		});
+		expect(orphanUser).toBeNull();
+
+		// ...its CasePermission grant cascaded away with it (not merely
+		// unreachable via the now-deleted integration)...
+		const orphanGrant = await prisma.casePermission.findUnique({
+			where: {
+				caseId_userId: { caseId: testCase.id, userId: systemUserId },
+			},
+		});
+		expect(orphanGrant).toBeNull();
+
+		// ...and neither the username nor the email that used to collide on
+		// re-registration exist anywhere any more — the leftover-collision
+		// path `registerIntegration`'s catch-all unique-constraint handler
+		// used to hit is now unreachable, not merely worked around.
+		expect(
+			await prisma.user.findUnique({
+				where: { username: `integration-${name}` },
+			})
+		).toBeNull();
+		expect(
+			await prisma.user.findUnique({
+				where: { email: `integration+${name}@tea-platform.internal` },
+			})
+		).toBeNull();
+
+		// Re-registering the exact same name now succeeds instead of
+		// misreporting the orphan's leftover unique-constraint collision as
+		// "An integration with this name already exists".
+		const reregisterResponse = await registerPost(
+			jsonRequest("/api/integrations", "POST", {
+				name,
+				scopes: ["case:read"],
+			})
+		);
+		expect(reregisterResponse.status).toBe(201);
+		const reregisterBody = await reregisterResponse.json();
+		expect(reregisterBody.integration.name).toBe(name);
+		expect(reregisterBody.integration.id).not.toBe(integrationId);
+		expect(reregisterBody.integration.systemUserId).not.toBe(systemUserId);
+	});
+
+	it("does not touch a DIFFERENT integration's system user or its case-access grants", async () => {
+		const owner = await createTestUser();
+		const { integration: toDelete, systemUser: systemUserToDelete } =
+			await createTestIntegrationWithSystemUser(owner.id, {
+				name: "isolation-delete-me",
+			});
+		const { integration: toKeep, systemUser: systemUserToKeep } =
+			await createTestIntegrationWithSystemUser(owner.id, {
+				name: "isolation-keep-me",
+			});
+		const testCase = await createTestCase(owner.id, {
+			name: "isolation-case",
+		});
+		await createTestPermission(
+			testCase.id,
+			systemUserToDelete.id,
+			owner.id,
+			"VIEW"
+		);
+		await createTestPermission(
+			testCase.id,
+			systemUserToKeep.id,
+			owner.id,
+			"VIEW"
+		);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { DELETE } = await import("@/app/api/integrations/[id]/route");
+		const response = await DELETE(
+			jsonRequest(`/api/integrations/${toDelete.id}`, "DELETE"),
+			idParams(toDelete.id)
+		);
+		expect(response.status).toBe(200);
+
+		expect(
+			await prisma.user.findUnique({ where: { id: systemUserToDelete.id } })
+		).toBeNull();
+		expect(
+			await prisma.user.findUnique({ where: { id: systemUserToKeep.id } })
+		).not.toBeNull();
+		expect(
+			await prisma.integration.findUnique({ where: { id: toKeep.id } })
+		).not.toBeNull();
+		expect(
+			await prisma.casePermission.findUnique({
+				where: {
+					caseId_userId: { caseId: testCase.id, userId: systemUserToKeep.id },
+				},
+			})
+		).not.toBeNull();
+	});
+
+	it("still rejects a genuine live name collision with 'already exists' — distinct from the leftover-orphan collision this fix makes unreachable", async () => {
+		// `Integration.name` is its own `@unique` column (independent of the
+		// system user's username/email uniqueness this fix addresses), so a
+		// second registration under the same name MUST keep failing for as
+		// long as the first integration is alive and un-deleted. This is the
+		// genuine-collision path — it must remain reachable and correctly
+		// reported after this fix, never silently swallowed alongside the
+		// leftover-orphan path the journey test above proves is now closed.
+		const owner = await createTestUser();
+		await mockAuth(owner.id, owner.username, owner.email);
+		const name = `live-collision-${owner.id}`;
+
+		const { POST } = await import("@/app/api/integrations/route");
+		const firstResponse = await POST(
+			jsonRequest("/api/integrations", "POST", {
+				name,
+				scopes: ["case:read"],
+			})
+		);
+		expect(firstResponse.status).toBe(201);
+		const { integration: first } = await firstResponse.json();
+
+		const secondResponse = await POST(
+			jsonRequest("/api/integrations", "POST", {
+				name,
+				scopes: ["case:read"],
+			})
+		);
+		expect(secondResponse.status).toBe(409);
+		const secondBody = await secondResponse.json();
+		expect(secondBody.error).toBe(
+			"An integration with this name already exists"
+		);
+
+		// The first integration and its system user are untouched — this
+		// path never deletes anything, it just refuses the duplicate.
+		expect(
+			await prisma.integration.findUnique({ where: { id: first.id } })
+		).not.toBeNull();
+		expect(
+			await prisma.user.findUnique({ where: { id: first.systemUserId } })
+		).not.toBeNull();
 	});
 });
 

--- a/src/__tests__/integration/backfill-orphaned-integration-system-users.test.ts
+++ b/src/__tests__/integration/backfill-orphaned-integration-system-users.test.ts
@@ -1,0 +1,149 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import prisma from "@/lib/prisma";
+import { registerIntegration } from "@/lib/services/integration-registry-service";
+import { createTestUser } from "../utils/prisma-factories";
+
+/**
+ * Pins the hand-written data migration
+ * `prisma/migrations/20260714000000_backfill_delete_orphaned_integration_system_users/migration.sql`
+ * (TEA — Integration delete leaves the machine user behind; QA proved live
+ * on staging that a system user orphaned by the OLD `deleteIntegrationRegistration`
+ * bug — before it deleted the system user alongside the `Integration` row —
+ * still blocks same-name re-registration today: `integration-darter-pipeline`).
+ * The service-level fix only stops NEW orphans; this migration cleans up
+ * ones the old code already left behind.
+ *
+ * Reads and executes the migration file's ACTUAL SQL (not a hand-copied
+ * predicate that could drift from what `prisma migrate deploy` really
+ * applies) via `$executeRawUnsafe`, against rows set up with `prisma`
+ * directly — this is data cleanup, not something exercised by any API
+ * route, so there is no route/service call that goes through it.
+ */
+const MIGRATION_SQL = readFileSync(
+	path.join(
+		import.meta.dirname,
+		"../../../prisma/migrations/20260714000000_backfill_delete_orphaned_integration_system_users/migration.sql"
+	),
+	"utf8"
+);
+
+const INTEGRATION_USERNAME_PATTERN = /^integration-/;
+const INTEGRATION_EMAIL_PATTERN = /^integration\+.*@tea-platform\.internal$/;
+
+async function runBackfillMigration(): Promise<void> {
+	// The migration file is exactly one statement (with leading `--`
+	// comments) — sent verbatim, the same text `prisma migrate deploy` would
+	// apply. Naively splitting on `;` first is NOT safe here: several of the
+	// comment lines above the statement themselves contain `;` in prose
+	// (e.g. "already excludes it; it is also never referenced by"), so a
+	// blind split produces a fragment that doesn't start with `--` and gets
+	// sent as if it were SQL.
+	await prisma.$executeRawUnsafe(MIGRATION_SQL);
+}
+
+describe("backfill: delete orphaned integration system users", () => {
+	it("deletes an orphan-shaped system user with no referencing Integration, and a same-name registration then succeeds", async () => {
+		const owner = await createTestUser();
+		const slug = "orphan-backfill-test";
+
+		const orphan = await prisma.user.create({
+			data: {
+				email: `integration+${slug}@tea-platform.internal`,
+				username: `integration-${slug}`,
+				isSystemUser: true,
+				authProvider: "SYSTEM",
+				emailVerified: true,
+			},
+		});
+		// No `Integration` row references this user — exactly the shape the OLD
+		// bug left behind.
+		expect(
+			await prisma.integration.findFirst({
+				where: { systemUserId: orphan.id },
+			})
+		).toBeNull();
+
+		await runBackfillMigration();
+
+		expect(
+			await prisma.user.findUnique({ where: { id: orphan.id } })
+		).toBeNull();
+
+		// Re-registering under the name the orphan's username/email were
+		// derived from now succeeds instead of colliding on the orphan's
+		// leftover unique username/email.
+		const registerResult = await registerIntegration(
+			{ name: slug, scopes: ["case:read"] },
+			owner.id
+		);
+		expect("data" in registerResult).toBe(true);
+		if ("data" in registerResult) {
+			expect(registerResult.data.integration.name).toBe(slug);
+		}
+	});
+
+	it("does NOT delete the generic fallback system account (`getOrCreateSystemUser`'s shape)", async () => {
+		// Mirrors `getOrCreateSystemUser`'s own fixed literals
+		// (`lib/services/user-management-service.ts`, ~line 290) — a
+		// deliberately separate account from any integration's system user.
+		// Its username/email shape does not match `integration-%` /
+		// `integration+%@tea-platform.internal`, so it must survive the
+		// backfill by construction, not by coincidence.
+		const genericSystemAccount = await prisma.user.upsert({
+			where: { email: "system@tea-platform.internal" },
+			create: {
+				email: "system@tea-platform.internal",
+				username: "system",
+				isSystemUser: true,
+				authProvider: "SYSTEM",
+				emailVerified: true,
+			},
+			update: {},
+		});
+		expect(genericSystemAccount.username).not.toMatch(
+			INTEGRATION_USERNAME_PATTERN
+		);
+		expect(genericSystemAccount.email).not.toMatch(INTEGRATION_EMAIL_PATTERN);
+
+		await runBackfillMigration();
+
+		expect(
+			await prisma.user.findUnique({ where: { id: genericSystemAccount.id } })
+		).not.toBeNull();
+	});
+
+	it("does NOT delete a LIVE integration's system user, even though its username/email match the integration-shape", async () => {
+		const owner = await createTestUser();
+		const name = "backfill-live-integration";
+		const registerResult = await registerIntegration(
+			{ name, scopes: ["case:read"] },
+			owner.id
+		);
+		expect("data" in registerResult).toBe(true);
+		if (!("data" in registerResult)) {
+			throw new Error("expected registerIntegration to succeed");
+		}
+		const { integration, systemUserId } = registerResult.data;
+
+		// Confirm this system user genuinely matches the integration-shape the
+		// migration's predicate targets — it is protected by the
+		// no-referencing-Integration condition, not by falling outside the
+		// shape entirely.
+		const liveSystemUserBefore = await prisma.user.findUniqueOrThrow({
+			where: { id: systemUserId },
+		});
+		expect(liveSystemUserBefore.username).toMatch(INTEGRATION_USERNAME_PATTERN);
+		expect(liveSystemUserBefore.email).toMatch(INTEGRATION_EMAIL_PATTERN);
+
+		await runBackfillMigration();
+
+		expect(
+			await prisma.user.findUnique({ where: { id: systemUserId } })
+		).not.toBeNull();
+		expect(
+			await prisma.integration.findUnique({ where: { id: integration.id } })
+		).not.toBeNull();
+	});
+});


### PR DESCRIPTION
## Problem

Deleting an integration removed the `Integration` row but left its system (machine) user behind. The orphaned user's unique username/email then blocked re-registering an integration under the same name, misreported as "An integration with this name already exists". The orphan also retained its case-access grants (`CasePermission` cascades only on user delete). Found in the 2026-07-14 staging review; the orphan is inert (no tokens, cannot log in) — a lifecycle-completeness bug, not an exposure.

## Fix

- `deleteIntegrationRegistration` now deletes the integration row and its system user in one transaction (integration first — `systemUserId`/`ownerId` are `onDelete: Restrict` FKs, so the order is load-bearing). Grants clean up via the existing cascade.
- Backfill migration removes system users orphaned by the old behaviour (`isSystemUser`, `integration-<slug>` shape, no referencing `Integration`; the generic system account is excluded). Frees the `darter-pipeline` name on staging on deploy.
- The 409 for a non-active grant now discloses the integration's actual status, with a fail-closed gate (unknown status still refuses) and a uniform fallback mapping so future enum values 409 rather than 500.
- Doc comment records that `plugin_health_evidence.created_by_id` has no FK, so evidence rows lose a resolvable actor after system-user deletion.

## Tests

Full register → grant → revoke → delete → re-register journey; orphan-user and orphan-grant assertions; genuine name collision still rejected; backfill migration pinned (3 tests). Suites green: 82/82 + 3/3 + 29/29; tsc + lint clean.

## Merge note

**Matched pair with the case-grant copy PR** — the server 409 status detail added here is what the client copy keys off. Merge both into the same staging deploy (either alone degrades safely to fallback copy).