### PR TITLE
Accept evidence URLs without a scheme prefix

### DIFF
--- a/hooks/__tests__/use-new-link-form.test.ts
+++ b/hooks/__tests__/use-new-link-form.test.ts
@@ -1,0 +1,133 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import type { Node } from "reactflow";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createElementSchema } from "@/lib/schemas/element";
+import type { AssuranceCaseResponse } from "@/lib/services/case-response-types";
+import { toast } from "@/lib/toast";
+import { server } from "@/src/__tests__/mocks/server";
+import useStore from "@/store/store";
+import { useNewLinkForm } from "../use-new-link-form";
+
+/**
+ * Mimics the real POST /api/cases/[id]/elements route: validates the body
+ * with the actual createElementSchema and returns the same shape of
+ * success/error response. This is what lets these tests prove the plain
+ * -English message from lib/schemas/base.ts's lenientUrlSchema actually
+ * reaches the evidence-creation toast a user sees, not just the schema
+ * in isolation.
+ */
+function mockElementsRoute() {
+	let receivedBody: Record<string, unknown> | undefined;
+	server.use(
+		http.post("/api/cases/:caseId/elements", async ({ request }) => {
+			const body = (await request.json()) as Record<string, unknown>;
+			receivedBody = body;
+			const parsed = createElementSchema.safeParse(body);
+			if (!parsed.success) {
+				return HttpResponse.json(
+					{ error: parsed.error.issues[0]?.message ?? "Invalid input" },
+					{ status: 400 }
+				);
+			}
+			// apiSuccess() returns the element flat (no envelope) — matches
+			// what createAssuranceCaseNode (lib/case/api.ts) expects.
+			return HttpResponse.json(
+				{
+					id: "evidence-1",
+					...parsed.data,
+					propertyClaimId: body.propertyClaimId,
+					name: "E1",
+				},
+				{ status: 201 }
+			);
+		})
+	);
+	return {
+		getReceivedBody: () => receivedBody,
+	};
+}
+
+const NODE: Node = {
+	id: "1",
+	type: "property",
+	position: { x: 0, y: 0 },
+	data: { id: "claim-1" },
+};
+
+const CASE_WITH_CLAIM = {
+	id: "case-1",
+	goals: [
+		{
+			propertyClaims: [{ id: "claim-1", propertyClaims: [], evidence: [] }],
+			strategies: [],
+		},
+	],
+} as unknown as AssuranceCaseResponse;
+
+function setup() {
+	return renderHook(() =>
+		useNewLinkForm({
+			node: NODE,
+			linkType: "evidence",
+			actions: {
+				setSelectedLink: vi.fn(),
+				setLinkToCreate: vi.fn(),
+				handleClose: vi.fn(),
+			},
+			setUnresolvedChanges: vi.fn(),
+		})
+	);
+}
+
+beforeEach(() => {
+	useStore.setState({ assuranceCase: CASE_WITH_CLAIM });
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	useStore.setState({ assuranceCase: null });
+});
+
+describe("useNewLinkForm — evidence URL submission", () => {
+	it("accepts a bare domain, sending it as typed and normalising it server-side to https://", async () => {
+		const { getReceivedBody } = mockElementsRoute();
+		const { result } = setup();
+
+		act(() => {
+			result.current.form.setValue("urls.0.value", "example.com/report.pdf");
+		});
+
+		await act(async () => {
+			await result.current.onSubmit(result.current.form.getValues());
+		});
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		// The client sends the bare domain exactly as typed — normalisation
+		// is the schema's job, not the form's.
+		expect(getReceivedBody()?.urls).toEqual(["example.com/report.pdf"]);
+		expect(vi.mocked(toast)).not.toHaveBeenCalled();
+	});
+
+	it("surfaces the plain-English message when the address is genuinely invalid", async () => {
+		mockElementsRoute();
+		const { result } = setup();
+
+		act(() => {
+			result.current.form.setValue("urls.0.value", "not a url at all");
+		});
+
+		await act(async () => {
+			await result.current.onSubmit(result.current.form.getValues());
+		});
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		expect(vi.mocked(toast)).toHaveBeenCalledWith(
+			expect.objectContaining({
+				variant: "destructive",
+				description: "Enter a web address, such as example.com/report.pdf",
+			})
+		);
+	});
+});

