### PR TITLE
Split case-grant refusal copy by integration status; close stale grant form

### DIFF
--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/case-access-section.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/case-access-section.test.tsx
@@ -130,6 +130,64 @@ describe("CaseAccessSection", () => {
 		});
 	});
 
+	describe("stale-form path (revoke/suspend while the grant form is open)", () => {
+		// `CaseAccessSection` itself carries no logic to force its own `addOpen`
+		// state closed when `integrationActive` flips — that reset is owned by
+		// `IntegrationCard`, which keys this component to activity so a
+		// revoke/suspend remounts it (see `integration-card.tsx` and its own
+		// "closes the open grant form..." test). This test exercises that exact
+		// contract — a real key change across rerenders, matching how
+		// `IntegrationCard` renders this component in production — rather than
+		// a plain prop rerender, which would (correctly) leave `addOpen` alone
+		// since React never remounts on a bare prop change.
+		it("discards the open grant form when remounted via a key change on integrationActive, without ever calling onGrant", async () => {
+			const onGrant = vi.fn().mockResolvedValue(true);
+			const user = userEvent.setup();
+			const { rerender } = renderWithoutProviders(
+				<CaseAccessSection
+					key="active"
+					{...baseProps}
+					grants={[]}
+					integrationActive={true}
+					onGrant={onGrant}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+			);
+			await waitFor(() =>
+				expect(
+					screen.getByRole("button", { name: GRANT_SUBMIT_REGEX })
+				).toBeInTheDocument()
+			);
+
+			// Same card, same session: the integration is revoked/suspended out
+			// from under the still-open form — `IntegrationCard` re-renders this
+			// section with a new `key` once its status flips non-ACTIVE, forcing
+			// exactly the remount this test performs directly.
+			rerender(
+				<CaseAccessSection
+					key="inactive"
+					{...baseProps}
+					grants={[]}
+					integrationActive={false}
+					onGrant={onGrant}
+				/>
+			);
+
+			await waitFor(() =>
+				expect(
+					screen.queryByRole("button", { name: GRANT_SUBMIT_REGEX })
+				).not.toBeInTheDocument()
+			);
+			expect(
+				screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+			).toBeDisabled();
+			expect(onGrant).not.toHaveBeenCalled();
+		});
+	});
+
 	describe("load error", () => {
 		it("shows a Try again button wired to onRetry alongside the error message", async () => {
 			const onRetry = vi.fn();

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/case-access-section.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/case-access-section.test.tsx
@@ -49,6 +49,7 @@ const baseProps = {
 	integrationActive: true,
 	loadError: null,
 	loading: false,
+	onClearGrantError: vi.fn(),
 	onGrant: vi.fn().mockResolvedValue(true),
 	onRemove: vi.fn(),
 	onRetry: vi.fn(),
@@ -381,6 +382,58 @@ describe("CaseAccessSection", () => {
 
 			await user.click(submitButton);
 			expect(onGrant).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("stale grant-error banner (N2)", () => {
+		it("calls onClearGrantError when the grant form is opened", async () => {
+			const onClearGrantError = vi.fn();
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<CaseAccessSection
+					{...baseProps}
+					grants={[]}
+					onClearGrantError={onClearGrantError}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+			);
+
+			expect(onClearGrantError).toHaveBeenCalledTimes(1);
+		});
+
+		it("calls onClearGrantError when the grant form is cancelled, so a past attempt's banner doesn't resurface on the next open", async () => {
+			const onClearGrantError = vi.fn();
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<CaseAccessSection
+					{...baseProps}
+					grantError="Revoked integrations cannot be restored — register a new integration and grant it access instead."
+					grants={[]}
+					onClearGrantError={onClearGrantError}
+				/>
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+			);
+			onClearGrantError.mockClear();
+
+			await waitFor(() =>
+				expect(
+					screen.getByRole("button", { name: CANCEL_BUTTON_REGEX })
+				).toBeInTheDocument()
+			);
+			await user.click(
+				screen.getByRole("button", { name: CANCEL_BUTTON_REGEX })
+			);
+
+			expect(onClearGrantError).toHaveBeenCalledTimes(1);
+			expect(
+				screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+			).toBeInTheDocument();
 		});
 	});
 

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
@@ -758,5 +758,63 @@ describe("IntegrationCard", () => {
 				screen.queryByRole("button", { name: GRANT_SUBMIT_REGEX })
 			).not.toBeInTheDocument();
 		});
+
+		it("closes the open grant form and never POSTs when the same card's integration is revoked out from under it (stale-form path, real hook)", async () => {
+			let postCalls = 0;
+			server.use(
+				http.get("/api/integrations/:id/case-grants", () =>
+					HttpResponse.json({ grants: [] })
+				),
+				http.post("/api/integrations/:id/case-grants", () => {
+					postCalls += 1;
+					return HttpResponse.json(
+						{ error: "Cannot grant case access for a non-active integration" },
+						{ status: 409 }
+					);
+				})
+			);
+
+			const user = userEvent.setup();
+			const { rerender } = renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({ status: "ACTIVE" })}
+				/>
+			);
+
+			await waitFor(() =>
+				expect(
+					screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+				).toBeInTheDocument()
+			);
+			await user.click(
+				screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+			);
+			await waitFor(() =>
+				expect(
+					screen.getByRole("combobox", { name: CASE_COMBOBOX_REGEX })
+				).toBeInTheDocument()
+			);
+
+			// Revoked from the same card: `IntegrationCard` re-renders with the
+			// integration's new status, exactly as it would after
+			// `useIntegrations`'s `revokeIntegration` resolves and refetches.
+			rerender(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({ status: "REVOKED" })}
+				/>
+			);
+
+			await waitFor(() =>
+				expect(
+					screen.queryByRole("combobox", { name: CASE_COMBOBOX_REGEX })
+				).not.toBeInTheDocument()
+			);
+			expect(
+				screen.queryByRole("button", { name: GRANT_SUBMIT_REGEX })
+			).not.toBeInTheDocument();
+			expect(postCalls).toBe(0);
+		});
 	});
 });

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
@@ -31,6 +31,7 @@ const GRANT_SUBMIT_REGEX = /^grant access$/i;
 const CASE_COMBOBOX_REGEX = /^case$/i;
 const PERMISSION_COMBOBOX_REGEX = /permission level/i;
 const DELETING_LABEL_REGEX = /deleting…/i;
