### PR TITLE
Add assertionStatus core field (ADR 0004 D3)

### DIFF
--- a/app/api/cases/[id]/elements/route.ts
+++ b/app/api/cases/[id]/elements/route.ts
@@ -9,6 +9,7 @@ import { validationError } from "@/lib/errors";
 import { createElementSchema } from "@/lib/schemas/element";
 import type { CreateElementInput } from "@/lib/services/element-service";
 import { createElement } from "@/lib/services/element-service";
+import type { AssertionStatus } from "@/src/generated/prisma";
 
 /**
  * Resolves `parentId` from the request body.
@@ -60,6 +61,10 @@ function buildCreateInput(
 		urls: body.urls as string[] | undefined,
 		assumption: body.assumption as string | undefined,
 		justification: body.justification as string | undefined,
+		// Per-assertion status (ADR 0004 D3) — validated by createElementSchema;
+		// the guard against machine/integration writers and AS_CITED declaration
+		// lives in element-service.ts (createElement), not here.
+		assertionStatus: body.assertionStatus as AssertionStatus | null | undefined,
 	};
 }
 

--- a/app/api/elements/[id]/route.ts
+++ b/app/api/elements/[id]/route.ts
@@ -13,6 +13,7 @@ import {
 	getElement,
 	updateElement,
 } from "@/lib/services/element-service";
+import type { AssertionStatus } from "@/src/generated/prisma";
 
 /**
  * GET /api/elements/[id]
@@ -55,6 +56,10 @@ function buildUpdateInput(body: Record<string, unknown>): UpdateElementInput {
 		justification: body.justification as string | undefined,
 		context: body.context as string[] | undefined,
 		inSandbox: body.inSandbox as boolean | undefined,
+		// Per-assertion status (ADR 0004 D3) — validated by updateElementSchema;
+		// the guard against machine/integration writers and AS_CITED declaration
+		// lives in element-service.ts (updateElement), not here.
+		assertionStatus: body.assertionStatus as AssertionStatus | null | undefined,
 	};
 }
 

--- a/docs/database/schema.dbml
+++ b/docs/database/schema.dbml
@@ -237,6 +237,7 @@ Table assurance_elements {
   isDefeater Boolean [not null, default: false, note: 'True if element is a counter-argument']
   defeatsElementId String [note: 'Element this defeater challenges']
   level Int [note: 'Hierarchy depth level for property claims']
+  assertionStatus AssertionStatus
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime [not null]
   createdById String [not null]
@@ -747,6 +748,15 @@ Enum ElementType {
   MODULE
   AWAY_GOAL
   CONTRACT
+}
+
+Enum AssertionStatus {
+  ASSERTED
+  NEEDS_SUPPORT
+  ASSUMED
+  AXIOMATIC
+  DEFEATED
+  AS_CITED
 }
 
 Enum ElementRole {

--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -129,6 +129,13 @@ const ERROR_MAPPINGS: Array<{
 	// (integration management API, work item 7): an unknown scope is a
 	// validation failure (400), not an unmapped 500.
 	{ pattern: /^Unknown scope/, factory: () => validationError("") },
+	// `element-service.ts`'s `rejectDeclaredAsCited` (ADR 0004 D3): AS_CITED
+	// is machine-derived from the cited element's own status, never author-
+	// declared — a rejected write is a validation failure (400), not a 500.
+	{
+		pattern: /^assertionStatus cannot be set to AS_CITED/,
+		factory: () => validationError(""),
+	},
 	// Lifecycle/state-guard errors from the integration registry service —
 	// the integration or token exists and is owned by the caller, but its
 	// current status makes the requested action a no-op or a terminal-state

--- a/lib/schemas/case-export.ts
+++ b/lib/schemas/case-export.ts
@@ -43,9 +43,30 @@ export const ModuleEmbedTypeSchema = z
 		"How a module is embedded - COPY creates independent copy, REFERENCE links to original"
 	);
 
+/**
+ * Per-assertion status (ADR 0004 D3), mirroring SACM §11.8. Author-declared
+ * except AS_CITED, which is machine-derivable (transitively computed from
+ * the cited claim's own status) rather than author-set. Unset (null) means
+ * ASSERTED — SACM's own default — and the export layer always resolves the
+ * field to a concrete value rather than omitting it.
+ */
+export const AssertionStatusSchema = z
+	.enum([
+		"ASSERTED",
+		"NEEDS_SUPPORT",
+		"ASSUMED",
+		"AXIOMATIC",
+		"DEFEATED",
+		"AS_CITED",
+	])
+	.describe(
+		"Per-assertion status of an element (SACM §11.8); unset is treated as ASSERTED"
+	);
+
 export type ElementType = z.infer<typeof ElementTypeSchema>;
 export type ElementRole = z.infer<typeof ElementRoleSchema>;
 export type ModuleEmbedType = z.infer<typeof ModuleEmbedTypeSchema>;
+export type AssertionStatus = z.infer<typeof AssertionStatusSchema>;
 
 // ============================================
 // V2 SCHEMAS (New Prisma Format)
@@ -87,6 +108,11 @@ export const ElementV2Schema = z
 			.nullable()
 			.optional()
 			.describe("Hierarchy level for property claims"),
+		assertionStatus: AssertionStatusSchema.nullable()
+			.optional()
+			.describe(
+				"Per-assertion status (ADR 0004 D3); null/unset means ASSERTED"
+			),
 		inSandbox: z
 			.boolean()
 			.default(false)
