### PR TITLE
Fix layout-direction toggle failing to persist (key-case mismatch)

### DIFF
--- a/components/cases/__tests__/case-settings-popover.test.tsx
+++ b/components/cases/__tests__/case-settings-popover.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import useStore from "@/store/store";
+import { CaseSettingsPopover } from "../case-settings-popover";
+
+// useThemePreset throws outside a ThemePresetProvider — stub it the same way
+// action-buttons.test.tsx stubs the whole component, but here we're testing
+// case-settings-popover itself, so only the preset context is stubbed.
+vi.mock("@/providers/theme-preset-provider", () => ({
+	useThemePreset: () => ({
+		preset: { id: "default", name: "Default", light: {}, dark: {} },
+		setPreset: vi.fn(),
+		availablePresets: [],
+	}),
+}));
+
+function resetStore(): void {
+	useStore.setState({
+		assuranceCase: {
+			id: "case-1",
+			name: "Test Case",
+			type: "assurance-case",
+			permissions: "manage",
+			createdDate: new Date().toISOString(),
+			comments: [],
+		},
+		layoutDirection: "TB",
+		nodes: [],
+		edges: [],
+	});
+}
+
+describe("CaseSettingsPopover — layout direction persistence", () => {
+	beforeEach(() => {
+		resetStore();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
+		);
+	});
+
+	it("PUTs a camelCase layoutDirection body when the direction is changed", async () => {
+		const user = userEvent.setup();
+		render(<CaseSettingsPopover />);
+
+		const settingsTrigger = await screen.findByRole("button", {
+			name: "Settings",
+		});
+		await user.click(settingsTrigger);
+
+		const leftRightOption = await screen.findByRole("button", {
+			name: "Left-right",
+		});
+		await user.click(leftRightOption);
+
+		// Proof this fails on the pre-fix key: the assertion pins the exact
+		// request body to `{"layoutDirection":"LR"}`. The pre-fix component
+		// sent `JSON.stringify({ layout_direction: dir })` — a body that does
+		// not match this string — so this expectation fails against the
+		// pre-fix code and only passes once the client sends the camelCase key.
+		await waitFor(() => {
+			expect(fetch).toHaveBeenCalledWith(
+				"/api/cases/case-1",
+				expect.objectContaining({
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ layoutDirection: "LR" }),
+				})
+			);
+		});
+	});
+
+	it("does not PUT when the clicked direction matches the current one", async () => {
+		const user = userEvent.setup();
+		render(<CaseSettingsPopover />);
+
+		const settingsTrigger = await screen.findByRole("button", {
+			name: "Settings",
+		});
+		await user.click(settingsTrigger);
+
+		// Store starts at "TB" — clicking "Top-down" again is a no-op.
+		const topDownOption = await screen.findByRole("button", {
+			name: "Top-down",
+		});
+		await user.click(topDownOption);
+
+		expect(fetch).not.toHaveBeenCalled();
+	});
+});