+const REACTIVATE_IT_TEXT_REGEX = /reactivate it/i;
 
 vi.mock("@/actions/assurance-cases", () => ({
 	fetchAssuranceCases: vi
@@ -815,6 +816,124 @@ describe("IntegrationCard", () => {
 				screen.queryByRole("button", { name: GRANT_SUBMIT_REGEX })
 			).not.toBeInTheDocument();
 			expect(postCalls).toBe(0);
+		});
+
+		it("surfaces the server's revoked-integration copy even though this card's own status prop still says ACTIVE (cross-tab revoke, real hook probe)", async () => {
+			server.use(
+				http.get("/api/integrations/:id/case-grants", () =>
+					HttpResponse.json({ grants: [] })
+				),
+				http.post("/api/integrations/:id/case-grants", () =>
+					HttpResponse.json(
+						{ error: "Cannot grant case access for a revoked integration" },
+						{ status: 409 }
+					)
+				)
+			);
+
+			// The card itself still renders `status: "ACTIVE"` — another tab (or
+			// another admin) revoked the integration server-side after this
+			// card's last render, so the prop is stale. The grant form is
+			// reachable (the button isn't disabled) precisely because this card
+			// doesn't know yet.
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({ status: "ACTIVE" })}
+				/>
+			);
+
+			await waitFor(() =>
+				expect(
+					screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+				).toBeInTheDocument()
+			);
+			await user.click(
+				screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+			);
+			await waitFor(() =>
+				expect(
+					screen.getByRole("combobox", { name: CASE_COMBOBOX_REGEX })
+				).toBeInTheDocument()
+			);
+			await user.click(
+				screen.getByRole("combobox", { name: CASE_COMBOBOX_REGEX })
+			);
+			await user.click(screen.getByRole("option", { name: "Assurance" }));
+			await user.click(
+				screen.getByRole("button", { name: GRANT_SUBMIT_REGEX })
+			);
+
+			expect(await screen.findByRole("alert")).toHaveTextContent(
+				"Revoked integrations cannot be restored"
+			);
+			expect(screen.queryByRole("alert")).not.toHaveTextContent(
+				REACTIVATE_IT_TEXT_REGEX
+			);
+		});
+
+		it("clears the stale error banner on close and doesn't show it again on reopen without a new attempt (real hook probe)", async () => {
+			server.use(
+				http.get("/api/integrations/:id/case-grants", () =>
+					HttpResponse.json({ grants: [] })
+				),
+				http.post("/api/integrations/:id/case-grants", () =>
+					HttpResponse.json(
+						{ error: "Cannot grant case access for a revoked integration" },
+						{ status: 409 }
+					)
+				)
+			);
+
+			const user = userEvent.setup();
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={makeIntegration({ status: "ACTIVE" })}
+				/>
+			);
+
+			await waitFor(() =>
+				expect(
+					screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+				).toBeInTheDocument()
+			);
+			await user.click(
+				screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+			);
+			await waitFor(() =>
+				expect(
+					screen.getByRole("combobox", { name: CASE_COMBOBOX_REGEX })
+				).toBeInTheDocument()
+			);
+			await user.click(
+				screen.getByRole("combobox", { name: CASE_COMBOBOX_REGEX })
+			);
+			await user.click(screen.getByRole("option", { name: "Assurance" }));
+			await user.click(
+				screen.getByRole("button", { name: GRANT_SUBMIT_REGEX })
+			);
+			expect(await screen.findByRole("alert")).toBeInTheDocument();
+
+			await user.click(
+				screen.getByRole("button", { name: CANCEL_BUTTON_REGEX })
+			);
+			await waitFor(() =>
+				expect(
+					screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+				).toBeInTheDocument()
+			);
+
+			await user.click(
+				screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
+			);
+			await waitFor(() =>
+				expect(
+					screen.getByRole("combobox", { name: CASE_COMBOBOX_REGEX })
+				).toBeInTheDocument()
+			);
+			expect(screen.queryByRole("alert")).not.toBeInTheDocument();
 		});
 	});
 });