@@ -188,8 +214,15 @@ export interface ExportComment {
  * - modulePublicSummary: MODULE only
  * - isDefeater, defeatsElementId: any type (dialogical reasoning)
  * - comments: optional, included when includeComments export option is true
+ * - assertionStatus: any type (ADR 0004 D3). Typed optional here (so
+ *   existing TreeNode-typed fixtures/consumers elsewhere in the codebase
+ *   don't all need updating), but exports THIS repo produces always set it —
+ *   buildCleanNode (lib/transforms/build-tree.ts) resolves a null/unset
+ *   stored value to "ASSERTED" (SACM's own default) rather than omitting
+ *   the field, unlike the type-specific fields above.
  */
 export interface TreeNode {
+	assertionStatus?: AssertionStatus;
 	assumption?: string | null;
 	children: TreeNode[];
 	// Comments (optional - included when export option enabled)
@@ -252,6 +285,10 @@ export const TreeNodeSchema: z.ZodType<any> = z.lazy(() =>
 		// Dialogical reasoning
 		isDefeater: z.boolean().optional(),
 		defeatsElementId: z.string().uuid().optional(),
+		// Per-assertion status (ADR 0004 D3) — optional/nullable here purely
+		// for import leniency with pre-D3 exports that never had the field;
+		// exports WE produce always set it (see buildCleanNode in build-tree.ts).
+		assertionStatus: AssertionStatusSchema.nullable().optional(),
 		// Comments (optional - included when export option enabled)
 		comments: z.array(ExportCommentSchema).optional(),
 	})

--- a/lib/schemas/element-validation.ts
+++ b/lib/schemas/element-validation.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from "zod";
+import { AssertionStatusSchema } from "./case-export";
 
 // ============================================
 // ELEMENT TYPE DEFINITIONS
@@ -173,6 +174,8 @@ const BaseElementSchema = z
 			.nullable()
 			.optional()
 			.describe("ID of the element this defeats"),
+		// Per-assertion status (ADR 0004 D3) - available to all types
+		assertionStatus: AssertionStatusSchema.nullable().optional(),
 	})
 	.describe("Base fields common to all element types");
 
@@ -352,6 +355,10 @@ export function getValidFieldsForType(elementType: string): string[] {
 		"modifiedFromPattern",
 		"isDefeater",
 		"defeatsElementId",
+		// Per-assertion status (ADR 0004 D3) — applies to every element type,
+		// same as isDefeater/defeatsElementId above, so it belongs with the
+		// base fields rather than FIELD_APPLICABILITY.
+		"assertionStatus",
 		"createdAt",
 		"updatedAt",
 		"createdById",

--- a/lib/schemas/element.ts
+++ b/lib/schemas/element.ts
@@ -1,5 +1,13 @@
 import { z } from "zod";
 import { lenientUrlSchema, optionalString, optionalUrlSchema } from "./base";
+import { AssertionStatusSchema } from "./case-export";
+
+/**
+ * Per-assertion status on create/update input (ADR 0004 D3). Author-writable
+ * via the standard element mutation path only — element-service.ts rejects
+ * this field when the acting principal is a machine/integration system user.
+ */
+const assertionStatusInputSchema = AssertionStatusSchema.nullable().optional();
 
 /**
  * Element type enum — accepts various frontend formats
@@ -33,6 +41,9 @@ export const createElementSchema = z.object({
 	assumption: optionalString(5000),
 	justification: optionalString(5000),
 	context: z.array(z.string()).optional(),
+
+	// Per-assertion status (ADR 0004 D3)
+	assertionStatus: assertionStatusInputSchema,
 });
 
 export type CreateElementSchemaInput = z.input<typeof createElementSchema>;
@@ -60,6 +71,9 @@ export const updateElementSchema = z.object({
 	assumption: optionalString(5000),
 	justification: optionalString(5000),
 	context: z.array(z.string()).optional(),
+
+	// Per-assertion status (ADR 0004 D3)
+	assertionStatus: assertionStatusInputSchema,
 
 	// Sandbox flag
 	inSandbox: z.boolean().optional(),

--- a/lib/services/case-export-service.ts
+++ b/lib/services/case-export-service.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import type {
+	AssertionStatus,
 	CaseExportNested,
 	ElementRole,
 	ElementType,
@@ -139,6 +140,8 @@ export async function exportCase(
 						// Dialogical reasoning
 						isDefeater: true,
 						defeatsElementId: true,
+						// Per-assertion status (ADR 0004 D3)
+						assertionStatus: true,
 						// Include evidence linked TO this element (claims get their evidence)
 						evidenceLinksTo: {
 							where: {
@@ -170,6 +173,8 @@ export async function exportCase(
 										// Dialogical reasoning
 										isDefeater: true,
 										defeatsElementId: true,
+										// Per-assertion status (ADR 0004 D3)
+										assertionStatus: true,
 									},
 								},
 							},
@@ -226,6 +231,8 @@ export async function exportCase(
 			// Dialogical reasoning
 			isDefeater: el.isDefeater,
 			defeatsElementId: el.defeatsElementId,
+			// Per-assertion status (ADR 0004 D3)
+			assertionStatus: el.assertionStatus as AssertionStatus | null,
 			// Comments (if requested)
 			comments: includeComments ? commentsMap.get(el.id) : undefined,
 			evidenceLinksTo: el.evidenceLinksTo.map((link) => ({
@@ -254,6 +261,9 @@ export async function exportCase(
 					// Dialogical reasoning
 					isDefeater: link.evidence.isDefeater,
 					defeatsElementId: link.evidence.defeatsElementId,
+					// Per-assertion status (ADR 0004 D3)
+					assertionStatus: link.evidence
+						.assertionStatus as AssertionStatus | null,
 					// Comments for evidence (if requested)
 					comments: includeComments
 						? commentsMap.get(link.evidence.id)

--- a/lib/services/case-import-service.ts
+++ b/lib/services/case-import-service.ts
@@ -203,6 +203,14 @@ async function createElements(
 				inSandbox: el.inSandbox,
 				fromPattern: el.fromPattern ?? false,
 				modifiedFromPattern: el.modifiedFromPattern ?? false,
+				// Per-assertion status (ADR 0004 D3) — lead ruling: import
+				// PRESERVES a declared status rather than dropping it. This is a
+				// direct createMany write (not through createElement/updateElement),
+				// so it intentionally bypasses guardAssertionStatusWrite/
+				// rejectDeclaredAsCited: import is a bulk data-load operation, not
+				// an author declaring a NEW status, and the source data already
+				// passed through export's own AS_CITED derivation.
+				assertionStatus: el.assertionStatus,
 				createdById: userId,
 			};
 		})

--- a/lib/services/element-service.ts
+++ b/lib/services/element-service.ts
@@ -92,6 +92,24 @@ async function guardAssertionStatusWrite(
 }
 
 /**
+ * ADR 0004 D3: AS_CITED is transitively DERIVED by the exporter from the
+ * cited element's own status (see build-tree.ts) — it is never author-
+ * declared. This is a value constraint (applies to every acting principal,
+ * including a genuine human author), so it is checked independently of
+ * `guardAssertionStatusWrite`, which is a principal constraint. No live
+ * exploit today (the D5 auto-derivation work hasn't landed), but the write
+ * rule must hold before these routes open to authors.
+ */
+function rejectDeclaredAsCited(
+	status: AssertionStatus | null | undefined
+): string | undefined {
+	if (status === "AS_CITED") {
+		return "assertionStatus cannot be set to AS_CITED: it is derived automatically from the cited element's status, not author-declared";
+	}
+	return;
+}
+
+/**
  * Resolves parent ID from input.
  * Returns undefined if no parent field is specified (to distinguish from explicitly setting null).
  */
@@ -410,6 +428,10 @@ export async function createElement(
 	}
 
 	if (input.assertionStatus !== undefined) {
+		const citedError = rejectDeclaredAsCited(input.assertionStatus);
+		if (citedError) {
+			return { error: citedError };
+		}
 		const writeError = await guardAssertionStatusWrite(userId);
 		if (writeError) {
 			return { error: writeError };
@@ -600,6 +622,10 @@ export async function updateElement(
 		// see guardAssertionStatusWrite's docstring for why case-level EDIT
 		// access alone isn't a sufficient gate.
 		if (input.assertionStatus !== undefined) {
+			const citedError = rejectDeclaredAsCited(input.assertionStatus);
+			if (citedError) {
+				return { error: citedError };
+			}
 			const writeError = await guardAssertionStatusWrite(userId);
 			if (writeError) {
 				return { error: writeError };

--- a/lib/services/element-service.ts
+++ b/lib/services/element-service.ts
@@ -10,6 +10,7 @@ import {
 	getDescendantIds,
 } from "@/lib/utils/tree-traversal";
 import type {
+	AssertionStatus,
 	PermissionLevel,
 	ElementType as PrismaElementType,
 } from "@/src/generated/prisma";
@@ -32,6 +33,7 @@ export type CreateElementInput = CreateElementSchemaOutput & {
 export type UpdateElementInput = UpdateElementSchemaOutput;
 
 export interface ElementResponse {
+	assertionStatus?: AssertionStatus | null;
 	assumption?: string;
 	assuranceCaseId: string;
 	comments?: unknown[];
@@ -61,6 +63,32 @@ async function validateCaseAccess(
 ): Promise<boolean> {
 	const { canAccessCase } = await import("@/lib/permissions");
 	return canAccessCase({ userId, caseId }, requiredLevel);
+}
+
+/**
+ * ADR 0004 D3 write rule: `assertionStatus` is author-declared and must
+ * never be machine-overwritten. Case-level permission (`validateCaseAccess`)
+ * is necessary but not sufficient — an integration's system user can hold a
+ * genuine EDIT grant on a case (`grantIntegrationCaseAccess`) and would
+ * otherwise pass that check identically to a human author. This is the
+ * dedicated, defense-in-depth check that keeps the standard element
+ * mutation path (`createElement`/`updateElement`) as the ONLY route that can
+ * set the field, regardless of what future machine/plugin routes end up
+ * calling into this service. Returns an error string (matching this
+ * service's `ServiceResult` convention) when the acting user is a system
+ * user; `undefined` when the write may proceed.
+ */
+async function guardAssertionStatusWrite(
+	userId: string
+): Promise<string | undefined> {
+	const actor = await prisma.user.findUnique({
+		where: { id: userId },
+		select: { isSystemUser: true },
+	});
+	if (actor?.isSystemUser) {
+		return "Permission denied: assertionStatus can only be set by a case author, not a machine or integration principal";
+	}
+	return;
 }
 
 /**
@@ -340,6 +368,7 @@ async function createElementInDatabase(
 			justification: input.justification,
 			context: input.context ?? [],
 			level,
+			assertionStatus: input.assertionStatus,
 			createdById: userId,
 		},
 		include: {
@@ -378,6 +407,13 @@ export async function createElement(
 	const hasAccess = await validateCaseAccess(userId, caseId, "EDIT");
 	if (!hasAccess) {
 		return { error: "Permission denied" };
+	}
+
+	if (input.assertionStatus !== undefined) {
+		const writeError = await guardAssertionStatusWrite(userId);
+		if (writeError) {
+			return { error: writeError };
+		}
 	}
 
 	const elementType = toPrismaType(input.elementType);
@@ -488,6 +524,9 @@ function buildUpdateData(input: UpdateElementInput): Record<string, unknown> {
 	if (input.inSandbox !== undefined) {
 		updateData.inSandbox = input.inSandbox;
 	}
+	if (input.assertionStatus !== undefined) {
+		updateData.assertionStatus = input.assertionStatus;
+	}
 
 	return updateData;
 }
@@ -555,6 +594,16 @@ export async function updateElement(
 		const hasAccess = await validateCaseAccess(userId, existing.caseId, "EDIT");
 		if (!hasAccess) {
 			return { error: "Element not found" };
+		}
+
+		// ADR 0004 D3 write rule: assertionStatus is author-declared only —
+		// see guardAssertionStatusWrite's docstring for why case-level EDIT
+		// access alone isn't a sufficient gate.
+		if (input.assertionStatus !== undefined) {
+			const writeError = await guardAssertionStatusWrite(userId);
+			if (writeError) {
+				return { error: writeError };
+			}
 		}
 
 		// Build update data from input fields

--- a/lib/transforms/build-tree.ts
+++ b/lib/transforms/build-tree.ts
@@ -6,6 +6,7 @@
  */
 
 import type {
+	AssertionStatus,
 	ElementRole,
 	ElementType,
 	ExportComment,
@@ -18,6 +19,10 @@ import { fieldAppliesTo } from "../schemas/element-validation";
  * Element with evidence links as returned from Prisma query.
  */
 export interface ElementWithLinks {
+	// ADR 0004 D3 — null means unset; buildCleanNode resolves it to
+	// "ASSERTED" (SACM's own default) rather than omitting the field, unlike
+	// every other field below.
+	assertionStatus: AssertionStatus | null;
 	assumption: string | null;
 	// Comments (optional - only included when export includes comments)
 	comments?: ExportComment[];
@@ -137,6 +142,10 @@ function buildCleanNode(
 		name: element.name,
 		description: element.description,
 		inSandbox: element.inSandbox,
+		// ADR 0004 D3: always present on export, never omitted — null/unset
+		// resolves to the SACM default rather than disappearing like the
+		// TYPE_SPECIFIC_FIELDS below.
+		assertionStatus: element.assertionStatus ?? "ASSERTED",
 	};
 
 	// Cast to allow dynamic field assignment

--- a/lib/transforms/element-response.ts
+++ b/lib/transforms/element-response.ts
@@ -1,5 +1,6 @@
 import { toDisplayType } from "@/lib/element-types";
 import type { ElementResponse } from "@/lib/services/element-service";
+import type { AssertionStatus } from "@/src/generated/prisma";
 
 /**
  * Adds parent reference to response based on parent element type
@@ -46,6 +47,10 @@ export function transformToResponse(element: {
 	urls: string[];
 	inSandbox: boolean;
 	level: number | null;
+	// ADR 0004 D3 — nullable; null means unset (interpreted as ASSERTED at
+	// export time in build-tree.ts, not here — this response mirrors the
+	// raw stored value for the canvas/JSON-editor UI).
+	assertionStatus?: AssertionStatus | null;
 	caseId: string;
 	parentId: string | null;
 	createdAt: Date;
@@ -89,6 +94,9 @@ export function transformToResponse(element: {
 	}
 	if (element.level !== null) {
 		response.level = element.level;
+	}
+	if (element.assertionStatus) {
+		response.assertionStatus = element.assertionStatus;
 	}
 
 	return response;

--- a/lib/transforms/nested-to-flat.ts
+++ b/lib/transforms/nested-to-flat.ts
@@ -91,6 +91,10 @@ function nodeToElement(
 		inSandbox: node.inSandbox,
 		fromPattern: node.fromPattern,
 		modifiedFromPattern: node.modifiedFromPattern,
+		// Per-assertion status (ADR 0004 D3) — preserve the declared status
+		// through the nested→flat step; case-import-service.ts's createElements
+		// carries it the rest of the way into the createMany rows.
+		assertionStatus: node.assertionStatus,
 	};
 
 	// Preserve comments if present

--- a/prisma/migrations/20260719000000_add_element_assertion_status/migration.sql
+++ b/prisma/migrations/20260719000000_add_element_assertion_status/migration.sql
@@ -1,0 +1,9 @@
+-- ADR 0004 D3: per-assertion status core field. Additive only — nullable
+-- column, no backfill, no behaviour change for existing rows. Null means
+-- "unset" and is interpreted/exported as the SACM default (ASSERTED).
+
+-- CreateEnum
+CREATE TYPE "AssertionStatus" AS ENUM ('ASSERTED', 'NEEDS_SUPPORT', 'ASSUMED', 'AXIOMATIC', 'DEFEATED', 'AS_CITED');
+
+-- AlterTable
+ALTER TABLE "assurance_elements" ADD COLUMN "assertion_status" "AssertionStatus";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -413,6 +413,13 @@ model AssuranceElement {
   // Level (calculated, for property claims)
   level               Int?             /// Hierarchy depth level for property claims
 
+  // Per-assertion status (ADR 0004 D3): author-declared argumentation
+  // semantics mirroring SACM §11.8. Nullable — null means unset and is
+  // interpreted/exported as the SACM default (ASSERTED). Write rule
+  // (author-declared, machine-derivable/proposable, never machine-
+  // overwritten) is enforced in lib/services/element-service.ts, not here.
+  assertionStatus     AssertionStatus? @map("assertion_status")
+
   // Timestamps
   createdAt           DateTime         @default(now()) @map("created_at")
   updatedAt           DateTime         @updatedAt @map("updated_at")
@@ -459,6 +466,18 @@ enum ElementType {
   MODULE
   AWAY_GOAL
   CONTRACT
+}
+
+/// Per-assertion status (ADR 0004 D3), mirroring SACM §11.8. AS_CITED is
+/// machine-derivable (transitively computed from the cited claim's own
+/// status) — the other five are author-declared only.
+enum AssertionStatus {
+  ASSERTED
+  NEEDS_SUPPORT
+  ASSUMED
+  AXIOMATIC
+  DEFEATED
+  AS_CITED
 }
 
 enum ElementRole {

--- a/src/__tests__/integration/api-elements-assertion-status.test.ts
+++ b/src/__tests__/integration/api-elements-assertion-status.test.ts
@@ -1,0 +1,180 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	createTestCase,
+	createTestElement,
+	createTestIntegrationWithSystemUser,
+	createTestPermission,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+/**
+ * Review follow-up (round 2, vincent, BLOCKER): both mutation routes
+ * validated `assertionStatus` via Zod, then dropped it in their hand-
+ * maintained input builders (`buildCreateInput` / `buildUpdateInput`) — the
+ * guarded service (element-service.ts) never received it, so no author
+ * could actually set the field through the API. The permission-matrix
+ * tests in element-assertion-status-permissions.test.ts call
+ * `createElement`/`updateElement` directly, which is why they never caught
+ * this — these tests exercise the ACTUAL route handlers
+ * (app/api/cases/[id]/elements/route.ts, app/api/elements/[id]/route.ts)
+ * to prove the field is reachable end-to-end, not just correct at the
+ * service layer.
+ */
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/services/sse-connection-manager", () => ({
+	emitSSEEvent: vi.fn(),
+	sseConnectionManager: { broadcast: vi.fn() },
+}));
+
+const PERMISSION_DENIED_PATTERN = /Permission denied/;
+
+beforeEach(async () => {
+	await mockNoAuth();
+});
+
+describe("POST /api/cases/[id]/elements — assertionStatus (ADR 0004 D3)", () => {
+	it("lets an author set assertionStatus through the route handler, persisted per a separate refetch", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import("@/app/api/cases/[id]/elements/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/elements`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					type: "goal",
+					name: "Root Goal",
+					description: "Top-level goal",
+					assertionStatus: "NEEDS_SUPPORT",
+				}),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await POST(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(201);
+		const body = await response.json();
+		expect(body.assertionStatus).toBe("NEEDS_SUPPORT");
+
+		// Separate refetch — proves DB persistence, not just an echoed response.
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: body.id },
+		});
+		expect(inDb?.assertionStatus).toBe("NEEDS_SUPPORT");
+	});
+
+	it("rejects a system/integration user through the route (proves the guard is reachable via the real HTTP path)", async () => {
+		const owner = await createTestUser();
+		const { systemUser } = await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(owner.id);
+		// A genuine EDIT grant, as a real integration would hold
+		// (grantIntegrationCaseAccess) — not a test-only shortcut.
+		await createTestPermission(testCase.id, systemUser.id, owner.id, "EDIT");
+		await mockAuth(systemUser.id, systemUser.username, systemUser.email);
+
+		const { POST } = await import("@/app/api/cases/[id]/elements/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/elements`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					type: "goal",
+					name: "Root Goal",
+					description: "Top-level goal",
+					assertionStatus: "ASSUMED",
+				}),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await POST(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(403);
+		const body = await response.json();
+		expect(body.error).toMatch(PERMISSION_DENIED_PATTERN);
+
+		const elements = await prisma.assuranceElement.findMany({
+			where: { caseId: testCase.id },
+		});
+		expect(elements).toHaveLength(0);
+	});
+});
+
+describe("PUT /api/elements/[id] — assertionStatus (ADR 0004 D3)", () => {
+	it("lets an author set assertionStatus through the route handler, persisted per a separate refetch", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const element = await createTestElement(testCase.id, owner.id, {
+			elementType: "GOAL",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await import("@/app/api/elements/[id]/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/elements/${element.id}`,
+			{
+				method: "PUT",
+				body: JSON.stringify({ assertionStatus: "DEFEATED" }),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: element.id }),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.assertionStatus).toBe("DEFEATED");
+
+		// Separate refetch — proves DB persistence, not just an echoed response.
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: element.id },
+		});
+		expect(inDb?.assertionStatus).toBe("DEFEATED");
+	});
+
+	it("rejects a system/integration user through the route (proves the guard is reachable via the real HTTP path)", async () => {
+		const owner = await createTestUser();
+		const { systemUser } = await createTestIntegrationWithSystemUser(owner.id);
+		const testCase = await createTestCase(owner.id);
+		await createTestPermission(testCase.id, systemUser.id, owner.id, "EDIT");
+		const element = await createTestElement(testCase.id, owner.id, {
+			elementType: "GOAL",
+		});
+		await mockAuth(systemUser.id, systemUser.username, systemUser.email);
+
+		const { PUT } = await import("@/app/api/elements/[id]/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/elements/${element.id}`,
+			{
+				method: "PUT",
+				body: JSON.stringify({ assertionStatus: "DEFEATED" }),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: element.id }),
+		});
+
+		expect(response.status).toBe(403);
+		const body = await response.json();
+		expect(body.error).toMatch(PERMISSION_DENIED_PATTERN);
+
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: element.id },
+		});
+		expect(inDb?.assertionStatus).toBeNull();
+	});
+});

