### PR TITLE
Replace partner-named example text in the integration form

### DIFF
--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-register-dialog.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-register-dialog.test.tsx
@@ -43,6 +43,9 @@ describe("IntegrationRegisterDialog", () => {
 		);
 
 		expect(screen.getByLabelText(NAME_LABEL_REGEX)).toBeInTheDocument();
+		expect(
+			screen.getByPlaceholderText("example-integration")
+		).toBeInTheDocument();
 		expect(screen.getByLabelText(DESCRIPTION_LABEL_REGEX)).toBeInTheDocument();
 		expect(screen.getAllByRole("checkbox")).toHaveLength(3);
 		expect(screen.getByText("case:read")).toBeInTheDocument();

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-register-dialog.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-register-dialog.tsx
@@ -114,7 +114,7 @@ export function IntegrationRegisterDialog({
 								<FormItem>
 									<FormLabel>Name</FormLabel>
 									<FormControl>
-										<Input placeholder="darter-evidence-pipeline" {...field} />
+										<Input placeholder="example-integration" {...field} />
 									</FormControl>
 									<FormMessage />
 								</FormItem>

--- a/docs/database/schema.dbml
+++ b/docs/database/schema.dbml
@@ -601,7 +601,7 @@ ORGANISATION tier\'s referent does not exist yet (deliberate).'
 
 Table integrations {
   id String [pk]
-  name String [unique, not null, note: 'e.g. "evidence-pipeline"']
+  name String [unique, not null, note: 'e.g. "example-integration"']
   description String
   ownerId String [not null, note: 'The human accountable for this integration']
   systemUserId String [unique, not null, note: 'The machine principal (User with isSystemUser)']

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -987,7 +987,7 @@ enum PluginScopeType {
 /// service layer when the registry service lands.
 model Integration {
   id           String            @id @default(uuid())
-  name         String            @unique /// e.g. "darter-evidence-pipeline"
+  name         String            @unique /// e.g. "example-integration"
   description  String?
   ownerId      String            @map("owner_id") /// The human accountable for this integration
   systemUserId String            @unique @map("system_user_id") /// The machine principal (User with isSystemUser)


### PR DESCRIPTION
## Problem

The integration registration form's empty Name field showed `darter-evidence-pipeline` as its example text (noted in the 2026-07-16 staging validation). The string's source is a doc-comment in `prisma/schema.prisma`, which also feeds the generated `docs/database/schema.dbml` — so the earlier manual edit to that doc (#866) would have regressed on the next `prisma generate`.

## Fix

- Form placeholder → `example-integration`, pinned by a test assertion so it can't silently regress
- The `schema.prisma` doc-comment updated at source (comment-only, no schema semantics, migrations untouched)
- `docs/database/schema.dbml` regenerated properly rather than hand-edited — verified byte-identical to fresh generator output

A sweep of the app confirmed the remaining `darter` references are the real DARTER integration service code and test fixtures, both correctly untouched.

## Tests

Register-dialog suite 7/7 (including the new placeholder pin, verified to actually fail on regression); integrations settings suite 80/80; tsc + lint clean.