### PR TITLE
Publishing schema and state model (ADR 0003)

### DIFF
--- a/actions/assurance-cases.ts
+++ b/actions/assurance-cases.ts
@@ -100,8 +100,8 @@ interface PublishedCaseForStudy {
 }
 
 /**
- * Fetches the current user's cases that are available for linking to case studies
- * (those with READY_TO_PUBLISH or PUBLISHED status).
+ * Fetches the current user's cases that are available for linking to case
+ * studies (those with PUBLISHED status).
  */
 export async function fetchPublishedCasesForStudy(): Promise<
 	PublishedCaseForStudy[]

--- a/app/api/cases/[id]/status/route.ts
+++ b/app/api/cases/[id]/status/route.ts
@@ -18,7 +18,7 @@ import type { PublishStatus as PrismaPublishStatus } from "@/src/generated/prism
  * GET /api/cases/[id]/status
  *
  * Returns the full publish status of an assurance case including:
- * - publishStatus (DRAFT, READY_TO_PUBLISH, PUBLISHED)
+ * - publishStatus (DRAFT, PUBLISHED)
  * - isPublished
  * - publishedAt
  * - markedReadyAt
@@ -52,15 +52,14 @@ export async function GET(
  *
  * Request body:
  * {
- *   targetStatus: "DRAFT" | "READY_TO_PUBLISH" | "PUBLISHED"
+ *   targetStatus: "DRAFT" | "PUBLISHED"
  *   description?: string  // Optional description for publish
  * }
  *
  * Valid transitions:
- * - DRAFT -> READY_TO_PUBLISH (mark as ready)
- * - READY_TO_PUBLISH -> DRAFT (unmark)
- * - READY_TO_PUBLISH -> PUBLISHED (publish)
+ * - DRAFT -> PUBLISHED (publish)
  * - PUBLISHED -> DRAFT (unpublish)
+ * - PUBLISHED -> PUBLISHED (republish: fresh snapshot, same slug)
  */
 export async function PATCH(
 	request: Request,

--- a/app/api/published-assurance-cases/route.ts
+++ b/app/api/published-assurance-cases/route.ts
@@ -11,8 +11,7 @@ import { getCasesAvailableForCaseStudy } from "@/lib/services/case-study-service
  * GET /api/published-assurance-cases
  *
  * Returns assurance cases that can be linked to case studies.
- * Returns cases owned by the current user with
- * publishStatus in (READY_TO_PUBLISH, PUBLISHED).
+ * Returns cases owned by the current user with publishStatus PUBLISHED.
  */
 export async function GET() {
 	try {

--- a/components/cases/header.tsx
+++ b/components/cases/header.tsx
@@ -34,24 +34,20 @@ const Header = ({ setOpen }: HeaderProps) => {
 
 	const { setCenter } = useReactFlow();
 
-	// Get the display status based on case study public status
-	// Show "Published" only when linked to a PUBLIC case study
+	// Show "Published" when linked to a public case study, or when the case's
+	// own publishStatus is PUBLISHED. (The "Ready to Publish" intermediate
+	// display was retired alongside the status itself, ADR 0003 §2 — there is
+	// no longer a distinct "published but not yet public" state to show.)
 	const getDisplayStatus = (): PublishStatusType => {
 		if (!assuranceCase) {
 			return "DRAFT";
 		}
 
-		// Check if any linked case study is actually public
-		if (assuranceCase.hasPublicCaseStudy) {
-			return "PUBLISHED";
-		}
-
-		// If marked ready or "published" but no public case study, show as ready
 		if (
-			assuranceCase.publishStatus === "PUBLISHED" ||
-			assuranceCase.publishStatus === "READY_TO_PUBLISH"
+			assuranceCase.hasPublicCaseStudy ||
+			assuranceCase.publishStatus === "PUBLISHED"
 		) {
-			return "READY_TO_PUBLISH";
+			return "PUBLISHED";
 		}
 
 		return "DRAFT";

--- a/components/publishing/status-badge.tsx
+++ b/components/publishing/status-badge.tsx
@@ -19,10 +19,6 @@ const statusConfig: Record<
 		className:
 			"bg-muted-foreground/10 text-muted-foreground ring-muted-foreground/20 hover:bg-muted-foreground/20",
 	},
-	READY_TO_PUBLISH: {
-		label: "Ready to Publish",
-		className: "bg-warning/10 text-warning ring-warning/20 hover:bg-warning/20",
-	},
 	PUBLISHED: {
 		label: "Published",
 		className: "bg-success/10 text-success ring-success/20 hover:bg-success/20",
@@ -34,7 +30,6 @@ const statusConfig: Record<
  *
  * Status colours:
  * - Draft: Grey
- * - Ready to Publish: Amber
  * - Published: Green (with amber dot if hasChanges)
  */
 export function StatusBadge({

--- a/components/publishing/status-button.tsx
+++ b/components/publishing/status-button.tsx
@@ -31,11 +31,6 @@ const statusConfig: Record<
 			"bg-muted-foreground/10 text-muted-foreground ring-muted-foreground/20 hover:bg-muted-foreground/20",
 		tooltip: "Click to manage publish status",
 	},
-	READY_TO_PUBLISH: {
-		label: "Ready to Publish",
-		className: "bg-warning/10 text-warning ring-warning/20 hover:bg-warning/20",
-		tooltip: "Ready to link to case studies - click to manage",
-	},
 	PUBLISHED: {
 		label: "Published",
 		className: "bg-success/10 text-success ring-success/20 hover:bg-success/20",
@@ -49,7 +44,6 @@ const statusConfig: Record<
  *
  * Status colours:
  * - Draft: Grey
- * - Ready to Publish: Amber
  * - Published: Green (with amber dot if hasChanges)
  */
 export function StatusButton({

--- a/components/publishing/status-modal-wrapper.tsx
+++ b/components/publishing/status-modal-wrapper.tsx
@@ -25,7 +25,7 @@ export function StatusModalWrapper() {
 	});
 
 	const handleStatusTransition = async (
-		targetStatus: "DRAFT" | "READY_TO_PUBLISH" | "PUBLISHED",
+		targetStatus: "DRAFT" | "PUBLISHED",
 		description?: string
 	) => {
 		if (!statusModal.caseId) {
@@ -75,10 +75,6 @@ export function StatusModalWrapper() {
 					title: "Returned to draft",
 					description: "Your case is now a private draft",
 				},
-				READY_TO_PUBLISH: {
-					title: "Marked as ready",
-					description: "Your case can now be linked to case studies",
-				},
 				PUBLISHED: {
 					title: "Case published",
 					description: "Your case is now publicly available",
@@ -105,10 +101,6 @@ export function StatusModalWrapper() {
 		}
 	};
 
-	const handleMarkAsReady = async () => {
-		await handleStatusTransition("READY_TO_PUBLISH");
-	};
-
 	const handleUpdatePublished = async () => {
 		await handleStatusTransition("PUBLISHED");
 	};
@@ -117,7 +109,6 @@ export function StatusModalWrapper() {
 		<StatusModal
 			hasChanges={hasChanges || statusModal.hasChanges}
 			linkedCaseStudyCount={statusModal.linkedCaseStudyCount}
-			onMarkAsReady={loading ? undefined : handleMarkAsReady}
 			onOpenChange={(open) => {
 				if (!open) {
 					statusModal.onClose();

--- a/components/publishing/status-modal.tsx
+++ b/components/publishing/status-modal.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { ExternalLink, Info, Loader2 } from "lucide-react";
-import Link from "next/link";
+import { Info, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -19,7 +18,6 @@ import type { PublishStatusType } from "@/lib/services/case-response-types";
 interface StatusModalProps {
 	hasChanges?: boolean;
 	linkedCaseStudyCount?: number;
-	onMarkAsReady?: () => Promise<void>;
 	onOpenChange: (open: boolean) => void;
 	onUpdatePublished?: () => Promise<void>;
 	open: boolean;
@@ -31,8 +29,10 @@ interface StatusModalProps {
  * Modal for managing publish status transitions.
  *
  * Shows different content based on current status:
- * - Draft: Option to mark as ready
- * - Ready to Publish: Link to create case study
+ * - Draft: informational only (the "Ready to Publish" intermediate step and
+ *   its "mark as ready" trigger were retired, ADR 0003 §2/§4 — the guided
+ *   single-action Publish flow that replaces it is a later issue in the
+ *   chain, not wired here)
  * - Published: Info about linked case studies and option to update (if hasChanges)
  */
 export function StatusModal({
@@ -42,7 +42,6 @@ export function StatusModal({
 	hasChanges = false,
 	publishedAt,
 	linkedCaseStudyCount = 0,
-	onMarkAsReady,
 	onUpdatePublished,
 }: StatusModalProps) {
 	const [loading, setLoading] = useState(false);
@@ -88,17 +87,7 @@ export function StatusModal({
 
 				<Separator />
 
-				{status === "DRAFT" && (
-					<DraftContent
-						handleAction={handleAction}
-						loading={loading}
-						onMarkAsReady={onMarkAsReady}
-					/>
-				)}
-
-				{status === "READY_TO_PUBLISH" && (
-					<ReadyContent onOpenChange={onOpenChange} />
-				)}
+				{status === "DRAFT" && <DraftContent />}
 
 				{status === "PUBLISHED" && (
 					<PublishedContent
@@ -129,8 +118,6 @@ function getStatusLabel(status: PublishStatusType): string {
 	switch (status) {
 		case "DRAFT":
 			return "Draft";
-		case "READY_TO_PUBLISH":
-			return "Ready to Publish";
 		case "PUBLISHED":
 			return "Published";
 		default:
@@ -141,9 +128,7 @@ function getStatusLabel(status: PublishStatusType): string {
 function getStatusDescription(status: PublishStatusType): string {
 	switch (status) {
 		case "DRAFT":
-			return "This case is private and not available for case study linking.";
-		case "READY_TO_PUBLISH":
-			return "This case is linked to a case study. It will show as 'Published' once the case study is made public.";
+			return "This case is private. Use Publish (in the case editor) to make it available on Discover.";
 		case "PUBLISHED":
 			return "This case is published and visible in case studies.";
 		default:
@@ -151,53 +136,17 @@ function getStatusDescription(status: PublishStatusType): string {
 	}
 }
 
-interface DraftContentProps {
-	handleAction: (action: (() => Promise<void>) | undefined) => void;
-	loading: boolean;
-	onMarkAsReady?: () => Promise<void>;
-}
-
-function DraftContent({
-	loading,
-	onMarkAsReady,
-	handleAction,
-}: DraftContentProps) {
+// A future issue in the ADR 0003 chain wires the guided single-action
+// Publish flow (§2: validate case information, confirm, snapshot) onto this
+// Draft state — not built here, so this content is informational only.
+function DraftContent() {
 	return (
-		<div className="space-y-4">
-			<Alert>
-				<AlertDescription>
-					Draft cases are only visible to you and collaborators with edit
-					permissions. Mark as &quot;Ready to Publish&quot; when you want to
-					link this case to a case study.
-				</AlertDescription>
-			</Alert>
-
-			{onMarkAsReady && (
-				<Button
-					className="w-full bg-warning text-warning-foreground hover:bg-warning/90"
-					disabled={loading}
-					onClick={() => handleAction(onMarkAsReady)}
-				>
-					{loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-					Mark as Ready to Publish
-				</Button>
-			)}
-		</div>
-	);
-}
-
-interface ReadyContentProps {
-	onOpenChange: (open: boolean) => void;
-}
-
-function ReadyContent({ onOpenChange }: ReadyContentProps) {
-	return (
-		<Button asChild className="w-full" onClick={() => onOpenChange(false)}>
-			<Link href="/dashboard/case-studies/create">
-				<ExternalLink className="mr-2 h-4 w-4" />
-				Create a Case Study
-			</Link>
-		</Button>
+		<Alert>
+			<AlertDescription>
+				Draft cases are only visible to you and collaborators with edit
+				permissions.
+			</AlertDescription>
+		</Alert>
 	);
 }
 

--- a/docs/database/schema.dbml
+++ b/docs/database/schema.dbml
@@ -153,6 +153,7 @@ Table assurance_cases {
   invites case_invites [not null]
   comments comments [not null]
   caseImage case_images
+  caseInformation case_information
   caseTypes case_type_assignments [not null]
   pluginData plugin_data [not null]
   sourceReleases releases [not null]
@@ -455,6 +456,31 @@ Table case_images {
   Note: 'Cover/thumbnail image for an assurance case. One image per case.'
 }
 
+Table case_information {
+  id String [pk]
+  caseId String [unique, not null]
+  description String
+  authors String
+  sector String
+  featureImageUrl String
+  createdAt DateTime [default: `now()`, not null]
+  updatedAt DateTime [not null]
+  case assurance_cases [not null]
+
+  Note: 'The canonical case-information record (ADR 0003 §1): description,
+authors, sector, and a feature image, editable at any time under the
+case\'s normal edit permissions. Deliberately broader than "publication
+metadata" — other services and plugins may read it; publishing (see
+`PublishedAssuranceCase`) is its first consumer, not its only one.
+One-to-one and optional: a case with no curated information yet has no
+row here, not a row of nulls.
+
+`description` is distinct from `AssuranceCase.description`: the case\'s
+own field describes the argument\'s purpose and scope for people working
+on it; this one is the public-facing narrative shown on Discover once
+published, mirroring what the retired case-study form collected.'
+}
+
 Table case_types {
   id String [pk]
   name String [unique, not null, note: 'Display name of the type']
@@ -546,6 +572,9 @@ Table case_study_images {
 
 Table published_assurance_cases {
   id String [pk]
+  type PublishableItemType [not null, default: 'ASSURANCE_CASE', note: 'Discriminator (ADR 0003 §5) — only ASSURANCE_CASE is implemented; ready for a future pattern type with no rework.']
+  slug String [not null, note: 'Stable, name-derived, deployment-unique public address (ADR 0003 §6). Generated once at first publish (see `slug-service.ts`) and carried forward verbatim — UNCHANGED — onto every later republish row of the same source case, never regenerated on rename. Collisions append a numeric suffix. NOT `@unique` here: every historical version of the same case shares one slug by design (that is what "stable" means), so true uniqueness is scoped to the CURRENT version only — see `isCurrent` and the hand-written partial index below (same DSL limitation as `PluginData`\'s case-level partial index; Prisma cannot express a partial unique constraint).']
+  isCurrent Boolean [not null, default: true, note: 'True for exactly one row per `assuranceCaseId` at a time — the version Discover and the public API serve. Republishing flips the previous current row to `false` in the same transaction that inserts the new current row (`updatePublishedCase`). That "exactly one" invariant is enforced at the service layer, not the DB — the partial unique index below only stops two DIFFERENT cases\' current rows from colliding on the same slug.']
   title String [not null, note: 'Title at time of publishing']
   content Json [not null, note: 'Full case content as JSON snapshot']
   createdAt DateTime [default: `now()`, not null]
@@ -554,7 +583,20 @@ Table published_assurance_cases {
   assuranceCase assurance_cases [not null]
   caseStudyLinks case_study_published_cases [not null]
 
-  Note: 'Snapshot of an assurance case for case study integration. Content stored as JSON.'
+  Note: 'Frozen, point-in-time snapshot of an assurance case (ADR 0003 §3): the
+public/Discover-facing published record. Content stored as JSON;
+multiple versions per case (history) via repeated publish/republish —
+republishing INSERTS a new row rather than updating the old one, so a
+case\'s full publish history stays queryable. Distinct from the `Release`
+model (community releases, a separate, currently-unused mechanism).
+
+`description` here is the free-text note optionally supplied by the
+caller at publish time (e.g. "Initial release") — NOT the case\'s curated
+`CaseInformation.description`. The latter, along with `authors`, `sector`,
+and `featureImageUrl`, is frozen verbatim into `content.caseInformation`
+at publish time (see `publish-service.ts`), composed the same way as
+`content.pluginData` (ADR 0002 v2 §3) — undefined, not an empty object,
+when the case holds no case information at all.'
 }
 
 Table plugin_data {
@@ -678,7 +720,6 @@ Enum CaseMode {
 
 Enum PublishStatus {
   DRAFT
-  READY_TO_PUBLISH
   PUBLISHED
 }
 
@@ -740,6 +781,11 @@ Enum CaseTypeCategory {
   DOMAIN
   TECHNIQUE
   STANDARD
+}
+
+Enum PublishableItemType {
+  ASSURANCE_CASE
+  ARGUMENT_PATTERN
 }
 
 Enum PluginScopeType {
@@ -839,6 +885,8 @@ Ref: comments.resolvedById > users.id
 Ref: comments.parentCommentId - comments.id
 
 Ref: case_images.caseId - assurance_cases.id [delete: Cascade]
+
+Ref: case_information.caseId - assurance_cases.id [delete: Cascade]
 
 Ref: case_type_assignments.caseId > assurance_cases.id [delete: Cascade]
 

--- a/lib/schemas/case-information.ts
+++ b/lib/schemas/case-information.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import { optionalString } from "./base";
+
+/**
+ * Case information fields (ADR 0003 §1): description, authors, sector, and a
+ * feature image URL. Mirrors the field inventory the retired case-study form
+ * collected (`app/(authenticated)/dashboard/case-studies/_components/_form/form-schema.ts`),
+ * minus fields that were specific to the old case-study/case-study-linking
+ * model (`category`, `contact`, `type`) — those are not part of the ADR's
+ * named case-information set and are not carried forward.
+ */
+export const caseInformationSchema = z.object({
+	description: optionalString(5000),
+	authors: optionalString(255),
+	sector: optionalString(100),
+	featureImageUrl: optionalString(2000),
+});
+
+/**
+ * Create-or-update input. A case's information is a single optional 1:1
+ * record edited in place (ADR §1: "editable any time") — there is no
+ * separate create-vs-update distinction at the API boundary, only "save
+ * whatever fields are provided". At least one field must be provided, same
+ * rule as `updateCaseStudySchema`.
+ */
+export const upsertCaseInformationSchema = caseInformationSchema.refine(
+	(data) => Object.values(data).some((v) => v !== undefined),
+	{ message: "At least one field must be provided" }
+);
+
+export type CaseInformationInput = z.input<typeof upsertCaseInformationSchema>;
+export type CaseInformationData = z.output<typeof upsertCaseInformationSchema>;

--- a/lib/schemas/index.ts
+++ b/lib/schemas/index.ts
@@ -4,6 +4,7 @@
 export * from "./assurance-case";
 export * from "./auth";
 export * from "./base";
+export * from "./case-information";
 export * from "./case-study";
 export * from "./comment";
 export * from "./element";

--- a/lib/schemas/status.ts
+++ b/lib/schemas/status.ts
@@ -5,9 +5,8 @@ import { optionalString } from "./base";
  * Update case publish status input
  */
 export const updateCaseStatusSchema = z.object({
-	targetStatus: z.enum(["DRAFT", "READY_TO_PUBLISH", "PUBLISHED"], {
-		message:
-			"Invalid targetStatus. Must be one of: DRAFT, READY_TO_PUBLISH, PUBLISHED",
+	targetStatus: z.enum(["DRAFT", "PUBLISHED"], {
+		message: "Invalid targetStatus. Must be one of: DRAFT, PUBLISHED",
 	}),
 	description: optionalString(5000),
 });

--- a/lib/services/__tests__/slug-service.test.ts
+++ b/lib/services/__tests__/slug-service.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { slugify } from "../slug-service";
+
+// ---------------------------------------------------------------------------
+// slugify
+// ---------------------------------------------------------------------------
+// Pure-function unit tests — no database required. Kept in lockstep with the
+// equivalent backfill expression in this feature's migration
+// (`prisma/migrations/20260716000000_publishing_schema_and_state_model`).
+
+describe("slugify", () => {
+	it("falls back to 'item' for an empty string", () => {
+		expect(slugify("")).toBe("item");
+	});
+
+	it("falls back to 'item' for whitespace-only input", () => {
+		expect(slugify("   ")).toBe("item");
+	});
+
+	it("falls back to 'item' for punctuation-only input", () => {
+		expect(slugify("!!!___$$$")).toBe("item");
+	});
+
+	it("falls back to 'item' when every character is stripped as non-alphanumeric (e.g. non-Latin scripts)", () => {
+		expect(slugify("日本語")).toBe("item");
+	});
+
+	it("replaces accented/unicode letters rather than transliterating them", () => {
+		// Accented letters are outside [a-z0-9] and are collapsed like any
+		// other non-alphanumeric run — not transliterated to their ASCII
+		// equivalent. This pins the current (deliberately simple) behaviour.
+		expect(slugify("Café Münster")).toBe("caf-m-nster");
+	});
+
+	it("collapses a run of multiple hyphens into one", () => {
+		expect(slugify("Hello---World")).toBe("hello-world");
+	});
+
+	it("collapses mixed punctuation/whitespace runs into a single hyphen", () => {
+		expect(slugify("Hello,   World!")).toBe("hello-world");
+	});
+
+	it("trims leading and trailing hyphens produced by leading/trailing punctuation", () => {
+		expect(slugify("--Hello World--")).toBe("hello-world");
+	});
+
+	it("lowercases mixed-case input", () => {
+		expect(slugify("My Great Case")).toBe("my-great-case");
+	});
+});

--- a/lib/services/case-fetch-service.ts
+++ b/lib/services/case-fetch-service.ts
@@ -274,12 +274,10 @@ export async function fetchCaseFromPrisma(
 			permissions,
 			type: "assurance_case",
 			comments: [],
-			// Publish status fields
+			// Publish status fields (DRAFT / PUBLISHED — the "Ready to Publish"
+			// intermediate step was retired, ADR 0003 §2)
 			published: caseData.publishStatus === "PUBLISHED",
-			publishStatus: caseData.publishStatus as
-				| "DRAFT"
-				| "READY_TO_PUBLISH"
-				| "PUBLISHED",
+			publishStatus: caseData.publishStatus as "DRAFT" | "PUBLISHED",
 			publishedAt: caseData.publishedAt?.toISOString() ?? null,
 			markedReadyAt: caseData.markedReadyAt?.toISOString() ?? null,
 			// Case study integration

--- a/lib/services/case-information-service.ts
+++ b/lib/services/case-information-service.ts
@@ -1,0 +1,156 @@
+import { canAccessCase } from "@/lib/permissions";
+import { prisma } from "@/lib/prisma";
+import type { CaseInformation } from "@/src/generated/prisma";
+import type { ServiceResult } from "@/types/service";
+
+/**
+ * Case information CRUD (ADR 0003 §1) — the canonical, curatorial record on
+ * an assurance case (description, authors, sector, feature image), editable
+ * at any time under the case's normal edit permissions. This service owns
+ * only the record itself; the publish-time freeze into a snapshot lives in
+ * `captureCaseInformationForSnapshot` below and is consumed by
+ * `publish-service.ts`, not by callers of the CRUD functions.
+ */
+
+export interface CaseInformationInput {
+	authors?: string;
+	description?: string;
+	featureImageUrl?: string;
+	sector?: string;
+}
+
+/**
+ * Reads the case information record for a case. Requires VIEW.
+ *
+ * Returns `{ data: null }` — not an error — when no record exists yet: a
+ * case with no curated information is a normal, common state, not a
+ * not-found condition. Returns the same "Permission denied" error for a
+ * non-existent case as for an inaccessible one (repo convention — prevents
+ * resource-enumeration via this surface).
+ */
+export async function getCaseInformation(
+	userId: string,
+	caseId: string
+): ServiceResult<CaseInformation | null> {
+	const hasAccess = await canAccessCase({ userId, caseId }, "VIEW");
+	if (!hasAccess) {
+		return { error: "Permission denied" };
+	}
+
+	try {
+		const record = await prisma.caseInformation.findUnique({
+			where: { caseId },
+		});
+		return { data: record };
+	} catch (error) {
+		console.error("Failed to get case information:", error);
+		return { error: "Failed to fetch case information" };
+	}
+}
+
+/**
+ * Creates or updates the case information record for a case. Requires EDIT.
+ * A single upsert, not separate create/update entry points: the record is a
+ * 1:1 "save whatever fields are provided" resource (ADR §1 — "editable any
+ * time"), so there is no meaningful distinction between "first save" and
+ * "later save" for a caller to get right or wrong. Fields left `undefined`
+ * are only defaulted to `null` on first creation; on an existing record they
+ * are left untouched (only the keys actually provided are written).
+ */
+export async function upsertCaseInformation(
+	userId: string,
+	caseId: string,
+	data: CaseInformationInput
+): ServiceResult<CaseInformation> {
+	const hasAccess = await canAccessCase({ userId, caseId }, "EDIT");
+	if (!hasAccess) {
+		return { error: "Permission denied" };
+	}
+
+	try {
+		const record = await prisma.caseInformation.upsert({
+			where: { caseId },
+			create: {
+				caseId,
+				description: data.description ?? null,
+				authors: data.authors ?? null,
+				sector: data.sector ?? null,
+				featureImageUrl: data.featureImageUrl ?? null,
+			},
+			update: {
+				...(data.description !== undefined && {
+					description: data.description,
+				}),
+				...(data.authors !== undefined && { authors: data.authors }),
+				...(data.sector !== undefined && { sector: data.sector }),
+				...(data.featureImageUrl !== undefined && {
+					featureImageUrl: data.featureImageUrl,
+				}),
+			},
+		});
+		return { data: record };
+	} catch (error) {
+		console.error("Failed to upsert case information:", error);
+		return { error: "Failed to save case information" };
+	}
+}
+
+/**
+ * Deletes the case information record for a case, if any. Requires EDIT.
+ * A no-op success (not an error) when no record exists — deleting an
+ * already-absent record is not a failure condition.
+ */
+export async function deleteCaseInformation(
+	userId: string,
+	caseId: string
+): ServiceResult<true> {
+	const hasAccess = await canAccessCase({ userId, caseId }, "EDIT");
+	if (!hasAccess) {
+		return { error: "Permission denied" };
+	}
+
+	try {
+		await prisma.caseInformation.deleteMany({ where: { caseId } });
+		return { data: true };
+	} catch (error) {
+		console.error("Failed to delete case information:", error);
+		return { error: "Failed to delete case information" };
+	}
+}
+
+/** Case-information fields frozen verbatim into a publish snapshot. */
+export interface CaseInformationSnapshot {
+	authors: string | null;
+	description: string | null;
+	featureImageUrl: string | null;
+	sector: string | null;
+}
+
+/**
+ * Reads the case information row verbatim for embedding in a publish
+ * snapshot (ADR 0003 §3 — "the snapshot freezes metadata as well as
+ * content"). Mirrors `capturePluginDataForSnapshot`'s deliberate bypass of
+ * the per-call permission guard: the caller (`publish-service.ts`) has
+ * already verified case-level EDIT access before calling this, so there is
+ * no additional permission check to perform here.
+ *
+ * Returns `undefined` — never a record of all-nulls — when no case
+ * information exists yet, so a snapshot never gains a
+ * `caseInformation: { authors: null, ... }` section for a case that was
+ * never curated. Same "present data, not undefined key" discipline as
+ * `capturePluginDataForSnapshot`.
+ */
+export async function captureCaseInformationForSnapshot(
+	caseId: string
+): Promise<CaseInformationSnapshot | undefined> {
+	const record = await prisma.caseInformation.findUnique({
+		where: { caseId },
+		select: {
+			description: true,
+			authors: true,
+			sector: true,
+			featureImageUrl: true,
+		},
+	});
+	return record ?? undefined;
+}

--- a/lib/services/case-response-types.ts
+++ b/lib/services/case-response-types.ts
@@ -8,7 +8,9 @@
 
 import type { CommentResponse } from "./comment-service";
 
-export type PublishStatusType = "DRAFT" | "READY_TO_PUBLISH" | "PUBLISHED";
+// The "Ready to Publish" intermediate step was retired (ADR 0003 §2) — DRAFT
+// and PUBLISHED are the only two states now.
+export type PublishStatusType = "DRAFT" | "PUBLISHED";
 
 export interface GoalResponse {
 	assumption?: string;

--- a/lib/services/case-study-service.ts
+++ b/lib/services/case-study-service.ts
@@ -495,43 +495,16 @@ async function getLatestPublishedVersionId(
 }
 
 /**
- * Attempts to publish a case and returns the published ID if successful.
- * Handles legacy table issues gracefully by catching errors.
- */
-async function tryPublishCase(
-	ownerId: string,
-	caseId: string
-): Promise<string | null> {
-	const { publishAssuranceCase } = await import(
-		"@/lib/services/publish-service"
-	);
-
-	try {
-		const result = await publishAssuranceCase(ownerId, caseId);
-		return "error" in result ? null : result.data.publishedId;
-	} catch (error) {
-		console.warn(
-			`Failed to publish case ${caseId} (legacy table issue):`,
-			error
-		);
-		return null;
-	}
-}
-
-/**
  * Resolves source AssuranceCase IDs to their latest PublishedAssuranceCase IDs.
- * For cases that are READY_TO_PUBLISH but not yet published, this will publish them first.
  *
  * Note: The legacy PublishedAssuranceCase table has type mismatches with the new schema.
  * We query publishedVersions separately with error handling to avoid crashes.
  *
  * @param sourceCaseIds - Array of source AssuranceCase IDs
- * @param ownerId - The user ID performing the operation (for publishing)
  * @returns Array of PublishedAssuranceCase IDs
  */
 export async function resolvePublishedCaseIds(
-	sourceCaseIds: string[],
-	ownerId?: string
+	sourceCaseIds: string[]
 ): Promise<string[]> {
 	if (sourceCaseIds.length === 0) {
 		return [];
@@ -546,7 +519,7 @@ export async function resolvePublishedCaseIds(
 	const publishedCaseIds: string[] = [];
 
 	for (const sourceCase of sourceCases) {
-		const publishedId = await resolvePublishedIdForCase(sourceCase, ownerId);
+		const publishedId = await resolvePublishedIdForCase(sourceCase);
 		if (publishedId) {
 			publishedCaseIds.push(publishedId);
 		}
@@ -557,29 +530,25 @@ export async function resolvePublishedCaseIds(
 
 /**
  * Resolves a single case to its published version ID.
+ *
+ * There used to be a second path here: a case in the retired READY_TO_PUBLISH
+ * status (ADR 0003 §2) could be auto-published on first link. That status no
+ * longer exists — every case reaching this function is either PUBLISHED
+ * (has a published version) or DRAFT (does not, and is not auto-published) —
+ * so this is now a direct lookup.
  */
-async function resolvePublishedIdForCase(
-	sourceCase: { id: string; publishStatus: string; createdById: string },
-	ownerId?: string
-): Promise<string | null> {
+async function resolvePublishedIdForCase(sourceCase: {
+	id: string;
+	publishStatus: string;
+	createdById: string;
+}): Promise<string | null> {
 	const latestPublishedId = await getLatestPublishedVersionId(sourceCase.id);
 
 	if (latestPublishedId) {
 		await syncPublishStatusIfNeeded(sourceCase);
-		return latestPublishedId;
 	}
 
-	// If READY_TO_PUBLISH, owner provided, and owner is the case creator, publish it now
-	const canPublish =
-		sourceCase.publishStatus === "READY_TO_PUBLISH" &&
-		ownerId &&
-		sourceCase.createdById === ownerId;
-
-	if (canPublish) {
-		return tryPublishCase(ownerId, sourceCase.id);
-	}
-
-	return null;
+	return latestPublishedId;
 }
 
 /**
@@ -613,11 +582,8 @@ export async function createCaseStudyWithLinks(
 	try {
 		const now = new Date();
 
-		// Resolve source case IDs to published case IDs (publishes READY_TO_PUBLISH cases)
-		const publishedCaseIds = await resolvePublishedCaseIds(
-			sourceCaseIds,
-			ownerId
-		);
+		// Resolve source case IDs to their published case IDs
+		const publishedCaseIds = await resolvePublishedCaseIds(sourceCaseIds);
 
 		// Create case study and links in a transaction
 		const caseStudy = await prisma.$transaction(async (tx) => {
@@ -704,10 +670,10 @@ export async function updateCaseStudyWithLinks(
 		const wasPublished = existing.published;
 		const isNowPublished = data.published ?? existing.published;
 
-		// Resolve source case IDs to published case IDs if provided (publishes READY_TO_PUBLISH cases)
+		// Resolve source case IDs to their published case IDs, if provided
 		const publishedCaseIds =
 			sourceCaseIds !== undefined
-				? await resolvePublishedCaseIds(sourceCaseIds, ownerId)
+				? await resolvePublishedCaseIds(sourceCaseIds)
 				: undefined;
 
 		// Update case study and links in a transaction
@@ -789,8 +755,10 @@ export interface CaseAvailableForStudy {
 }
 
 /**
- * Gets cases that are ready to publish OR published for a specific user.
- * Used for case study linking - shows cases available for selection.
+ * Gets published cases for a specific user. Used for case study linking -
+ * shows cases available for selection. (Previously also included cases in
+ * the now-retired READY_TO_PUBLISH status — ADR 0003 §2 removed that
+ * intermediate step, so PUBLISHED is the only qualifying status left.)
  *
  * Note: The publishedVersions relation uses a legacy Django table that may have
  * type mismatches with UUID-based case IDs. We query it separately to handle errors.
@@ -803,9 +771,7 @@ export async function getCasesAvailableForCaseStudy(
 		const cases = await prisma.assuranceCase.findMany({
 			where: {
 				createdById: userId,
-				publishStatus: {
-					in: ["READY_TO_PUBLISH", "PUBLISHED"],
-				},
+				publishStatus: "PUBLISHED",
 			},
 			select: {
 				id: true,

--- a/lib/services/publish-service.ts
+++ b/lib/services/publish-service.ts
@@ -13,6 +13,109 @@ import type {
 	UnpublishResult,
 } from "@/lib/services/publish-service.types";
 import { generateUniqueSlug } from "@/lib/services/slug-service";
+import type { Prisma } from "@/src/generated/prisma";
+
+// Derived from `prisma.$transaction`'s own callback parameter — same pattern
+// as `slug-service.ts` (kept local rather than imported: `Prisma.
+// TransactionClient` does not structurally match this project's
+// `.$extends()`-wrapped client from `lib/prisma.ts`).
+type TransactionCallback = Parameters<typeof prisma.$transaction>[0];
+type TransactionClient = TransactionCallback extends (
+	tx: infer T
+) => Promise<unknown>
+	? T
+	: never;
+
+// ============================================
+// Shared helpers — publish / republish
+// ============================================
+
+/**
+ * Composes the JSON snapshot content shared by every publish flow: the
+ * exported case tree plus captured plugin data (ADR 0002 v2 §3) and case
+ * information (ADR 0003 §3), each included only when present — `undefined`,
+ * not an empty object, when there is none — so a snapshot never gains a key
+ * for data the case doesn't hold.
+ *
+ * Shared verbatim between `publishAssuranceCase` (first publish) and
+ * `updatePublishedCase` (republish) — both must freeze identical content
+ * shapes, so this is the single place that composition happens.
+ */
+async function composeSnapshotContent(
+	userId: string,
+	caseId: string
+): Promise<{ data: Record<string, unknown> } | { error: string }> {
+	const exportResult = await exportCase(userId, caseId, {
+		includeComments: true,
+	});
+	if ("error" in exportResult) {
+		return { error: exportResult.error };
+	}
+
+	// Every plugin namespace holding data on this case, captured verbatim
+	// (ADR 0002 v2 §3) — follows data present, not this (or any) viewer's
+	// plugin toggles. `undefined` when the case holds no plugin data at all,
+	// so the snapshot gains no `pluginData` key rather than an empty one.
+	const pluginData = await capturePluginDataForSnapshot(caseId);
+	// Case information (ADR 0003 §3 — "the snapshot freezes metadata as well
+	// as content"), composed the same way: `undefined`, not an empty object,
+	// when the case has no case information at all.
+	const caseInformation = await captureCaseInformationForSnapshot(caseId);
+
+	return {
+		data: {
+			...exportResult.data,
+			...(pluginData && { pluginData }),
+			...(caseInformation && { caseInformation }),
+		},
+	};
+}
+
+/**
+ * Retires whichever row is currently `isCurrent: true` for `caseId` and
+ * inserts its replacement, inside the caller's transaction. Retirement must
+ * run BEFORE the insert — the partial unique index on (slug) WHERE
+ * is_current would otherwise reject the new row for reusing the same slug
+ * while the old row is still marked current.
+ *
+ * `updateMany` (not `update` on one known id) so this is correct whether
+ * zero or one row is currently marked: first-publish has none (this call is
+ * then a defensive no-op guarding the "at most one current row per case"
+ * invariant against being called twice on an already-published case — e.g.
+ * directly via `POST /api/cases/[id]/publish`, outside `transitionStatus`'s
+ * DRAFT-only gate); republish has exactly one.
+ *
+ * Shared verbatim between `publishAssuranceCase` and `updatePublishedCase`;
+ * each layers its own extra side effects (case status flip vs case-study
+ * link migration) around this call.
+ */
+async function swapCurrentPublishedVersion(
+	tx: TransactionClient,
+	input: {
+		caseId: string;
+		title: string;
+		slug: string;
+		content: Prisma.InputJsonValue;
+		description: string | null;
+		createdAt: Date;
+	}
+) {
+	await tx.publishedAssuranceCase.updateMany({
+		where: { assuranceCaseId: input.caseId, isCurrent: true },
+		data: { isCurrent: false },
+	});
+
+	return tx.publishedAssuranceCase.create({
+		data: {
+			title: input.title,
+			slug: input.slug,
+			content: input.content,
+			description: input.description,
+			assuranceCaseId: input.caseId,
+			createdAt: input.createdAt,
+		},
+	});
+}
 
 // ============================================
 // Service Functions
@@ -111,29 +214,21 @@ export async function publishAssuranceCase(
 		return { error: "Case not found" };
 	}
 
-	// Export case content as JSON
-	const exportResult = await exportCase(userId, caseId, {
-		includeComments: true,
-	});
-
-	if ("error" in exportResult) {
-		return { error: exportResult.error };
+	// Compose the JSON snapshot content (export + plugin data + case
+	// information) — shared with `updatePublishedCase`, see
+	// `composeSnapshotContent` above.
+	const contentResult = await composeSnapshotContent(userId, caseId);
+	if ("error" in contentResult) {
+		return { error: contentResult.error };
 	}
-
-	// Every plugin namespace holding data on this case, captured verbatim
-	// (ADR 0002 v2 §3) — follows data present, not this (or any) viewer's
-	// plugin toggles. `undefined` when the case holds no plugin data at all,
-	// so the snapshot gains no `pluginData` key rather than an empty one.
-	const pluginData = await capturePluginDataForSnapshot(caseId);
-	// Case information (ADR 0003 §3 — "the snapshot freezes metadata as well
-	// as content"), composed the same way: `undefined`, not an empty object,
-	// when the case has no case information at all.
-	const caseInformation = await captureCaseInformationForSnapshot(caseId);
-	const content = {
-		...exportResult.data,
-		...(pluginData && { pluginData }),
-		...(caseInformation && { caseInformation }),
-	};
+	// The composed snapshot is plain JSON but, as a plain object built from
+	// named interfaces (`CaseInformationSnapshot` etc.) with no index
+	// signature of their own, doesn't structurally satisfy `InputJsonObject`
+	// even though every value it can hold is a valid `InputJsonValue`.
+	// Routing through `unknown` is TS's own prescribed escape hatch for
+	// exactly this "no sufficient overlap" case (same pattern as
+	// `health-scoring-service.ts`) — not a blind `any`.
+	const content = contentResult.data as unknown as Prisma.InputJsonValue;
 
 	const now = new Date();
 
@@ -146,26 +241,13 @@ export async function publishAssuranceCase(
 		// behaviour ADR 0003 §6 promises).
 		const publishedCase = await prisma.$transaction(async (tx) => {
 			const slug = await generateUniqueSlug(assuranceCase.name, tx);
-			// Defensive, not load-bearing for the normal DRAFT->PUBLISHED path
-			// (a case only reaches DRAFT via `unpublishAssuranceCase`, which
-			// deletes every prior published row): guards this function's OWN
-			// invariant — "at most one current row per case" — against being
-			// called again on an already-published case (e.g. directly via
-			// `POST /api/cases/[id]/publish`, outside `transitionStatus`'s
-			// DRAFT-only gate).
-			await tx.publishedAssuranceCase.updateMany({
-				where: { assuranceCaseId: caseId, isCurrent: true },
-				data: { isCurrent: false },
-			});
-			const created = await tx.publishedAssuranceCase.create({
-				data: {
-					title: assuranceCase.name,
-					slug,
-					content,
-					description: description ?? null,
-					assuranceCaseId: caseId,
-					createdAt: now,
-				},
+			const created = await swapCurrentPublishedVersion(tx, {
+				caseId,
+				title: assuranceCase.name,
+				slug,
+				content,
+				description: description ?? null,
+				createdAt: now,
 			});
 			await tx.assuranceCase.update({
 				where: { id: caseId },
@@ -492,50 +574,30 @@ export async function updatePublishedCase(
 		return { error: "No published version found" };
 	}
 
-	// Export current case content
-	const exportResult = await exportCase(userId, caseId, {
-		includeComments: true,
-	});
-
-	if ("error" in exportResult) {
-		return { error: exportResult.error };
+	// Compose the JSON snapshot content — shared with `publishAssuranceCase`,
+	// see `composeSnapshotContent` above.
+	const contentResult = await composeSnapshotContent(userId, caseId);
+	if ("error" in contentResult) {
+		return { error: contentResult.error };
 	}
-
-	// See `publishAssuranceCase` above for the same capture + merge.
-	const pluginData = await capturePluginDataForSnapshot(caseId);
-	const caseInformation = await captureCaseInformationForSnapshot(caseId);
-	const content = {
-		...exportResult.data,
-		...(pluginData && { pluginData }),
-		...(caseInformation && { caseInformation }),
-	};
+	// See `publishAssuranceCase` above for why this cast is needed.
+	const content = contentResult.data as unknown as Prisma.InputJsonValue;
 
 	const now = new Date();
 
 	try {
 		// Create new version and migrate links in a transaction
 		const newPublished = await prisma.$transaction(async (tx) => {
-			// Retire the version being superseded BEFORE inserting its
-			// replacement — the partial unique index on (slug) WHERE
-			// is_current would otherwise reject the new row for reusing the
-			// same slug while the old row is still marked current.
-			await tx.publishedAssuranceCase.update({
-				where: { id: currentPublished.id },
-				data: { isCurrent: false },
-			});
-
-			// Create new published version — carrying the EXISTING slug forward
-			// verbatim (ADR 0003 §6: stable across renames). Never regenerated
-			// here, even if `assuranceCase.name` has changed since first publish.
-			const published = await tx.publishedAssuranceCase.create({
-				data: {
-					title: assuranceCase.name,
-					slug: currentPublished.slug,
-					content,
-					description: description ?? null,
-					assuranceCaseId: caseId,
-					createdAt: now,
-				},
+			// Carrying the EXISTING slug forward verbatim (ADR 0003 §6: stable
+			// across renames) — never regenerated here, even if
+			// `assuranceCase.name` has changed since first publish.
+			const published = await swapCurrentPublishedVersion(tx, {
+				caseId,
+				title: assuranceCase.name,
+				slug: currentPublished.slug,
+				content,
+				description: description ?? null,
+				createdAt: now,
 			});
 
 			// Get case study IDs linked to old version

--- a/lib/services/publish-service.ts
+++ b/lib/services/publish-service.ts
@@ -1,18 +1,18 @@
 import { canAccessCase } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import { exportCase } from "@/lib/services/case-export-service";
+import { captureCaseInformationForSnapshot } from "@/lib/services/case-information-service";
 import { detectChanges } from "@/lib/services/change-detection-service";
 import { capturePluginDataForSnapshot } from "@/lib/services/plugin-data-service";
 import type {
 	FullPublishStatus,
-	MarkReadyResult,
 	PrismaPublishStatus,
 	PublishResult,
 	PublishStatus,
 	StatusTransitionResult,
-	UnmarkReadyResult,
 	UnpublishResult,
 } from "@/lib/services/publish-service.types";
+import { generateUniqueSlug } from "@/lib/services/slug-service";
 
 // ============================================
 // Service Functions
@@ -125,33 +125,58 @@ export async function publishAssuranceCase(
 	// plugin toggles. `undefined` when the case holds no plugin data at all,
 	// so the snapshot gains no `pluginData` key rather than an empty one.
 	const pluginData = await capturePluginDataForSnapshot(caseId);
-	const content = pluginData
-		? { ...exportResult.data, pluginData }
-		: exportResult.data;
+	// Case information (ADR 0003 §3 — "the snapshot freezes metadata as well
+	// as content"), composed the same way: `undefined`, not an empty object,
+	// when the case has no case information at all.
+	const caseInformation = await captureCaseInformationForSnapshot(caseId);
+	const content = {
+		...exportResult.data,
+		...(pluginData && { pluginData }),
+		...(caseInformation && { caseInformation }),
+	};
 
 	const now = new Date();
 
 	try {
-		// Create the published version and update the case in a transaction
-		const [publishedCase] = await prisma.$transaction([
-			prisma.publishedAssuranceCase.create({
+		// Generating the slug and creating the row must share one transaction
+		// — otherwise a concurrent first-publish of a same-named case could
+		// observe the same "no collision yet" result and both try to claim
+		// the identical slug (the table's unique index would then reject the
+		// second, surfacing as an opaque 500 rather than the numeric-suffix
+		// behaviour ADR 0003 §6 promises).
+		const publishedCase = await prisma.$transaction(async (tx) => {
+			const slug = await generateUniqueSlug(assuranceCase.name, tx);
+			// Defensive, not load-bearing for the normal DRAFT->PUBLISHED path
+			// (a case only reaches DRAFT via `unpublishAssuranceCase`, which
+			// deletes every prior published row): guards this function's OWN
+			// invariant — "at most one current row per case" — against being
+			// called again on an already-published case (e.g. directly via
+			// `POST /api/cases/[id]/publish`, outside `transitionStatus`'s
+			// DRAFT-only gate).
+			await tx.publishedAssuranceCase.updateMany({
+				where: { assuranceCaseId: caseId, isCurrent: true },
+				data: { isCurrent: false },
+			});
+			const created = await tx.publishedAssuranceCase.create({
 				data: {
 					title: assuranceCase.name,
+					slug,
 					content,
 					description: description ?? null,
 					assuranceCaseId: caseId,
 					createdAt: now,
 				},
-			}),
-			prisma.assuranceCase.update({
+			});
+			await tx.assuranceCase.update({
 				where: { id: caseId },
 				data: {
 					published: true,
 					publishedAt: now,
 					publishStatus: "PUBLISHED",
 				},
-			}),
-		]);
+			});
+			return created;
+		});
 
 		return {
 			data: { publishedId: publishedCase.id, publishedAt: now },
@@ -307,12 +332,12 @@ export async function getPublishedCasesByUser(
 }
 
 // ============================================
-// 3-State Publishing Workflow Functions
+// Publishing Workflow Functions
 // ============================================
 
 /**
- * Gets the full publish status including 3-state workflow information.
- * Returns publish status, ready status, and change detection.
+ * Gets the full publish status (DRAFT / PUBLISHED — the "Ready to Publish"
+ * intermediate step was retired, ADR 0003 §2) plus change detection.
  *
  * Note: The publishedVersions relation uses a legacy Django table that may have
  * type mismatches with UUID-based case IDs. We handle this gracefully by
@@ -411,145 +436,6 @@ export async function getFullPublishStatus(
 }
 
 /**
- * Marks an assurance case as ready to publish.
- * Transitions from DRAFT to READY_TO_PUBLISH status.
- *
- * Requires EDIT permission or higher.
- */
-export async function markCaseAsReady(
-	userId: string,
-	caseId: string
-): Promise<MarkReadyResult> {
-	// Check user has EDIT permission
-	const hasAccess = await canAccessCase({ userId, caseId }, "EDIT");
-	if (!hasAccess) {
-		return { error: "Permission denied" };
-	}
-
-	// Get the case to check its current status
-	const assuranceCase = await prisma.assuranceCase.findUnique({
-		where: { id: caseId },
-		select: {
-			id: true,
-			publishStatus: true,
-		},
-	});
-
-	if (!assuranceCase) {
-		return { error: "Case not found" };
-	}
-
-	// Only allow transition from DRAFT
-	if (assuranceCase.publishStatus !== "DRAFT") {
-		return {
-			error: `Cannot mark as ready: case is currently ${assuranceCase.publishStatus}`,
-		};
-	}
-
-	const now = new Date();
-
-	try {
-		await prisma.assuranceCase.update({
-			where: { id: caseId },
-			data: {
-				publishStatus: "READY_TO_PUBLISH",
-				markedReadyAt: now,
-				markedReadyById: userId,
-			},
-		});
-
-		return { data: { markedReadyAt: now } };
-	} catch (error) {
-		console.error("Failed to mark case as ready:", error);
-		return { error: "Failed to mark case as ready" };
-	}
-}
-
-/**
- * Unmarks an assurance case as ready to publish.
- * Transitions from READY_TO_PUBLISH back to DRAFT status.
- *
- * Requires EDIT permission or higher.
- */
-export async function unmarkCaseAsReady(
-	userId: string,
-	caseId: string
-): Promise<UnmarkReadyResult> {
-	// Check user has EDIT permission
-	const hasAccess = await canAccessCase({ userId, caseId }, "EDIT");
-	if (!hasAccess) {
-		return { error: "Permission denied" };
-	}
-
-	// Get the case to check its current status
-	const assuranceCase = await prisma.assuranceCase.findUnique({
-		where: { id: caseId },
-		select: {
-			id: true,
-			publishStatus: true,
-		},
-	});
-
-	if (!assuranceCase) {
-		return { error: "Case not found" };
-	}
-
-	// Only allow transition from READY_TO_PUBLISH
-	if (assuranceCase.publishStatus !== "READY_TO_PUBLISH") {
-		return {
-			error: `Cannot unmark: case is currently ${assuranceCase.publishStatus}`,
-		};
-	}
-
-	try {
-		await prisma.assuranceCase.update({
-			where: { id: caseId },
-			data: {
-				publishStatus: "DRAFT",
-				markedReadyAt: null,
-				markedReadyById: null,
-			},
-		});
-
-		return { data: { success: true as const } };
-	} catch (error) {
-		console.error("Failed to unmark case as ready:", error);
-		return { error: "Failed to unmark case as ready" };
-	}
-}
-
-/**
- * Gets cases that are ready to publish for a specific user.
- * Returns cases owned by the user with READY_TO_PUBLISH status.
- */
-export async function getReadyToPublishCases(userId: string): Promise<
-	{
-		id: string;
-		name: string;
-		description: string;
-		markedReadyAt: Date | null;
-	}[]
-> {
-	const cases = await prisma.assuranceCase.findMany({
-		where: {
-			createdById: userId,
-			publishStatus: "READY_TO_PUBLISH",
-		},
-		select: {
-			id: true,
-			name: true,
-			description: true,
-			markedReadyAt: true,
-		},
-		orderBy: {
-			markedReadyAt: "desc",
-		},
-	});
-
-	return cases;
-}
-
-/**
  * Updates an existing published assurance case with current content.
  * Creates a new PublishedAssuranceCase record and migrates case study links.
  *
@@ -575,8 +461,10 @@ export async function updatePublishedCase(
 			published: true,
 			publishStatus: true,
 			publishedVersions: {
+				where: { isCurrent: true },
 				select: {
 					id: true,
+					slug: true,
 					caseStudyLinks: {
 						select: {
 							caseStudyId: true,
@@ -615,19 +503,34 @@ export async function updatePublishedCase(
 
 	// See `publishAssuranceCase` above for the same capture + merge.
 	const pluginData = await capturePluginDataForSnapshot(caseId);
-	const content = pluginData
-		? { ...exportResult.data, pluginData }
-		: exportResult.data;
+	const caseInformation = await captureCaseInformationForSnapshot(caseId);
+	const content = {
+		...exportResult.data,
+		...(pluginData && { pluginData }),
+		...(caseInformation && { caseInformation }),
+	};
 
 	const now = new Date();
 
 	try {
 		// Create new version and migrate links in a transaction
 		const newPublished = await prisma.$transaction(async (tx) => {
-			// Create new published version
+			// Retire the version being superseded BEFORE inserting its
+			// replacement — the partial unique index on (slug) WHERE
+			// is_current would otherwise reject the new row for reusing the
+			// same slug while the old row is still marked current.
+			await tx.publishedAssuranceCase.update({
+				where: { id: currentPublished.id },
+				data: { isCurrent: false },
+			});
+
+			// Create new published version — carrying the EXISTING slug forward
+			// verbatim (ADR 0003 §6: stable across renames). Never regenerated
+			// here, even if `assuranceCase.name` has changed since first publish.
 			const published = await tx.publishedAssuranceCase.create({
 				data: {
 					title: assuranceCase.name,
+					slug: currentPublished.slug,
 					content,
 					description: description ?? null,
 					assuranceCaseId: caseId,
@@ -710,13 +613,7 @@ function executeStatusTransition(
 	description?: string
 ): Promise<StatusTransitionResult> {
 	switch (transitionKey) {
-		case "DRAFT->READY_TO_PUBLISH":
-			return handleMarkAsReady(userId, caseId);
-
-		case "READY_TO_PUBLISH->DRAFT":
-			return handleUnmarkAsReady(userId, caseId);
-
-		case "READY_TO_PUBLISH->PUBLISHED":
+		case "DRAFT->PUBLISHED":
 			return handlePublish(userId, caseId, description);
 
 		case "PUBLISHED->DRAFT":
@@ -731,28 +628,6 @@ function executeStatusTransition(
 				error: `Invalid status transition: ${transitionKey.replace("->", " to ")}`,
 			});
 	}
-}
-
-async function handleMarkAsReady(
-	userId: string,
-	caseId: string
-): Promise<StatusTransitionResult> {
-	const result = await markCaseAsReady(userId, caseId);
-	if ("error" in result) {
-		return { error: result.error };
-	}
-	return { data: { newStatus: "READY_TO_PUBLISH" } };
-}
-
-async function handleUnmarkAsReady(
-	userId: string,
-	caseId: string
-): Promise<StatusTransitionResult> {
-	const result = await unmarkCaseAsReady(userId, caseId);
-	if ("error" in result) {
-		return { error: result.error };
-	}
-	return { data: { newStatus: "DRAFT" } };
 }
 
 async function handlePublish(

--- a/lib/services/publish-service.types.ts
+++ b/lib/services/publish-service.types.ts
@@ -11,7 +11,8 @@ export interface PublishStatus {
 	publishedId: string | null;
 }
 
-// Full status including 3-state workflow
+// Full status (DRAFT / PUBLISHED — the "Ready to Publish" intermediate step
+// was retired, ADR 0003 §2)
 export interface FullPublishStatus {
 	hasChanges: boolean;
 	isPublished: boolean;
@@ -30,11 +31,9 @@ export type UnpublishResult =
 	| { data: { success: true } }
 	| { error: string; linkedCaseStudies?: { id: number; title: string }[] };
 
-export type MarkReadyResult =
-	| { data: { markedReadyAt: Date } }
-	| { error: string };
-
-export type UnmarkReadyResult = { data: { success: true } } | { error: string };
+// MarkReadyResult / UnmarkReadyResult retired alongside READY_TO_PUBLISH
+// (ADR 0003 §2/§4) — the "Ready to Publish" intermediate step no longer
+// exists, so there is nothing left to mark or unmark.
 
 export type StatusTransitionResult =
 	| {

--- a/lib/services/slug-service.ts
+++ b/lib/services/slug-service.ts
@@ -1,0 +1,76 @@
+import { prisma } from "@/lib/prisma";
+
+// Derived from `prisma.$transaction`'s own callback parameter, the same
+// pattern `case-batch-update-service.ts` uses — `Prisma.TransactionClient`
+// (the generated client's own type) does not structurally match this
+// project's client, which is `.$extends()`-wrapped with the element
+// validation extension in `lib/prisma.ts`.
+type TransactionCallback = Parameters<typeof prisma.$transaction>[0];
+type TransactionClient = TransactionCallback extends (
+	tx: infer T
+) => Promise<unknown>
+	? T
+	: never;
+
+/**
+ * Converts a name into a URL-safe slug base: lowercase, non-alphanumerics
+ * collapsed to single hyphens, leading/trailing hyphens trimmed. An
+ * all-punctuation/empty input falls back to "item" so a slug is always
+ * produced (ADR 0003 §6 requires every published item to have one). Kept in
+ * lockstep with the equivalent backfill expression in this feature's
+ * migration (`prisma/migrations/20260716000000_publishing_schema_and_state_model`).
+ */
+export function slugify(name: string): string {
+	const base = name
+		.toLowerCase()
+		.trim()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return base || "item";
+}
+
+/**
+ * Generates a slug for `name` that is unique among existing CURRENT
+ * `PublishedAssuranceCase` slugs, appending a numeric suffix (`-2`, `-3`, …)
+ * on collision (ADR 0003 §6). Checked against `isCurrent: true` rows only —
+ * that is the actual uniqueness domain the schema enforces (a partial index,
+ * not a plain `@@unique`): historical/superseded rows are expected to share
+ * a slug with their own case's current row, and are no longer publicly
+ * addressable, so they cannot collide with a brand-new case's fresh slug.
+ *
+ * Call this ONCE, at first publish only. Every later republish of the same
+ * source case must carry its existing slug forward verbatim instead of
+ * calling this again — see `publishAssuranceCase` / `updatePublishedCase` in
+ * `publish-service.ts` — so a case's public address survives any number of
+ * renames.
+ *
+ * Accepts an optional transaction client so the uniqueness check and the
+ * row insert that consumes its result can run inside the same transaction
+ * (`publishAssuranceCase` does this) without a TOCTOU gap between the two.
+ */
+export async function generateUniqueSlug(
+	name: string,
+	client: TransactionClient = prisma
+): Promise<string> {
+	const base = slugify(name);
+	let candidate = base;
+	let suffix = 1;
+
+	// A loop, not a single "count existing + 1": unpublishing deletes rows,
+	// so a straight count can still collide if earlier suffixes were freed
+	// up and reused elsewhere in the meantime. This stays correct regardless,
+	// bounded by however many collisions actually exist, not by case volume.
+	// Sequential awaits are deliberate: each iteration depends on the
+	// previous candidate's collision result, so this cannot be parallelised.
+	while (
+		(await client.publishedAssuranceCase.findFirst({
+			where: { slug: candidate, isCurrent: true },
+			select: { id: true },
+		})) !== null
+	) {
+		suffix += 1;
+		candidate = `${base}-${suffix}`;
+	}
+
+	return candidate;
+}

--- a/prisma/migrations/20260716000000_publishing_schema_and_state_model/migration.sql
+++ b/prisma/migrations/20260716000000_publishing_schema_and_state_model/migration.sql
@@ -1,0 +1,113 @@
+-- ADR 0003 (publishing and Discover) — data layer, first issue in the chain.
+-- Three independent changes:
+--   1. case_information: the canonical case-information record (ADR §1).
+--   2. published_assurance_cases gains a generic-item type discriminator and
+--      a stable, name-derived slug (ADR §5, §6).
+--   3. publish_status loses READY_TO_PUBLISH (ADR §2/§4) — existing rows map
+--      to DRAFT before the enum type is rebuilt without the retired value.
+
+-- ============================================
+-- 1. case_information
+-- ============================================
+
+-- CreateTable
+CREATE TABLE "case_information" (
+    "id" TEXT NOT NULL,
+    "case_id" TEXT NOT NULL,
+    "description" TEXT,
+    "authors" VARCHAR(255),
+    "sector" VARCHAR(100),
+    "feature_image_url" VARCHAR(2000),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "case_information_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "case_information_case_id_key" ON "case_information"("case_id");
+
+-- AddForeignKey
+ALTER TABLE "case_information" ADD CONSTRAINT "case_information_case_id_fkey" FOREIGN KEY ("case_id") REFERENCES "assurance_cases"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- ============================================
+-- 2. published_assurance_cases: type discriminator + slug + isCurrent
+-- ============================================
+
+-- CreateEnum
+CREATE TYPE "PublishableItemType" AS ENUM ('ASSURANCE_CASE', 'ARGUMENT_PATTERN');
+
+-- AlterTable: add `type` with a default so existing rows backfill cleanly
+-- (every row published before this migration is, by definition, an
+-- assurance case).
+ALTER TABLE "published_assurance_cases" ADD COLUMN "type" "PublishableItemType" NOT NULL DEFAULT 'ASSURANCE_CASE';
+
+-- AlterTable: add `is_current` — every row starts `true`, corrected below for
+-- cases that already have more than one historical published version (only
+-- the latest may stay current).
+ALTER TABLE "published_assurance_cases" ADD COLUMN "is_current" BOOLEAN NOT NULL DEFAULT true;
+
+-- AlterTable: add `slug` nullable first — it cannot be backfilled until
+-- existing rows have a value.
+ALTER TABLE "published_assurance_cases" ADD COLUMN "slug" VARCHAR(255);
+
+-- Backfill: derive a slug from each existing row's title using the same
+-- normalisation as `slug-service.ts`'s `slugify` (lowercase, non-alphanumerics
+-- collapsed to single hyphens, leading/trailing hyphens trimmed, "item" as
+-- the fallback for an all-punctuation/empty title), then suffix with the
+-- row's own id fragment. The id fragment — not a numeric suffix — is
+-- deliberate here: it guarantees uniqueness across this whole backfill in
+-- one pass with no self-referential collision loop, which the ordinary
+-- runtime path (`generateUniqueSlug`) does not need because it only ever
+-- inserts one new row at a time.
+UPDATE "published_assurance_cases"
+SET "slug" = (
+    CASE
+        WHEN trim(both '-' from regexp_replace(lower(trim("title")), '[^a-z0-9]+', '-', 'g')) = ''
+            THEN 'item'
+        ELSE trim(both '-' from regexp_replace(lower(trim("title")), '[^a-z0-9]+', '-', 'g'))
+    END
+) || '-' || substr("id"::text, 1, 8)
+WHERE "slug" IS NULL;
+
+ALTER TABLE "published_assurance_cases" ALTER COLUMN "slug" SET NOT NULL;
+
+-- Correct `is_current` for cases with more than one historical version: only
+-- the most recently created row per `assurance_case_id` stays current. Every
+-- row defaulted to `true` above, so this only ever flips rows to `false`.
+UPDATE "published_assurance_cases" AS pac
+SET "is_current" = false
+WHERE EXISTS (
+    SELECT 1 FROM "published_assurance_cases" AS newer
+    WHERE newer."assurance_case_id" = pac."assurance_case_id"
+      AND (newer."created_at", newer."id") > (pac."created_at", pac."id")
+);
+
+-- CreateIndex: general lookup index (slug is no longer globally unique — see
+-- the model comment in schema.prisma).
+CREATE INDEX "published_assurance_cases_slug_current_idx" ON "published_assurance_cases"("slug", "is_current");
+
+-- Partial unique index: the actual uniqueness invariant is "no two CURRENT
+-- rows share a slug" — two historical (superseded) rows for the SAME case are
+-- expected to share one by design (ADR 0003 §6: the slug is stable across
+-- republishes). Cannot be expressed as a plain `@@unique` in Prisma's schema
+-- DSL (same limitation as `PluginData`'s case-level partial index above),
+-- hence raw SQL here. Keep both in sync if this model changes.
+CREATE UNIQUE INDEX "published_assurance_cases_slug_is_current_key" ON "published_assurance_cases"("slug") WHERE "is_current";
+
+-- ============================================
+-- 3. publish_status: retire READY_TO_PUBLISH
+-- ============================================
+
+-- Map existing rows first — the new enum type below has no READY_TO_PUBLISH
+-- value to cast into.
+UPDATE "assurance_cases" SET "publish_status" = 'DRAFT' WHERE "publish_status" = 'READY_TO_PUBLISH';
+
+-- Postgres has no `ALTER TYPE ... DROP VALUE`, so the enum is rebuilt:
+-- create the new type, swap the column over, drop the old type, rename.
+CREATE TYPE "PublishStatus_new" AS ENUM ('DRAFT', 'PUBLISHED');
+ALTER TABLE "assurance_cases" ALTER COLUMN "publish_status" DROP DEFAULT;
+ALTER TABLE "assurance_cases" ALTER COLUMN "publish_status" TYPE "PublishStatus_new" USING ("publish_status"::text::"PublishStatus_new");
+ALTER TABLE "assurance_cases" ALTER COLUMN "publish_status" SET DEFAULT 'DRAFT';
+DROP TYPE "PublishStatus";
+ALTER TYPE "PublishStatus_new" RENAME TO "PublishStatus";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -105,9 +105,17 @@ enum CaseMode {
   ADVANCED
 }
 
+/// DRAFT and PUBLISHED are the only two states now that the "Ready to
+/// Publish" intermediate step is retired (ADR 0003 §2). READY_TO_PUBLISH
+/// existed here until migration 20260716000000, which maps every existing
+/// row to DRAFT before dropping the enum value.
+///
+/// Extension seam (ADR 0003 §4): a future SUBMITTED/approval state slots in
+/// alongside these two when deployments grow multi-team usage. This is a
+/// documented placeholder only — no workflow, UI, or notification plumbing
+/// ships until that state is actually built.
 enum PublishStatus {
   DRAFT
-  READY_TO_PUBLISH
   PUBLISHED
 }
 
@@ -269,6 +277,7 @@ model AssuranceCase {
   invites         CaseInvite[]
   comments        Comment[]
   caseImage       CaseImage?
+  caseInformation CaseInformation?
   caseTypes       CaseTypeAssignment[]
   pluginData      PluginData[]
 
@@ -781,6 +790,36 @@ model CaseImage {
   @@map("case_images")
 }
 
+/// The canonical case-information record (ADR 0003 §1): description,
+/// authors, sector, and a feature image, editable at any time under the
+/// case's normal edit permissions. Deliberately broader than "publication
+/// metadata" — other services and plugins may read it; publishing (see
+/// `PublishedAssuranceCase`) is its first consumer, not its only one.
+/// One-to-one and optional: a case with no curated information yet has no
+/// row here, not a row of nulls.
+///
+/// `description` is distinct from `AssuranceCase.description`: the case's
+/// own field describes the argument's purpose and scope for people working
+/// on it; this one is the public-facing narrative shown on Discover once
+/// published, mirroring what the retired case-study form collected.
+model CaseInformation {
+  id              String   @id @default(uuid())
+  caseId          String   @unique @map("case_id")
+
+  description     String?
+  authors         String?  @db.VarChar(255)
+  sector          String?  @db.VarChar(100)
+  featureImageUrl String?  @map("feature_image_url") @db.VarChar(2000)
+
+  createdAt       DateTime @default(now()) @map("created_at")
+  updatedAt       DateTime @updatedAt @map("updated_at")
+
+  // Relations
+  case            AssuranceCase @relation(fields: [caseId], references: [id], onDelete: Cascade)
+
+  @@map("case_information")
+}
+
 /// Classification type for assurance cases: DOMAIN (healthcare), TECHNIQUE (ML safety), STANDARD (ISO 26262).
 model CaseType {
   id          String               @id @default(uuid())
@@ -899,19 +938,49 @@ model CaseStudyImage {
   @@map("case_study_images")
 }
 
-/// Snapshot of an assurance case for case study integration. Content stored as JSON.
-// Multiple versions per case (history). Distinct from Release model (for community releases).
+/// A publishable item's concrete type (ADR 0003 §5). Only ASSURANCE_CASE
+/// ships in 1.0 — ARGUMENT_PATTERN is a discriminator placeholder so the
+/// fast-follow issue that publishes reusable pattern templates needs no
+/// schema rework on `PublishedAssuranceCase`.
+enum PublishableItemType {
+  ASSURANCE_CASE
+  ARGUMENT_PATTERN
+}
+
+/// Frozen, point-in-time snapshot of an assurance case (ADR 0003 §3): the
+/// public/Discover-facing published record. Content stored as JSON;
+/// multiple versions per case (history) via repeated publish/republish —
+/// republishing INSERTS a new row rather than updating the old one, so a
+/// case's full publish history stays queryable. Distinct from the `Release`
+/// model (community releases, a separate, currently-unused mechanism).
+///
+/// `description` here is the free-text note optionally supplied by the
+/// caller at publish time (e.g. "Initial release") — NOT the case's curated
+/// `CaseInformation.description`. The latter, along with `authors`, `sector`,
+/// and `featureImageUrl`, is frozen verbatim into `content.caseInformation`
+/// at publish time (see `publish-service.ts`), composed the same way as
+/// `content.pluginData` (ADR 0002 v2 §3) — undefined, not an empty object,
+/// when the case holds no case information at all.
 model PublishedAssuranceCase {
-  id              String   @id @default(uuid()) @db.Uuid
-  title           String   @db.VarChar(255) /// Title at time of publishing
-  content         Json     /// Full case content as JSON snapshot
-  createdAt       DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
-  assuranceCaseId String   @map("assurance_case_id") /// Source case this was published from
-  description     String?  @db.VarChar(1000) /// Description at time of publishing
+  id              String              @id @default(uuid()) @db.Uuid
+  type            PublishableItemType @default(ASSURANCE_CASE) /// Discriminator (ADR 0003 §5) — only ASSURANCE_CASE is implemented; ready for a future pattern type with no rework.
+  slug            String              @db.VarChar(255) /// Stable, name-derived, deployment-unique public address (ADR 0003 §6). Generated once at first publish (see `slug-service.ts`) and carried forward verbatim — UNCHANGED — onto every later republish row of the same source case, never regenerated on rename. Collisions append a numeric suffix. NOT `@unique` here: every historical version of the same case shares one slug by design (that is what "stable" means), so true uniqueness is scoped to the CURRENT version only — see `isCurrent` and the hand-written partial index below (same DSL limitation as `PluginData`'s case-level partial index; Prisma cannot express a partial unique constraint).
+  isCurrent       Boolean             @default(true) @map("is_current") /// True for exactly one row per `assuranceCaseId` at a time — the version Discover and the public API serve. Republishing flips the previous current row to `false` in the same transaction that inserts the new current row (`updatePublishedCase`). That "exactly one" invariant is enforced at the service layer, not the DB — the partial unique index below only stops two DIFFERENT cases' current rows from colliding on the same slug.
+  title           String              @db.VarChar(255) /// Title at time of publishing
+  content         Json                /// Full case content as JSON snapshot
+  createdAt       DateTime            @default(now()) @map("created_at") @db.Timestamptz(6)
+  assuranceCaseId String              @map("assurance_case_id") /// Source case this was published from
+  description     String?             @db.VarChar(1000) /// Description at time of publishing
 
   // Relations
   assuranceCase   AssuranceCase            @relation(fields: [assuranceCaseId], references: [id])
   caseStudyLinks  CaseStudyPublishedCase[]
+
+  // @@unique/@@index below cover most access patterns, but the slug's TRUE
+  // uniqueness constraint (current version only) is a hand-written partial
+  // index in this feature's migration SQL — Prisma's schema DSL cannot
+  // express `WHERE is_current`. Keep both in sync if this model changes.
+  @@index([slug, isCurrent], map: "published_assurance_cases_slug_current_idx")
 
   @@index([assuranceCaseId], map: "published_assurance_cases_assurance_case_id_idx")
   @@map("published_assurance_cases")

--- a/src/__tests__/integration/api-public.test.ts
+++ b/src/__tests__/integration/api-public.test.ts
@@ -37,6 +37,7 @@ describe("GET /api/public/assurance-case/[id]", () => {
 		const published = await prisma.publishedAssuranceCase.create({
 			data: {
 				title: "Published Title",
+				slug: `published-title-${testCase.id.slice(0, 8)}`,
 				description: "Published description",
 				content: { nodes: [] },
 				assuranceCaseId: testCase.id,

--- a/src/__tests__/integration/case-information-service.test.ts
+++ b/src/__tests__/integration/case-information-service.test.ts
@@ -354,6 +354,38 @@ describe("deleteCaseInformation", () => {
 		expectSuccess(await deleteCaseInformation(owner.id, testCase.id));
 	});
 
+	it("direct EDIT share can delete", async () => {
+		const owner = await createTestUser();
+		const editor = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestPermission(testCase.id, editor.id, owner.id, "EDIT");
+		await createTestCaseInformation(testCase.id);
+
+		expectSuccess(await deleteCaseInformation(editor.id, testCase.id));
+
+		const stored = await prisma.caseInformation.findUnique({
+			where: { caseId: testCase.id },
+		});
+		expect(stored).toBeNull();
+	});
+
+	it("EDIT via team can delete", async () => {
+		const owner = await createTestUser();
+		const teamMember = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const team = await createTestTeam(owner.id);
+		await addTeamMember(team.id, teamMember.id);
+		await createTestTeamPermission(testCase.id, team.id, owner.id, "EDIT");
+		await createTestCaseInformation(testCase.id);
+
+		expectSuccess(await deleteCaseInformation(teamMember.id, testCase.id));
+
+		const stored = await prisma.caseInformation.findUnique({
+			where: { caseId: testCase.id },
+		});
+		expect(stored).toBeNull();
+	});
+
 	it("returns error for a user with only VIEW permission", async () => {
 		const owner = await createTestUser();
 		const viewer = await createTestUser();
@@ -367,6 +399,49 @@ describe("deleteCaseInformation", () => {
 		);
 	});
 
+	it("returns error for direct COMMENT share (read-only)", async () => {
+		const owner = await createTestUser();
+		const commenter = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestPermission(testCase.id, commenter.id, owner.id, "COMMENT");
+		await createTestCaseInformation(testCase.id);
+
+		expectError(
+			await deleteCaseInformation(commenter.id, testCase.id),
+			"Permission denied"
+		);
+	});
+
+	it("returns error for VIEW via team (read-only)", async () => {
+		const owner = await createTestUser();
+		const teamMember = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const team = await createTestTeam(owner.id);
+		await addTeamMember(team.id, teamMember.id);
+		await createTestTeamPermission(testCase.id, team.id, owner.id, "VIEW");
+		await createTestCaseInformation(testCase.id);
+
+		expectError(
+			await deleteCaseInformation(teamMember.id, testCase.id),
+			"Permission denied"
+		);
+	});
+
+	it("returns error for COMMENT via team (read-only)", async () => {
+		const owner = await createTestUser();
+		const teamMember = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const team = await createTestTeam(owner.id);
+		await addTeamMember(team.id, teamMember.id);
+		await createTestTeamPermission(testCase.id, team.id, owner.id, "COMMENT");
+		await createTestCaseInformation(testCase.id);
+
+		expectError(
+			await deleteCaseInformation(teamMember.id, testCase.id),
+			"Permission denied"
+		);
+	});
+
 	it("returns error for a user with no permission", async () => {
 		const owner = await createTestUser();
 		const stranger = await createTestUser();
@@ -376,6 +451,23 @@ describe("deleteCaseInformation", () => {
 			await deleteCaseInformation(stranger.id, testCase.id),
 			"Permission denied"
 		);
+	});
+
+	it("returns the same error for a non-existent case as for an inaccessible one", async () => {
+		const owner = await createTestUser();
+		const stranger = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+
+		const noAccessResult = await deleteCaseInformation(
+			stranger.id,
+			testCase.id
+		);
+		const notFoundResult = await deleteCaseInformation(
+			stranger.id,
+			NON_EXISTENT_CASE_ID
+		);
+
+		expectSameError(noAccessResult, notFoundResult);
 	});
 });
 

--- a/src/__tests__/integration/case-information-service.test.ts
+++ b/src/__tests__/integration/case-information-service.test.ts
@@ -1,0 +1,413 @@
+import { describe, expect, it } from "vitest";
+import prisma from "@/lib/prisma";
+import {
+	captureCaseInformationForSnapshot,
+	deleteCaseInformation,
+	getCaseInformation,
+	upsertCaseInformation,
+} from "@/lib/services/case-information-service";
+import {
+	expectError,
+	expectSameError,
+	expectSuccess,
+} from "../utils/assertion-helpers";
+import {
+	addTeamMember,
+	createTestCase,
+	createTestCaseInformation,
+	createTestPermission,
+	createTestTeam,
+	createTestTeamPermission,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+const NON_EXISTENT_CASE_ID = "00000000-0000-0000-0000-000000000000";
+
+// ============================================
+// getCaseInformation
+// ============================================
+
+describe("getCaseInformation", () => {
+	it("returns null data for a case with no case information yet", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+
+		// Not `expectSuccess`: its `data === null` branch is designed for
+		// void-result services (delete/reset) and returns `undefined` rather
+		// than asserting the value — here `null` is the meaningful "no case
+		// information yet" payload, so assert on the raw ServiceResult
+		// directly (same convention as `plugin-data-service.test.ts`).
+		const result = await getCaseInformation(owner.id, testCase.id);
+		expect("error" in result).toBe(false);
+		expect("data" in result && result.data).toBeNull();
+	});
+
+	it("returns the record when one exists", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestCaseInformation(testCase.id, {
+			description: "A narrative description",
+			authors: "Ada Lovelace",
+			sector: "Healthcare",
+			featureImageUrl: "https://example.com/feature.png",
+		});
+
+		const data = expectSuccess(await getCaseInformation(owner.id, testCase.id));
+		expect(data?.description).toBe("A narrative description");
+		expect(data?.authors).toBe("Ada Lovelace");
+		expect(data?.sector).toBe("Healthcare");
+		expect(data?.featureImageUrl).toBe("https://example.com/feature.png");
+	});
+
+	it("owner (implicit ADMIN) can read", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+
+		expectSuccess(await getCaseInformation(owner.id, testCase.id));
+	});
+
+	it("direct EDIT share can read", async () => {
+		const owner = await createTestUser();
+		const editor = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestPermission(testCase.id, editor.id, owner.id, "EDIT");
+
+		expectSuccess(await getCaseInformation(editor.id, testCase.id));
+	});
+
+	it("direct VIEW share can read", async () => {
+		const owner = await createTestUser();
+		const viewer = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestPermission(testCase.id, viewer.id, owner.id, "VIEW");
+
+		expectSuccess(await getCaseInformation(viewer.id, testCase.id));
+	});
+
+	it("direct COMMENT share can read", async () => {
+		const owner = await createTestUser();
+		const commenter = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestPermission(testCase.id, commenter.id, owner.id, "COMMENT");
+
+		expectSuccess(await getCaseInformation(commenter.id, testCase.id));
+	});
+
+	it("EDIT via team can read", async () => {
+		const owner = await createTestUser();
+		const teamMember = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const team = await createTestTeam(owner.id);
+		await addTeamMember(team.id, teamMember.id);
+		await createTestTeamPermission(testCase.id, team.id, owner.id, "EDIT");
+
+		expectSuccess(await getCaseInformation(teamMember.id, testCase.id));
+	});
+
+	it("VIEW via team can read", async () => {
+		const owner = await createTestUser();
+		const teamMember = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const team = await createTestTeam(owner.id);
+		await addTeamMember(team.id, teamMember.id);
+		await createTestTeamPermission(testCase.id, team.id, owner.id, "VIEW");
+
+		expectSuccess(await getCaseInformation(teamMember.id, testCase.id));
+	});
+
+	it("COMMENT via team can read", async () => {
+		const owner = await createTestUser();
+		const teamMember = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const team = await createTestTeam(owner.id);
+		await addTeamMember(team.id, teamMember.id);
+		await createTestTeamPermission(testCase.id, team.id, owner.id, "COMMENT");
+
+		expectSuccess(await getCaseInformation(teamMember.id, testCase.id));
+	});
+
+	it("returns error for a user with no permission", async () => {
+		const owner = await createTestUser();
+		const stranger = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+
+		expectError(
+			await getCaseInformation(stranger.id, testCase.id),
+			"Permission denied"
+		);
+	});
+
+	it("returns the same error for a non-existent case as for an inaccessible one", async () => {
+		const owner = await createTestUser();
+		const stranger = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+
+		const noAccessResult = await getCaseInformation(stranger.id, testCase.id);
+		const notFoundResult = await getCaseInformation(
+			stranger.id,
+			NON_EXISTENT_CASE_ID
+		);
+
+		expectSameError(noAccessResult, notFoundResult);
+	});
+});
+
+// ============================================
+// upsertCaseInformation
+// ============================================
+
+describe("upsertCaseInformation", () => {
+	it("creates a new record when none exists", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+
+		const data = expectSuccess(
+			await upsertCaseInformation(owner.id, testCase.id, {
+				description: "First description",
+				authors: "Grace Hopper",
+			})
+		);
+		expect(data.description).toBe("First description");
+		expect(data.authors).toBe("Grace Hopper");
+		expect(data.sector).toBeNull();
+		expect(data.featureImageUrl).toBeNull();
+
+		const stored = await prisma.caseInformation.findUnique({
+			where: { caseId: testCase.id },
+		});
+		expect(stored).not.toBeNull();
+	});
+
+	it("updates only the fields provided, leaving the rest untouched", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestCaseInformation(testCase.id, {
+			description: "Original description",
+			authors: "Original authors",
+			sector: "Original sector",
+		});
+
+		const data = expectSuccess(
+			await upsertCaseInformation(owner.id, testCase.id, {
+				sector: "Updated sector",
+			})
+		);
+		expect(data.sector).toBe("Updated sector");
+		expect(data.description).toBe("Original description");
+		expect(data.authors).toBe("Original authors");
+	});
+
+	it("owner (implicit ADMIN) can write", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+
+		expectSuccess(
+			await upsertCaseInformation(owner.id, testCase.id, {
+				description: "desc",
+			})
+		);
+	});
+
+	it("direct EDIT share can write", async () => {
+		const owner = await createTestUser();
+		const editor = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestPermission(testCase.id, editor.id, owner.id, "EDIT");
+
+		expectSuccess(
+			await upsertCaseInformation(editor.id, testCase.id, {
+				description: "desc",
+			})
+		);
+	});
+
+	it("EDIT via team can write", async () => {
+		const owner = await createTestUser();
+		const teamMember = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const team = await createTestTeam(owner.id);
+		await addTeamMember(team.id, teamMember.id);
+		await createTestTeamPermission(testCase.id, team.id, owner.id, "EDIT");
+
+		expectSuccess(
+			await upsertCaseInformation(teamMember.id, testCase.id, {
+				description: "desc",
+			})
+		);
+	});
+
+	it("returns error for direct VIEW share (read-only)", async () => {
+		const owner = await createTestUser();
+		const viewer = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestPermission(testCase.id, viewer.id, owner.id, "VIEW");
+
+		expectError(
+			await upsertCaseInformation(viewer.id, testCase.id, {
+				description: "desc",
+			}),
+			"Permission denied"
+		);
+	});
+
+	it("returns error for direct COMMENT share (read-only)", async () => {
+		const owner = await createTestUser();
+		const commenter = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestPermission(testCase.id, commenter.id, owner.id, "COMMENT");
+
+		expectError(
+			await upsertCaseInformation(commenter.id, testCase.id, {
+				description: "desc",
+			}),
+			"Permission denied"
+		);
+	});
+
+	it("returns error for VIEW via team (read-only)", async () => {
+		const owner = await createTestUser();
+		const teamMember = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const team = await createTestTeam(owner.id);
+		await addTeamMember(team.id, teamMember.id);
+		await createTestTeamPermission(testCase.id, team.id, owner.id, "VIEW");
+
+		expectError(
+			await upsertCaseInformation(teamMember.id, testCase.id, {
+				description: "desc",
+			}),
+			"Permission denied"
+		);
+	});
+
+	it("returns error for COMMENT via team (read-only)", async () => {
+		const owner = await createTestUser();
+		const teamMember = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const team = await createTestTeam(owner.id);
+		await addTeamMember(team.id, teamMember.id);
+		await createTestTeamPermission(testCase.id, team.id, owner.id, "COMMENT");
+
+		expectError(
+			await upsertCaseInformation(teamMember.id, testCase.id, {
+				description: "desc",
+			}),
+			"Permission denied"
+		);
+	});
+
+	it("returns error for a user with no permission", async () => {
+		const owner = await createTestUser();
+		const stranger = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+
+		expectError(
+			await upsertCaseInformation(stranger.id, testCase.id, {
+				description: "desc",
+			}),
+			"Permission denied"
+		);
+	});
+
+	it("returns the same error for a non-existent case as for an inaccessible one", async () => {
+		const owner = await createTestUser();
+		const stranger = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+
+		const noAccessResult = await upsertCaseInformation(
+			stranger.id,
+			testCase.id,
+			{ description: "desc" }
+		);
+		const notFoundResult = await upsertCaseInformation(
+			stranger.id,
+			NON_EXISTENT_CASE_ID,
+			{ description: "desc" }
+		);
+
+		expectSameError(noAccessResult, notFoundResult);
+	});
+});
+
+// ============================================
+// deleteCaseInformation
+// ============================================
+
+describe("deleteCaseInformation", () => {
+	it("deletes an existing record", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestCaseInformation(testCase.id);
+
+		expectSuccess(await deleteCaseInformation(owner.id, testCase.id));
+
+		const stored = await prisma.caseInformation.findUnique({
+			where: { caseId: testCase.id },
+		});
+		expect(stored).toBeNull();
+	});
+
+	it("is a no-op success when no record exists", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+
+		expectSuccess(await deleteCaseInformation(owner.id, testCase.id));
+	});
+
+	it("returns error for a user with only VIEW permission", async () => {
+		const owner = await createTestUser();
+		const viewer = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestPermission(testCase.id, viewer.id, owner.id, "VIEW");
+		await createTestCaseInformation(testCase.id);
+
+		expectError(
+			await deleteCaseInformation(viewer.id, testCase.id),
+			"Permission denied"
+		);
+	});
+
+	it("returns error for a user with no permission", async () => {
+		const owner = await createTestUser();
+		const stranger = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+
+		expectError(
+			await deleteCaseInformation(stranger.id, testCase.id),
+			"Permission denied"
+		);
+	});
+});
+
+// ============================================
+// captureCaseInformationForSnapshot
+// ============================================
+
+describe("captureCaseInformationForSnapshot", () => {
+	it("returns undefined when no case information exists", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+
+		const snapshot = await captureCaseInformationForSnapshot(testCase.id);
+		expect(snapshot).toBeUndefined();
+	});
+
+	it("returns the record verbatim when one exists", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestCaseInformation(testCase.id, {
+			description: "Snapshot description",
+			authors: "Snapshot authors",
+			sector: "Snapshot sector",
+			featureImageUrl: "https://example.com/snapshot.png",
+		});
+
+		const snapshot = await captureCaseInformationForSnapshot(testCase.id);
+		expect(snapshot).toStrictEqual({
+			description: "Snapshot description",
+			authors: "Snapshot authors",
+			sector: "Snapshot sector",
+			featureImageUrl: "https://example.com/snapshot.png",
+		});
+	});
+});

--- a/src/__tests__/integration/publish-service.test.ts
+++ b/src/__tests__/integration/publish-service.test.ts
@@ -4,10 +4,8 @@ import { setPluginEnabledForUser } from "@/lib/services/plugin-enablement-servic
 import {
 	getFullPublishStatus,
 	getPublishStatus,
-	markCaseAsReady,
 	publishAssuranceCase,
 	transitionStatus,
-	unmarkCaseAsReady,
 	unpublishAssuranceCase,
 	updatePublishedCase,
 } from "@/lib/services/publish-service";
@@ -18,6 +16,7 @@ import {
 } from "../utils/assertion-helpers";
 import {
 	createTestCase,
+	createTestCaseInformation,
 	createTestCaseStudy,
 	createTestCaseWithGoal,
 	createTestElement,
@@ -27,115 +26,7 @@ import {
 } from "../utils/prisma-factories";
 
 // Top-level regex constants required by lint/performance/useTopLevelRegex
-const CANNOT_MARK_AS_READY = /Cannot mark as ready/;
-const STATUS_READY_TO_PUBLISH = /READY_TO_PUBLISH/;
-const STATUS_PUBLISHED = /PUBLISHED/;
-const CANNOT_UNMARK = /Cannot unmark/;
-const STATUS_DRAFT = /DRAFT/;
 const INVALID_STATUS_TRANSITION = /Invalid status transition/;
-
-// ============================================
-// markCaseAsReady
-// ============================================
-
-describe("markCaseAsReady", () => {
-	it("transitions a DRAFT case to READY_TO_PUBLISH", async () => {
-		const owner = await createTestUser();
-		const testCase = await createTestCase(owner.id, {
-			publishStatus: "DRAFT",
-		});
-
-		const data = expectSuccess(await markCaseAsReady(owner.id, testCase.id));
-		expect(data.markedReadyAt).toBeInstanceOf(Date);
-
-		const updated = await prisma.assuranceCase.findUnique({
-			where: { id: testCase.id },
-			select: { publishStatus: true, markedReadyAt: true },
-		});
-		expect(updated?.publishStatus).toBe("READY_TO_PUBLISH");
-		expect(updated?.markedReadyAt).not.toBeNull();
-	});
-
-	it("returns error when case is already READY_TO_PUBLISH", async () => {
-		const owner = await createTestUser();
-		const testCase = await createTestCase(owner.id, {
-			publishStatus: "READY_TO_PUBLISH",
-		});
-
-		const result = await markCaseAsReady(owner.id, testCase.id);
-		expectError(result, CANNOT_MARK_AS_READY);
-		expectError(result, STATUS_READY_TO_PUBLISH);
-	});
-
-	it("returns error when case is already PUBLISHED", async () => {
-		const owner = await createTestUser();
-		const testCase = await createTestCase(owner.id, {
-			publishStatus: "PUBLISHED",
-			published: true,
-		});
-
-		const result = await markCaseAsReady(owner.id, testCase.id);
-		expectError(result, CANNOT_MARK_AS_READY);
-		expectError(result, STATUS_PUBLISHED);
-	});
-
-	it("returns error when caller lacks EDIT permission", async () => {
-		const owner = await createTestUser();
-		const viewer = await createTestUser();
-		const testCase = await createTestCase(owner.id);
-		await createTestPermission(testCase.id, viewer.id, owner.id, "VIEW");
-
-		expectError(
-			await markCaseAsReady(viewer.id, testCase.id),
-			"Permission denied"
-		);
-	});
-});
-
-// ============================================
-// unmarkCaseAsReady
-// ============================================
-
-describe("unmarkCaseAsReady", () => {
-	it("transitions a READY_TO_PUBLISH case back to DRAFT", async () => {
-		const owner = await createTestUser();
-		const testCase = await createTestCase(owner.id, {
-			publishStatus: "READY_TO_PUBLISH",
-		});
-
-		const data = expectSuccess(await unmarkCaseAsReady(owner.id, testCase.id));
-		expect(data.success).toBe(true);
-
-		const updated = await prisma.assuranceCase.findUnique({
-			where: { id: testCase.id },
-			select: { publishStatus: true, markedReadyAt: true },
-		});
-		expect(updated?.publishStatus).toBe("DRAFT");
-		expect(updated?.markedReadyAt).toBeNull();
-	});
-
-	it("returns error when case is in DRAFT status (not READY_TO_PUBLISH)", async () => {
-		const owner = await createTestUser();
-		const testCase = await createTestCase(owner.id, {
-			publishStatus: "DRAFT",
-		});
-
-		const result = await unmarkCaseAsReady(owner.id, testCase.id);
-		expectError(result, CANNOT_UNMARK);
-		expectError(result, STATUS_DRAFT);
-	});
-
-	it("returns error when case is PUBLISHED (not READY_TO_PUBLISH)", async () => {
-		const owner = await createTestUser();
-		const testCase = await createTestCase(owner.id, {
-			publishStatus: "PUBLISHED",
-			published: true,
-		});
-
-		const result = await unmarkCaseAsReady(owner.id, testCase.id);
-		expectError(result, CANNOT_UNMARK);
-	});
-});
 
 // ============================================
 // publishAssuranceCase
@@ -438,17 +329,6 @@ describe("getFullPublishStatus", () => {
 
 		expect(result.error).toBeDefined();
 	});
-
-	it("reflects READY_TO_PUBLISH status and markedReadyAt", async () => {
-		const owner = await createTestUser();
-		const testCase = await createTestCase(owner.id);
-		await markCaseAsReady(owner.id, testCase.id);
-
-		const result = await getFullPublishStatus(owner.id, testCase.id);
-
-		expect(result.data?.publishStatus).toBe("READY_TO_PUBLISH");
-		expect(result.data?.markedReadyAt).not.toBeNull();
-	});
 });
 
 // ============================================
@@ -496,39 +376,28 @@ describe("anti-enumeration: consistent error responses", () => {
 // ============================================
 
 describe("transitionStatus", () => {
-	it("transitions DRAFT to READY_TO_PUBLISH", async () => {
+	it("transitions DRAFT to PUBLISHED directly (the 'Ready to Publish' intermediate step is retired, ADR 0003 §2)", async () => {
 		const owner = await createTestUser();
 		const testCase = await createTestCaseWithGoal(owner.id);
-
-		const data = expectSuccess(
-			await transitionStatus(owner.id, testCase.id, "READY_TO_PUBLISH")
-		);
-		expect(data.newStatus).toBe("READY_TO_PUBLISH");
-
-		const updated = await prisma.assuranceCase.findUnique({
-			where: { id: testCase.id },
-			select: { publishStatus: true },
-		});
-		expect(updated?.publishStatus).toBe("READY_TO_PUBLISH");
-	});
-
-	it("transitions READY_TO_PUBLISH to PUBLISHED", async () => {
-		const owner = await createTestUser();
-		const testCase = await createTestCaseWithGoal(owner.id);
-		await markCaseAsReady(owner.id, testCase.id);
 
 		const data = expectSuccess(
 			await transitionStatus(owner.id, testCase.id, "PUBLISHED")
 		);
 		expect(data.newStatus).toBe("PUBLISHED");
 		expect(data.publishedId).toBeDefined();
+
+		const updated = await prisma.assuranceCase.findUnique({
+			where: { id: testCase.id },
+			select: { publishStatus: true },
+		});
+		expect(updated?.publishStatus).toBe("PUBLISHED");
 	});
 
-	it("returns error for an invalid transition (DRAFT to PUBLISHED directly)", async () => {
+	it("returns error for an invalid transition (DRAFT to DRAFT is a no-op, not a defined transition)", async () => {
 		const owner = await createTestUser();
 		const testCase = await createTestCaseWithGoal(owner.id);
 
-		const result = await transitionStatus(owner.id, testCase.id, "PUBLISHED");
+		const result = await transitionStatus(owner.id, testCase.id, "DRAFT");
 		expectError(result, INVALID_STATUS_TRANSITION);
 	});
 
@@ -537,9 +406,7 @@ describe("transitionStatus", () => {
 		const stranger = await createTestUser();
 		const testCase = await createTestCaseWithGoal(owner.id);
 
-		expectError(
-			await transitionStatus(stranger.id, testCase.id, "READY_TO_PUBLISH")
-		);
+		expectError(await transitionStatus(stranger.id, testCase.id, "PUBLISHED"));
 	});
 });
 
@@ -693,5 +560,176 @@ describe("updatePublishedCase — snapshot pluginData capture", () => {
 		expect(content.pluginData).toStrictEqual({
 			"tea.health": [{ elementId: claim.id, data: dataRow.data }],
 		});
+	});
+});
+
+// ============================================
+// Slugs (ADR 0003 §6)
+// ============================================
+
+describe("publishAssuranceCase — slug generation", () => {
+	it("generates a name-derived slug on first publish", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCaseWithGoal(owner.id, "My Great Case");
+
+		const data = expectSuccess(
+			await publishAssuranceCase(owner.id, testCase.id)
+		);
+		const published = await prisma.publishedAssuranceCase.findUnique({
+			where: { id: data.publishedId },
+		});
+		expect(published?.slug).toBe("my-great-case");
+		expect(published?.type).toBe("ASSURANCE_CASE");
+	});
+
+	it("appends a numeric suffix when two cases share a name", async () => {
+		const owner = await createTestUser();
+		const first = await createTestCaseWithGoal(owner.id, "Duplicate Name");
+		const second = await createTestCaseWithGoal(owner.id, "Duplicate Name");
+
+		const firstData = expectSuccess(
+			await publishAssuranceCase(owner.id, first.id)
+		);
+		const secondData = expectSuccess(
+			await publishAssuranceCase(owner.id, second.id)
+		);
+
+		const [firstPublished, secondPublished] = await Promise.all([
+			prisma.publishedAssuranceCase.findUnique({
+				where: { id: firstData.publishedId },
+			}),
+			prisma.publishedAssuranceCase.findUnique({
+				where: { id: secondData.publishedId },
+			}),
+		]);
+
+		expect(firstPublished?.slug).toBe("duplicate-name");
+		expect(secondPublished?.slug).toBe("duplicate-name-2");
+	});
+
+	it("stays stable across a rename and republish (never regenerated)", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCaseWithGoal(owner.id, "Original Name");
+
+		const published = expectSuccess(
+			await publishAssuranceCase(owner.id, testCase.id)
+		);
+		const firstVersion = await prisma.publishedAssuranceCase.findUnique({
+			where: { id: published.publishedId },
+		});
+		expect(firstVersion?.slug).toBe("original-name");
+
+		await prisma.assuranceCase.update({
+			where: { id: testCase.id },
+			data: { name: "Renamed Case" },
+		});
+
+		const republished = expectSuccess(
+			await updatePublishedCase(owner.id, testCase.id)
+		);
+		const secondVersion = await prisma.publishedAssuranceCase.findUnique({
+			where: { id: republished.publishedId },
+		});
+		expect(secondVersion?.title).toBe("Renamed Case");
+		expect(secondVersion?.slug).toBe("original-name");
+	});
+});
+
+// ============================================
+// Case information snapshot freeze (ADR 0003 §3)
+// ============================================
+
+describe("publishAssuranceCase — case information snapshot capture", () => {
+	it("omits the caseInformation section when the case has none", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCaseWithGoal(owner.id);
+
+		const data = expectSuccess(
+			await publishAssuranceCase(owner.id, testCase.id)
+		);
+		const published = await prisma.publishedAssuranceCase.findUnique({
+			where: { id: data.publishedId },
+		});
+		const content = published?.content as {
+			caseInformation?: Record<string, unknown>;
+		};
+		expect(content.caseInformation).toBeUndefined();
+	});
+
+	it("freezes case information present at publish time", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCaseWithGoal(owner.id);
+		await createTestCaseInformation(testCase.id, {
+			description: "Published-time description",
+			authors: "Published-time authors",
+			sector: "Finance",
+			featureImageUrl: "https://example.com/original.png",
+		});
+
+		const data = expectSuccess(
+			await publishAssuranceCase(owner.id, testCase.id)
+		);
+		const published = await prisma.publishedAssuranceCase.findUnique({
+			where: { id: data.publishedId },
+		});
+		const content = published?.content as {
+			caseInformation?: Record<string, unknown>;
+		};
+		expect(content.caseInformation).toStrictEqual({
+			description: "Published-time description",
+			authors: "Published-time authors",
+			sector: "Finance",
+			featureImageUrl: "https://example.com/original.png",
+		});
+	});
+
+	it("leaves the published snapshot unchanged when case information is edited after publish", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCaseWithGoal(owner.id);
+		await createTestCaseInformation(testCase.id, {
+			description: "Original description",
+		});
+
+		const data = expectSuccess(
+			await publishAssuranceCase(owner.id, testCase.id)
+		);
+
+		await prisma.caseInformation.update({
+			where: { caseId: testCase.id },
+			data: { description: "Edited after publish" },
+		});
+
+		const published = await prisma.publishedAssuranceCase.findUnique({
+			where: { id: data.publishedId },
+		});
+		const content = published?.content as {
+			caseInformation?: { description?: string };
+		};
+		expect(content.caseInformation?.description).toBe("Original description");
+	});
+
+	it("captures fresh case information on republish (updatePublishedCase)", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCaseWithGoal(owner.id);
+		await createTestCaseInformation(testCase.id, {
+			description: "Before republish",
+		});
+		await publishAssuranceCase(owner.id, testCase.id);
+
+		await prisma.caseInformation.update({
+			where: { caseId: testCase.id },
+			data: { description: "After republish" },
+		});
+
+		const updated = expectSuccess(
+			await updatePublishedCase(owner.id, testCase.id)
+		);
+		const published = await prisma.publishedAssuranceCase.findUnique({
+			where: { id: updated.publishedId },
+		});
+		const content = published?.content as {
+			caseInformation?: { description?: string };
+		};
+		expect(content.caseInformation?.description).toBe("After republish");
 	});
 });

--- a/src/__tests__/integration/publish-service.test.ts
+++ b/src/__tests__/integration/publish-service.test.ts
@@ -9,6 +9,7 @@ import {
 	unpublishAssuranceCase,
 	updatePublishedCase,
 } from "@/lib/services/publish-service";
+import { Prisma } from "@/src/generated/prisma";
 import {
 	expectError,
 	expectSameError,
@@ -234,6 +235,15 @@ describe("updatePublishedCase", () => {
 		});
 		expect(newVersion).not.toBeNull();
 		expect(newVersion?.description).toBe("Updated description");
+
+		// The superseded row is retired and the replacement takes over as the
+		// sole current row — the exact two-row invariant the partial unique
+		// index on (slug) WHERE is_current exists to protect (ADR 0003 §6).
+		const oldVersion = await prisma.publishedAssuranceCase.findUnique({
+			where: { id: publishData.publishedId },
+		});
+		expect(oldVersion?.isCurrent).toBe(false);
+		expect(newVersion?.isCurrent).toBe(true);
 	});
 
 	it("returns error when case is not published", async () => {
@@ -607,6 +617,43 @@ describe("publishAssuranceCase — slug generation", () => {
 		expect(secondPublished?.slug).toBe("duplicate-name-2");
 	});
 
+	it("reuses a freed slug after the case holding it is unpublished, rather than continuing the suffix sequence", async () => {
+		const owner = await createTestUser();
+		const caseA = await createTestCaseWithGoal(owner.id, "Foo");
+		const caseB = await createTestCaseWithGoal(owner.id, "Foo");
+		const caseC = await createTestCaseWithGoal(owner.id, "Foo");
+
+		// A claims "foo", B collides onto "foo-2"
+		const publishedA = expectSuccess(
+			await publishAssuranceCase(owner.id, caseA.id)
+		);
+		const publishedB = expectSuccess(
+			await publishAssuranceCase(owner.id, caseB.id)
+		);
+		const [versionA, versionB] = await Promise.all([
+			prisma.publishedAssuranceCase.findUnique({
+				where: { id: publishedA.publishedId },
+			}),
+			prisma.publishedAssuranceCase.findUnique({
+				where: { id: publishedB.publishedId },
+			}),
+		]);
+		expect(versionA?.slug).toBe("foo");
+		expect(versionB?.slug).toBe("foo-2");
+
+		// Unpublishing A frees "foo" — its row (and the slug it held) is gone
+		expectSuccess(await unpublishAssuranceCase(owner.id, caseA.id));
+
+		// C should reclaim the freed "foo", not continue on to "foo-3"
+		const publishedC = expectSuccess(
+			await publishAssuranceCase(owner.id, caseC.id)
+		);
+		const versionC = await prisma.publishedAssuranceCase.findUnique({
+			where: { id: publishedC.publishedId },
+		});
+		expect(versionC?.slug).toBe("foo");
+	});
+
 	it("stays stable across a rename and republish (never regenerated)", async () => {
 		const owner = await createTestUser();
 		const testCase = await createTestCaseWithGoal(owner.id, "Original Name");
@@ -632,6 +679,45 @@ describe("publishAssuranceCase — slug generation", () => {
 		});
 		expect(secondVersion?.title).toBe("Renamed Case");
 		expect(secondVersion?.slug).toBe("original-name");
+	});
+});
+
+// ============================================
+// Database constraint hardening (ADR 0003 §6)
+// ============================================
+
+describe("published_assurance_cases_slug_is_current_key — partial unique index", () => {
+	it("rejects a raw insert of a second CURRENT row reusing another case's current slug", async () => {
+		const owner = await createTestUser();
+		const caseA = await createTestCaseWithGoal(owner.id, "Solo Slug");
+		const caseB = await createTestCase(owner.id);
+
+		await publishAssuranceCase(owner.id, caseA.id);
+
+		// Bypass the service entirely — the service's own transaction
+		// discipline (retire the old current row before inserting the new one,
+		// see `swapCurrentPublishedVersion` in publish-service.ts) never
+		// produces two CURRENT rows sharing a slug. This proves the partial
+		// unique index on (slug) WHERE is_current is itself the backstop, not
+		// merely a property of well-behaved callers.
+		let caught: unknown;
+		try {
+			await prisma.publishedAssuranceCase.create({
+				data: {
+					title: "Colliding Case",
+					slug: "solo-slug",
+					isCurrent: true,
+					content: {},
+					assuranceCaseId: caseB.id,
+					createdAt: new Date(),
+				},
+			});
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(Prisma.PrismaClientKnownRequestError);
+		expect((caught as Prisma.PrismaClientKnownRequestError).code).toBe("P2002");
 	});
 });
 

--- a/src/__tests__/integration/publishing-schema-migration.test.ts
+++ b/src/__tests__/integration/publishing-schema-migration.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Pins the hand-written migration for this feature
+ * (`prisma/migrations/20260716000000_publishing_schema_and_state_model`):
+ * legacy `READY_TO_PUBLISH` rows must map to `DRAFT`, and existing
+ * `published_assurance_cases` rows must get a valid, unique, backfilled
+ * slug — both BEFORE the `PublishStatus` enum is rebuilt without the
+ * retired value.
+ *
+ * Every other integration test in this suite runs against a worker database
+ * (`tea_test_w*`) already migrated to HEAD — by the time any of those tests
+ * run, `READY_TO_PUBLISH` no longer exists as a valid enum value at all, so
+ * there is no way to construct the "before" state through the normal Prisma
+ * client. This test instead drives `prisma migrate deploy` directly, twice,
+ * against its own throwaway database and its own COPY of the migrations
+ * directory (never the real `prisma/migrations/`, and never the shared
+ * `tea_test_w*`/`tea_test_template` databases) — safe to run alongside the
+ * rest of the parallel integration suite.
+ */
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { Pool } from "pg";
+import { afterAll, describe, expect, it } from "vitest";
+import { INTEGRATION_TEST_ADMIN_DATABASE_URL } from "../scripts/test-db-config";
+
+// src/__tests__/integration/ -> project root is three levels up.
+const PROJECT_ROOT = path.resolve(import.meta.dirname, "../../..");
+const REAL_MIGRATIONS_DIR = path.join(PROJECT_ROOT, "prisma/migrations");
+const NEW_MIGRATION_NAME = "20260716000000_publishing_schema_and_state_model";
+
+const scratchDbName = `tea_test_migration_pin_${randomUUID().replaceAll("-", "").slice(0, 12)}`;
+const tmpDir = path.join(PROJECT_ROOT, ".tmp", `migration-pin-${randomUUID()}`);
+
+function scratchDatabaseUrl(): string {
+	const url = new URL(INTEGRATION_TEST_ADMIN_DATABASE_URL);
+	url.pathname = `/${scratchDbName}`;
+	return url.toString();
+}
+
+/** Copies every migration folder in `names` from the real migrations dir into the tmp copy. */
+function copyMigrations(names: string[]): void {
+	for (const name of names) {
+		fs.cpSync(
+			path.join(REAL_MIGRATIONS_DIR, name),
+			path.join(tmpDir, "prisma/migrations", name),
+			{ recursive: true }
+		);
+	}
+}
+
+function runMigrateDeploy(): void {
+	execFileSync("npx", ["prisma", "migrate", "deploy"], {
+		cwd: tmpDir,
+		env: { ...process.env, DATABASE_URL: scratchDatabaseUrl() },
+		stdio: "pipe",
+	});
+}
+
+function setUpTmpProject(): void {
+	fs.mkdirSync(path.join(tmpDir, "prisma/migrations"), { recursive: true });
+	fs.copyFileSync(
+		path.join(REAL_MIGRATIONS_DIR, "migration_lock.toml"),
+		path.join(tmpDir, "prisma/migrations/migration_lock.toml")
+	);
+	fs.copyFileSync(
+		path.join(PROJECT_ROOT, "prisma/schema.prisma"),
+		path.join(tmpDir, "prisma/schema.prisma")
+	);
+	// Minimal prisma.config.ts: same shape as the real one, pointed at this
+	// tmp copy's own schema/migrations, relative to `cwd: tmpDir` above.
+	fs.writeFileSync(
+		path.join(tmpDir, "prisma.config.ts"),
+		[
+			'import { defineConfig, env } from "prisma/config";',
+			"",
+			"export default defineConfig({",
+			'	schema: "prisma/schema.prisma",',
+			'	migrations: { path: "prisma/migrations" },',
+			'	datasource: { url: env("DATABASE_URL") },',
+			"});",
+			"",
+		].join("\n")
+	);
+}
+
+describe("publishing-schema-and-state-model migration", () => {
+	afterAll(async () => {
+		const adminPool = new Pool({
+			connectionString: INTEGRATION_TEST_ADMIN_DATABASE_URL,
+		});
+		try {
+			await adminPool.query(
+				`DROP DATABASE IF EXISTS "${scratchDbName}" WITH (FORCE)`
+			);
+		} finally {
+			await adminPool.end();
+		}
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	}, 30_000);
+
+	it("maps legacy READY_TO_PUBLISH rows to DRAFT and backfills a unique slug, before rebuilding the enum", async () => {
+		const allMigrations = fs
+			.readdirSync(REAL_MIGRATIONS_DIR)
+			.filter(
+				(name) => name !== "migration_lock.toml" && name !== NEW_MIGRATION_NAME
+			);
+
+		const adminPool = new Pool({
+			connectionString: INTEGRATION_TEST_ADMIN_DATABASE_URL,
+		});
+		await adminPool.query(`CREATE DATABASE "${scratchDbName}"`);
+		await adminPool.end();
+
+		setUpTmpProject();
+		copyMigrations(allMigrations);
+		runMigrateDeploy();
+
+		const scratchPool = new Pool({ connectionString: scratchDatabaseUrl() });
+		try {
+			const userId = randomUUID();
+			const legacyCaseId = randomUUID();
+			const punctuationCaseId = randomUUID();
+			const historyCaseId = randomUUID();
+			const publishedNormalId = randomUUID();
+			const publishedPunctuationId = randomUUID();
+			const historyOlderId = randomUUID();
+			const historyNewerId = randomUUID();
+
+			await scratchPool.query(
+				`INSERT INTO users (id, email, username, password_algorithm, auth_provider, created_at, updated_at)
+					 VALUES ($1, $2, $3, 'argon2id', 'LOCAL', now(), now())`,
+				[
+					userId,
+					`migration-pin-${userId}@example.com`,
+					`migrationpin${userId.slice(0, 8)}`,
+				]
+			);
+
+			for (const [caseId, name] of [
+				[legacyCaseId, "Legacy Ready Case"],
+				[punctuationCaseId, "***"],
+				[historyCaseId, "Republished Case"],
+			] as const) {
+				await scratchPool.query(
+					`INSERT INTO assurance_cases
+						 (id, name, description, created_by_id, mode, color_profile, is_demo, layout_direction, created_at, updated_at, published, publish_status)
+						 VALUES ($1, $2, 'desc', $3, 'STANDARD', 'default', false, 'TB', now(), now(), false, 'READY_TO_PUBLISH')`,
+					[caseId, name, userId]
+				);
+			}
+
+			await scratchPool.query(
+				`INSERT INTO published_assurance_cases (id, title, content, created_at, assurance_case_id, description)
+					 VALUES ($1, 'My Great Case!!!', '{}'::jsonb, now(), $2, 'note')`,
+				[publishedNormalId, legacyCaseId]
+			);
+			await scratchPool.query(
+				`INSERT INTO published_assurance_cases (id, title, content, created_at, assurance_case_id, description)
+					 VALUES ($1, '***', '{}'::jsonb, now(), $2, 'note2')`,
+				[publishedPunctuationId, punctuationCaseId]
+			);
+			// Two historical versions of the SAME case, republished — only the
+			// later one (by created_at) should end up `is_current = true`.
+			await scratchPool.query(
+				`INSERT INTO published_assurance_cases (id, title, content, created_at, assurance_case_id, description)
+					 VALUES ($1, 'Republished Case', '{}'::jsonb, now() - interval '1 day', $2, 'first version')`,
+				[historyOlderId, historyCaseId]
+			);
+			await scratchPool.query(
+				`INSERT INTO published_assurance_cases (id, title, content, created_at, assurance_case_id, description)
+					 VALUES ($1, 'Republished Case', '{}'::jsonb, now(), $2, 'second version')`,
+				[historyNewerId, historyCaseId]
+			);
+
+			copyMigrations([NEW_MIGRATION_NAME]);
+			runMigrateDeploy();
+
+			const statuses = await scratchPool.query<{
+				id: string;
+				publish_status: string;
+			}>("SELECT id, publish_status FROM assurance_cases WHERE id = ANY($1)", [
+				[legacyCaseId, punctuationCaseId, historyCaseId],
+			]);
+			for (const row of statuses.rows) {
+				expect(row.publish_status).toBe("DRAFT");
+			}
+
+			const slugs = await scratchPool.query<{
+				id: string;
+				title: string;
+				slug: string;
+				type: string;
+				is_current: boolean;
+			}>(
+				"SELECT id, title, slug, type, is_current FROM published_assurance_cases WHERE id = ANY($1)",
+				[
+					[
+						publishedNormalId,
+						publishedPunctuationId,
+						historyOlderId,
+						historyNewerId,
+					],
+				]
+			);
+			const byId = new Map(slugs.rows.map((r) => [r.id, r]));
+
+			const normalRow = byId.get(publishedNormalId);
+			expect(normalRow?.slug).toBe(
+				`my-great-case-${publishedNormalId.slice(0, 8)}`
+			);
+			expect(normalRow?.type).toBe("ASSURANCE_CASE");
+			expect(normalRow?.is_current).toBe(true);
+
+			const punctuationRow = byId.get(publishedPunctuationId);
+			expect(punctuationRow?.slug).toBe(
+				`item-${publishedPunctuationId.slice(0, 8)}`
+			);
+
+			// Uniqueness constraint actually landed (not just present values).
+			expect(normalRow?.slug).not.toBe(punctuationRow?.slug);
+
+			// Multi-version backfill: the id-fragment suffix means each legacy
+			// row still gets its OWN unique slug (there is no shared "case
+			// identity" to derive a common one from pre-migration) — the
+			// invariant this backfill must uphold is "at most one current row
+			// per case", not slug equality. Only the NEWER row stays current;
+			// runtime republishes going forward carry one slug forward instead
+			// (see `publish-service.test.ts`'s rename-stability test).
+			const olderRow = byId.get(historyOlderId);
+			const newerRow = byId.get(historyNewerId);
+			expect(olderRow?.slug).not.toBe(newerRow?.slug);
+			expect(olderRow?.is_current).toBe(false);
+			expect(newerRow?.is_current).toBe(true);
+		} finally {
+			await scratchPool.end();
+		}
+	}, 60_000);
+});

--- a/src/__tests__/utils/prisma-factories.ts
+++ b/src/__tests__/utils/prisma-factories.ts
@@ -3,6 +3,7 @@ import type {
 	ApiToken,
 	AssuranceCase,
 	AssuranceElement,
+	CaseInformation,
 	CasePermission,
 	CaseStudy,
 	CaseTeamPermission,
@@ -113,7 +114,7 @@ type CaseOverrides = Partial<{
 	name: string;
 	description: string;
 	mode: "STANDARD" | "ADVANCED";
-	publishStatus: "DRAFT" | "READY_TO_PUBLISH" | "PUBLISHED";
+	publishStatus: "DRAFT" | "PUBLISHED";
 	published: boolean;
 	isDemo: boolean;
 }>;
@@ -559,6 +560,34 @@ export function createTestCaseStudy(
 			ownerId,
 			createdOn: now,
 			lastModifiedOn: now,
+		},
+	});
+}
+
+// ============================================
+// CASE INFORMATION (ADR 0003 §1)
+// ============================================
+
+type CaseInformationOverrides = Partial<{
+	description: string;
+	authors: string;
+	sector: string;
+	featureImageUrl: string;
+}>;
+
+export function createTestCaseInformation(
+	caseId: string,
+	overrides: CaseInformationOverrides = {}
+): Promise<CaseInformation> {
+	const n = nextId();
+	return prisma.caseInformation.create({
+		data: {
+			caseId,
+			description: overrides.description ?? `Test case information ${n}`,
+			authors: overrides.authors ?? "Ada Lovelace",
+			sector: overrides.sector ?? "Healthcare",
+			featureImageUrl:
+				overrides.featureImageUrl ?? `https://example.com/image-${n}.png`,
 		},
 	});
 }


### PR DESCRIPTION
The data layer for the new publishing model — first of the publishing chain; the case information pane, publish flow, and Discover work all build on this.

## What's here

- **`CaseInformation`** — a 1:1 optional record on the assurance case for the explanatory material the old case-study form collected (description, authors, sector, feature image). Editable any time under normal case permissions; "no information yet" is no row, not a row of nulls. Zod schemas + service-layer CRUD; no route/UI yet (the case-information pane is the next issue).
- **Published snapshots freeze metadata** — the published record now captures case information alongside content and plugin data, making it a citable point-in-time artefact end to end. Verified by tests that mutate the live record post-publish and assert the snapshot is unchanged.
- **Slugs** — published items get stable, name-derived slugs. Only the *current* version of a case claims its slug (partial unique index on `(slug) WHERE is_current`); historical versions keep theirs for the record. Republish retires the old current row and inserts the new one in a single transaction. Slugs never change on rename; collisions suffix; a slug freed by unpublishing is reclaimable.
- **`READY_TO_PUBLISH` retired** — hand-written migration maps existing rows to `DRAFT`, backfills slugs and `is_current`, then rebuilds the enum. Proven on scratch databases including pre-seeded legacy data. A documented seam (comment-only) is left for a future SUBMITTED/approval state.
- **Generic publishable-item shape** — type discriminator in place for future argument-pattern publishing; only the assurance-case type is implemented.

## One behavioural fix, deliberately included

`components/cases/header.tsx`: due to a pre-existing stub, a published case has been showing the amber "Ready to Publish" badge instead of green "Published". Removing the retired enum value surfaced this; the fix is included per the ADR's decision to fold the display-layer findings into this implementation. The other UI edits are mechanical dead-branch removal only.

## Also

- The publish/republish snapshot-composition and version-swap logic is factored into shared helpers (was an 80-line duplication).
- Dead auto-publish-on-link path removed from the case-study service (only reachable via the retired status).

## Tests

164 integration (incl. full permission matrices on the new CRUD, migration pins, slug reuse/stability/collision, a raw-insert proof of the partial unique index) + 1,113 unit + 9 new slugify unit tests; tsc + lint clean; `prisma migrate deploy` verified on three scratch databases.