--- a/src/__tests__/integration/case-batch-update-service.test.ts
+++ b/src/__tests__/integration/case-batch-update-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ElementChange } from "@/lib/case/tree-diff";
+import type { ElementChange, UpdateElementData } from "@/lib/case/tree-diff";
 import prisma from "@/lib/prisma";
 import {
 	expectError,
@@ -404,5 +404,58 @@ describe("applyBatchUpdate", () => {
 			where: { id: element.id },
 		});
 		expect(unchanged?.name).toBe("Should Remain Unchanged");
+	});
+
+	/**
+	 * ADR 0004 D3, review follow-up: the batch/JSON-editor path is deliberately
+	 * NOT wired for assertionStatus (deferred to
+	 * "TEA — assertionStatus surface completion (batch, undo-redo, UI)").
+	 * `UpdateElementData` has no `assertionStatus` field and `buildUpdateData`'s
+	 * fixed field allowlist doesn't include it, so this is structurally
+	 * impossible today. This test locks that down: a future refactor of the
+	 * field list (e.g. spreading `data` instead of allowlisting fields) could
+	 * silently open an unguarded write route that bypasses
+	 * `guardAssertionStatusWrite`/`rejectDeclaredAsCited` entirely — this test
+	 * pins the current safe behaviour so that regression fails loudly.
+	 */
+	it("PINS: a batch update payload carrying assertionStatus cannot set or alter a stored value", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+		const element = await createTestElement(testCase.id, user.id, {
+			elementType: "GOAL",
+			name: "Batch Target",
+			description: "Original description",
+		});
+		expect(element.assertionStatus).toBeNull();
+
+		const { applyBatchUpdate } = await import(
+			"@/lib/services/case-batch-update-service"
+		);
+
+		const changes: ElementChange[] = [
+			{
+				type: "update",
+				elementId: element.id,
+				// UpdateElementData has no assertionStatus field — this cast
+				// simulates a payload that tries to smuggle it in anyway.
+				data: {
+					name: "Batch Target Renamed",
+					assertionStatus: "DEFEATED",
+				} as unknown as UpdateElementData,
+			},
+		];
+
+		const data = expectSuccess(
+			await applyBatchUpdate(user.id, testCase.id, changes)
+		);
+		expect(data.summary.updated).toBe(1);
+
+		const afterBatch = await prisma.assuranceElement.findUnique({
+			where: { id: element.id },
+		});
+		// The allowlisted field DID apply...
+		expect(afterBatch?.name).toBe("Batch Target Renamed");
+		// ...but the smuggled field did not.
+		expect(afterBatch?.assertionStatus).toBeNull();
 	});
 });