--- a/lib/schemas/__tests__/element-url.test.ts
+++ b/lib/schemas/__tests__/element-url.test.ts
@@ -58,6 +58,52 @@ describe("lenientUrlSchema", () => {
 	it("rejects an empty string", () => {
 		expect(lenientUrlSchema.safeParse("").success).toBe(false);
 	});
+
+	it("rejects a mailto: address rather than mangling it", () => {
+		const result = lenientUrlSchema.safeParse("mailto:x@y.z");
+		expect(result.success).toBe(false);
+		expect(result.success || result.error.issues[0]?.message).toBe(
+			SCHEME_MESSAGE
+		);
+	});
+
+	it("rejects a javascript: address (colon, no slashes)", () => {
+		const result = lenientUrlSchema.safeParse("javascript:alert(1)");
+		expect(result.success).toBe(false);
+		expect(result.success || result.error.issues[0]?.message).toBe(
+			SCHEME_MESSAGE
+		);
+	});
+
+	it("rejects a data: address (colon, no slashes)", () => {
+		const result = lenientUrlSchema.safeParse(
+			"data:text/plain;base64,SGVsbG8="
+		);
+		expect(result.success).toBe(false);
+		expect(result.success || result.error.issues[0]?.message).toBe(
+			SCHEME_MESSAGE
+		);
+	});
+
+	it("rejects a javascript:// address (scheme with slashes, not http/https)", () => {
+		const result = lenientUrlSchema.safeParse("javascript://alert(1)");
+		expect(result.success).toBe(false);
+		expect(result.success || result.error.issues[0]?.message).toBe(
+			SCHEME_MESSAGE
+		);
+	});
+
+	it("accepts a protocol-relative address and stores it as https://", () => {
+		const result = lenientUrlSchema.safeParse("//example.com");
+		expect(result.success).toBe(true);
+		expect(result.success && result.data).toBe("https://example.com");
+	});
+
+	it("passes an uppercase HTTPS:// value through byte-unchanged", () => {
+		const result = lenientUrlSchema.safeParse("HTTPS://example.com");
+		expect(result.success).toBe(true);
+		expect(result.success && result.data).toBe("HTTPS://example.com");
+	});
 });
 
 describe("optionalUrlSchema", () => {

--- a/lib/schemas/__tests__/element-url.test.ts
+++ b/lib/schemas/__tests__/element-url.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import { lenientUrlSchema, optionalUrlSchema } from "../base";
+import { createElementSchema, updateElementSchema } from "../element";
+
+const SCHEME_MESSAGE = "Enter a web address, such as example.com/report.pdf";
+
+describe("lenientUrlSchema", () => {
+	it("accepts a bare domain and normalises it to https://", () => {
+		const result = lenientUrlSchema.safeParse("example.com");
+		expect(result.success).toBe(true);
+		expect(result.success && result.data).toBe("https://example.com");
+	});
+
+	it("accepts a bare domain with a path and normalises it", () => {
+		const result = lenientUrlSchema.safeParse("example.com/report.pdf");
+		expect(result.success).toBe(true);
+		expect(result.success && result.data).toBe(
+			"https://example.com/report.pdf"
+		);
+	});
+
+	it("passes an existing https:// value through byte-unchanged", () => {
+		const result = lenientUrlSchema.safeParse("https://example.com/report.pdf");
+		expect(result.success).toBe(true);
+		expect(result.success && result.data).toBe(
+			"https://example.com/report.pdf"
+		);
+	});
+
+	it("passes an existing http:// value through byte-unchanged", () => {
+		const result = lenientUrlSchema.safeParse("http://example.com/report.pdf");
+		expect(result.success).toBe(true);
+		expect(result.success && result.data).toBe("http://example.com/report.pdf");
+	});
+
+	it("trims surrounding whitespace before validating", () => {
+		const result = lenientUrlSchema.safeParse("  example.com  ");
+		expect(result.success).toBe(true);
+		expect(result.success && result.data).toBe("https://example.com");
+	});
+
+	it("rejects genuinely invalid input with the plain-English message", () => {
+		const result = lenientUrlSchema.safeParse("not a url at all");
+		expect(result.success).toBe(false);
+		expect(result.success || result.error.issues[0]?.message).toBe(
+			SCHEME_MESSAGE
+		);
+	});
+
+	it("rejects a space breaking the host (spaces mid-string)", () => {
+		const result = lenientUrlSchema.safeParse("exa mple.com");
+		expect(result.success).toBe(false);
+		expect(result.success || result.error.issues[0]?.message).toBe(
+			SCHEME_MESSAGE
+		);
+	});
+
+	it("rejects an empty string", () => {
+		expect(lenientUrlSchema.safeParse("").success).toBe(false);
+	});
+});
+
+describe("optionalUrlSchema", () => {
+	it("treats undefined, null, and empty/whitespace strings as absent", () => {
+		expect(optionalUrlSchema.safeParse(undefined)).toMatchObject({
+			success: true,
+			data: undefined,
+		});
+		expect(optionalUrlSchema.safeParse(null)).toMatchObject({
+			success: true,
+			data: undefined,
+		});
+		expect(optionalUrlSchema.safeParse("")).toMatchObject({
+			success: true,
+			data: undefined,
+		});
+		expect(optionalUrlSchema.safeParse("   ")).toMatchObject({
+			success: true,
+			data: undefined,
+		});
+	});
+
+	it("normalises a bare domain when present", () => {
+		const result = optionalUrlSchema.safeParse("example.com");
+		expect(result.success).toBe(true);
+		expect(result.success && result.data).toBe("https://example.com");
+	});
+
+	it("rejects a genuinely invalid value with the plain-English message", () => {
+		const result = optionalUrlSchema.safeParse("not a url at all");
+		expect(result.success).toBe(false);
+		expect(result.success || result.error.issues[0]?.message).toBe(
+			SCHEME_MESSAGE
+		);
+	});
+});
+
+describe("createElementSchema — evidence urls field", () => {
+	it("accepts a bare domain in the urls array and normalises it", () => {
+		const result = createElementSchema.safeParse({
+			type: "evidence",
+			urls: ["example.com/report.pdf"],
+		});
+		expect(result.success).toBe(true);
+		expect(result.success && result.data.urls).toEqual([
+			"https://example.com/report.pdf",
+		]);
+	});
+
+	it("rejects an invalid entry in the urls array with the plain-English message", () => {
+		const result = createElementSchema.safeParse({
+			type: "evidence",
+			urls: ["not a url at all"],
+		});
+		expect(result.success).toBe(false);
+		expect(result.success || result.error.issues[0]?.message).toBe(
+			SCHEME_MESSAGE
+		);
+	});
+
+	it("accepts a bare domain in the legacy url field and normalises it", () => {
+		const result = createElementSchema.safeParse({
+			type: "evidence",
+			url: "example.com",
+		});
+		expect(result.success).toBe(true);
+		expect(result.success && result.data.url).toBe("https://example.com");
+	});
+
+	it("accepts a bare domain in the legacy URL field and normalises it", () => {
+		const result = createElementSchema.safeParse({
+			type: "evidence",
+			URL: "example.com",
+		});
+		expect(result.success).toBe(true);
+		expect(result.success && result.data.URL).toBe("https://example.com");
+	});
+
+	it("still allows omitting urls entirely", () => {
+		const result = createElementSchema.safeParse({ type: "goal" });
+		expect(result.success).toBe(true);
+	});
+});
+
+describe("updateElementSchema — evidence urls field", () => {
+	it("accepts a bare domain in the urls array and normalises it", () => {
+		const result = updateElementSchema.safeParse({
+			urls: ["example.com/report.pdf"],
+		});
+		expect(result.success).toBe(true);
+		expect(result.success && result.data.urls).toEqual([
+			"https://example.com/report.pdf",
+		]);
+	});
+
+	it("passes an existing https:// value through byte-unchanged", () => {
+		const result = updateElementSchema.safeParse({
+			urls: ["https://example.com/report.pdf"],
+		});
+		expect(result.success).toBe(true);
+		expect(result.success && result.data.urls).toEqual([
+			"https://example.com/report.pdf",
+		]);
+	});
+
+	it("rejects an invalid entry in the urls array with the plain-English message", () => {
+		const result = updateElementSchema.safeParse({
+			urls: ["not a url at all"],
+		});
+		expect(result.success).toBe(false);
+		expect(result.success || result.error.issues[0]?.message).toBe(
+			SCHEME_MESSAGE
+		);
+	});
+
+	it("rejects an entry with a space breaking the host", () => {
+		const result = updateElementSchema.safeParse({
+			urls: ["exa mple.com"],
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("accepts a bare domain in the legacy URL field and normalises it", () => {
+		const result = updateElementSchema.safeParse({ URL: "example.com" });
+		expect(result.success).toBe(true);
+		expect(result.success && result.data.URL).toBe("https://example.com");
+	});
+});

--- a/lib/schemas/base.ts
+++ b/lib/schemas/base.ts
@@ -74,6 +74,43 @@ export const stringIdSchema = z
 	.transform((v) => v.trim())
 	.describe("Non-empty string identifier");
 
+/**
+ * Matches a URI scheme immediately followed by "//" (e.g. "https://",
+ * "ftp://") — used to detect whether a user-supplied address already
+ * carries a scheme before we consider prepending one.
+ */
+const URL_SCHEME_PREFIX = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//;
+
+const URL_ERROR_MESSAGE = "Enter a web address, such as example.com/report.pdf";
+
+/**
+ * Web address, lenient about the scheme — most people type "example.com",
+ * not "https://example.com". Trims, prepends "https://" when no scheme is
+ * present, then validates as a URL. The normalised value (always carrying a
+ * scheme) is what gets stored, so there is no silent divergence between what
+ * a user typed and what is saved.
+ */
+export const lenientUrlSchema = z
+	.string()
+	.trim()
+	.transform((v) => (URL_SCHEME_PREFIX.test(v) ? v : `https://${v}`))
+	.pipe(z.string().url(URL_ERROR_MESSAGE))
+	.describe("Web address, normalised to always include a scheme");
+
+/**
+ * Optional web address field (empty string, null, or undefined all become
+ * undefined). Non-empty values are validated and normalised via
+ * lenientUrlSchema.
+ */
+export const optionalUrlSchema = z
+	.string()
+	.nullable()
+	.optional()
+	.transform((v) => (v?.trim() ? v.trim() : undefined))
+	.pipe(z.union([z.undefined(), lenientUrlSchema]))
+	.optional()
+	.describe("Optional web address field");
+
 // ============================================
 // Number Primitives
 // ============================================

--- a/lib/schemas/base.ts
+++ b/lib/schemas/base.ts
@@ -81,20 +81,55 @@ export const stringIdSchema = z
  */
 const URL_SCHEME_PREFIX = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//;
 
+/**
+ * Matches any URI scheme prefix, with or without the following "//" (e.g.
+ * "mailto:", "javascript:", "https://"). Used together with
+ * URL_SCHEME_PREFIX to detect a scheme that is NOT followed by "//" — those
+ * are non-web addresses (mailto:, javascript:, data:, …) and must never be
+ * silently rewritten into "https://mailto:..." nonsense.
+ */
+const URL_SCHEME_ONLY = /^[a-zA-Z][a-zA-Z\d+\-.]*:/;
+
+/**
+ * Protocol allowlist applied to the final, normalised value. Only http(s)
+ * addresses are ever stored — closes the javascript:// stored-XSS surface,
+ * since zod's url() check accepts any WHATWG-parseable URL (including
+ * javascript: and other non-web schemes) and evidence hrefs are rendered
+ * raw.
+ */
+const URL_ALLOWED_PROTOCOL = /^https?:\/\//i;
+
 const URL_ERROR_MESSAGE = "Enter a web address, such as example.com/report.pdf";
 
 /**
  * Web address, lenient about the scheme — most people type "example.com",
  * not "https://example.com". Trims, prepends "https://" when no scheme is
- * present, then validates as a URL. The normalised value (always carrying a
- * scheme) is what gets stored, so there is no silent divergence between what
- * a user typed and what is saved.
+ * present (or just "https:" for a protocol-relative "//example.com"), then
+ * validates as a URL and checks the result against the http(s) allowlist.
+ * The normalised value (always carrying a scheme) is what gets stored, so
+ * there is no silent divergence between what a user typed and what is
+ * saved. A scheme that isn't followed by "//" (mailto:, javascript:,
+ * data:, …) is rejected outright rather than mangled.
  */
 export const lenientUrlSchema = z
 	.string()
 	.trim()
-	.transform((v) => (URL_SCHEME_PREFIX.test(v) ? v : `https://${v}`))
-	.pipe(z.string().url(URL_ERROR_MESSAGE))
+	.refine(
+		(v) => !(URL_SCHEME_ONLY.test(v) && !URL_SCHEME_PREFIX.test(v)),
+		URL_ERROR_MESSAGE
+	)
+	.transform((v) => {
+		if (v.startsWith("//")) {
+			return `https:${v}`;
+		}
+		return URL_SCHEME_PREFIX.test(v) ? v : `https://${v}`;
+	})
+	.pipe(
+		z
+			.string()
+			.url(URL_ERROR_MESSAGE)
+			.refine((v) => URL_ALLOWED_PROTOCOL.test(v), URL_ERROR_MESSAGE)
+	)
 	.describe("Web address, normalised to always include a scheme");
 
 /**
@@ -108,6 +143,18 @@ export const optionalUrlSchema = z
 	.optional()
 	.transform((v) => (v?.trim() ? v.trim() : undefined))
 	.pipe(z.union([z.undefined(), lenientUrlSchema]))
+	// NOTE (V3, reverted): dropping this trailing .optional() was flagged by
+	// review as "redundant" because the piped union already accepts
+	// undefined at RUNTIME. It is not redundant for TYPE INFERENCE: zod only
+	// treats a z.object() field as an optional key (`url?:`) when the field
+	// schema is itself ZodOptional at the top level. Without this wrapper,
+	// `url`/`URL` on CreateElementInput/UpdateElementInput flip from an
+	// optional key to a required-but-possibly-undefined key, which broke
+	// tsc across 70 call sites in three integration test files outside this
+	// batch's scope (case-crud.test.ts, element-service.test.ts,
+	// identifier-service.test.ts) that construct input objects without
+	// url/URL. Kept in place; reported to cid rather than touching those
+	// files.
 	.optional()
 	.describe("Optional web address field");
 

--- a/lib/schemas/element.ts
+++ b/lib/schemas/element.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { optionalString } from "./base";
+import { lenientUrlSchema, optionalString, optionalUrlSchema } from "./base";
 
 /**
  * Element type enum — accepts various frontend formats
@@ -25,9 +25,9 @@ export const createElementSchema = z.object({
 	parentId: z.string().nullable().optional(),
 
 	// Evidence-specific
-	url: optionalString(2000),
-	URL: optionalString(2000),
-	urls: z.array(z.string().url()).optional(),
+	url: optionalUrlSchema,
+	URL: optionalUrlSchema,
+	urls: z.array(lenientUrlSchema).optional(),
 
 	// GSN-specific
 	assumption: optionalString(5000),
@@ -52,9 +52,9 @@ export const updateElementSchema = z.object({
 	parentId: z.string().nullable().optional(),
 
 	// Evidence-specific
-	url: optionalString(2000),
-	URL: optionalString(2000),
-	urls: z.array(z.string().url()).optional(),
+	url: optionalUrlSchema,
+	URL: optionalUrlSchema,
+	urls: z.array(lenientUrlSchema).optional(),
 
 	// GSN-specific
 	assumption: optionalString(5000),


### PR DESCRIPTION
## Problem

Evidence links were rejected with a generic "Invalid url" unless the user typed a full `http(s)://` address — most people type `example.com`, and the error gave non-technical users nothing to act on.

## Fix

- Shared lenient URL schema (`lib/schemas/base.ts`): trims, prepends `https://` when no scheme is present, normalises the stored value; friendly error ("Enter a web address, such as example.com/report.pdf")
- Applied to `urls` and the live `url`/`URL` mirror fields (which previously had **no** URL validation at all)
- **Hardening from review:** scheme-only inputs (`mailto:`, `javascript:`, `data:`) are rejected rather than mangled; non-http(s) schemes are rejected outright (closes a stored-XSS surface — evidence links render as raw hrefs); protocol-relative `//host` input normalises correctly

## Tests

27 schema tests (incl. exact-message and XSS-form regressions) + 2 form-level toast tests + element-service shard 29/29; full unit suite green; tsc + lint clean.