### PR TITLE
Case information pane and toolbar swap (ADR 0003)

### DIFF
--- a/app/api/cases/[id]/information/image/route.ts
+++ b/app/api/cases/[id]/information/image/route.ts
@@ -1,0 +1,136 @@
+import type { NextRequest } from "next/server";
+import {
+	apiError,
+	apiErrorFromUnknown,
+	apiSuccess,
+	requireAuth,
+	serviceErrorToAppError,
+} from "@/lib/api-response";
+import { validationError } from "@/lib/errors";
+import {
+	getCaseInformation,
+	upsertCaseInformation,
+} from "@/lib/services/case-information-service";
+import { deleteFile, saveFile } from "@/lib/services/file-storage-service";
+
+interface RouteParams {
+	params: Promise<{ id: string }>;
+}
+
+/**
+ * POST /api/cases/[id]/information/image
+ *
+ * @description Uploads the feature image for a case's case-information
+ * record (ADR 0003 §1). Mirrors the case-study feature-image upload
+ * pattern (`/api/case-studies/[id]/image`): the file is saved via the
+ * shared file-storage service (Azure Blob in production, local disk in
+ * development), then the resulting URL is persisted onto the
+ * case-information record. Requires EDIT permission, enforced by
+ * `upsertCaseInformation` — if the persist step rejects (no EDIT access),
+ * the just-saved file is deleted so nothing orphans in storage.
+ *
+ * @pathParam id - Case ID (UUID)
+ * @body multipart/form-data with an `image` file field
+ * @response 200 - `{ featureImageUrl }`
+ * @response 400 - No file provided
+ * @response 401 - Unauthorised
+ * @response 403 - Permission denied (also returned for a non-existent case)
+ * @auth bearer
+ * @tag Cases
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+	try {
+		const userId = await requireAuth();
+		const { id: caseId } = await params;
+
+		// VIEW-gated existence/access check, so an unauthenticated stranger
+		// never reaches the storage write below (the EDIT check that
+		// actually authorises the change happens in `upsertCaseInformation`).
+		const existing = await getCaseInformation(userId, caseId);
+		if ("error" in existing) {
+			return apiError(serviceErrorToAppError(existing.error));
+		}
+
+		const formData = await request.formData();
+		const imageFile = formData.get("image") as File | null;
+
+		if (!imageFile || imageFile.size === 0) {
+			return apiError(validationError("No image file provided"));
+		}
+
+		const saveResult = await saveFile(
+			imageFile,
+			`cases/${caseId}/case-information`
+		);
+		if ("error" in saveResult) {
+			return apiError(serviceErrorToAppError(saveResult.error));
+		}
+
+		const updateResult = await upsertCaseInformation(userId, caseId, {
+			featureImageUrl: saveResult.data.path,
+		});
+		if ("error" in updateResult) {
+			// Not authorised to persist the change after all — clean up the
+			// file we just wrote rather than leaving it orphaned in storage.
+			await deleteFile(saveResult.data.path);
+			return apiError(serviceErrorToAppError(updateResult.error));
+		}
+
+		// Best-effort cleanup of the previous image, if any and different.
+		const previousUrl = existing.data?.featureImageUrl;
+		if (previousUrl && previousUrl !== saveResult.data.path) {
+			await deleteFile(previousUrl);
+		}
+
+		return apiSuccess({ featureImageUrl: saveResult.data.path });
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}
+
+/**
+ * DELETE /api/cases/[id]/information/image
+ *
+ * @description Removes the feature image from a case's case-information
+ * record. Deletes the stored file (best-effort) and clears
+ * `featureImageUrl` on the record. Calls `upsertCaseInformation` directly
+ * with an empty string rather than through the zod schema — the schema's
+ * `optionalString` transform treats an empty string as "field omitted",
+ * which would leave the existing image untouched instead of clearing it.
+ * Requires EDIT permission.
+ *
+ * @pathParam id - Case ID (UUID)
+ * @response 200 - `{ success: true }`
+ * @response 401 - Unauthorised
+ * @response 403 - Permission denied (also returned for a non-existent case)
+ * @auth bearer
+ * @tag Cases
+ */
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+	try {
+		const userId = await requireAuth();
+		const { id: caseId } = await params;
+
+		const existing = await getCaseInformation(userId, caseId);
+		if ("error" in existing) {
+			return apiError(serviceErrorToAppError(existing.error));
+		}
+
+		const currentUrl = existing.data?.featureImageUrl;
+
+		const updateResult = await upsertCaseInformation(userId, caseId, {
+			featureImageUrl: "",
+		});
+		if ("error" in updateResult) {
+			return apiError(serviceErrorToAppError(updateResult.error));
+		}
+
+		if (currentUrl) {
+			await deleteFile(currentUrl);
+		}
+
+		return apiSuccess({ success: true });
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}

--- a/app/api/cases/[id]/information/image/route.ts
+++ b/app/api/cases/[id]/information/image/route.ts
@@ -7,6 +7,7 @@ import {
 	serviceErrorToAppError,
 } from "@/lib/api-response";
 import { validationError } from "@/lib/errors";