--- a/src/__tests__/integration/case-export.test.ts
+++ b/src/__tests__/integration/case-export.test.ts
@@ -190,4 +190,69 @@ describe("exportCase", () => {
 		// Comments should be undefined when not requested
 		expect(rootNode.comments).toBeUndefined();
 	});
+
+	describe("assertionStatus (ADR 0004 D3)", () => {
+		it("exports an unset (null) assertionStatus as the SACM default ASSERTED, never omitted", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			const goal = await createTestElement(testCase.id, owner.id, {
+				elementType: "GOAL",
+				name: "Root Goal",
+				description: "Top-level goal",
+				role: "TOP_LEVEL",
+			});
+			expect(goal.assertionStatus).toBeNull();
+
+			const { exportCase } = await import("@/lib/services/case-export-service");
+			const data = expectSuccess(await exportCase(owner.id, testCase.id));
+
+			expect(data.tree.assertionStatus).toBe("ASSERTED");
+		});
+
+		it("round-trips a declared assertionStatus through export", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			await createTestElement(testCase.id, owner.id, {
+				elementType: "GOAL",
+				name: "Root Goal",
+				description: "Top-level goal",
+				role: "TOP_LEVEL",
+				assertionStatus: "NEEDS_SUPPORT",
+			});
+
+			const { exportCase } = await import("@/lib/services/case-export-service");
+			const data = expectSuccess(await exportCase(owner.id, testCase.id));
+
+			expect(data.tree.assertionStatus).toBe("NEEDS_SUPPORT");
+		});
+
+		it("resolves assertionStatus per-node — evidence linked to an unset claim still carries its own declared status", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			const goal = await createTestElement(testCase.id, owner.id, {
+				elementType: "GOAL",
+				name: "Root Goal",
+				description: "Top-level goal",
+				role: "TOP_LEVEL",
+			});
+			const evidence = await createTestElement(testCase.id, owner.id, {
+				elementType: "EVIDENCE",
+				name: "Evidence",
+				description: "Supporting evidence",
+				assertionStatus: "AS_CITED",
+			});
+			await prisma.evidenceLink.create({
+				data: { evidenceId: evidence.id, claimId: goal.id },
+			});
+
+			const { exportCase } = await import("@/lib/services/case-export-service");
+			const data = expectSuccess(await exportCase(owner.id, testCase.id));
+
+			expect(data.tree.assertionStatus).toBe("ASSERTED");
+			const evidenceNode = data.tree.children.find(
+				(c: { type: string }) => c.type === "EVIDENCE"
+			);
+			expect(evidenceNode?.assertionStatus).toBe("AS_CITED");
+		});
+	});
 });