--- a/app/(authenticated)/dashboard/settings/integrations/_components/case-access-section.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/case-access-section.tsx
@@ -40,6 +40,17 @@ export interface CaseAccessSectionProps {
  * callback prop, and this component (and its tests) never call
  * `useIntegrationCaseGrants` directly — `IntegrationCard` owns that hook and
  * threads its state down here.
+ *
+ * This component's own `addOpen` state (whether the grant form is showing)
+ * deliberately has no logic to force it closed when `integrationActive`
+ * turns false — that reset lives one level up, in `IntegrationCard`, via a
+ * `key` on this component keyed to activity. Remounting on that transition
+ * discards `addOpen` (and every other bit of local state) for free, with no
+ * Effect and no stale-then-corrected render — the two ways of clearing state
+ * "by hand" that both caused a react-doctor regression (a one-frame stale
+ * flash from a `useEffect`, then an "impure state updater" flag from doing
+ * the reset synchronously in the render body) before this file settled on
+ * leaving the reset out of this component entirely.
  */
 export function CaseAccessSection({
 	granting,

--- a/app/(authenticated)/dashboard/settings/integrations/_components/case-access-section.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/case-access-section.tsx
@@ -21,6 +21,8 @@ export interface CaseAccessSectionProps {
 	loadError: string | null;
 	/** True while the initial list fetch is in flight. */
 	loading: boolean;
+	/** Clears the hook-held `grantError` — called on both the grant form opening and closing, so a past attempt's copy never resurfaces on an unrelated later open (QA: stale "Reactivate it" banner on reopen with no new attempt). */
+	onClearGrantError: () => void;
 	onGrant: (
 		caseId: string,
 		permission: CaseGrantPermission
@@ -59,6 +61,7 @@ export function CaseAccessSection({
 	integrationActive,
 	loading,
 	loadError,
+	onClearGrantError,
 	onGrant,
 	onRemove,
 	onRetry,
@@ -66,10 +69,26 @@ export function CaseAccessSection({
 }: CaseAccessSectionProps) {
 	const [addOpen, setAddOpen] = useState(false);
 
+	// Both the open-trigger and Cancel route through these, not just Cancel:
+	// clearing only on close would still leave a window (open → immediately
+	// re-triggered `onClearGrantError` a caller forgot to wire, or a future
+	// close path added here) where a stale banner could resurface on open.
+	// Clearing at both transitions costs nothing (the hook's clear is an
+	// idempotent `setGrantError(null)`) and needs no Effect.
+	function openForm() {
+		onClearGrantError();
+		setAddOpen(true);
+	}
+
+	function closeForm() {
+		onClearGrantError();
+		setAddOpen(false);
+	}
+
 	async function handleGrant(caseId: string, permission: CaseGrantPermission) {
 		const granted = await onGrant(caseId, permission);
 		if (granted) {
-			setAddOpen(false);
+			closeForm();
 		}
 		return granted;
 	}
@@ -120,13 +139,13 @@ export function CaseAccessSection({
 						existingCaseIds={grants.map((grant) => grant.caseId)}
 						grantError={grantError}
 						granting={granting}
-						onCancel={() => setAddOpen(false)}
+						onCancel={closeForm}
 						onGrant={handleGrant}
 					/>
 				) : (
 					<Button
 						disabled={!integrationActive}
-						onClick={() => setAddOpen(true)}
+						onClick={openForm}
 						size="sm"
 						title={
 							integrationActive

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
@@ -90,6 +90,7 @@ export function IntegrationCard({
 		loadError: caseGrantsLoadError,
 		granting: grantingCaseAccess,
 		grantError,
+		clearGrantError,
 		grantAccess,
 		removingCaseId,
 		removeAccess,
@@ -272,6 +273,7 @@ export function IntegrationCard({
 				key={integrationActive ? "active" : "inactive"}
 				loadError={caseGrantsLoadError}
 				loading={caseGrantsLoading}
+				onClearGrantError={clearGrantError}
 				onGrant={grantAccess}
 				onRemove={removeAccess}
 				onRetry={refetchCaseGrants}

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
@@ -56,9 +56,13 @@ export interface IntegrationCardProps {
  * this component's own tests never touch that hook directly. The one
  * exception is case-access grants: unlike tokens, they are NOT embedded in
  * `IntegrationListItem` (a deliberate separate-resource choice on the API
- * side), so this component calls `useIntegrationCaseGrants(integration.id)`
- * itself — one hook call per card instance, not a hook-in-a-loop — and
- * threads its state down into the presentational `CaseAccessSection`.
+ * side), so this component calls
+ * `useIntegrationCaseGrants(integration.id, integration.status)` itself —
+ * one hook call per card instance, not a hook-in-a-loop — and
+ * threads its state down into the presentational `CaseAccessSection`. The
+ * integration's own `status` is passed alongside its id so the hook's 409
+ * copy stays correct even if the card revokes/suspends the integration
+ * while this card's grant form is open.
  */
 export function IntegrationCard({
 	deleting,
@@ -90,7 +94,7 @@ export function IntegrationCard({
 		removingCaseId,
 		removeAccess,
 		refetch: refetchCaseGrants,
-	} = useIntegrationCaseGrants(integration.id);
+	} = useIntegrationCaseGrants(integration.id, integration.status);
 
 	const isIssuing = pendingTokenKey === integration.id;
 	const integrationActive = integration.status === "ACTIVE";
@@ -258,6 +262,14 @@ export function IntegrationCard({
 				granting={grantingCaseAccess}
 				grants={caseGrants}
 				integrationActive={integrationActive}
+				// Keyed to activity, not `integration.id`: crossing the
+				// ACTIVE/non-ACTIVE boundary (revoke or suspend from this same
+				// card) remounts the section, which discards its own `addOpen`
+				// state — the stale-form path this closes off — for free, with
+				// no effect and no manual reset. Re-activating (SUSPENDED →
+				// ACTIVE via Reactivate) remounts the same way, which is fine:
+				// the form was never open across a state it can't act in anyway.
+				key={integrationActive ? "active" : "inactive"}
 				loadError={caseGrantsLoadError}
 				loading={caseGrantsLoading}
 				onGrant={grantAccess}

--- a/hooks/__tests__/use-integration-case-grants.test.ts
+++ b/hooks/__tests__/use-integration-case-grants.test.ts
@@ -104,7 +104,7 @@ describe("useIntegrationCaseGrants", () => {
 			expect(result.current.grantError).toBeNull();
 		});
 
-		it("maps a 409 on a SUSPENDED integration to the 'Reactivate it' message", async () => {
+		it("falls back to the prop-keyed 'Reactivate it' message when the server still serves the old uniform 409 (pre-cutover: production before both branches land) for a SUSPENDED integration", async () => {
 			server.use(
 				http.get(CASE_GRANTS_PATH, () => HttpResponse.json({ grants: [] })),
 				http.post(CASE_GRANTS_PATH, () =>
@@ -132,7 +132,7 @@ describe("useIntegrationCaseGrants", () => {
 			expect(result.current.grants).toHaveLength(0);
 		});
 
-		it("maps a 409 on a REVOKED integration to the 'cannot be restored' message, not the impossible 'Reactivate it' advice", async () => {
+		it("falls back to the prop-keyed 'cannot be restored' message when the server still serves the old uniform 409 for a REVOKED integration", async () => {
 			server.use(
 				http.get(CASE_GRANTS_PATH, () => HttpResponse.json({ grants: [] })),
 				http.post(CASE_GRANTS_PATH, () =>
@@ -145,6 +145,95 @@ describe("useIntegrationCaseGrants", () => {
 
 			const { result } = renderHook(() =>
 				useIntegrationCaseGrants(INTEGRATION_ID, "REVOKED")
+			);
+			await waitFor(() => expect(result.current.loading).toBe(false));
+
+			let success: boolean | undefined;
+			await act(async () => {
+				success = await result.current.grantAccess("case-1", "EDIT");
+			});
+
+			expect(success).toBe(false);
+			expect(result.current.grantError).toBe(
+				"Revoked integrations cannot be restored — register a new integration and grant it access instead."
+			);
+			expect(result.current.grants).toHaveLength(0);
+		});
+
+		it("maps the server's verbatim 'suspended integration' 409 message to the 'Reactivate it' copy", async () => {
+			server.use(
+				http.get(CASE_GRANTS_PATH, () => HttpResponse.json({ grants: [] })),
+				http.post(CASE_GRANTS_PATH, () =>
+					HttpResponse.json(
+						{ error: "Cannot grant case access for a suspended integration" },
+						{ status: 409 }
+					)
+				)
+			);
+
+			const { result } = renderHook(() =>
+				useIntegrationCaseGrants(INTEGRATION_ID, "SUSPENDED")
+			);
+			await waitFor(() => expect(result.current.loading).toBe(false));
+
+			let success: boolean | undefined;
+			await act(async () => {
+				success = await result.current.grantAccess("case-1", "EDIT");
+			});
+
+			expect(success).toBe(false);
+			expect(result.current.grantError).toBe(
+				"This integration must be ACTIVE before it can be granted access to a case. Reactivate it, then try again."
+			);
+			expect(result.current.grants).toHaveLength(0);
+		});
+
+		it("maps the server's verbatim 'revoked integration' 409 message to the 'cannot be restored' copy, not the impossible 'Reactivate it' advice", async () => {
+			server.use(
+				http.get(CASE_GRANTS_PATH, () => HttpResponse.json({ grants: [] })),
+				http.post(CASE_GRANTS_PATH, () =>
+					HttpResponse.json(
+						{ error: "Cannot grant case access for a revoked integration" },
+						{ status: 409 }
+					)
+				)
+			);
+
+			const { result } = renderHook(() =>
+				useIntegrationCaseGrants(INTEGRATION_ID, "REVOKED")
+			);
+			await waitFor(() => expect(result.current.loading).toBe(false));
+
+			let success: boolean | undefined;
+			await act(async () => {
+				success = await result.current.grantAccess("case-1", "EDIT");
+			});
+
+			expect(success).toBe(false);
+			expect(result.current.grantError).toBe(
+				"Revoked integrations cannot be restored — register a new integration and grant it access instead."
+			);
+			expect(result.current.grants).toHaveLength(0);
+		});
+
+		it("keys the 409 copy off the server's revoked message over a stale ACTIVE status prop (cross-tab revoke)", async () => {
+			server.use(
+				http.get(CASE_GRANTS_PATH, () => HttpResponse.json({ grants: [] })),
+				http.post(CASE_GRANTS_PATH, () =>
+					HttpResponse.json(
+						{ error: "Cannot grant case access for a revoked integration" },
+						{ status: 409 }
+					)
+				)
+			);
+
+			// This card still believes the integration is ACTIVE — another tab
+			// (or another admin) revoked it after this card last rendered, and
+			// the prop hasn't caught up yet. The server's own 409 body is the
+			// only up-to-date signal at grant time, so it — not the stale
+			// prop — must decide the copy.
+			const { result } = renderHook(() =>
+				useIntegrationCaseGrants(INTEGRATION_ID, "ACTIVE")
 			);
 			await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -217,6 +306,37 @@ describe("useIntegrationCaseGrants", () => {
 				await result.current.grantAccess("case-1", "EDIT");
 			});
 			expect(result.current.grantError).toBeNull();
+		});
+	});
+
+	describe("clearGrantError", () => {
+		it("clears a set grantError without making a new attempt — the form close/reopen path, not a retry", async () => {
+			server.use(
+				http.get(CASE_GRANTS_PATH, () => HttpResponse.json({ grants: [] })),
+				http.post(CASE_GRANTS_PATH, () =>
+					HttpResponse.json(
+						{ error: "Cannot grant case access for a revoked integration" },
+						{ status: 409 }
+					)
+				)
+			);
+
+			const { result } = renderHook(() =>
+				useIntegrationCaseGrants(INTEGRATION_ID, "REVOKED")
+			);
+			await waitFor(() => expect(result.current.loading).toBe(false));
+
+			await act(async () => {
+				await result.current.grantAccess("case-1", "EDIT");
+			});
+			expect(result.current.grantError).not.toBeNull();
+
+			act(() => {
+				result.current.clearGrantError();
+			});
+
+			expect(result.current.grantError).toBeNull();
+			expect(result.current.grants).toHaveLength(0);
 		});
 	});
 

--- a/hooks/__tests__/use-integration-case-grants.test.ts
+++ b/hooks/__tests__/use-integration-case-grants.test.ts
@@ -33,7 +33,7 @@ describe("useIntegrationCaseGrants", () => {
 		);
 
 		const { result } = renderHook(() =>
-			useIntegrationCaseGrants(INTEGRATION_ID)
+			useIntegrationCaseGrants(INTEGRATION_ID, "ACTIVE")
 		);
 
 		expect(result.current.loading).toBe(true);
@@ -58,7 +58,7 @@ describe("useIntegrationCaseGrants", () => {
 		);
 
 		const { result } = renderHook(() =>
-			useIntegrationCaseGrants(INTEGRATION_ID)
+			useIntegrationCaseGrants(INTEGRATION_ID, "ACTIVE")
 		);
 
 		await waitFor(() => expect(result.current.loading).toBe(false));
@@ -89,7 +89,7 @@ describe("useIntegrationCaseGrants", () => {
 			);
 
 			const { result } = renderHook(() =>
-				useIntegrationCaseGrants(INTEGRATION_ID)
+				useIntegrationCaseGrants(INTEGRATION_ID, "ACTIVE")
 			);
 			await waitFor(() => expect(result.current.loading).toBe(false));
 			expect(result.current.grants).toHaveLength(0);
@@ -104,7 +104,7 @@ describe("useIntegrationCaseGrants", () => {
 			expect(result.current.grantError).toBeNull();
 		});
 
-		it("maps a 409 to a fixed, faithful 'integration must be ACTIVE' message", async () => {
+		it("maps a 409 on a SUSPENDED integration to the 'Reactivate it' message", async () => {
 			server.use(
 				http.get(CASE_GRANTS_PATH, () => HttpResponse.json({ grants: [] })),
 				http.post(CASE_GRANTS_PATH, () =>
@@ -116,7 +116,7 @@ describe("useIntegrationCaseGrants", () => {
 			);
 
 			const { result } = renderHook(() =>
-				useIntegrationCaseGrants(INTEGRATION_ID)
+				useIntegrationCaseGrants(INTEGRATION_ID, "SUSPENDED")
 			);
 			await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -132,6 +132,34 @@ describe("useIntegrationCaseGrants", () => {
 			expect(result.current.grants).toHaveLength(0);
 		});
 
+		it("maps a 409 on a REVOKED integration to the 'cannot be restored' message, not the impossible 'Reactivate it' advice", async () => {
+			server.use(
+				http.get(CASE_GRANTS_PATH, () => HttpResponse.json({ grants: [] })),
+				http.post(CASE_GRANTS_PATH, () =>
+					HttpResponse.json(
+						{ error: "Cannot grant case access for a non-active integration" },
+						{ status: 409 }
+					)
+				)
+			);
+
+			const { result } = renderHook(() =>
+				useIntegrationCaseGrants(INTEGRATION_ID, "REVOKED")
+			);
+			await waitFor(() => expect(result.current.loading).toBe(false));
+
+			let success: boolean | undefined;
+			await act(async () => {
+				success = await result.current.grantAccess("case-1", "EDIT");
+			});
+
+			expect(success).toBe(false);
+			expect(result.current.grantError).toBe(
+				"Revoked integrations cannot be restored — register a new integration and grant it access instead."
+			);
+			expect(result.current.grants).toHaveLength(0);
+		});
+
 		it("maps a 404 to a generic 'case not found' message, whatever the server's own wording", async () => {
 			server.use(
 				http.get(CASE_GRANTS_PATH, () => HttpResponse.json({ grants: [] })),
@@ -141,7 +169,7 @@ describe("useIntegrationCaseGrants", () => {
 			);
 
 			const { result } = renderHook(() =>
-				useIntegrationCaseGrants(INTEGRATION_ID)
+				useIntegrationCaseGrants(INTEGRATION_ID, "ACTIVE")
 			);
 			await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -176,7 +204,7 @@ describe("useIntegrationCaseGrants", () => {
 			);
 
 			const { result } = renderHook(() =>
-				useIntegrationCaseGrants(INTEGRATION_ID)
+				useIntegrationCaseGrants(INTEGRATION_ID, "ACTIVE")
 			);
 			await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -204,7 +232,7 @@ describe("useIntegrationCaseGrants", () => {
 			);
 
 			const { result } = renderHook(() =>
-				useIntegrationCaseGrants(INTEGRATION_ID)
+				useIntegrationCaseGrants(INTEGRATION_ID, "ACTIVE")
 			);
 			await waitFor(() => expect(result.current.loading).toBe(false));
 			expect(result.current.grants).toHaveLength(1);
@@ -231,7 +259,7 @@ describe("useIntegrationCaseGrants", () => {
 			);
 
 			const { result } = renderHook(() =>
-				useIntegrationCaseGrants(INTEGRATION_ID)
+				useIntegrationCaseGrants(INTEGRATION_ID, "ACTIVE")
 			);
 			await waitFor(() => expect(result.current.loading).toBe(false));
 			expect(result.current.grants).toHaveLength(1);

--- a/hooks/use-integration-case-grants.ts
+++ b/hooks/use-integration-case-grants.ts
@@ -5,6 +5,7 @@ import { RequestJsonError, requestJson } from "@/lib/request-json";
 import type {
 	CaseGrantPermission,
 	IntegrationCaseGrant,
+	IntegrationStatus,
 } from "@/lib/schemas/integration";
 import { toast } from "@/lib/toast";
 
@@ -14,17 +15,26 @@ function errorMessage(err: unknown): string {
 
 /**
  * Maps a failed grant attempt to the fixed, faithful message the settings
- * UI should show — 409 always means "the integration isn't ACTIVE" (the
+ * UI should show. A 409 always means "the integration isn't ACTIVE" (the
  * only conflict `POST .../case-grants` ever returns, per its own doc
- * comment), and 404 is deliberately generic: it covers a nonexistent case,
- * a soft-deleted one, AND the caller lacking case-ADMIN, all with the exact
- * same message server-side (no enumeration oracle) — this hook does not
- * try to tell those apart either, on purpose.
+ * comment) — but the two non-ACTIVE statuses need different advice, because
+ * only one of them is reversible: SUSPENDED can be reactivated, so "reactivate
+ * it" is genuinely actionable there; REVOKED is permanent by design (the
+ * revoke confirmation dialog itself says so), so telling a REVOKED integration
+ * to "reactivate" is impossible advice. 404 is deliberately generic: it
+ * covers a nonexistent case, a soft-deleted one, AND the caller lacking
+ * case-ADMIN, all with the exact same message server-side (no enumeration
+ * oracle) — this hook does not try to tell those apart either, on purpose.
  */
-function grantErrorMessage(err: unknown): string {
+function grantErrorMessage(
+	err: unknown,
+	integrationStatus: IntegrationStatus
+): string {
 	if (err instanceof RequestJsonError) {
 		if (err.status === 409) {
-			return "This integration must be ACTIVE before it can be granted access to a case. Reactivate it, then try again.";
+			return integrationStatus === "REVOKED"
+				? "Revoked integrations cannot be restored — register a new integration and grant it access instead."
+				: "This integration must be ACTIVE before it can be granted access to a case. Reactivate it, then try again.";
 		}
 		if (err.status === 404) {
 			return "Case not found. Check that the case still exists and that you hold admin access to it.";
@@ -64,9 +74,15 @@ export interface UseIntegrationCaseGrantsResult {
  * Every mutation re-fetches the full list on success, same rationale as
  * `useIntegrations`: cheaper to re-resolve through the same GET the section
  * renders from than to hand-reconcile a nested array locally.
+ *
+ * `integrationStatus` is threaded in (rather than read once at mount) so a
+ * 409 raised after the card's own status has just changed — e.g. the user
+ * revokes the integration while this card's grant form is still open — maps
+ * to the status-appropriate copy, not a stale one from first render.
  */
 export function useIntegrationCaseGrants(
-	integrationId: string
+	integrationId: string,
+	integrationStatus: IntegrationStatus
 ): UseIntegrationCaseGrantsResult {
 	const [grants, setGrants] = useState<IntegrationCaseGrant[]>([]);
 	const [loading, setLoading] = useState(true);
@@ -117,13 +133,13 @@ export function useIntegrationCaseGrants(
 				await load();
 				return true;
 			} catch (err) {
-				setGrantError(grantErrorMessage(err));
+				setGrantError(grantErrorMessage(err, integrationStatus));
 				return false;
 			} finally {
 				setGranting(false);
 			}
 		},
-		[integrationId, load]
+		[integrationId, integrationStatus, load]
 	);
 
 	const removeAccess = useCallback(

--- a/hooks/use-integration-case-grants.ts
+++ b/hooks/use-integration-case-grants.ts
@@ -13,11 +13,23 @@ function errorMessage(err: unknown): string {
 	return err instanceof Error ? err.message : "Something went wrong";
 }
 
+// The two distinct, server-disclosed 409 bodies `POST .../case-grants` now
+// returns (fix/integration-delete-orphan @ 8a413d5b, landing alongside this
+// branch) — verbatim, so a change to either wording is a loud test failure
+// here rather than a silently-wrong fallback match.
+const SUSPENDED_409_MESSAGE =
+	"Cannot grant case access for a suspended integration";
+const REVOKED_409_MESSAGE =
+	"Cannot grant case access for a revoked integration";
+
+const REACTIVATE_COPY =
+	"This integration must be ACTIVE before it can be granted access to a case. Reactivate it, then try again.";
+const REVOKED_COPY =
+	"Revoked integrations cannot be restored — register a new integration and grant it access instead.";
+
 /**
  * Maps a failed grant attempt to the fixed, faithful message the settings
- * UI should show. A 409 always means "the integration isn't ACTIVE" (the
- * only conflict `POST .../case-grants` ever returns, per its own doc
- * comment) — but the two non-ACTIVE statuses need different advice, because
+ * UI should show. The two non-ACTIVE statuses need different advice, because
  * only one of them is reversible: SUSPENDED can be reactivated, so "reactivate
  * it" is genuinely actionable there; REVOKED is permanent by design (the
  * revoke confirmation dialog itself says so), so telling a REVOKED integration
@@ -25,6 +37,18 @@ function errorMessage(err: unknown): string {
  * covers a nonexistent case, a soft-deleted one, AND the caller lacking
  * case-ADMIN, all with the exact same message server-side (no enumeration
  * oracle) — this hook does not try to tell those apart either, on purpose.
+ *
+ * Server truth wins over the client-held `integrationStatus` prop: the 409
+ * body's own `error` string is matched first against the two verbatim
+ * messages above, because the prop can be stale (another tab, or another
+ * admin, revokes/suspends the integration while this card's grant form is
+ * still open and still believes the old status — a real probe caught the
+ * prop-keyed version giving the impossible "Reactivate it" advice for an
+ * integration the server had already told it was revoked). The prop is only
+ * a fallback, for the old uniform 409 message ("...for a non-active
+ * integration") that production keeps serving until both branches land
+ * together — once the server discloses which status it actually is, that
+ * disclosure is authoritative.
  */
 function grantErrorMessage(
 	err: unknown,
@@ -32,9 +56,13 @@ function grantErrorMessage(
 ): string {
 	if (err instanceof RequestJsonError) {
 		if (err.status === 409) {
-			return integrationStatus === "REVOKED"
-				? "Revoked integrations cannot be restored — register a new integration and grant it access instead."
-				: "This integration must be ACTIVE before it can be granted access to a case. Reactivate it, then try again.";
+			if (err.message === REVOKED_409_MESSAGE) {
+				return REVOKED_COPY;
+			}
+			if (err.message === SUSPENDED_409_MESSAGE) {
+				return REACTIVATE_COPY;
+			}
+			return integrationStatus === "REVOKED" ? REVOKED_COPY : REACTIVATE_COPY;
 		}
 		if (err.status === 404) {
 			return "Case not found. Check that the case still exists and that you hold admin access to it.";
@@ -44,6 +72,8 @@ function grantErrorMessage(
 }
 
 export interface UseIntegrationCaseGrantsResult {
+	/** Clears a mapped grant error without a new attempt — called when the grant form closes or reopens, so a past failure's copy (e.g. a stale "Reactivate it") never resurfaces on an unrelated later open. */
+	clearGrantError: () => void;
 	grantAccess: (
 		caseId: string,
 		permission: CaseGrantPermission
@@ -164,6 +194,14 @@ export function useIntegrationCaseGrants(
 		[integrationId, load]
 	);
 
+	// Deliberately not folded into `grantAccess`'s own `setGrantError(null)`
+	// at the start of an attempt: this clears the banner on the form
+	// closing/reopening, i.e. specifically WITHOUT a new attempt — the two
+	// call sites are the section's open-trigger click and its Cancel, not
+	// this hook's own request lifecycle (`grantAccess` already owns clearing
+	// for the "new attempt" case).
+	const clearGrantError = useCallback(() => setGrantError(null), []);
+
 	return {
 		grants,
 		loading,
@@ -171,6 +209,7 @@ export function useIntegrationCaseGrants(
 		refetch: load,
 		granting,
 		grantError,
+		clearGrantError,
 		grantAccess,
 		removingCaseId,
 		removeAccess,


### PR DESCRIPTION
## Problem

The 409 refusal for granting case access to a non-ACTIVE integration always said "Reactivate it, then try again" — impossible advice for a REVOKED integration (revoke is irreversible by design; Reactivate exists only for SUSPENDED). It also contradicted the product's own revoke dialog. Secondary: a grant form already open when the integration was revoked from the same card stayed open and submittable (the server 409 backstop refused correctly). Found in the 2026-07-14 staging review.

## Fix

- 409 copy split by integration status — SUSPENDED → "Reactivate it, then try again"; REVOKED → register a new integration instead. Copy keys off the server 409's status detail first (server truth wins over the client-held prop, which can go stale cross-tab), with the prop as fallback.
- Open `GrantCaseAccessForm` is remounted (key on the ACTIVE boundary) when the integration leaves ACTIVE, so the stale-form path can no longer submit.
- Stale grant-error banner cleared on form close/open rather than lingering until the next submit.

## Tests

Both 409 copy branches pinned verbatim (wording drift fails loudly); grant-form-open-then-revoke closes the form; cross-tab stale-status case covered; prior uniform-409 tests retained as fallback-path pins. Suites green: 217/217 directory shard, 1081/1081 full unit at review; tsc + lint clean.

## Merge note

**Matched pair with the integration delete PR (#863)** — that PR adds the server 409 status detail this copy keys off. Merge both into the same staging deploy (either alone degrades safely to fallback copy).