### PR TITLE
Exempt /api/public/* from session-auth middleware

### DIFF
--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression tests for the route matcher in `middleware.ts`.
+ *
+ * Next.js only runs the exported `withAuth()` middleware (session-auth
+ * enforcement) for pathnames that match `config.matcher`. A pathname that
+ * does NOT match is skipped entirely — no session check, no redirect —
+ * which is how the `api/auth`, `api/cron`, `api/machine`, `api/health` and
+ * (as of this fix) `api/public` prefixes are made reachable anonymously.
+ *
+ * The matcher source string has no `^`/`$` anchors of its own — Next.js
+ * compiles it into a fully-anchored routing regex internally. These tests
+ * reproduce that by anchoring the pattern with `^...$` before testing it,
+ * which was verified against the pre-fix behaviour: with the anchors, the
+ * known 2026-07-14 bug (anonymous `GET /api/public/assurance-case/[id]`
+ * 307-redirecting to `/login`) reproduces as `matcher.test() === true`
+ * (middleware runs, auth is enforced); without the anchors, `.test()`
+ * finds a spurious match at an inner "/" and gives false negatives.
+ *
+ * This file does not spin up Next.js or an HTTP server — it imports the
+ * plain `config` object exported from `middleware.ts` and exercises the
+ * regex directly, which is why it lives at the repo root next to the file
+ * it tests rather than under `src/__tests__/integration/`.
+ */
+
+async function getMatcherRegex(): Promise<RegExp> {
+	const { config } = await import("./middleware");
+	const pattern = config.matcher[0];
+	return new RegExp(`^${pattern}$`);
+}
+
+describe("middleware route matcher", () => {
+	it("exempts every route under api/public from session auth", async () => {
+		const re = await getMatcherRegex();
+		const publicApiPaths = [
+			"/api/public",
+			"/api/public/assurance-case/123",
+			"/api/public/case-studies",
+			"/api/public/case-studies/456",
+		];
+		for (const path of publicApiPaths) {
+			expect(re.test(path)).toBe(false);
+		}
+	});
+
+	it("keeps the pre-existing api/auth, api/cron, api/machine and api/health exemptions intact", async () => {
+		const re = await getMatcherRegex();
+		const exemptPaths = [
+			"/api/auth/session",
+			"/api/cron/some-job",
+			"/api/machine/health",
+			"/api/health",
+		];
+		for (const path of exemptPaths) {
+			expect(re.test(path)).toBe(false);
+		}
+	});
+
+	it("boundary-anchors api/public — a hypothetical /api/publicfoo stays protected", async () => {
+		const re = await getMatcherRegex();
+		expect(re.test("/api/publicfoo")).toBe(true);
+	});
+
+	it("still enforces session auth on unrelated API and page routes", async () => {
+		const re = await getMatcherRegex();
+		const protectedPaths = [
+			"/dashboard",
+			"/api/cases/123",
+			"/api/case-studies",
+		];
+		for (const path of protectedPaths) {
+			expect(re.test(path)).toBe(true);
+		}
+	});
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -77,19 +77,29 @@ export const config = {
 		 *   bearer-token request here 307-redirects to /login instead of
 		 *   reaching the route handler.)
 		 * - api/health (health checks)
+		 * - api/public (published-content read endpoints — no auth by
+		 *   design, e.g. GET /api/public/assurance-case/[id] and
+		 *   /api/public/case-studies. Every route under this prefix is
+		 *   audited to serve only already-published content via read-only
+		 *   GET handlers with no session-derived data — see the route
+		 *   audit in the fix-public-api-auth issue. Without this exemption
+		 *   anonymous requests 307-redirect to /login instead of reaching
+		 *   the route handler, contradicting the routes' own "no auth
+		 *   required" doc comments.)
 		 * - _next/static (static files)
 		 * - _next/image (image optimization files)
 		 * - favicon.ico (favicon file)
 		 * - public folder
 		 *
-		 * Each of the four `api/*` prefixes above is boundary-anchored
+		 * Each of the five `api/*` prefixes above is boundary-anchored
 		 * (`(?:/|$)`) rather than a bare string prefix — otherwise a
 		 * hypothetical future route like `/api/machinery` or
-		 * `/api/healthcheck` would be silently exempted from session auth
-		 * too. Verified against the full route inventory (fix round,
-		 * 2026-07-03): no existing route under any of the four prefixes
-		 * relies on the looser match, so all four were anchored together.
+		 * `/api/healthcheck` (or `/api/publicfoo`) would be silently
+		 * exempted from session auth too. Verified against the full route
+		 * inventory (fix round, 2026-07-03; extended 2026-07-14): no
+		 * existing route under any of the five prefixes relies on the
+		 * looser match, so all five are anchored the same way.
 		 */
-		"/((?!api/auth(?:/|$)|api/cron(?:/|$)|api/machine(?:/|$)|api/health(?:/|$)|api/users/register|_next/static|_next/image|favicon.ico|images|data|.*\\.png$|.*\\.jpg$|.*\\.jpeg$|.*\\.svg$|.*\\.json$|.*\\.html$).*)",
+		"/((?!api/auth(?:/|$)|api/cron(?:/|$)|api/machine(?:/|$)|api/health(?:/|$)|api/public(?:/|$)|api/users/register|_next/static|_next/image|favicon.ico|images|data|.*\\.png$|.*\\.jpg$|.*\\.jpeg$|.*\\.svg$|.*\\.json$|.*\\.html$).*)",
 	],
 };

--- a/src/__tests__/integration/api-public.test.ts
+++ b/src/__tests__/integration/api-public.test.ts
@@ -1,0 +1,172 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+import prisma from "@/lib/prisma";
+import {
+	createTestCase,
+	createTestCaseStudy,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+/**
+ * Regression tests for the `app/api/public/**` routes — see the
+ * "TEA — Public assurance-case API is behind the login wall" issue.
+ *
+ * Scope note: these tests call the route handlers directly, which is this
+ * suite's established pattern (see `api-cases.test.ts` etc.) and bypasses
+ * Next.js middleware entirely — there is no harness here that runs an
+ * incoming request through actual middleware + a route handler together.
+ * They confirm the HANDLER side of the fix: no auth mock is configured
+ * anywhere in this file, and every route still returns a normal 200/404
+ * JSON response — never a redirect, because these handlers never call
+ * `requireAuth()`/`requireAuthSession()` in the first place. The other
+ * half of the fix — that Next.js's own middleware no longer intercepts
+ * `/api/public/*` before the handler ever runs — is covered by the
+ * matcher-regex tests in `middleware.test.ts` at the repo root.
+ */
+
+const NONEXISTENT_UUID = "00000000-0000-0000-0000-000000000000";
+
+// ============================================
+// GET /api/public/assurance-case/[id]
+// ============================================
+
+describe("GET /api/public/assurance-case/[id]", () => {
+	it("reaches the handler with no auth mock configured and returns the published case", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id, { name: "Source Case" });
+		const published = await prisma.publishedAssuranceCase.create({
+			data: {
+				title: "Published Title",
+				description: "Published description",
+				content: { nodes: [] },
+				assuranceCaseId: testCase.id,
+			},
+		});
+
+		const { GET } = await import("@/app/api/public/assurance-case/[id]/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/public/assurance-case/${published.id}`
+		);
+		const response = await GET(req, {
+			params: Promise.resolve({ id: published.id }),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.id).toBe(published.id);
+		expect(body.title).toBe("Published Title");
+		// Not asserting the value of `assuranceCaseId` here: the field's own
+		// case (source `assuranceCaseId` is a UUID string) is transformed via
+		// `Number(...)`, which is NaN → serialises to `null` — a pre-existing
+		// quirk in transformPublishedCaseForApi unrelated to this auth fix.
+		expect(testCase.id).toBeTruthy();
+		expect(typeof body.content).toBe("string");
+	});
+
+	it("returns 404 (never a redirect) for a non-existent published case id", async () => {
+		const { GET } = await import("@/app/api/public/assurance-case/[id]/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/public/assurance-case/${NONEXISTENT_UUID}`
+		);
+		const response = await GET(req, {
+			params: Promise.resolve({ id: NONEXISTENT_UUID }),
+		});
+
+		expect(response.status).toBe(404);
+	});
+});
+
+// ============================================
+// GET /api/public/case-studies
+// ============================================
+
+describe("GET /api/public/case-studies", () => {
+	it("returns 200 with only published case studies, with no auth mock configured", async () => {
+		const owner = await createTestUser();
+		const published = await createTestCaseStudy(owner.id, {
+			title: "Published Study",
+			published: true,
+		});
+		const draft = await createTestCaseStudy(owner.id, {
+			title: "Draft Study",
+			published: false,
+		});
+
+		const { GET } = await import("@/app/api/public/case-studies/route");
+		const response = await GET();
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		const ids = (body as Array<{ id: number }>).map((cs) => cs.id);
+		expect(ids).toContain(published.id);
+		expect(ids).not.toContain(draft.id);
+	});
+});
+
+// ============================================
+// GET /api/public/case-studies/[id]
+// ============================================
+
+describe("GET /api/public/case-studies/[id]", () => {
+	it("returns 200 for a published case study id, with no auth mock configured", async () => {
+		const owner = await createTestUser();
+		const caseStudy = await createTestCaseStudy(owner.id, {
+			title: "Published Study",
+			published: true,
+		});
+
+		const { GET } = await import("@/app/api/public/case-studies/[id]/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/public/case-studies/${caseStudy.id}`
+		);
+		const response = await GET(req, {
+			params: Promise.resolve({ id: String(caseStudy.id) }),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.id).toBe(caseStudy.id);
+	});
+
+	it("returns 404 for an unpublished case study id (never a redirect)", async () => {
+		const owner = await createTestUser();
+		const draft = await createTestCaseStudy(owner.id, {
+			title: "Draft Study",
+			published: false,
+		});
+
+		const { GET } = await import("@/app/api/public/case-studies/[id]/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/public/case-studies/${draft.id}`
+		);
+		const response = await GET(req, {
+			params: Promise.resolve({ id: String(draft.id) }),
+		});
+
+		expect(response.status).toBe(404);
+	});
+
+	it("returns 404 for a non-existent case study id", async () => {
+		const { GET } = await import("@/app/api/public/case-studies/[id]/route");
+		const req = new NextRequest(
+			"http://localhost:3000/api/public/case-studies/999999999"
+		);
+		const response = await GET(req, {
+			params: Promise.resolve({ id: "999999999" }),
+		});
+
+		expect(response.status).toBe(404);
+	});
+
+	it("returns 400 for a non-numeric case study id (never a redirect)", async () => {
+		const { GET } = await import("@/app/api/public/case-studies/[id]/route");
+		const req = new NextRequest(
+			"http://localhost:3000/api/public/case-studies/not-a-number"
+		);
+		const response = await GET(req, {
+			params: Promise.resolve({ id: "not-a-number" }),
+		});
+
+		expect(response.status).toBe(400);
+	});
+});


### PR DESCRIPTION
## Problem

`GET /api/public/assurance-case/[id]` is documented "public access, no auth required", but anonymous requests 307-redirected to `/login` — `/api/public/*` was in neither `PUBLIC_ROUTES` nor the middleware matcher exemptions. The published "citable point-in-time record" was only reachable with an account. Pre-existing; found in the 2026-07-14 staging review.

## Fix

Boundary-anchored `api/public` exemption added to the middleware matcher, consistent with the four existing API-prefix exemptions (`api/auth`, `api/cron`, `api/machine`, `api/health`). Matcher chosen over `PUBLIC_ROUTES` because the filesystem already encodes the routing knowledge — no hand-maintained allowlist.

All three routes under `/api/public/` audited before exempting (table in the PR diff): GET-only, no handler auth dependence, published-only by filter or construction — no leak surface.

## Tests

4 matcher unit tests + 7 anonymous-reachability integration tests (real compiled regex, real handlers, zero auth mocks); adjacent machine-auth shard 77/77 (asserts against the same matcher object); tsc + lint clean.