--- a/src/__tests__/integration/case-import.test.ts
+++ b/src/__tests__/integration/case-import.test.ts
@@ -8,6 +8,8 @@ import {
 import {
 	createNestedCaseJSON,
 	createNestedCaseWithChainJSON,
+	createTestCase,
+	createTestElement,
 	createTestUser,
 } from "../utils/prisma-factories";
 
@@ -201,5 +203,45 @@ describe("validateImportData", () => {
 		expect(exportData.tree.type).toBe("GOAL");
 		// Should have at least the strategy as a child
 		expect(exportData.tree.children.length).toBeGreaterThanOrEqual(1);
+	});
+
+	/**
+	 * ADR 0004 D3, review follow-up (round 2, both reviewers independently):
+	 * `createElements` (case-import-service.ts) previously dropped
+	 * `assertionStatus` from the createMany rows, so any declared status
+	 * silently reset to unset on import — a 1.0 round-trip fidelity break.
+	 * Lead ruling: import PRESERVES a declared status, it does not drop it.
+	 */
+	it("preserves a declared assertionStatus through export -> import -> export (round-trip fidelity)", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await createTestElement(testCase.id, owner.id, {
+			elementType: "GOAL",
+			name: "Root Goal",
+			description: "Top-level goal",
+			role: "TOP_LEVEL",
+			assertionStatus: "NEEDS_SUPPORT",
+		});
+
+		const { exportCase } = await import("@/lib/services/case-export-service");
+		const { importCase } = await import("@/lib/services/case-import-service");
+
+		const firstExport = expectSuccess(await exportCase(owner.id, testCase.id));
+		expect(firstExport.tree.assertionStatus).toBe("NEEDS_SUPPORT");
+
+		const importer = await createTestUser();
+		const imported = expectSuccess(await importCase(importer.id, firstExport));
+
+		// Direct DB check — proves the createMany write itself carries the
+		// status, not just whatever the next export happens to resolve.
+		const importedGoal = await prisma.assuranceElement.findFirst({
+			where: { caseId: imported.caseId, elementType: "GOAL" },
+		});
+		expect(importedGoal?.assertionStatus).toBe("NEEDS_SUPPORT");
+
+		const secondExport = expectSuccess(
+			await exportCase(importer.id, imported.caseId)
+		);
+		expect(secondExport.tree.assertionStatus).toBe("NEEDS_SUPPORT");
 	});
 });