--- a/components/cases/case-settings-popover.tsx
+++ b/components/cases/case-settings-popover.tsx
@@ -64,7 +64,7 @@ export function CaseSettingsPopover() {
 			fetch(`/api/cases/${assuranceCase.id}`, {
 				method: "PUT",
 				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ layout_direction: dir }),
+				body: JSON.stringify({ layoutDirection: dir }),
 			}).catch(() => {
 				toast({
 					variant: "destructive",

--- a/lib/services/__tests__/history-service.test.ts
+++ b/lib/services/__tests__/history-service.test.ts
@@ -319,6 +319,84 @@ describe('applyUndo("move")', () => {
 });
 
 // ---------------------------------------------------------------------------
+// applyUndo -- update
+// ---------------------------------------------------------------------------
+
+describe('applyUndo("update")', () => {
+	beforeEach(() => {
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockOkResponse()));
+	});
+
+	it("fetches the element endpoint with the before snapshot, including inSandbox", async () => {
+		// Regression test for the history-service half of the layout-direction
+		// key-case fix: undo of an "update" command must send `inSandbox`
+		// (camelCase) — an `in_sandbox` body is silently stripped by the zod
+		// schema and the undo never persists. This assertion pins the exact
+		// request body, so it fails against the pre-fix `in_sandbox` key.
+		const command: HistoryCommand = {
+			type: "update",
+			elementId: "elem-90",
+			elementType: "evidence",
+			before: {
+				id: "elem-90",
+				elementType: "evidence",
+				name: "Before Name",
+				description: "Before description",
+				url: "https://example.com/before",
+				urls: ["https://example.com/before"],
+				assumption: null,
+				justification: null,
+				context: [],
+				inSandbox: true,
+			},
+			after: {
+				id: "elem-90",
+				elementType: "evidence",
+				name: "After Name",
+				description: "After description",
+				url: "https://example.com/after",
+				urls: ["https://example.com/after"],
+				assumption: null,
+				justification: null,
+				context: [],
+				inSandbox: false,
+			},
+		};
+
+		await applyUndo(command);
+
+		expect(fetch).toHaveBeenCalledWith("/api/elements/elem-90", {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				name: "Before Name",
+				description: "Before description",
+				url: "https://example.com/before",
+				urls: ["https://example.com/before"],
+				assumption: null,
+				justification: null,
+				context: [],
+				inSandbox: true,
+			}),
+		});
+	});
+
+	it("does not fetch when before is null", async () => {
+		const command: HistoryCommand = {
+			type: "update",
+			elementId: "elem-91",
+			elementType: "evidence",
+			before: null,
+			after: null,
+		};
+
+		await applyUndo(command);
+
+		expect(fetch).not.toHaveBeenCalled();
+	});
+});
+
+// ---------------------------------------------------------------------------
 // applyUndo -- detach
 // ---------------------------------------------------------------------------
 
@@ -570,6 +648,79 @@ describe('applyRedo("attach")', () => {
 			type: "attach",
 			elementId: "elem-82",
 			elementType: "strategy",
+			before: null,
+			after: null,
+		};
+
+		await applyRedo(command);
+
+		expect(fetch).not.toHaveBeenCalled();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// applyRedo -- update
+// ---------------------------------------------------------------------------
+
+describe('applyRedo("update")', () => {
+	beforeEach(() => {
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockOkResponse()));
+	});
+
+	it("fetches the element endpoint with the after snapshot, including inSandbox", async () => {
+		const command: HistoryCommand = {
+			type: "update",
+			elementId: "elem-92",
+			elementType: "evidence",
+			before: {
+				id: "elem-92",
+				elementType: "evidence",
+				name: "Before Name",
+				description: "Before description",
+				url: "https://example.com/before",
+				urls: ["https://example.com/before"],
+				assumption: null,
+				justification: null,
+				context: [],
+				inSandbox: false,
+			},
+			after: {
+				id: "elem-92",
+				elementType: "evidence",
+				name: "After Name",
+				description: "After description",
+				url: "https://example.com/after",
+				urls: ["https://example.com/after"],
+				assumption: null,
+				justification: null,
+				context: [],
+				inSandbox: true,
+			},
+		};
+
+		await applyRedo(command);
+
+		expect(fetch).toHaveBeenCalledWith("/api/elements/elem-92", {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				name: "After Name",
+				description: "After description",
+				url: "https://example.com/after",
+				urls: ["https://example.com/after"],
+				assumption: null,
+				justification: null,
+				context: [],
+				inSandbox: true,
+			}),
+		});
+	});
+
+	it("does not fetch when after is null", async () => {
+		const command: HistoryCommand = {
+			type: "update",
+			elementId: "elem-93",
+			elementType: "evidence",
 			before: null,
 			after: null,
 		};

--- a/lib/services/history-service.ts
+++ b/lib/services/history-service.ts
@@ -34,7 +34,7 @@ export async function applyUndo(command: HistoryCommand): Promise<void> {
 						assumption: command.before.assumption,
 						justification: command.before.justification,
 						context: command.before.context,
-						in_sandbox: command.before.inSandbox,
+						inSandbox: command.before.inSandbox,
 					}),
 				});
 			}
@@ -109,7 +109,7 @@ export async function applyRedo(command: HistoryCommand): Promise<void> {
 						assumption: command.after.assumption,
 						justification: command.after.justification,
 						context: command.after.context,
-						in_sandbox: command.after.inSandbox,
+						inSandbox: command.after.inSandbox,
 					}),
 				});
 			}