+import { upsertCaseInformationSchema } from "@/lib/schemas/case-information";
 import {
 	getCaseInformation,
 	upsertCaseInformation,
@@ -15,6 +16,29 @@ import { deleteFile, saveFile } from "@/lib/services/file-storage-service";
 
 interface RouteParams {
 	params: Promise<{ id: string }>;
+}
+
+/**
+ * Resolves the authenticated user and the case-information record's current
+ * state, shared by POST and DELETE below — both need the same VIEW-gated
+ * existence/access check before touching storage (the EDIT check that
+ * actually authorises the change happens in `upsertCaseInformation`).
+ * Returns a discriminated union rather than throwing so callers can return
+ * the prepared error response directly.
+ */
+async function requireExistingCaseInformation(params: RouteParams["params"]) {
+	const userId = await requireAuth();
+	const { id: caseId } = await params;
+
+	const existing = await getCaseInformation(userId, caseId);
+	if ("error" in existing) {
+		return {
+			ok: false as const,
+			response: apiError(serviceErrorToAppError(existing.error)),
+		};
+	}
+
+	return { ok: true as const, userId, caseId, existing: existing.data };
 }
 
 /**
@@ -40,16 +64,11 @@ interface RouteParams {
  */
 export async function POST(request: NextRequest, { params }: RouteParams) {
 	try {
-		const userId = await requireAuth();
-		const { id: caseId } = await params;
-
-		// VIEW-gated existence/access check, so an unauthenticated stranger
-		// never reaches the storage write below (the EDIT check that
-		// actually authorises the change happens in `upsertCaseInformation`).
-		const existing = await getCaseInformation(userId, caseId);
-		if ("error" in existing) {
-			return apiError(serviceErrorToAppError(existing.error));
+		const guard = await requireExistingCaseInformation(params);
+		if (!guard.ok) {
+			return guard.response;
 		}
+		const { userId, caseId, existing } = guard;
 
 		const formData = await request.formData();
 		const imageFile = formData.get("image") as File | null;
@@ -77,7 +96,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 		}
 
 		// Best-effort cleanup of the previous image, if any and different.
-		const previousUrl = existing.data?.featureImageUrl;
+		const previousUrl = existing?.featureImageUrl;
 		if (previousUrl && previousUrl !== saveResult.data.path) {
 			await deleteFile(previousUrl);
 		}
@@ -93,10 +112,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
  *
  * @description Removes the feature image from a case's case-information
  * record. Deletes the stored file (best-effort) and clears
- * `featureImageUrl` on the record. Calls `upsertCaseInformation` directly
- * with an empty string rather than through the zod schema — the schema's
- * `optionalString` transform treats an empty string as "field omitted",
- * which would leave the existing image untouched instead of clearing it.
+ * `featureImageUrl` on the record. Goes through `upsertCaseInformationSchema`
+ * like every other write, passing `featureImageUrl: null` — the schema
+ * treats `null` as an explicit clear, distinct from `undefined` ("leave
+ * untouched"), so there is no need to bypass it as a plain string write.
  * Requires EDIT permission.
  *
  * @pathParam id - Case ID (UUID)
@@ -108,19 +127,28 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
  */
 export async function DELETE(_request: NextRequest, { params }: RouteParams) {
 	try {
-		const userId = await requireAuth();
-		const { id: caseId } = await params;
+		const guard = await requireExistingCaseInformation(params);
+		if (!guard.ok) {
+			return guard.response;
+		}
+		const { userId, caseId, existing } = guard;
 
-		const existing = await getCaseInformation(userId, caseId);
-		if ("error" in existing) {
-			return apiError(serviceErrorToAppError(existing.error));
+		const currentUrl = existing?.featureImageUrl;
+
+		const parsed = upsertCaseInformationSchema.safeParse({
+			featureImageUrl: null,
+		});
+		if (!parsed.success) {
+			return apiError(
+				validationError(parsed.error.issues[0]?.message ?? "Invalid input")
+			);
 		}
 
-		const currentUrl = existing.data?.featureImageUrl;
-
-		const updateResult = await upsertCaseInformation(userId, caseId, {
-			featureImageUrl: "",
-		});
+		const updateResult = await upsertCaseInformation(
+			userId,
+			caseId,
+			parsed.data
+		);
 		if ("error" in updateResult) {
 			return apiError(serviceErrorToAppError(updateResult.error));
 		}

--- a/app/api/cases/[id]/information/route.ts
+++ b/app/api/cases/[id]/information/route.ts
@@ -1,0 +1,91 @@
+import type { NextRequest } from "next/server";
+import {
+	apiError,
+	apiErrorFromUnknown,
+	apiSuccess,
+	requireAuth,
+	serviceErrorToAppError,
+} from "@/lib/api-response";
+import { validationError } from "@/lib/errors";
+import { upsertCaseInformationSchema } from "@/lib/schemas/case-information";
+import {
+	getCaseInformation,
+	upsertCaseInformation,
+} from "@/lib/services/case-information-service";
+
+interface RouteParams {
+	params: Promise<{ id: string }>;
+}
+
+/**
+ * GET /api/cases/[id]/information
+ *
+ * @description Reads the case-information record for an assurance case
+ * (description, authors, sector, feature image — ADR 0003 §1). Requires
+ * VIEW permission. Returns `data: null` (not a 404) when the case has not
+ * been curated yet — that is a normal state, not an error.
+ *
+ * @pathParam id - Case ID (UUID)
+ * @response 200 - The case-information record, or `null` if none exists
+ * @response 401 - Unauthorised
+ * @response 403 - Permission denied (also returned for a non-existent case)
+ * @auth bearer
+ * @tag Cases
+ */
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+	try {
+		const userId = await requireAuth();
+		const { id: caseId } = await params;
+
+		const result = await getCaseInformation(userId, caseId);
+		if ("error" in result) {
+			return apiError(serviceErrorToAppError(result.error));
+		}
+
+		return apiSuccess(result.data);
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}
+
+/**
+ * PUT /api/cases/[id]/information
+ *
+ * @description Creates or updates the case-information record for an
+ * assurance case. A single upsert — there is no separate create vs. update
+ * distinction (ADR 0003 §1: "editable any time"). Only the fields supplied
+ * are written; omitted fields are left untouched on an existing record.
+ * Requires EDIT permission.
+ *
+ * @pathParam id - Case ID (UUID)
+ * @body { description?, authors?, sector?, featureImageUrl? }
+ * @response 200 - The saved case-information record
+ * @response 400 - Validation error
+ * @response 401 - Unauthorised
+ * @response 403 - Permission denied
+ * @auth bearer
+ * @tag Cases
+ */
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+	try {
+		const userId = await requireAuth();
+		const { id: caseId } = await params;
+
+		const raw = await request.json().catch(() => null);
+		const parsed = upsertCaseInformationSchema.safeParse(raw);
+		if (!parsed.success) {
+			return apiError(
+				validationError(parsed.error.issues[0]?.message ?? "Invalid input")
+			);
+		}
+
+		const result = await upsertCaseInformation(userId, caseId, parsed.data);
+		if ("error" in result) {
+			return apiError(serviceErrorToAppError(result.error));
+		}
+
+		return apiSuccess(result.data);
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}

--- a/components/cases/__tests__/action-buttons.test.tsx
+++ b/components/cases/__tests__/action-buttons.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import useStore from "@/store/store";
+import ActionButtons from "../action-buttons";
+
+// CaseSettingsPopover pulls in the theme-preset provider/context, which is
+// unrelated to the toolbar reachability behaviour under test here — stub it
+// out rather than wrapping the whole tree in that provider.
+vi.mock("../case-settings-popover", () => ({
+	CaseSettingsPopover: () => null,
+}));
+
+const onOpenSpy = vi.fn();
+
+vi.mock("@/hooks/modal-hooks", async () => {
+	const actual = await vi.importActual<typeof import("@/hooks/modal-hooks")>(
+		"@/hooks/modal-hooks"
+	);
+	return {
+		...actual,
+		useExportModal: () => ({
+			isOpen: false,
+			onOpen: vi.fn(),
+			onClose: vi.fn(),
+		}),
+		useHelpModal: () => ({
+			isOpen: false,
+			onOpen: onOpenSpy,
+			onClose: vi.fn(),
+		}),
+	};
+});
+
+function resetStore(): void {
+	useStore.setState({ caseDetailsOpen: false });
+}
+
+describe("ActionButtons toolbar — Case Information / Help reachability", () => {
+	beforeEach(() => {
+		resetStore();
+		onOpenSpy.mockClear();
+	});
+
+	it("renders a Case Information button (ADR 0003 §2 — the repurposed ⓘ button)", () => {
+		render(
+			<ActionButtons actions={{ onLayout: vi.fn() }} notifyError={vi.fn()} />
+		);
+
+		expect(screen.getByTestId("toolbar-case-information")).toBeInTheDocument();
+		expect(screen.queryByTestId("toolbar-resources")).not.toBeInTheDocument();
+	});
+
+	it("opens the case-information sheet (store flag) when the Case Information button is clicked", async () => {
+		const user = userEvent.setup();
+		render(
+			<ActionButtons actions={{ onLayout: vi.fn() }} notifyError={vi.fn()} />
+		);
+
+		expect(useStore.getState().caseDetailsOpen).toBe(false);
+		await user.click(screen.getByTestId("toolbar-case-information"));
+		expect(useStore.getState().caseDetailsOpen).toBe(true);
+	});
+
+	it("renders a Help button that opens the (relocated) Resources content", async () => {
+		const user = userEvent.setup();
+		render(
+			<ActionButtons actions={{ onLayout: vi.fn() }} notifyError={vi.fn()} />
+		);
+
+		const helpButton = screen.getByTestId("toolbar-help");
+		expect(helpButton).toBeInTheDocument();
+		await user.click(helpButton);
+		expect(onOpenSpy).toHaveBeenCalledTimes(1);
+	});
+});

--- a/components/cases/__tests__/case-details.test.tsx
+++ b/components/cases/__tests__/case-details.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import useStore from "@/store/store";
+import CaseDetails from "../case-details";
+
+// Isolate this test from the case-information data-fetching hook — that
+// behaviour has its own dedicated test in case-information-section.test.tsx.
+vi.mock("@/hooks/use-case-information", () => ({
+	useCaseInformation: () => ({
+		information: null,
+		loading: false,
+		saving: false,
+		uploadingImage: false,
+		save: vi.fn(),
+		uploadFeatureImage: vi.fn(),
+		removeFeatureImage: vi.fn(),
+	}),
+}));
+
+function resetStore(): void {
+	useStore.setState({
+		assuranceCase: {
+			id: "case-1",
+			name: "Test Case",
+			type: "assurance-case",
+			permissions: "manage",
+			createdDate: new Date().toISOString(),
+			comments: [],
+		},
+	});
+}
+
+describe("CaseDetails — shared sheet for both entry points (ADR 0003 §2)", () => {
+	beforeEach(() => {
+		resetStore();
+	});
+
+	it("renders the sheet content, including the Case Information section, when isOpen is true", async () => {
+		render(<CaseDetails isOpen={true} setOpen={vi.fn()} />);
+
+		// The skeleton-while-mounting branch resolves on the next tick.
+		expect(
+			await screen.findByRole("heading", { name: "Case Information" })
+		).toBeInTheDocument();
+	});
+});

--- a/components/cases/__tests__/case-information-section.test.tsx
+++ b/components/cases/__tests__/case-information-section.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useCaseInformation } from "@/hooks/use-case-information";
+import { CaseInformationSection } from "../case-information-section";
+
+vi.mock("@/hooks/use-case-information", () => ({
+	useCaseInformation: vi.fn(),
+}));
+
+const mockedUseCaseInformation = vi.mocked(useCaseInformation);
+const SAVE_BUTTON_PATTERN = /save/i;
+const SAVE_CASE_INFORMATION_BUTTON_PATTERN = /save case information/i;
+
+function stubHook(overrides: Partial<ReturnType<typeof useCaseInformation>>) {
+	mockedUseCaseInformation.mockReturnValue({
+		information: null,
+		loading: false,
+		saving: false,
+		uploadingImage: false,
+		save: vi.fn().mockResolvedValue(true),
+		uploadFeatureImage: vi.fn().mockResolvedValue(true),
+		removeFeatureImage: vi.fn().mockResolvedValue(true),
+		...overrides,
+	});
+}
+
+describe("CaseInformationSection", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("shows a loading skeleton while the record is being fetched", () => {
+		stubHook({ loading: true });
+
+		render(<CaseInformationSection canEdit={true} caseId="case-1" />);
+
+		expect(screen.getByTestId("case-information-loading")).toBeInTheDocument();
+	});
+
+	it("renders a read-only view for a user without EDIT permission", () => {
+		stubHook({
+			information: {
+				description: "A worked example",
+				authors: "Ada Lovelace",
+				sector: "Healthcare",
+				featureImageUrl: null,
+			},
+		});
+
+		render(<CaseInformationSection canEdit={false} caseId="case-1" />);
+
+		expect(screen.getByTestId("case-information-view")).toBeInTheDocument();
+		expect(screen.getByText("A worked example")).toBeInTheDocument();
+		expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+		expect(screen.getByText("Healthcare")).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: SAVE_BUTTON_PATTERN })
+		).not.toBeInTheDocument();
+	});
+
+	it("renders placeholder copy for empty fields in the read-only view", () => {
+		stubHook({ information: null });
+
+		render(<CaseInformationSection canEdit={false} caseId="case-1" />);
+
+		expect(screen.getByText("No description provided.")).toBeInTheDocument();
+	});
+
+	it("renders an editable form for a user with EDIT permission and saves on submit", async () => {
+		const save = vi.fn().mockResolvedValue(true);
+		stubHook({
+			information: {
+				description: "Original description",
+				authors: "Grace Hopper",
+				sector: "Defence",
+				featureImageUrl: null,
+			},
+			save,
+		});
+		const user = userEvent.setup();
+
+		render(<CaseInformationSection canEdit={true} caseId="case-1" />);
+
+		const form = await screen.findByTestId("case-information-form");
+		expect(form).toBeInTheDocument();
+
+		const descriptionField = screen.getByLabelText("Description");
+		await user.clear(descriptionField);
+		await user.type(descriptionField, "Updated description");
+		await user.click(
+			screen.getByRole("button", {
+				name: SAVE_CASE_INFORMATION_BUTTON_PATTERN,
+			})
+		);
+
+		expect(save).toHaveBeenCalledWith(
+			expect.objectContaining({ description: "Updated description" })
+		);
+	});
+});

--- a/components/cases/action-buttons.tsx
+++ b/components/cases/action-buttons.tsx
@@ -4,6 +4,7 @@ import {
 	Code2,
 	Download,
 	Group,
+	HelpCircle,
 	Info,
 	Loader2,
 	Notebook,
@@ -14,7 +15,7 @@ import {
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { useExportModal, useResourcesModal } from "@/hooks/modal-hooks";
+import { useExportModal, useHelpModal } from "@/hooks/modal-hooks";
 import { useCaseSharingModal } from "@/hooks/use-case-sharing-modal";
 import useStore from "@/store/store";
 import { AlertModal } from "../modals/alert-modal";
@@ -40,7 +41,7 @@ const ActionButtons = ({ actions, notifyError }: ActionButtonProps) => {
 	const [loading, setLoading] = useState(false);
 	const [isLayouting, setIsLayouting] = useState(false);
 
-	const { assuranceCase, layoutDirection } = useStore();
+	const { assuranceCase, layoutDirection, setCaseDetailsOpen } = useStore();
 	const router = useRouter();
 
 	const { onLayout } = actions;
@@ -53,7 +54,7 @@ const ActionButtons = ({ actions, notifyError }: ActionButtonProps) => {
 
 	const caseSharingModal = useCaseSharingModal();
 	const exportModal = useExportModal();
-	const resourcesModal = useResourcesModal();
+	const helpModal = useHelpModal();
 
 	const onDelete = async () => {
 		if (!assuranceCase) {
@@ -145,17 +146,30 @@ const ActionButtons = ({ actions, notifyError }: ActionButtonProps) => {
 								</Button>
 							</ActionTooltip>
 						)}
-					<ActionTooltip label="Resources">
+					<ActionTooltip label="Case Information">
 						<Button
 							className="rounded-full p-3"
-							data-testid="toolbar-resources"
-							data-tour="toolbar-resources"
-							onClick={() => resourcesModal.onOpen()}
+							data-testid="toolbar-case-information"
+							data-tour="toolbar-case-information"
+							onClick={() => setCaseDetailsOpen(true)}
 							size="icon"
 							type="button"
 						>
 							<Info className="h-5 w-5" />
-							<span className="sr-only">Resources</span>
+							<span className="sr-only">Case Information</span>
+						</Button>
+					</ActionTooltip>
+					<ActionTooltip label="Help">
+						<Button
+							className="rounded-full p-3"
+							data-testid="toolbar-help"
+							data-tour="toolbar-help"
+							onClick={() => helpModal.onOpen()}
+							size="icon"
+							type="button"
+						>
+							<HelpCircle className="h-5 w-5" />
+							<span className="sr-only">Help</span>
 						</Button>
 					</ActionTooltip>
 				</div>

--- a/components/cases/case-container.tsx
+++ b/components/cases/case-container.tsx
@@ -103,9 +103,14 @@ function showEventToast(event: SSEEvent): void {
 
 const CaseContainer = ({ caseId }: CaseContainerProps) => {
 	const [loading, setLoading] = useState(true);
-	const { assuranceCase, setAssuranceCase, setOrphanedElements } = useStore();
+	const {
+		assuranceCase,
+		setAssuranceCase,
+		setOrphanedElements,
+		caseDetailsOpen,
+		setCaseDetailsOpen,
+	} = useStore();
 	const { setCaseId: setHistoryCaseId } = useHistoryStore();
-	const [open, setOpen] = useState(false);
 
 	const params = useParams();
 	const router = useRouter();
@@ -300,7 +305,7 @@ const CaseContainer = ({ caseId }: CaseContainerProps) => {
 					enabled={!loading}
 					tourId={assuranceCase?.isDemo ? "demo-case" : "case-canvas"}
 				/>
-				<Header setOpen={setOpen} />
+				<Header setOpen={setCaseDetailsOpen} />
 				<ErrorBoundary
 					fallback={
 						<div className="flex min-h-screen items-center justify-center text-muted-foreground">
@@ -310,7 +315,7 @@ const CaseContainer = ({ caseId }: CaseContainerProps) => {
 				>
 					<Flow />
 				</ErrorBoundary>
-				<CaseDetails isOpen={open} setOpen={setOpen} />
+				<CaseDetails isOpen={caseDetailsOpen} setOpen={setCaseDetailsOpen} />
 			</ReactFlowProvider>
 		);
 	}

--- a/components/cases/case-details.tsx
+++ b/components/cases/case-details.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { AlertModal } from "@/components/modals/alert-modal";
+import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import useStore from "@/store/store";
 import CaseSheet from "../ui/case-sheet";
 import CaseEditForm from "./case-edit-form";
+import { CaseInformationSection } from "./case-information-section";
 
 interface CaseDetailsProps {
 	isOpen: boolean;
-	setOpen: Dispatch<SetStateAction<boolean>>;
+	setOpen: (open: boolean) => void;
 }
 
 const CaseDetails = ({ isOpen, setOpen }: CaseDetailsProps) => {
@@ -19,6 +21,9 @@ const CaseDetails = ({ isOpen, setOpen }: CaseDetailsProps) => {
 	const [alertOpen, setAlertOpen] = useState(false);
 
 	const { assuranceCase } = useStore();
+	const canEditCase =
+		assuranceCase?.permissions === "manage" ||
+		assuranceCase?.permissions === "edit";
 
 	useEffect(() => {
 		setIsMounted(true);
@@ -68,11 +73,19 @@ const CaseDetails = ({ isOpen, setOpen }: CaseDetailsProps) => {
 			onClose={handleClose}
 			title={`${assuranceCase?.permissions === "manage" ? "Update" : ""} Assurance Case`}
 		>
-			<div className="my-6">
+			<div className="my-6 space-y-6">
 				<CaseEditForm
 					onClose={handleClose}
 					setUnresolvedChanges={setUnresolvedChanges}
 				/>
+				<Separator />
+				<div>
+					<h3 className="mb-4 font-semibold text-lg">Case Information</h3>
+					<CaseInformationSection
+						canEdit={canEditCase}
+						caseId={assuranceCase?.id?.toString()}
+					/>
+				</div>
 				<AlertModal
 					cancelButtonText={"No, keep editing"}
 					confirmButtonText={"Yes, discard changes!"}

--- a/components/cases/case-information-section.tsx
+++ b/components/cases/case-information-section.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2 } from "lucide-react";
+import Image from "next/image";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import {
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/ui/form";
+import { ImageUpload } from "@/components/ui/image-upload";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import { useCaseInformation } from "@/hooks/use-case-information";
+import type {
+	CaseInformationData,
+	CaseInformationInput,
+} from "@/lib/schemas/case-information";
+import { upsertCaseInformationSchema } from "@/lib/schemas/case-information";
+import { Button } from "../ui/button";
+
+interface CaseInformationSectionProps {
+	canEdit: boolean;
+	caseId: string | undefined;
+}
+
+/**
+ * Read/edit surface for a case's case-information record (ADR 0003 §1) —
+ * description, authors, sector, and feature image. Anyone with case access
+ * can view it; only case EDIT permission can save changes, matching the
+ * server-side gate in `upsertCaseInformation`. Rendered inside the shared
+ * `CaseSheet` (`case-details.tsx`), reachable from both the title-click
+ * entry point and the toolbar's "Case Information" button (ADR 0003
+ * implementation shape §2 — two entry points, one component).
+ */
+export function CaseInformationSection({
+	caseId,
+	canEdit,
+}: CaseInformationSectionProps) {
+	const {
+		information,
+		loading,
+		saving,
+		uploadingImage,
+		save,
+		uploadFeatureImage,
+		removeFeatureImage,
+	} = useCaseInformation(caseId);
+
+	const form = useForm<CaseInformationInput, unknown, CaseInformationData>({
+		resolver: zodResolver(upsertCaseInformationSchema),
+		defaultValues: {
+			description: "",
+			authors: "",
+			sector: "",
+			featureImageUrl: "",
+		},
+	});
+	const { reset } = form;
+
+	// Sync fetched values into the form once they arrive (the form mounts
+	// before the fetch resolves).
+	useEffect(() => {
+		reset({
+			description: information?.description ?? "",
+			authors: information?.authors ?? "",
+			sector: information?.sector ?? "",
+			featureImageUrl: information?.featureImageUrl ?? "",
+		});
+	}, [information, reset]);
+
+	const onSubmit = async (values: CaseInformationData) => {
+		await save(values);
+	};
+
+	const onImageChange = async (file: File | string) => {
+		if (typeof file !== "string") {
+			await uploadFeatureImage(file);
+		}
+	};
+
+	const onImageRemove = async () => {
+		await removeFeatureImage();
+	};
+
+	if (loading) {
+		return (
+			<div className="space-y-4" data-testid="case-information-loading">
+				<Skeleton className="h-4 w-32" />
+				<Skeleton className="h-20 w-full" />
+				<Skeleton className="h-4 w-32" />
+				<Skeleton className="h-10 w-full" />
+			</div>
+		);
+	}
+
+	if (!canEdit) {
+		return (
+			<div className="space-y-4" data-testid="case-information-view">
+				<div>
+					<h4 className="font-medium text-muted-foreground text-sm">
+						Description
+					</h4>
+					<p className="text-sm">
+						{information?.description || "No description provided."}
+					</p>
+				</div>
+				<div>
+					<h4 className="font-medium text-muted-foreground text-sm">Authors</h4>
+					<p className="text-sm">{information?.authors || "Not provided."}</p>
+				</div>
+				<div>
+					<h4 className="font-medium text-muted-foreground text-sm">Sector</h4>
+					<p className="text-sm">{information?.sector || "Not provided."}</p>
+				</div>
+				{information?.featureImageUrl && (
+					<div>
+						<h4 className="font-medium text-muted-foreground text-sm">
+							Feature image
+						</h4>
+						<div className="relative mt-2 aspect-video w-full max-w-2xl overflow-hidden rounded-lg border">
+							<Image
+								alt="Case feature"
+								className="object-cover"
+								fill
+								sizes="(max-width: 768px) 100vw, 672px"
+								src={information.featureImageUrl}
+							/>
+						</div>
+					</div>
+				)}
+			</div>
+		);
+	}
+
+	return (
+		<Form {...form}>
+			<form
+				className="space-y-6"
+				data-testid="case-information-form"
+				onSubmit={form.handleSubmit(onSubmit)}
+			>
+				<FormField
+					control={form.control}
+					name="description"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>Description</FormLabel>
+							<FormControl>
+								<Textarea
+									placeholder="A short description of this assurance case"
+									rows={4}
+									{...field}
+									value={field.value ?? ""}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<FormField
+					control={form.control}
+					name="authors"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>Authors</FormLabel>
+							<FormControl>
+								<Input
+									placeholder="e.g. Ada Lovelace"
+									{...field}
+									value={field.value ?? ""}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<FormField
+					control={form.control}
+					name="sector"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>Sector</FormLabel>
+							<FormControl>
+								<Input
+									placeholder="e.g. Healthcare"
+									{...field}
+									value={field.value ?? ""}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<div className="space-y-2">
+					<span className="font-medium text-sm">Feature image</span>
+					<ImageUpload
+						disabled={uploadingImage}
+						onChange={onImageChange}
+						onRemove={onImageRemove}
+						value={information?.featureImageUrl ?? ""}
+					/>
+				</div>
+				<Separator />
+				<Button disabled={saving} type="submit">
+					{saving ? (
+						<span className="flex items-center justify-center gap-2">
+							<Loader2 className="h-4 w-4 animate-spin" />
+							Saving...
+						</span>
+					) : (
+						<span>Save case information</span>
+					)}
+				</Button>
+			</form>
+		</Form>
+	);
+}

--- a/components/cases/header.tsx
+++ b/components/cases/header.tsx
@@ -189,6 +189,7 @@ const Header = ({ setOpen }: HeaderProps) => {
 					</Button>
 					<button
 						className="border-none bg-transparent p-0 font-semibold text-sidebar-foreground hover:cursor-pointer"
+						data-testid="case-title-button"
 						data-tour="case-header"
 						onClick={() => setOpen(true)}
 						type="button"

--- a/components/cases/header.tsx
+++ b/components/cases/header.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeft } from "lucide-react";
 import { useRouter } from "next/navigation";
 import type React from "react";
-import { type Dispatch, type SetStateAction, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useReactFlow, useUpdateNodeInternals } from "reactflow";
 import SearchNodes from "@/components/cases/search-nodes";
 import { useChangeDetection } from "@/hooks/use-change-detection";
@@ -16,7 +16,7 @@ import { Button } from "../ui/button";
 import ActiveUsersList from "./active-users-list";
 
 interface HeaderProps {
-	setOpen: Dispatch<SetStateAction<boolean>>;
+	setOpen: (open: boolean) => void;
 }
 
 const Header = ({ setOpen }: HeaderProps) => {

--- a/components/modals/help-modal.tsx
+++ b/components/modals/help-modal.tsx
@@ -9,11 +9,18 @@ import {
 } from "lucide-react";
 import React from "react";
 import { Modal } from "@/components/ui/modal";
-import { useResourcesModal } from "@/hooks/modal-hooks";
+import { useHelpModal } from "@/hooks/modal-hooks";
 import { cn } from "@/lib/utils";
 
-export const ResourcesModal = () => {
-	const resourcesModal = useResourcesModal();
+/**
+ * Help modal — the element-legend content formerly shown by the toolbar's
+ * "Resources" button. Mechanically relocated behind a new "?" Help button
+ * when the ⓘ button was repurposed as "Case Information" (ADR 0003
+ * implementation shape §2); content is unchanged. A genuine redesign of
+ * this modal is tracked separately (not this issue's scope).
+ */
+export const HelpModal = () => {
+	const helpModal = useHelpModal();
 
 	const components: {
 		title: string;
@@ -62,8 +69,8 @@ export const ResourcesModal = () => {
 		<Modal
 			classNames="min-w-[800px]"
 			description="Here is some useful information about each element, select each to find out more."
-			isOpen={resourcesModal.isOpen}
-			onClose={resourcesModal.onClose}
+			isOpen={helpModal.isOpen}
+			onClose={helpModal.onClose}
 			title="Element Legend"
 		>
 			<ul className="grid gap-3 py-2 md:grid-cols-2">

--- a/e2e/cases.spec.ts
+++ b/e2e/cases.spec.ts
@@ -86,4 +86,20 @@ test.describe("Case management", () => {
 		await dashboard.goto();
 		await expect(page.getByText("Delete Me Case")).not.toBeVisible();
 	});
+
+	test("clicking the case title opens the case information sheet", async ({
+		page,
+	}) => {
+		const dashboard = new DashboardPage(page);
+		await dashboard.goto();
+
+		await dashboard.caseCard("Simple Case").click();
+		await page.waitForURL(CASE_URL_PATTERN);
+
+		await page.getByTestId("case-title-button").click();
+
+		await expect(
+			page.getByRole("heading", { name: "Case Information" })
+		).toBeVisible();
+	});
 });

--- a/e2e/pages/case-editor-page.ts
+++ b/e2e/pages/case-editor-page.ts
@@ -16,7 +16,8 @@ export class CaseEditorPage {
 	readonly notesButton: Locator;
 	readonly settingsButton: Locator;
 	readonly deleteButton: Locator;
-	readonly resourcesButton: Locator;
+	readonly caseInformationButton: Locator;
+	readonly helpButton: Locator;
 
 	constructor(page: Page) {
 		this.statusButton = page.getByRole("button", {
@@ -30,6 +31,10 @@ export class CaseEditorPage {
 		this.notesButton = page.getByTestId("toolbar-notes");
 		this.settingsButton = page.getByTestId("toolbar-settings");
 		this.deleteButton = page.getByTestId("toolbar-delete");
-		this.resourcesButton = page.getByTestId("toolbar-resources");
+		// ADR 0003 implementation shape §2: the toolbar's ⓘ button was
+		// repurposed as "Case Information"; its former "Resources" content
+		// moved verbatim to a new "?" Help button.
+		this.caseInformationButton = page.getByTestId("toolbar-case-information");
+		this.helpButton = page.getByTestId("toolbar-help");
 	}
 }

--- a/hooks/__tests__/modal-hooks.test.ts
+++ b/hooks/__tests__/modal-hooks.test.ts
@@ -8,9 +8,9 @@ import {
 	useCreateCaseModal,
 	useEmailModal,
 	useExportModal,
+	useHelpModal,
 	useImportModal,
 	usePermissionsModal,
-	useResourcesModal,
 } from "@/hooks/modal-hooks";
 
 // Type for modal hook return value
@@ -178,7 +178,7 @@ describe("Modal Hooks", () => {
 			usePermissionsModal,
 			useImportModal,
 			useEmailModal,
-			useResourcesModal,
+			useHelpModal,
 		];
 
 		// Reset each store to its initial state
@@ -193,7 +193,7 @@ describe("Modal Hooks", () => {
 	testModalHook("usePermissionsModal", usePermissionsModal);
 	testModalHook("useImportModal", useImportModal);
 	testModalHook("useEmailModal", useEmailModal);
-	testModalHook("useResourcesModal", useResourcesModal);
+	testModalHook("useHelpModal", useHelpModal);
 
 	describe("Cross-modal interactions", () => {
 		it("should allow multiple modals to be open simultaneously", () => {
@@ -350,7 +350,7 @@ describe("Modal Hooks", () => {
 				usePermissionsModal,
 				useImportModal,
 				useEmailModal,
-				useResourcesModal,
+				useHelpModal,
 			];
 
 			const results = hooks.map((hook) => renderHook(hook));

--- a/hooks/__tests__/use-case-information.test.ts
+++ b/hooks/__tests__/use-case-information.test.ts
@@ -1,0 +1,159 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { act } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { server } from "@/src/__tests__/mocks/server";
+import { useCaseInformation } from "../use-case-information";
+
+const CASE_ID = "case-1";
+const INFORMATION_PATH = `/api/cases/${CASE_ID}/information`;
+const IMAGE_PATH = `/api/cases/${CASE_ID}/information/image`;
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("useCaseInformation", () => {
+	it("starts loading, then resolves the fetched record", async () => {
+		server.use(
+			http.get(INFORMATION_PATH, () =>
+				HttpResponse.json({
+					description: "A worked example",
+					authors: "Ada Lovelace",
+					sector: "Healthcare",
+					featureImageUrl: null,
+				})
+			)
+		);
+
+		const { result } = renderHook(() => useCaseInformation(CASE_ID));
+
+		expect(result.current.loading).toBe(true);
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.information?.description).toBe("A worked example");
+	});
+
+	it("resolves to null information when the case has none yet", async () => {
+		server.use(http.get(INFORMATION_PATH, () => HttpResponse.json(null)));
+
+		const { result } = renderHook(() => useCaseInformation(CASE_ID));
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		expect(result.current.information).toBeNull();
+	});
+
+	it("does not fetch when caseId is undefined", async () => {
+		const { result } = renderHook(() => useCaseInformation(undefined));
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		expect(result.current.information).toBeNull();
+	});
+
+	it("save() PUTs the values and updates local state on success", async () => {
+		server.use(
+			http.get(INFORMATION_PATH, () => HttpResponse.json(null)),
+			http.put(INFORMATION_PATH, () =>
+				HttpResponse.json({
+					description: "New description",
+					authors: null,
+					sector: null,
+					featureImageUrl: null,
+				})
+			)
+		);
+
+		const { result } = renderHook(() => useCaseInformation(CASE_ID));
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		let saveResult: boolean | undefined;
+		await act(async () => {
+			saveResult = await result.current.save({
+				description: "New description",
+			});
+		});
+
+		expect(saveResult).toBe(true);
+		expect(result.current.information?.description).toBe("New description");
+	});
+
+	it("save() returns false and leaves state untouched when the PUT fails", async () => {
+		server.use(
+			http.get(INFORMATION_PATH, () => HttpResponse.json(null)),
+			http.put(INFORMATION_PATH, () =>
+				HttpResponse.json({ error: "Permission denied" }, { status: 403 })
+			)
+		);
+
+		const { result } = renderHook(() => useCaseInformation(CASE_ID));
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		let saveResult: boolean | undefined;
+		await act(async () => {
+			saveResult = await result.current.save({ description: "x" });
+		});
+
+		expect(saveResult).toBe(false);
+		expect(result.current.information).toBeNull();
+	});
+
+	it("uploadFeatureImage() POSTs the file and merges the returned URL into state", async () => {
+		server.use(
+			http.get(INFORMATION_PATH, () =>
+				HttpResponse.json({
+					description: "Existing",
+					authors: null,
+					sector: null,
+					featureImageUrl: null,
+				})
+			),
+			http.post(IMAGE_PATH, () =>
+				HttpResponse.json({ featureImageUrl: "/uploads/cases/new.png" })
+			)
+		);
+
+		const { result } = renderHook(() => useCaseInformation(CASE_ID));
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		const file = new File(["x"], "feature.png", { type: "image/png" });
+		let uploadResult: boolean | undefined;
+		await act(async () => {
+			uploadResult = await result.current.uploadFeatureImage(file);
+		});
+
+		expect(uploadResult).toBe(true);
+		expect(result.current.information?.featureImageUrl).toBe(
+			"/uploads/cases/new.png"
+		);
+		// Fields untouched by the image upload are preserved.
+		expect(result.current.information?.description).toBe("Existing");
+	});
+
+	it("removeFeatureImage() DELETEs and clears the URL from state", async () => {
+		server.use(
+			http.get(INFORMATION_PATH, () =>
+				HttpResponse.json({
+					description: null,
+					authors: null,
+					sector: null,
+					featureImageUrl: "/uploads/cases/old.png",
+				})
+			),
+			http.delete(IMAGE_PATH, () => HttpResponse.json({ success: true }))
+		);
+
+		const { result } = renderHook(() => useCaseInformation(CASE_ID));
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		expect(result.current.information?.featureImageUrl).toBe(
+			"/uploads/cases/old.png"
+		);
+
+		let removeResult: boolean | undefined;
+		await act(async () => {
+			removeResult = await result.current.removeFeatureImage();
+		});
+
+		expect(removeResult).toBe(true);
+		expect(result.current.information?.featureImageUrl).toBeNull();
+	});
+});

--- a/hooks/modal-hooks.ts
+++ b/hooks/modal-hooks.ts
@@ -4,6 +4,6 @@ export const useCreateCaseModal = createModalStore();
 export const useCreateTeamModal = createModalStore();
 export const useEmailModal = createModalStore();
 export const useExportModal = createModalStore();
+export const useHelpModal = createModalStore();
 export const useImportModal = createModalStore();
 export const usePermissionsModal = createModalStore();
-export const useResourcesModal = createModalStore();

--- a/hooks/use-case-information.ts
+++ b/hooks/use-case-information.ts
@@ -1,0 +1,199 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { CaseInformationData } from "@/lib/schemas/case-information";
+// Reusing the service's snapshot shape rather than hand-declaring a parallel
+// type: it already names exactly the four case-information fields (ADR 0003
+// §1), so this can't drift from the real record shape.
+import type { CaseInformationSnapshot } from "@/lib/services/case-information-service";
+import { toast } from "@/lib/toast";
+
+interface UseCaseInformationReturn {
+	information: CaseInformationSnapshot | null;
+	loading: boolean;
+	removeFeatureImage: () => Promise<boolean>;
+	save: (values: CaseInformationData) => Promise<boolean>;
+	saving: boolean;
+	uploadFeatureImage: (file: File) => Promise<boolean>;
+	uploadingImage: boolean;
+}
+
+/**
+ * Client-side data access for a case's case-information record (ADR 0003
+ * §1). Fetches on mount/caseId change, and exposes save / feature-image
+ * upload / feature-image remove actions against the `/api/cases/[id]/
+ * information` route pair. Mirrors the shape of `use-case-study-image.ts`
+ * for the image half — this is the case-information analogue.
+ */
+export function useCaseInformation(
+	caseId: string | undefined
+): UseCaseInformationReturn {
+	const [information, setInformation] =
+		useState<CaseInformationSnapshot | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [saving, setSaving] = useState(false);
+	const [uploadingImage, setUploadingImage] = useState(false);
+
+	const fetchInformation = useCallback(async () => {
+		if (!caseId) {
+			setLoading(false);
+			return;
+		}
+
+		setLoading(true);
+		try {
+			const response = await fetch(`/api/cases/${caseId}/information`);
+			if (!response.ok) {
+				setInformation(null);
+				return;
+			}
+			const data = await response.json();
+			setInformation(data);
+		} catch {
+			setInformation(null);
+		} finally {
+			setLoading(false);
+		}
+	}, [caseId]);
+
+	useEffect(() => {
+		fetchInformation();
+	}, [fetchInformation]);
+
+	const save = useCallback(
+		async (values: CaseInformationData): Promise<boolean> => {
+			if (!caseId) {
+				return false;
+			}
+
+			setSaving(true);
+			try {
+				const response = await fetch(`/api/cases/${caseId}/information`, {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(values),
+				});
+
+				if (!response.ok) {
+					toast({
+						variant: "destructive",
+						title: "Failed to save case information",
+						description: "Something went wrong trying to save the changes.",
+					});
+					return false;
+				}
+
+				const data = await response.json();
+				setInformation(data);
+				toast({
+					variant: "success",
+					title: "Case information saved",
+				});
+				return true;
+			} catch {
+				toast({
+					variant: "destructive",
+					title: "Failed to save case information",
+					description: "Something went wrong trying to save the changes.",
+				});
+				return false;
+			} finally {
+				setSaving(false);
+			}
+		},
+		[caseId]
+	);
+
+	const uploadFeatureImage = useCallback(
+		async (file: File): Promise<boolean> => {
+			if (!caseId) {
+				return false;
+			}
+
+			setUploadingImage(true);
+			try {
+				const formData = new FormData();
+				formData.append("image", file);
+
+				const response = await fetch(`/api/cases/${caseId}/information/image`, {
+					method: "POST",
+					body: formData,
+				});
+
+				if (!response.ok) {
+					toast({
+						variant: "destructive",
+						title: "Image upload failed",
+						description: "Could not upload the feature image.",
+					});
+					return false;
+				}
+
+				const data = await response.json();
+				setInformation((prev) => ({
+					authors: prev?.authors ?? null,
+					description: prev?.description ?? null,
+					sector: prev?.sector ?? null,
+					featureImageUrl: data.featureImageUrl,
+				}));
+				return true;
+			} catch {
+				toast({
+					variant: "destructive",
+					title: "Image upload failed",
+					description: "Could not upload the feature image.",
+				});
+				return false;
+			} finally {
+				setUploadingImage(false);
+			}
+		},
+		[caseId]
+	);
+
+	const removeFeatureImage = useCallback(async (): Promise<boolean> => {
+		if (!caseId) {
+			return false;
+		}
+
+		setUploadingImage(true);
+		try {
+			const response = await fetch(`/api/cases/${caseId}/information/image`, {
+				method: "DELETE",
+			});
+
+			if (!response.ok) {
+				toast({
+					variant: "destructive",
+					title: "Failed to remove image",
+					description: "Could not remove the feature image.",
+				});
+				return false;
+			}
+
+			setInformation((prev) =>
+				prev ? { ...prev, featureImageUrl: null } : prev
+			);
+			return true;
+		} catch {
+			toast({
+				variant: "destructive",
+				title: "Failed to remove image",
+				description: "Could not remove the feature image.",
+			});
+			return false;
+		} finally {
+			setUploadingImage(false);
+		}
+	}, [caseId]);
+
+	return {
+		information,
+		loading,
+		saving,
+		uploadingImage,
+		save,
+		uploadFeatureImage,
+		removeFeatureImage,
+	};
+}

--- a/lib/schemas/case-information.ts
+++ b/lib/schemas/case-information.ts
@@ -13,7 +13,21 @@ export const caseInformationSchema = z.object({
 	description: optionalString(5000),
 	authors: optionalString(255),
 	sector: optionalString(100),
-	featureImageUrl: optionalString(2000),
+	// Distinct from `optionalString`: the image field needs a genuine
+	// null-vs-undefined distinction so a caller can explicitly *clear* the
+	// image (`null`) without that being indistinguishable from "leave the
+	// existing image untouched" (`undefined` — the key omitted).
+	// `optionalString` collapses both `null` and `""` to `undefined`, which
+	// is exactly the ambiguity that used to force the image DELETE handler
+	// to bypass this schema and write an empty string directly.
+	featureImageUrl: z
+		.string()
+		.max(2000, "Must be less than 2000 characters")
+		.nullable()
+		.optional()
+		.describe(
+			"Feature image URL — null clears it, omitted leaves it untouched"
+		),
 });
 
 /**

--- a/lib/services/case-information-service.ts
+++ b/lib/services/case-information-service.ts
@@ -15,7 +15,9 @@ import type { ServiceResult } from "@/types/service";
 export interface CaseInformationInput {
 	authors?: string;
 	description?: string;
-	featureImageUrl?: string;
+	// `null` explicitly clears the stored value; `undefined` (the key
+	// omitted) leaves it untouched — see `lib/schemas/case-information.ts`.
+	featureImageUrl?: string | null;
 	sector?: string;
 }
 

--- a/lib/tours/case-canvas-tour.ts
+++ b/lib/tours/case-canvas-tour.ts
@@ -42,7 +42,7 @@ export const caseCanvasTour: Tour = {
 			icon: "🛠️",
 			title: "The Toolbar",
 			content:
-				"All your editing tools are here — Undo/Redo, Auto-Layout, Resources, Share, Export, JSON View, Notes, and Settings. Hover over each icon to see what it does.",
+				"All your editing tools are here — Undo/Redo, Auto-Layout, Case Information, Help, Share, Export, JSON View, Notes, and Settings. Hover over each icon to see what it does.",
 			selector: "[data-tour='toolbar']",
 			side: "top",
 			showControls: true,

--- a/providers/modal-provider.tsx
+++ b/providers/modal-provider.tsx
@@ -43,9 +43,8 @@ const PublishModal = dynamic(
 	() => import("@/components/modals/publish-modal").then((m) => m.PublishModal),
 	{ ssr: false }
 );
-const ResourcesModal = dynamic(
-	() =>
-		import("@/components/modals/resources-modal").then((m) => m.ResourcesModal),
+const HelpModal = dynamic(
+	() => import("@/components/modals/help-modal").then((m) => m.HelpModal),
 	{ ssr: false }
 );
 const ShareModal = dynamic(
@@ -97,7 +96,7 @@ export const ModalProvider = (): ReactNode => (
 		<PublishModal />
 		<StatusModalWrapper />
 		<EmailModal />
-		<ResourcesModal />
+		<HelpModal />
 		<CreateTeamDialog />
 		<InviteMemberDialog />
 		<ErrorBoundary

--- a/src/__tests__/integration/api-case-information-image.test.ts
+++ b/src/__tests__/integration/api-case-information-image.test.ts
@@ -1,0 +1,266 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	createTestCase,
+	createTestCaseInformation,
+	createTestPermission,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+const NON_EXISTENT_CASE_ID = "00000000-0000-0000-0000-000000000000";
+const UPLOADED_PATH_PATTERN = /^\/uploads\/cases\//;
+
+function buildImageFormData(filename = "feature.png"): FormData {
+	const formData = new FormData();
+	const file = new File([new Uint8Array([1, 2, 3, 4])], filename, {
+		type: "image/png",
+	});
+	formData.append("image", file);
+	return formData;
+}
+
+beforeEach(async () => {
+	await mockNoAuth();
+	// saveFile() only writes to local disk (rather than erroring with
+	// "Storage not configured") when NODE_ENV is "development" or this flag
+	// is set — vitest runs with NODE_ENV "test", so this is required for the
+	// upload branch under test to be reachable at all.
+	vi.stubEnv("USE_LOCAL_STORAGE", "true");
+});
+
+afterEach(async () => {
+	vi.unstubAllEnvs();
+	// Clean up any files actually written to local disk during this suite.
+	const { deleteFile } = await import("@/lib/services/file-storage-service");
+	for (const path of writtenPaths.splice(0)) {
+		await deleteFile(path);
+	}
+});
+
+// Written-file tracker so afterEach can clean up local-disk uploads made
+// during the test run (public/uploads/ is gitignored but not otherwise
+// cleaned between runs).
+const writtenPaths: string[] = [];
+
+describe("POST /api/cases/[id]/information/image", () => {
+	it("uploads a feature image and persists it on the case-information record", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/cases/[id]/information/image/route"
+		);
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/information/image`,
+			{ method: "POST", body: buildImageFormData() }
+		);
+		const response = await POST(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.featureImageUrl).toMatch(UPLOADED_PATH_PATTERN);
+		writtenPaths.push(body.featureImageUrl);
+
+		const { getCaseInformation } = await import(
+			"@/lib/services/case-information-service"
+		);
+		const result = await getCaseInformation(owner.id, testCase.id);
+		expect("data" in result && result.data?.featureImageUrl).toBe(
+			body.featureImageUrl
+		);
+	});
+
+	it("deletes the previous image when a new one is uploaded", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/cases/[id]/information/image/route"
+		);
+		const firstReq = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/information/image`,
+			{ method: "POST", body: buildImageFormData("first.png") }
+		);
+		const firstResponse = await POST(firstReq, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+		const firstBody = await firstResponse.json();
+
+		const secondReq = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/information/image`,
+			{ method: "POST", body: buildImageFormData("second.png") }
+		);
+		const secondResponse = await POST(secondReq, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+		const secondBody = await secondResponse.json();
+		writtenPaths.push(secondBody.featureImageUrl);
+
+		expect(secondBody.featureImageUrl).not.toBe(firstBody.featureImageUrl);
+
+		const { fileExists } = await import("@/lib/services/file-storage-service");
+		expect(await fileExists(firstBody.featureImageUrl)).toBe(false);
+	});
+
+	it("returns 400 when no file is provided", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import(
+			"@/app/api/cases/[id]/information/image/route"
+		);
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/information/image`,
+			{ method: "POST", body: new FormData() }
+		);
+		const response = await POST(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns 401 when the request is not authenticated", async () => {
+		const { POST } = await import(
+			"@/app/api/cases/[id]/information/image/route"
+		);
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${NON_EXISTENT_CASE_ID}/information/image`,
+			{ method: "POST", body: buildImageFormData() }
+		);
+		const response = await POST(req, {
+			params: Promise.resolve({ id: NON_EXISTENT_CASE_ID }),
+		});
+
+		expect(response.status).toBe(401);
+	});
+
+	it("returns 403 for a user with only VIEW permission and does not orphan the file", async () => {
+		const owner = await createTestUser();
+		const viewer = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestPermission(testCase.id, viewer.id, owner.id, "VIEW");
+		await mockAuth(viewer.id, viewer.username, viewer.email);
+
+		const { POST } = await import(
+			"@/app/api/cases/[id]/information/image/route"
+		);
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/information/image`,
+			{ method: "POST", body: buildImageFormData() }
+		);
+		const response = await POST(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(403);
+	});
+});
+
+describe("DELETE /api/cases/[id]/information/image", () => {
+	it("clears the feature image and deletes the stored file", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST, DELETE } = await import(
+			"@/app/api/cases/[id]/information/image/route"
+		);
+		const uploadReq = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/information/image`,
+			{ method: "POST", body: buildImageFormData() }
+		);
+		const uploadResponse = await POST(uploadReq, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+		const { featureImageUrl } = await uploadResponse.json();
+
+		const deleteReq = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/information/image`,
+			{ method: "DELETE" }
+		);
+		const deleteResponse = await DELETE(deleteReq, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(deleteResponse.status).toBe(200);
+
+		const { fileExists } = await import("@/lib/services/file-storage-service");
+		expect(await fileExists(featureImageUrl)).toBe(false);
+
+		const { getCaseInformation } = await import(
+			"@/lib/services/case-information-service"
+		);
+		const result = await getCaseInformation(owner.id, testCase.id);
+		expect("data" in result && result.data?.featureImageUrl).toBe("");
+	});
+
+	it("is a no-op when there is no feature image", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestCaseInformation(testCase.id, { featureImageUrl: "" });
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { DELETE } = await import(
+			"@/app/api/cases/[id]/information/image/route"
+		);
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/information/image`,
+			{ method: "DELETE" }
+		);
+		const response = await DELETE(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(200);
+	});
+
+	it("returns 401 when the request is not authenticated", async () => {
+		const { DELETE } = await import(
+			"@/app/api/cases/[id]/information/image/route"
+		);
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${NON_EXISTENT_CASE_ID}/information/image`,
+			{ method: "DELETE" }
+		);
+		const response = await DELETE(req, {
+			params: Promise.resolve({ id: NON_EXISTENT_CASE_ID }),
+		});
+
+		expect(response.status).toBe(401);
+	});
+
+	it("returns 403 for a user with only VIEW permission", async () => {
+		const owner = await createTestUser();
+		const viewer = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestPermission(testCase.id, viewer.id, owner.id, "VIEW");
+		await createTestCaseInformation(testCase.id, {
+			featureImageUrl: "/uploads/cases/pre-existing.png",
+		});
+		await mockAuth(viewer.id, viewer.username, viewer.email);
+
+		const { DELETE } = await import(
+			"@/app/api/cases/[id]/information/image/route"
+		);
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/information/image`,
+			{ method: "DELETE" }
+		);
+		const response = await DELETE(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(403);
+	});
+});

--- a/src/__tests__/integration/api-case-information-image.test.ts
+++ b/src/__tests__/integration/api-case-information-image.test.ts
@@ -152,6 +152,17 @@ describe("POST /api/cases/[id]/information/image", () => {
 		await createTestPermission(testCase.id, viewer.id, owner.id, "VIEW");
 		await mockAuth(viewer.id, viewer.username, viewer.email);
 
+		// The route saves the file to disk before the EDIT-permission check
+		// rejects the persist step, then cleans up via deleteFile(). Spy on
+		// deleteFile (default vi.spyOn behaviour still calls through to the
+		// real implementation) to capture the path it was given, so we can
+		// independently verify the file is actually gone from disk rather
+		// than just trusting that deleteFile() was invoked.
+		const fileStorageService = await import(
+			"@/lib/services/file-storage-service"
+		);
+		const deleteFileSpy = vi.spyOn(fileStorageService, "deleteFile");
+
 		const { POST } = await import(
 			"@/app/api/cases/[id]/information/image/route"
 		);
@@ -164,6 +175,18 @@ describe("POST /api/cases/[id]/information/image", () => {
 		});
 
 		expect(response.status).toBe(403);
+		expect(deleteFileSpy).toHaveBeenCalledTimes(1);
+		const deleteFileCall = deleteFileSpy.mock.calls[0];
+		if (!deleteFileCall) {
+			throw new Error("deleteFile was not called");
+		}
+		const [savedPath] = deleteFileCall;
+		expect(savedPath).toMatch(UPLOADED_PATH_PATTERN);
+
+		const { fileExists } = fileStorageService;
+		expect(await fileExists(savedPath)).toBe(false);
+
+		deleteFileSpy.mockRestore();
 	});
 });
 
@@ -202,7 +225,7 @@ describe("DELETE /api/cases/[id]/information/image", () => {
 			"@/lib/services/case-information-service"
 		);
 		const result = await getCaseInformation(owner.id, testCase.id);
-		expect("data" in result && result.data?.featureImageUrl).toBe("");
+		expect("data" in result && result.data?.featureImageUrl).toBe(null);
 	});
 
 	it("is a no-op when there is no feature image", async () => {

--- a/src/__tests__/integration/api-case-information.test.ts
+++ b/src/__tests__/integration/api-case-information.test.ts
@@ -1,0 +1,262 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	createTestCase,
+	createTestCaseInformation,
+	createTestPermission,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+const NON_EXISTENT_CASE_ID = "00000000-0000-0000-0000-000000000000";
+
+beforeEach(async () => {
+	await mockNoAuth();
+});
+
+// ============================================
+// GET /api/cases/[id]/information
+// ============================================
+
+describe("GET /api/cases/[id]/information", () => {
+	it("returns null for a case with no case information yet", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { GET } = await import("@/app/api/cases/[id]/information/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/information`
+		);
+		const response = await GET(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toBeNull();
+	});
+
+	it("returns the record when one exists", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestCaseInformation(testCase.id, {
+			description: "A narrative description",
+			authors: "Ada Lovelace",
+			sector: "Healthcare",
+			featureImageUrl: "https://example.com/feature.png",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { GET } = await import("@/app/api/cases/[id]/information/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/information`
+		);
+		const response = await GET(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.description).toBe("A narrative description");
+		expect(body.authors).toBe("Ada Lovelace");
+		expect(body.sector).toBe("Healthcare");
+		expect(body.featureImageUrl).toBe("https://example.com/feature.png");
+	});
+
+	it("returns 401 when the request is not authenticated", async () => {
+		const { GET } = await import("@/app/api/cases/[id]/information/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${NON_EXISTENT_CASE_ID}/information`
+		);
+		const response = await GET(req, {
+			params: Promise.resolve({ id: NON_EXISTENT_CASE_ID }),
+		});
+
+		expect(response.status).toBe(401);
+	});
+
+	it("returns 403 for a non-existent case (anti-enumeration via Permission denied)", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { GET } = await import("@/app/api/cases/[id]/information/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${NON_EXISTENT_CASE_ID}/information`
+		);
+		const response = await GET(req, {
+			params: Promise.resolve({ id: NON_EXISTENT_CASE_ID }),
+		});
+
+		expect(response.status).toBe(403);
+	});
+
+	it("returns 403 for a case the user has no permission on", async () => {
+		const owner = await createTestUser();
+		const stranger = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(stranger.id, stranger.username, stranger.email);
+
+		const { GET } = await import("@/app/api/cases/[id]/information/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/information`
+		);
+		const response = await GET(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(403);
+	});
+
+	it("returns 200 for a user with VIEW permission", async () => {
+		const owner = await createTestUser();
+		const viewer = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestPermission(testCase.id, viewer.id, owner.id, "VIEW");
+		await mockAuth(viewer.id, viewer.username, viewer.email);
+
+		const { GET } = await import("@/app/api/cases/[id]/information/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/information`
+		);
+		const response = await GET(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(200);
+	});
+});
+
+// ============================================
+// PUT /api/cases/[id]/information
+// ============================================
+
+describe("PUT /api/cases/[id]/information", () => {
+	it("creates a case-information record for the owner", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await import("@/app/api/cases/[id]/information/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/information`,
+			{
+				method: "PUT",
+				body: JSON.stringify({
+					description: "New description",
+					authors: "Grace Hopper",
+					sector: "Defence",
+				}),
+			}
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.description).toBe("New description");
+		expect(body.authors).toBe("Grace Hopper");
+		expect(body.sector).toBe("Defence");
+	});
+
+	it("updates only the fields supplied, leaving others untouched", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestCaseInformation(testCase.id, {
+			description: "Original description",
+			authors: "Original authors",
+			sector: "Original sector",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await import("@/app/api/cases/[id]/information/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/information`,
+			{
+				method: "PUT",
+				body: JSON.stringify({ description: "Updated description" }),
+			}
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.description).toBe("Updated description");
+		expect(body.authors).toBe("Original authors");
+		expect(body.sector).toBe("Original sector");
+	});
+
+	it("returns 400 when no fields are supplied", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await import("@/app/api/cases/[id]/information/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/information`,
+			{ method: "PUT", body: JSON.stringify({}) }
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns 401 when the request is not authenticated", async () => {
+		const { PUT } = await import("@/app/api/cases/[id]/information/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${NON_EXISTENT_CASE_ID}/information`,
+			{ method: "PUT", body: JSON.stringify({ description: "x" }) }
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: NON_EXISTENT_CASE_ID }),
+		});
+
+		expect(response.status).toBe(401);
+	});
+
+	it("returns 403 for a user with only VIEW permission", async () => {
+		const owner = await createTestUser();
+		const viewer = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestPermission(testCase.id, viewer.id, owner.id, "VIEW");
+		await mockAuth(viewer.id, viewer.username, viewer.email);
+
+		const { PUT } = await import("@/app/api/cases/[id]/information/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/information`,
+			{ method: "PUT", body: JSON.stringify({ description: "x" }) }
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(403);
+	});
+
+	it("returns 200 for a user with EDIT permission", async () => {
+		const owner = await createTestUser();
+		const editor = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestPermission(testCase.id, editor.id, owner.id, "EDIT");
+		await mockAuth(editor.id, editor.username, editor.email);
+
+		const { PUT } = await import("@/app/api/cases/[id]/information/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/information`,
+			{ method: "PUT", body: JSON.stringify({ description: "x" }) }
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(200);
+	});
+});

--- a/src/__tests__/setup/framework-mocks.tsx
+++ b/src/__tests__/setup/framework-mocks.tsx
@@ -95,7 +95,7 @@ vi.mock("@/hooks/modal-hooks", () => ({
 	useExportModal: mockModalHook,
 	useImportModal: mockModalHook,
 	usePermissionsModal: mockModalHook,
-	useResourcesModal: mockModalHook,
+	useHelpModal: mockModalHook,
 }));
 
 // Mock the entire ModalProvider to prevent modal rendering in tests

--- a/store/__tests__/case-details-open.test.ts
+++ b/store/__tests__/case-details-open.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import useStore from "../store";
+
+/**
+ * The case-information sheet has two entry points — the title-click
+ * (`Header`) and the toolbar's "Case Information" button (`ActionButtons`)
+ * — that live in different parts of the component tree from where the
+ * sheet itself (`CaseDetails`) is rendered (`CaseContainer`). This one
+ * store flag is what connects them (same pattern as `commentsSheetOpen`),
+ * so it is worth pinning directly rather than only through each caller.
+ */
+describe("useStore — caseDetailsOpen", () => {
+	beforeEach(() => {
+		useStore.setState({ caseDetailsOpen: false });
+	});
+
+	it("defaults to closed", () => {
+		expect(useStore.getState().caseDetailsOpen).toBe(false);
+	});
+
+	it("opens via setCaseDetailsOpen(true)", () => {
+		useStore.getState().setCaseDetailsOpen(true);
+		expect(useStore.getState().caseDetailsOpen).toBe(true);
+	});
+
+	it("closes via setCaseDetailsOpen(false)", () => {
+		useStore.getState().setCaseDetailsOpen(true);
+		useStore.getState().setCaseDetailsOpen(false);
+		expect(useStore.getState().caseDetailsOpen).toBe(false);
+	});
+});

--- a/store/store.ts
+++ b/store/store.ts
@@ -40,6 +40,11 @@ interface Member {
 interface Store {
 	activeUsers: UserResponse[];
 	assuranceCase: AssuranceCaseResponse | null;
+	// Case information sheet state (ADR 0003 §1/§2 — the title-click sheet and
+	// the toolbar's "Case Information" button are two entry points onto the
+	// same component; both flip this one flag so the sheet lives in a single
+	// place in the tree, same pattern as `commentsSheetOpen` below).
+	caseDetailsOpen: boolean;
 	caseNotes: CommentResponse[];
 	commentsSheetNode: Node | null;
 	// Comments sheet state
@@ -58,6 +63,7 @@ interface Store {
 	reviewMembers: Member[];
 	setActiveUsers: (users: UserResponse[]) => void;
 	setAssuranceCase: (assuranceCase: AssuranceCaseResponse | null) => void;
+	setCaseDetailsOpen: (open: boolean) => void;
 	setCaseNotes: (comments: CommentResponse[]) => void;
 	setCommentsSheetNode: (node: Node | null) => void;
 	setCommentsSheetOpen: (open: boolean) => void;
@@ -231,6 +237,11 @@ const useStore = create<Store>((set, get) => ({
 	},
 	setCommentsSheetNode: (node: Node | null) => {
 		set({ commentsSheetNode: node });
+	},
+	// Case information sheet state
+	caseDetailsOpen: false,
+	setCaseDetailsOpen: (open: boolean) => {
+		set({ caseDetailsOpen: open });
 	},
 }));
 


### PR DESCRIPTION
## What this adds

The case information editing surface — second item of the publishing chain, consuming the schema/service layer that landed yesterday.

- **Case information section** in the case-details sheet: description, authors, sector, feature image. Anyone with case access can view; case EDIT permission can save. Two entry points, one component: the case title and the toolbar button.
- **Toolbar swap:** the ⓘ button (formerly "Resources") is now **Case Information**; the Resources content moved verbatim to a new **?** Help button. (Making Help genuinely useful is tracked separately.)
- **Routes:** `GET/PUT /api/cases/[id]/information` and `POST/DELETE .../information/image` (multipart upload reusing the shared file-storage service), delegating to the merged case-information service. `featureImageUrl` uses an explicit nullable-clear semantic (`null` clears, omitted leaves untouched) end to end.
- Onboarding tour reference and copy updated for the renamed button.

## Tests

55 integration (full permission matrices at the service layer, route wiring, image upload incl. a verified no-orphaned-files path) + 18 component/store/hook unit tests + e2e specs for both entry points (title-click spec runs in this PR's CI — local sandbox can't decrypt auth secrets); tsc + lint clean; react-doctor clean on new code.