--- a/src/__tests__/integration/element-assertion-status-permissions.test.ts
+++ b/src/__tests__/integration/element-assertion-status-permissions.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../utils/prisma-factories";
 
 const PERMISSION_DENIED_PATTERN = /Permission denied/;
+const AS_CITED_PATTERN = /AS_CITED/;
 
 /**
  * ADR 0004 D3 write rule: assertionStatus is author-declared, machine-
@@ -217,6 +218,82 @@ describe("assertionStatus write-rule permission matrix", () => {
 				}),
 				PERMISSION_DENIED_PATTERN
 			);
+		});
+	});
+
+	/**
+	 * ADR 0004 D3: AS_CITED is transitively DERIVED by the exporter from the
+	 * cited element's own status (build-tree.ts) — never author-declared.
+	 * Review follow-up (round 2, vincent): no live exploit today since D5
+	 * (auto-derivation) hasn't landed, but the write rule must hold before
+	 * routes open. This is a VALUE constraint, independent of the principal
+	 * checks above — even a genuine human author is rejected.
+	 */
+	describe("AS_CITED value rejection (write rule)", () => {
+		it("rejects an author declaring AS_CITED via createElement", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+
+			expectError(
+				await createElement(owner.id, {
+					caseId: testCase.id,
+					elementType: "goal",
+					assertionStatus: "AS_CITED",
+				}),
+				AS_CITED_PATTERN
+			);
+
+			const elements = await prisma.assuranceElement.findMany({
+				where: { caseId: testCase.id },
+			});
+			expect(elements).toHaveLength(0);
+		});
+
+		it("rejects an author declaring AS_CITED via updateElement", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			const created = expectSuccess(
+				await createElement(owner.id, {
+					caseId: testCase.id,
+					elementType: "goal",
+				})
+			);
+
+			expectError(
+				await updateElement(owner.id, created.id, {
+					assertionStatus: "AS_CITED",
+				}),
+				AS_CITED_PATTERN
+			);
+
+			const inDb = await prisma.assuranceElement.findUnique({
+				where: { id: created.id },
+			});
+			expect(inDb?.assertionStatus).toBeNull();
+		});
+
+		it.each([
+			"ASSERTED",
+			"NEEDS_SUPPORT",
+			"ASSUMED",
+			"AXIOMATIC",
+			"DEFEATED",
+		] as const)("accepts the author-declared, non-derived value %s via updateElement", async (status) => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			const created = expectSuccess(
+				await createElement(owner.id, {
+					caseId: testCase.id,
+					elementType: "goal",
+				})
+			);
+
+			const data = expectSuccess(
+				await updateElement(owner.id, created.id, {
+					assertionStatus: status,
+				})
+			);
+			expect(data.assertionStatus).toBe(status);
 		});
 	});
 });

