### PR TITLE
Exclude fallow baseline snapshots from Biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -41,7 +41,8 @@
       "!.patches",
       "!tea-docs",
       "!*.openapi.json",
-      "!public/openapi.json"
+      "!public/openapi.json",
+      "!.fallow-baseline.*.json"
     ]
   },
   "formatter": {


### PR DESCRIPTION
The `.fallow-baseline.*.json` files added in #861 are generated snapshots; Biome's format check wants to reformat them, which fails the project-wide lint job on every PR (first hit: #857). Byte-stability of the snapshots matters more than house formatting — exclude them explicitly.

One-line change to `biome.json`. Verified locally: `pnpm lint` clean with the exclusion in place.