--- a/src/__tests__/integration/api-cases.test.ts
+++ b/src/__tests__/integration/api-cases.test.ts
@@ -300,6 +300,45 @@ describe("PUT /api/cases/[id]", () => {
 		const getBody = await getResponse.json();
 		expect(getBody.layoutDirection).toBe("LR");
 	});
+
+	it("persists the other layoutDirection enum value (TB) and survives a refetch", async () => {
+		// Enum-symmetry companion to the "LR" case above — only one of the two
+		// valid layoutDirection values was exercised by the regression test.
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id, {
+			name: "Layout Toggle TB",
+		});
+		await mockAuth(user.id, user.username, user.email);
+
+		const { PUT, GET } = await import("@/app/api/cases/[id]/route");
+
+		const putReq = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}`,
+			{
+				method: "PUT",
+				body: JSON.stringify({ layoutDirection: "TB" }),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const putResponse = await PUT(putReq, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(putResponse.status).toBe(200);
+		const putBody = await putResponse.json();
+		expect(putBody.layoutDirection).toBe("TB");
+
+		const getReq = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}`
+		);
+		const getResponse = await GET(getReq, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(getResponse.status).toBe(200);
+		const getBody = await getResponse.json();
+		expect(getBody.layoutDirection).toBe("TB");
+	});
 });
 
 // ============================================

--- a/src/__tests__/integration/api-cases.test.ts
+++ b/src/__tests__/integration/api-cases.test.ts
@@ -258,6 +258,48 @@ describe("PUT /api/cases/[id]", () => {
 		const body = await response.json();
 		expect(body.description).toBe("Collaboratively updated");
 	});
+
+	it("persists layoutDirection sent in the UI's actual payload shape and survives a refetch", async () => {
+		// Regression test for the case-settings-popover toggle: the client must
+		// send `layoutDirection` (camelCase) — a `layout_direction` (snake_case)
+		// body is silently stripped by the zod schema and never persists.
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id, { name: "Layout Toggle" });
+		await mockAuth(user.id, user.username, user.email);
+
+		const { PUT, GET } = await import("@/app/api/cases/[id]/route");
+
+		// This is exactly the body components/cases/case-settings-popover.tsx
+		// constructs in handleDirectionChange.
+		const putReq = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}`,
+			{
+				method: "PUT",
+				body: JSON.stringify({ layoutDirection: "LR" }),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const putResponse = await PUT(putReq, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(putResponse.status).toBe(200);
+		const putBody = await putResponse.json();
+		expect(putBody.layoutDirection).toBe("LR");
+
+		// Refetch on a fresh request to prove the value was actually persisted,
+		// not just echoed back from the PUT response.
+		const getReq = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}`
+		);
+		const getResponse = await GET(getReq, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(getResponse.status).toBe(200);
+		const getBody = await getResponse.json();
+		expect(getBody.layoutDirection).toBe("LR");
+	});
 });
 
 // ============================================


### PR DESCRIPTION

## What

Two client-side field-name-casing bugs where the PUT body key didn't match the server's validation schema, so zod silently dropped the field and the write never persisted:

- **Layout direction** (`case-settings-popover.tsx`): sent `layout_direction`, schema reads `layoutDirection` — the setting reset on every reload while the canvas re-layout masked the failure.
- **Sandbox flag in undo/redo** (`history-service.ts`): sent `in_sandbox`, schema reads `inSandbox` — undoing/redoing an in-sandbox toggle never persisted the reverted state. Found by a sweep of all raw-fetch call sites for the same drift class.

## Tests

- Component test drives the real popover with a mocked `fetch` and pins the request body key (verified to fail against the pre-fix code by revert experiment, reproduced independently in QA).
- `applyUndo("update")` / `applyRedo("update")` unit tests — the previously untested update branch — pin `inSandbox` in the body.
- Integration round-trips (PUT + separate GET) for both enum values.

## Review chain

- QA: initial FAIL (regression test targeted the wrong layer) → tests amended → re-verdict PASS, including an independent mutation test.
- Code review: APPROVE ×2 (original + delta); lint clean; fallow audit clean (0 dead code / complexity / duplication in changed files).
- Full unit suite 1166/1166 green on the landing hash; affected integration shards independently green.

## Notes

- Known non-blocking: the TB round-trip test writes the schema default (no-op) — flagged for a future test pass.
- Root-cause hardening (mutation schemas silently strip unknown keys; `.strict()` candidate) is tracked separately.