--- a/src/__tests__/integration/element-assertion-status-permissions.test.ts
+++ b/src/__tests__/integration/element-assertion-status-permissions.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import prisma from "@/lib/prisma";
+import { createElement, updateElement } from "@/lib/services/element-service";
+import { expectError, expectSuccess } from "../utils/assertion-helpers";
+import {
+	createTestCase,
+	createTestIntegrationWithSystemUser,
+	createTestPermission,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+const PERMISSION_DENIED_PATTERN = /Permission denied/;
+
+/**
+ * ADR 0004 D3 write rule: assertionStatus is author-declared, machine-
+ * derivable/proposable, never machine-overwritten. The permission matrix
+ * here proves the rule at the SERVICE layer (element-service.ts), not just
+ * at the route layer — case-level EDIT access alone is not a sufficient
+ * gate, because an integration's system user can legitimately hold an EDIT
+ * grant on a case (`grantIntegrationCaseAccess`) and would otherwise pass
+ * `validateCaseAccess` identically to a human author.
+ */
+describe("assertionStatus write-rule permission matrix", () => {
+	describe("author (human session) write path", () => {
+		it("lets a case owner set assertionStatus via createElement", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+
+			const data = expectSuccess(
+				await createElement(owner.id, {
+					caseId: testCase.id,
+					elementType: "goal",
+					assertionStatus: "NEEDS_SUPPORT",
+				})
+			);
+
+			const inDb = await prisma.assuranceElement.findUnique({
+				where: { id: data.id },
+			});
+			expect(inDb?.assertionStatus).toBe("NEEDS_SUPPORT");
+		});
+
+		it("lets a case owner set assertionStatus via updateElement", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			const created = expectSuccess(
+				await createElement(owner.id, {
+					caseId: testCase.id,
+					elementType: "goal",
+				})
+			);
+
+			const data = expectSuccess(
+				await updateElement(owner.id, created.id, {
+					assertionStatus: "DEFEATED",
+				})
+			);
+			expect(data.assertionStatus).toBe("DEFEATED");
+
+			const inDb = await prisma.assuranceElement.findUnique({
+				where: { id: created.id },
+			});
+			expect(inDb?.assertionStatus).toBe("DEFEATED");
+		});
+
+		it("lets an EDIT-permission collaborator (not just the owner) set assertionStatus", async () => {
+			const owner = await createTestUser();
+			const collaborator = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			await createTestPermission(
+				testCase.id,
+				collaborator.id,
+				owner.id,
+				"EDIT"
+			);
+			const created = expectSuccess(
+				await createElement(owner.id, {
+					caseId: testCase.id,
+					elementType: "goal",
+				})
+			);
+
+			expectSuccess(
+				await updateElement(collaborator.id, created.id, {
+					assertionStatus: "ASSUMED",
+				})
+			);
+
+			const inDb = await prisma.assuranceElement.findUnique({
+				where: { id: created.id },
+			});
+			expect(inDb?.assertionStatus).toBe("ASSUMED");
+		});
+
+		it("returns 'Element not found' for a VIEW-only user attempting to set assertionStatus (anti-enumeration)", async () => {
+			const owner = await createTestUser();
+			const viewer = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			await createTestPermission(testCase.id, viewer.id, owner.id, "VIEW");
+			const created = expectSuccess(
+				await createElement(owner.id, {
+					caseId: testCase.id,
+					elementType: "goal",
+				})
+			);
+
+			expectError(
+				await updateElement(viewer.id, created.id, {
+					assertionStatus: "DEFEATED",
+				}),
+				"Element not found"
+			);
+
+			const inDb = await prisma.assuranceElement.findUnique({
+				where: { id: created.id },
+			});
+			expect(inDb?.assertionStatus).toBeNull();
+		});
+	});
+
+	describe("machine/integration (system user) write path", () => {
+		it("rejects a system user with case EDIT access setting assertionStatus via updateElement", async () => {
+			const owner = await createTestUser();
+			const { systemUser } = await createTestIntegrationWithSystemUser(
+				owner.id
+			);
+			const testCase = await createTestCase(owner.id);
+			// Simulates a real, sanctioned grant (grantIntegrationCaseAccess) —
+			// the system user's case access is genuine EDIT, not a test artifact.
+			await createTestPermission(testCase.id, systemUser.id, owner.id, "EDIT");
+			const created = expectSuccess(
+				await createElement(owner.id, {
+					caseId: testCase.id,
+					elementType: "goal",
+				})
+			);
+
+			expectError(
+				await updateElement(systemUser.id, created.id, {
+					assertionStatus: "DEFEATED",
+				}),
+				PERMISSION_DENIED_PATTERN
+			);
+
+			const inDb = await prisma.assuranceElement.findUnique({
+				where: { id: created.id },
+			});
+			expect(inDb?.assertionStatus).toBeNull();
+		});
+
+		it("rejects a system user with case EDIT access setting assertionStatus via createElement", async () => {
+			const owner = await createTestUser();
+			const { systemUser } = await createTestIntegrationWithSystemUser(
+				owner.id
+			);
+			const testCase = await createTestCase(owner.id);
+			await createTestPermission(testCase.id, systemUser.id, owner.id, "EDIT");
+			// A GOAL already exists (created by the owner) so this exercises a
+			// STRATEGY create rather than colliding with the one-goal-per-case rule.
+			const goal = expectSuccess(
+				await createElement(owner.id, {
+					caseId: testCase.id,
+					elementType: "goal",
+				})
+			);
+
+			expectError(
+				await createElement(systemUser.id, {
+					caseId: testCase.id,
+					elementType: "strategy",
+					parentId: goal.id,
+					assertionStatus: "ASSUMED",
+				}),
+				PERMISSION_DENIED_PATTERN
+			);
+		});
+
+		it("still lets a system user with case EDIT access update OTHER fields (the guard is scoped to assertionStatus only)", async () => {
+			const owner = await createTestUser();
+			const { systemUser } = await createTestIntegrationWithSystemUser(
+				owner.id
+			);
+			const testCase = await createTestCase(owner.id);
+			await createTestPermission(testCase.id, systemUser.id, owner.id, "EDIT");
+			const created = expectSuccess(
+				await createElement(owner.id, {
+					caseId: testCase.id,
+					elementType: "goal",
+				})
+			);
+
+			const data = expectSuccess(
+				await updateElement(systemUser.id, created.id, {
+					description: "Updated by the integration's system user",
+				})
+			);
+			expect(data.description).toBe("Updated by the integration's system user");
+		});
+
+		it("rejects a system user with case EDIT access even when no other field is being changed", async () => {
+			const owner = await createTestUser();
+			const { systemUser } = await createTestIntegrationWithSystemUser(
+				owner.id
+			);
+			const testCase = await createTestCase(owner.id);
+			await createTestPermission(testCase.id, systemUser.id, owner.id, "EDIT");
+			const created = expectSuccess(
+				await createElement(owner.id, {
+					caseId: testCase.id,
+					elementType: "goal",
+				})
+			);
+
+			expectError(
+				await updateElement(systemUser.id, created.id, {
+					assertionStatus: "AXIOMATIC",
+				}),
+				PERMISSION_DENIED_PATTERN
+			);
+		});
+	});
+});

--- a/src/__tests__/utils/prisma-factories.ts
+++ b/src/__tests__/utils/prisma-factories.ts
@@ -159,6 +159,14 @@ type ElementOverrides = Partial<{
 	role: "TOP_LEVEL" | "SUPPORTING";
 	url: string;
 	inSandbox: boolean;
+	// ADR 0004 D3
+	assertionStatus:
+		| "ASSERTED"
+		| "NEEDS_SUPPORT"
+		| "ASSUMED"
+		| "AXIOMATIC"
+		| "DEFEATED"
+		| "AS_CITED";
 }>;
 
 export function createTestElement(
@@ -178,6 +186,7 @@ export function createTestElement(
 			role: overrides.role,
 			url: overrides.url,
 			inSandbox: overrides.inSandbox ?? false,
+			assertionStatus: overrides.assertionStatus,
 		},
 	});
 }


### PR DESCRIPTION
Title: Add assertionStatus core field (ADR 0004 D3)
Base: staging

## What

Adds per-assertion status to the case model — the authorial state the argumentation standards define (SACM §11.8; GSN's undeveloped flag) and the largest hard gap in the SACM mapping:

- `AssertionStatus` enum (`ASSERTED | NEEDS_SUPPORT | ASSUMED | AXIOMATIC | DEFEATED | AS_CITED`) + nullable `assertionStatus` on `AssuranceElement`. Additive migration, no backfill, no behaviour change for existing cases.
- Export format carries the field; unset resolves to `ASSERTED` (the standard's default) — the 1.0 format can represent an undeveloped goal from day one.
- Write rule enforced: author-writable through the standard element routes only; system/integration users rejected (fail-closed guard in the service layer); `AS_CITED` cannot be author-declared (derived-only, reserved for the exporter).
- Import preserves declared statuses end-to-end (export → import → export round-trips), fixed at both hops (flatten step + createMany mapping).
- Batch/JSON-editor path deliberately unwired (deferred with reviewer sign-off, tracked) and pinned by a regression test proving a smuggled field cannot alter stored values.

## Tests

- 8-test permission matrix incl. a system user holding genuine case EDIT access (proves the dedicated guard, not general permissions, does the blocking).
- 4 route-level tests against the actual handlers (author persist via POST/PUT with separate refetch; system-user 403s) — regression-proofs reachability.
- AS_CITED rejection on create + update; all five author-declarable values accepted (parameterised).
- Round-trip fidelity test with direct DB assertion; batch negative pin; 3 export tests (default resolution, round-trip, per-node with evidence).

## Review chain

- Code review round 1: REQUEST-CHANGES (routes validated then dropped the field — feature unreachable; caught before merge). Fix round wired both routes + import + AS_CITED guard.
- QA both rounds mutation-verified: each guard/fix has a test that fails precisely and only when that guard/fix is removed.
- Round 2: code review APPROVE + QA PASS on the landing hash; lint clean; fallow audit clean vs baselines (two non-blocking notes logged: duplicated guard invocation, complexity tick on createElement — the cost of the required guard).
- Landing hash suite: full integration 46 files / 841 tests green (one known pre-existing teardown flake in an untouched file on first attempt); full unit 1160/1160.

## Notes

- UI badge/setter deliberately deferred: the fetch pipeline doesn't yet carry the field to canvas state (ADR 0004 D2 consolidation territory). Tracked with the batch/undo-redo surfaces.
