### PR TITLE
Add element-level citation (citedElementId) for AWAY_GOAL (ADR 0004 D5)

### DIFF
--- a/app/api/cases/[id]/elements/route.ts
+++ b/app/api/cases/[id]/elements/route.ts
@@ -65,6 +65,10 @@ function buildCreateInput(
 		// the guard against machine/integration writers and AS_CITED declaration
 		// lives in element-service.ts (createElement), not here.
 		assertionStatus: body.assertionStatus as AssertionStatus | null | undefined,
+		// Element-level citation (ADR 0004 D5) — validated by
+		// createElementSchema; applicability/existence/self-citation checks
+		// live in element-service.ts (createElement), not here.
+		citedElementId: body.citedElementId as string | null | undefined,
 	};
 }
 

--- a/app/api/elements/[id]/route.ts
+++ b/app/api/elements/[id]/route.ts
@@ -60,6 +60,10 @@ function buildUpdateInput(body: Record<string, unknown>): UpdateElementInput {
 		// the guard against machine/integration writers and AS_CITED declaration
 		// lives in element-service.ts (updateElement), not here.
 		assertionStatus: body.assertionStatus as AssertionStatus | null | undefined,
+		// Element-level citation (ADR 0004 D5) — validated by
+		// updateElementSchema; applicability/existence/self-citation checks
+		// live in element-service.ts (updateElement), not here.
+		citedElementId: body.citedElementId as string | null | undefined,
 	};
 }
 

--- a/docs/database/schema.dbml
+++ b/docs/database/schema.dbml
@@ -238,6 +238,8 @@ Table assurance_elements {
   defeatsElementId String [note: 'Element this defeater challenges']
   level Int [note: 'Hierarchy depth level for property claims']
   assertionStatus AssertionStatus
+  citedElementId String
+  citationDangling Boolean [not null, default: false]
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime [not null]
   createdById String [not null]
@@ -251,6 +253,8 @@ Table assurance_elements {
   defeatsElement assurance_elements
   defeatedBy assurance_elements [not null]
   moduleReference assurance_cases
+  citedElement assurance_elements
+  citedBy assurance_elements [not null]
   evidenceLinksFrom evidence_links [not null]
   evidenceLinksTo evidence_links [not null]
   comments comments [not null]
@@ -853,6 +857,8 @@ Ref: assurance_elements.parentId - assurance_elements.id [delete: Cascade]
 Ref: assurance_elements.defeatsElementId - assurance_elements.id [delete: Cascade]
 
 Ref: assurance_elements.moduleReferenceId > assurance_cases.id [delete: Cascade]
+
+Ref: assurance_elements.citedElementId - assurance_elements.id [delete: Cascade]
 
 Ref: evidence_links.evidenceId > assurance_elements.id [delete: Cascade]
 

--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -136,6 +136,11 @@ const ERROR_MAPPINGS: Array<{
 		pattern: /^assertionStatus cannot be set to AS_CITED/,
 		factory: () => validationError(""),
 	},
+	// `element-service.ts`'s `rejectCitedElementIdIfNotApplicable` /
+	// `validateCitedElementId` (ADR 0004 D5): a bad `citedElementId` (wrong
+	// element type, nonexistent target, self-citation) is a validation
+	// failure (400), not a 500.
+	{ pattern: /^citedElementId /, factory: () => validationError("") },
 	// Lifecycle/state-guard errors from the integration registry service —
 	// the integration or token exists and is owned by the caller, but its
 	// current status makes the requested action a no-op or a terminal-state

--- a/lib/schemas/case-export.ts
+++ b/lib/schemas/case-export.ts
@@ -113,6 +113,14 @@ export const ElementV2Schema = z
 			.describe(
 				"Per-assertion status (ADR 0004 D3); null/unset means ASSERTED"
 			),
+		// Element-level citation (ADR 0004 D5) — AWAY_GOAL only. Names the
+		// specific element cited within the case named by moduleReferenceId.
+		citedElementId: z
+			.string()
+			.uuid()
+			.nullable()
+			.optional()
+			.describe("ID of the element cited by an AWAY_GOAL (ADR 0004 D5)"),
 		inSandbox: z
 			.boolean()
 			.default(false)
@@ -212,6 +220,7 @@ export interface ExportComment {
  * - moduleReferenceId: MODULE (required), AWAY_GOAL (required)
  * - moduleEmbedType: MODULE only (required)
  * - modulePublicSummary: MODULE only
+ * - citedElementId: AWAY_GOAL only (ADR 0004 D5)
  * - isDefeater, defeatsElementId: any type (dialogical reasoning)
  * - comments: optional, included when includeComments export option is true
  * - assertionStatus: any type (ADR 0004 D3). Typed optional here (so
@@ -225,6 +234,8 @@ export interface TreeNode {
 	assertionStatus?: AssertionStatus;
 	assumption?: string | null;
 	children: TreeNode[];
+	// Element-level citation (ADR 0004 D5) — AWAY_GOAL only
+	citedElementId?: string | null;
 	// Comments (optional - included when export option enabled)
 	comments?: ExportComment[];
 	context?: string[];
@@ -279,6 +290,9 @@ export const TreeNodeSchema: z.ZodType<any> = z.lazy(() =>
 		moduleReferenceId: z.string().uuid().optional(),
 		moduleEmbedType: ModuleEmbedTypeSchema.optional(),
 		modulePublicSummary: z.string().nullable().optional(),
+		// Element-level citation (ADR 0004 D5) — AWAY_GOAL only; nullable/
+		// optional here for import leniency with pre-D5 exports.
+		citedElementId: z.string().uuid().nullable().optional(),
 		// Pattern metadata (optional - only included when true)
 		fromPattern: z.boolean().default(false).optional(),
 		modifiedFromPattern: z.boolean().default(false).optional(),

--- a/lib/schemas/element-validation.ts
+++ b/lib/schemas/element-validation.ts
@@ -56,6 +56,9 @@ export const FIELD_APPLICABILITY: Record<string, Set<string>> = {
 	moduleReferenceId: new Set(["MODULE", "AWAY_GOAL"]),
 	moduleEmbedType: new Set(["MODULE"]),
 	modulePublicSummary: new Set(["MODULE"]),
+	// Element-level citation (ADR 0004 D5) — names the specific element an
+	// AWAY_GOAL cites within the case named by moduleReferenceId.
+	citedElementId: new Set(["AWAY_GOAL"]),
 };
 
 /**
@@ -234,6 +237,11 @@ const AwayGoalSchema = BaseElementSchema.extend({
 	elementType: z.literal("AWAY_GOAL"),
 	assumption: z.string().nullable().optional(),
 	moduleReferenceId: z.string().uuid(),
+	// Element-level citation (ADR 0004 D5) — the specific element within the
+	// referenced case (moduleReferenceId) that this AWAY_GOAL cites.
+	// Existence and self-citation are validated at the service layer
+	// (element-service.ts), not here — this schema only checks shape.
+	citedElementId: z.string().uuid().nullable().optional(),
 });
 
 const ContractSchema = BaseElementSchema.extend({
@@ -313,6 +321,7 @@ export function cleanElementDataForType(
 		"moduleReferenceId",
 		"moduleEmbedType",
 		"modulePublicSummary",
+		"citedElementId",
 	];
 
 	for (const [key, value] of Object.entries(data)) {

--- a/lib/schemas/element.ts
+++ b/lib/schemas/element.ts
@@ -44,6 +44,9 @@ export const createElementSchema = z.object({
 
 	// Per-assertion status (ADR 0004 D3)
 	assertionStatus: assertionStatusInputSchema,
+	// Element-level citation (ADR 0004 D5) — AWAY_GOAL only; applicability,
+	// existence, and self-citation are enforced in element-service.ts.
+	citedElementId: z.string().uuid().nullable().optional(),
 });
 
 export type CreateElementSchemaInput = z.input<typeof createElementSchema>;
@@ -74,6 +77,9 @@ export const updateElementSchema = z.object({
 
 	// Per-assertion status (ADR 0004 D3)
 	assertionStatus: assertionStatusInputSchema,
+	// Element-level citation (ADR 0004 D5) — AWAY_GOAL only; applicability,
+	// existence, and self-citation are enforced in element-service.ts.
+	citedElementId: z.string().uuid().nullable().optional(),
 
 	// Sandbox flag
 	inSandbox: z.boolean().optional(),

--- a/lib/services/case-export-service.ts
+++ b/lib/services/case-export-service.ts
@@ -134,6 +134,8 @@ export async function exportCase(
 						moduleReferenceId: true,
 						moduleEmbedType: true,
 						modulePublicSummary: true,
+						// Element-level citation (ADR 0004 D5)
+						citedElementId: true,
 						// Pattern metadata
 						fromPattern: true,
 						modifiedFromPattern: true,
@@ -167,6 +169,8 @@ export async function exportCase(
 										moduleReferenceId: true,
 										moduleEmbedType: true,
 										modulePublicSummary: true,
+										// Element-level citation (ADR 0004 D5)
+										citedElementId: true,
 										// Pattern metadata
 										fromPattern: true,
 										modifiedFromPattern: true,
@@ -225,6 +229,8 @@ export async function exportCase(
 			moduleReferenceId: el.moduleReferenceId,
 			moduleEmbedType: el.moduleEmbedType as ModuleEmbedType | null,
 			modulePublicSummary: el.modulePublicSummary,
+			// Element-level citation (ADR 0004 D5)
+			citedElementId: el.citedElementId,
 			// Pattern metadata
 			fromPattern: el.fromPattern,
 			modifiedFromPattern: el.modifiedFromPattern,
@@ -255,6 +261,8 @@ export async function exportCase(
 					moduleEmbedType: link.evidence
 						.moduleEmbedType as ModuleEmbedType | null,
 					modulePublicSummary: link.evidence.modulePublicSummary,
+					// Element-level citation (ADR 0004 D5)
+					citedElementId: link.evidence.citedElementId,
 					// Pattern metadata
 					fromPattern: link.evidence.fromPattern,
 					modifiedFromPattern: link.evidence.modifiedFromPattern,

--- a/lib/services/case-import-service.ts
+++ b/lib/services/case-import-service.ts
@@ -169,6 +169,43 @@ async function createCaseWithPermission(
 }
 
 /**
+ * Batch-resolves citedElementId values (ADR 0004 D5, review fix item 1 —
+ * P2003 trace) that are NOT already covered by this import's idMap. An id
+ * present in idMap is import-internal and always resolves (see
+ * resolveImportedCitedElementId below); everything else names an element in
+ * a DIFFERENT case (the one referenced by moduleReferenceId), so it has to
+ * be checked against the target DB before the insert — the createMany FK
+ * (assurance_elements_cited_element_id_fkey) rejects unresolvable rows and
+ * previously took the whole import's transaction down with it.
+ *
+ * One findMany for the whole batch (not one query per element), run BEFORE
+ * the transaction opens — keeps the transaction short per CLAUDE.md and
+ * avoids doing this lookup once per createElements call.
+ */
+async function resolveExternalCitedElementIds(
+	elements: ElementV2[],
+	idMap: Map<string, string>
+): Promise<Set<string>> {
+	const externalIds = new Set<string>();
+	for (const el of elements) {
+		if (el.citedElementId && !idMap.has(el.citedElementId)) {
+			externalIds.add(el.citedElementId);
+		}
+	}
+
+	if (externalIds.size === 0) {
+		return externalIds;
+	}
+
+	const found = await prisma.assuranceElement.findMany({
+		where: { id: { in: [...externalIds] } },
+		select: { id: true },
+	});
+
+	return new Set(found.map((el) => el.id));
+}
+
+/**
  * Resolves a citedElementId (ADR 0004 D5) for the createMany row.
  *
  * citedElementId names an element in the case referenced by moduleReferenceId
@@ -177,24 +214,37 @@ async function createCaseWithPermission(
  * brief, cid 2026-07-19): try the idMap first (covers the edge case where a
  * test fixture or self-contained export happens to include the cited element
  * in the same payload — then the remap keeps the reference internally
- * consistent with the new ids); otherwise PRESERVE THE ORIGINAL ID VERBATIM.
+ * consistent with the new ids); otherwise PRESERVE THE ORIGINAL ID VERBATIM
+ * if — and only if — resolveExternalCitedElementIds proved it actually
+ * exists in the target DB.
  *
- * Flag: on import into a fresh/different deployment, a preserved id may not
- * resolve to any element at all (the away-case wasn't part of this import
- * and may not exist there under that id). moduleReferenceId itself has the
- * same exposure today and isn't carried through createElements at all yet —
- * pre-existing gap, not introduced here. No id-remapping table exists for
- * cross-case references in this codebase; guessing one up would be worse
- * than an honest verbatim pass-through.
+ * Review fix item 1: a preserved id that resolves NOWHERE in the target DB
+ * (the away-case wasn't part of this import and doesn't exist there under
+ * that id) used to hit the createMany FK and roll back the entire import.
+ * That is now a flagged, non-fatal outcome: citedElementId is dropped to
+ * null and citationDangling is set, matching the existing detach/delete
+ * dangling-citation contract in element-service.ts.
  */
 function resolveImportedCitedElementId(
 	citedElementId: string | null | undefined,
-	idMap: Map<string, string>
-): string | null {
+	idMap: Map<string, string>,
+	resolvedExternalIds: Set<string>
+): { citedElementId: string | null; citationDangling: boolean } {
 	if (!citedElementId) {
-		return null;
+		return { citedElementId: null, citationDangling: false };
 	}
-	return idMap.get(citedElementId) ?? citedElementId;
+
+	const remapped = idMap.get(citedElementId);
+	if (remapped) {
+		return { citedElementId: remapped, citationDangling: false };
+	}
+
+	if (resolvedExternalIds.has(citedElementId)) {
+		return { citedElementId, citationDangling: false };
+	}
+
+	// Unresolvable anywhere in the target DB — flag, don't fail the import.
+	return { citedElementId: null, citationDangling: true };
 }
 
 /**
@@ -204,6 +254,7 @@ async function createElements(
 	caseId: string,
 	elements: ElementV2[],
 	idMap: Map<string, string>,
+	resolvedExternalCitedElementIds: Set<string>,
 	userId: string
 ): Promise<number> {
 	// Sort elements topologically so parents are created before children
@@ -215,6 +266,16 @@ async function createElements(
 			if (!newId) {
 				return null;
 			}
+
+			// Element-level citation (ADR 0004 D5) — see
+			// resolveImportedCitedElementId's docstring for the
+			// remap-else-preserve-verbatim-else-flag-dangling decision.
+			const { citedElementId, citationDangling } =
+				resolveImportedCitedElementId(
+					el.citedElementId,
+					idMap,
+					resolvedExternalCitedElementIds
+				);
 
 			return {
 				id: newId,
@@ -240,10 +301,8 @@ async function createElements(
 				// an author declaring a NEW status, and the source data already
 				// passed through export's own AS_CITED derivation.
 				assertionStatus: el.assertionStatus,
-				// Element-level citation (ADR 0004 D5) — see
-				// resolveImportedCitedElementId's docstring for the
-				// remap-else-preserve-verbatim decision.
-				citedElementId: resolveImportedCitedElementId(el.citedElementId, idMap),
+				citedElementId,
+				citationDangling,
 				createdById: userId,
 			};
 		})
@@ -357,6 +416,12 @@ export async function importCase(
 		// Build ID mapping
 		const idMap = buildIdMap(v2Data.elements);
 
+		// Review fix item 1: batch-resolve external citedElementIds against the
+		// target DB BEFORE opening the transaction — keeps the transaction
+		// short and means the createMany insert never has to guess.
+		const resolvedExternalCitedElementIds =
+			await resolveExternalCitedElementIds(v2Data.elements, idMap);
+
 		// Use a transaction to ensure atomicity
 		const result = await prisma.$transaction(async () => {
 			// Create case
@@ -367,6 +432,7 @@ export async function importCase(
 				caseId,
 				v2Data.elements,
 				idMap,
+				resolvedExternalCitedElementIds,
 				userId
 			);
 

--- a/lib/services/case-import-service.ts
+++ b/lib/services/case-import-service.ts
@@ -169,6 +169,35 @@ async function createCaseWithPermission(
 }
 
 /**
+ * Resolves a citedElementId (ADR 0004 D5) for the createMany row.
+ *
+ * citedElementId names an element in the case referenced by moduleReferenceId
+ * — i.e. normally a DIFFERENT case from the one being imported here, so it is
+ * almost never present in this import's own idMap. Lead ruling (dispatch
+ * brief, cid 2026-07-19): try the idMap first (covers the edge case where a
+ * test fixture or self-contained export happens to include the cited element
+ * in the same payload — then the remap keeps the reference internally
+ * consistent with the new ids); otherwise PRESERVE THE ORIGINAL ID VERBATIM.
+ *
+ * Flag: on import into a fresh/different deployment, a preserved id may not
+ * resolve to any element at all (the away-case wasn't part of this import
+ * and may not exist there under that id). moduleReferenceId itself has the
+ * same exposure today and isn't carried through createElements at all yet —
+ * pre-existing gap, not introduced here. No id-remapping table exists for
+ * cross-case references in this codebase; guessing one up would be worse
+ * than an honest verbatim pass-through.
+ */
+function resolveImportedCitedElementId(
+	citedElementId: string | null | undefined,
+	idMap: Map<string, string>
+): string | null {
+	if (!citedElementId) {
+		return null;
+	}
+	return idMap.get(citedElementId) ?? citedElementId;
+}
+
+/**
  * Creates all elements in the correct order (parents before children).
  */
 async function createElements(
@@ -211,6 +240,10 @@ async function createElements(
 				// an author declaring a NEW status, and the source data already
 				// passed through export's own AS_CITED derivation.
 				assertionStatus: el.assertionStatus,
+				// Element-level citation (ADR 0004 D5) — see
+				// resolveImportedCitedElementId's docstring for the
+				// remap-else-preserve-verbatim decision.
+				citedElementId: resolveImportedCitedElementId(el.citedElementId, idMap),
 				createdById: userId,
 			};
 		})

--- a/lib/services/element-service.ts
+++ b/lib/services/element-service.ts
@@ -38,12 +38,12 @@ export interface ElementResponse {
 	assertionStatus?: AssertionStatus | null;
 	assumption?: string;
 	assuranceCaseId: string;
-	// Element-level citation (ADR 0004 D5) — AWAY_GOAL only
-	citedElementId?: string | null;
 	// Dangling-citation indicator: true when citedElementId was nullified
 	// because the cited element was deleted/detached (see deleteElement /
 	// detachElement below). Omitted (not false) when there is nothing to flag.
 	citationDangling?: boolean;
+	// Element-level citation (ADR 0004 D5) — AWAY_GOAL only
+	citedElementId?: string | null;
 	comments?: unknown[];
 	context?: string[];
 	createdDate: string;

--- a/lib/services/element-service.ts
+++ b/lib/services/element-service.ts
@@ -4,10 +4,12 @@ import type {
 	CreateElementSchemaOutput,
 	UpdateElementSchemaOutput,
 } from "@/lib/schemas/element";
+import { fieldAppliesTo } from "@/lib/schemas/element-validation";
 import { transformToResponse } from "@/lib/transforms/element-response";
 import {
 	getDeletedDescendantIds,
 	getDescendantIds,
+	type TxClient,
 } from "@/lib/utils/tree-traversal";
 import type {
 	AssertionStatus,
@@ -36,6 +38,12 @@ export interface ElementResponse {
 	assertionStatus?: AssertionStatus | null;
 	assumption?: string;
 	assuranceCaseId: string;
+	// Element-level citation (ADR 0004 D5) — AWAY_GOAL only
+	citedElementId?: string | null;
+	// Dangling-citation indicator: true when citedElementId was nullified
+	// because the cited element was deleted/detached (see deleteElement /
+	// detachElement below). Omitted (not false) when there is nothing to flag.
+	citationDangling?: boolean;
 	comments?: unknown[];
 	context?: string[];
 	createdDate: string;
@@ -92,6 +100,29 @@ async function guardAssertionStatusWrite(
 }
 
 /**
+ * ADR 0004 D5: `citedElementId` is applicable to AWAY_GOAL only. On create,
+ * the elementType is always known and the Prisma extension's
+ * `cleanElementDataForType` (lib/prisma.ts) would silently strip an
+ * inapplicable value anyway — but a silent drop is a worse UX than an
+ * explicit rejection, so this is checked here too for a consistent error on
+ * both routes. On update, `buildUpdateData` never puts `elementType` in the
+ * Prisma payload, so the extension's cleaning step is a no-op there — this
+ * check is the ONLY enforcement point on the update path.
+ */
+function rejectCitedElementIdIfNotApplicable(
+	elementType: string,
+	citedElementId: string | null | undefined
+): string | undefined {
+	if (citedElementId === undefined) {
+		return;
+	}
+	if (!fieldAppliesTo("citedElementId", elementType)) {
+		return "citedElementId is only applicable to AWAY_GOAL elements";
+	}
+	return;
+}
+
+/**
  * ADR 0004 D3: AS_CITED is transitively DERIVED by the exporter from the
  * cited element's own status (see build-tree.ts) — it is never author-
  * declared. This is a value constraint (applies to every acting principal,
@@ -105,6 +136,32 @@ function rejectDeclaredAsCited(
 ): string | undefined {
 	if (status === "AS_CITED") {
 		return "assertionStatus cannot be set to AS_CITED: it is derived automatically from the cited element's status, not author-declared";
+	}
+	return;
+}
+
+/**
+ * ADR 0004 D5: `citedElementId` must reference an existing, non-deleted
+ * element, and an element cannot cite itself. `ownElementId` is only
+ * available (and only checked) on update — a not-yet-created element has no
+ * id to collide with.
+ */
+async function validateCitedElementId(
+	citedElementId: string | null | undefined,
+	ownElementId?: string
+): Promise<string | undefined> {
+	if (!citedElementId) {
+		return;
+	}
+	if (ownElementId && citedElementId === ownElementId) {
+		return "citedElementId cannot reference the element itself";
+	}
+	const target = await prisma.assuranceElement.findFirst({
+		where: { id: citedElementId, deletedAt: null },
+		select: { id: true },
+	});
+	if (!target) {
+		return "citedElementId must reference an existing element";
 	}
 	return;
 }
@@ -387,6 +444,10 @@ async function createElementInDatabase(
 			context: input.context ?? [],
 			level,
 			assertionStatus: input.assertionStatus,
+			// Element-level citation (ADR 0004 D5) — applicability, existence,
+			// and self-citation are validated in createElement before this
+			// function is called.
+			citedElementId: input.citedElementId,
 			createdById: userId,
 		},
 		include: {
@@ -443,6 +504,20 @@ export async function createElement(
 
 	if (elementType === "GOAL" && (await caseHasGoal(caseId))) {
 		return { error: "A case can only have one goal claim" };
+	}
+
+	if (input.citedElementId !== undefined) {
+		const applicabilityError = rejectCitedElementIdIfNotApplicable(
+			elementType,
+			input.citedElementId
+		);
+		if (applicabilityError) {
+			return { error: applicabilityError };
+		}
+		const citedError = await validateCitedElementId(input.citedElementId);
+		if (citedError) {
+			return { error: citedError };
+		}
 	}
 
 	const { level, parentInfo } =
@@ -549,6 +624,13 @@ function buildUpdateData(input: UpdateElementInput): Record<string, unknown> {
 	if (input.assertionStatus !== undefined) {
 		updateData.assertionStatus = input.assertionStatus;
 	}
+	if (input.citedElementId !== undefined) {
+		updateData.citedElementId = input.citedElementId;
+		// The author explicitly set (or cleared) the citation — whatever
+		// dangling flag was left over from a previous deletion/detachment no
+		// longer describes the current state, declared or not.
+		updateData.citationDangling = false;
+	}
 
 	return updateData;
 }
@@ -632,6 +714,25 @@ export async function updateElement(
 			}
 		}
 
+		// ADR 0004 D5: citedElementId is AWAY_GOAL-only, must reference an
+		// existing element, and cannot reference the element itself.
+		if (input.citedElementId !== undefined) {
+			const applicabilityError = rejectCitedElementIdIfNotApplicable(
+				existing.elementType,
+				input.citedElementId
+			);
+			if (applicabilityError) {
+				return { error: applicabilityError };
+			}
+			const citedError = await validateCitedElementId(
+				input.citedElementId,
+				elementId
+			);
+			if (citedError) {
+				return { error: citedError };
+			}
+		}
+
 		// Build update data from input fields
 		const updateData = buildUpdateData(input);
 
@@ -690,6 +791,29 @@ export async function updateElement(
 }
 
 /**
+ * ADR 0004 D5 integrity rule (ruled by cid + Chris, 2026-07-19): when a cited
+ * element is deleted or detached from its case, citing elements are NOT left
+ * pointing at a dangling id — `citedElementId` is nullified and
+ * `citationDangling` is set so the citing element's own response can surface
+ * a "this citation broke" indicator (consistent with the rest of the
+ * codebase's soft-delete conventions: nothing is silently lost, but nothing
+ * blocks the deletion/detach either). Takes the Prisma client or an open
+ * transaction so callers can run it atomically with the delete/detach itself.
+ */
+async function nullifyDanglingCitations(
+	tx: TxClient,
+	citedElementIds: string[]
+): Promise<void> {
+	if (citedElementIds.length === 0) {
+		return;
+	}
+	await tx.assuranceElement.updateMany({
+		where: { citedElementId: { in: citedElementIds } },
+		data: { citedElementId: null, citationDangling: true },
+	});
+}
+
+/**
  * Soft-deletes an element and all its descendants
  */
 export async function deleteElement(
@@ -717,7 +841,8 @@ export async function deleteElement(
 			return { error: "Element not found" };
 		}
 
-		// Gather descendants and soft-delete atomically
+		// Gather descendants, soft-delete, and nullify+flag any dangling
+		// citations (ADR 0004 D5) atomically
 		await prisma.$transaction(async (tx) => {
 			const descendantIds = await getDescendantIds(elementId, tx);
 			const allIds = [elementId, ...descendantIds];
@@ -725,6 +850,11 @@ export async function deleteElement(
 				where: { id: { in: allIds } },
 				data: { deletedAt: new Date(), deletedById: userId },
 			});
+			// Citations are cross-case by design (an AWAY_GOAL cites an element
+			// in a DIFFERENT case), so this deliberately isn't scoped to
+			// `existing.caseId` — every deleted id (the element and its
+			// descendants) may be cited from anywhere.
+			await nullifyDanglingCitations(tx, allIds);
 		});
 
 		return { data: true };
@@ -762,13 +892,19 @@ export async function detachElement(
 			return { error: "Element not found" };
 		}
 
-		// Move to sandbox by clearing parent and setting inSandbox
-		await prisma.assuranceElement.update({
-			where: { id: elementId },
-			data: {
-				parentId: null,
-				inSandbox: true,
-			},
+		// Move to sandbox, clear parent, and nullify+flag any dangling
+		// citations (ADR 0004 D5) atomically — a detached element is no
+		// longer part of the case's argument tree, so a citation pointing at
+		// it is just as broken as one pointing at a deleted element.
+		await prisma.$transaction(async (tx) => {
+			await tx.assuranceElement.update({
+				where: { id: elementId },
+				data: {
+					parentId: null,
+					inSandbox: true,
+				},
+			});
+			await nullifyDanglingCitations(tx, [elementId]);
 		});
 
 		return { data: true };

--- a/lib/services/element-service.ts
+++ b/lib/services/element-service.ts
@@ -167,6 +167,31 @@ async function validateCitedElementId(
 }
 
 /**
+ * ADR 0004 D5: runs both citedElementId guards (applicability, then
+ * existence/self-citation) in the order createElement and updateElement both
+ * need — extracted so the checks live in exactly one place instead of being
+ * duplicated verbatim at each call site. `ownElementId` is only meaningful
+ * on update (see validateCitedElementId above).
+ */
+async function enforceCitedElementIdRules(
+	elementType: string,
+	citedElementId: string | null | undefined,
+	ownElementId?: string
+): Promise<string | undefined> {
+	if (citedElementId === undefined) {
+		return;
+	}
+	const applicabilityError = rejectCitedElementIdIfNotApplicable(
+		elementType,
+		citedElementId
+	);
+	if (applicabilityError) {
+		return applicabilityError;
+	}
+	return await validateCitedElementId(citedElementId, ownElementId);
+}
+
+/**
  * Resolves parent ID from input.
  * Returns undefined if no parent field is specified (to distinguish from explicitly setting null).
  */
@@ -506,18 +531,12 @@ export async function createElement(
 		return { error: "A case can only have one goal claim" };
 	}
 
-	if (input.citedElementId !== undefined) {
-		const applicabilityError = rejectCitedElementIdIfNotApplicable(
-			elementType,
-			input.citedElementId
-		);
-		if (applicabilityError) {
-			return { error: applicabilityError };
-		}
-		const citedError = await validateCitedElementId(input.citedElementId);
-		if (citedError) {
-			return { error: citedError };
-		}
+	const citedElementIdError = await enforceCitedElementIdRules(
+		elementType,
+		input.citedElementId
+	);
+	if (citedElementIdError) {
+		return { error: citedElementIdError };
 	}
 
 	const { level, parentInfo } =
@@ -716,21 +735,13 @@ export async function updateElement(
 
 		// ADR 0004 D5: citedElementId is AWAY_GOAL-only, must reference an
 		// existing element, and cannot reference the element itself.
-		if (input.citedElementId !== undefined) {
-			const applicabilityError = rejectCitedElementIdIfNotApplicable(
-				existing.elementType,
-				input.citedElementId
-			);
-			if (applicabilityError) {
-				return { error: applicabilityError };
-			}
-			const citedError = await validateCitedElementId(
-				input.citedElementId,
-				elementId
-			);
-			if (citedError) {
-				return { error: citedError };
-			}
+		const citedElementIdError = await enforceCitedElementIdRules(
+			existing.elementType,
+			input.citedElementId,
+			elementId
+		);
+		if (citedElementIdError) {
+			return { error: citedElementIdError };
 		}
 
 		// Build update data from input fields

--- a/lib/services/element-service.ts
+++ b/lib/services/element-service.ts
@@ -192,6 +192,29 @@ async function enforceCitedElementIdRules(
 }
 
 /**
+ * ADR 0004 D3: runs both assertionStatus write guards (value constraint via
+ * `rejectDeclaredAsCited`, then principal constraint via
+ * `guardAssertionStatusWrite`) in the order createElement and updateElement
+ * both need — extracted so the checks live in exactly one place instead of
+ * being duplicated verbatim at each call site (mirrors
+ * `enforceCitedElementIdRules` above, and keeps both mutation paths under
+ * the cognitive-complexity budget).
+ */
+async function enforceAssertionStatusRules(
+	assertionStatus: AssertionStatus | null | undefined,
+	userId: string
+): Promise<string | undefined> {
+	if (assertionStatus === undefined) {
+		return;
+	}
+	const citedError = rejectDeclaredAsCited(assertionStatus);
+	if (citedError) {
+		return citedError;
+	}
+	return await guardAssertionStatusWrite(userId);
+}
+
+/**
  * Resolves parent ID from input.
  * Returns undefined if no parent field is specified (to distinguish from explicitly setting null).
  */
@@ -513,15 +536,12 @@ export async function createElement(
 		return { error: "Permission denied" };
 	}
 
-	if (input.assertionStatus !== undefined) {
-		const citedError = rejectDeclaredAsCited(input.assertionStatus);
-		if (citedError) {
-			return { error: citedError };
-		}
-		const writeError = await guardAssertionStatusWrite(userId);
-		if (writeError) {
-			return { error: writeError };
-		}
+	const assertionStatusError = await enforceAssertionStatusRules(
+		input.assertionStatus,
+		userId
+	);
+	if (assertionStatusError) {
+		return { error: assertionStatusError };
 	}
 
 	const elementType = toPrismaType(input.elementType);
@@ -722,15 +742,12 @@ export async function updateElement(
 		// ADR 0004 D3 write rule: assertionStatus is author-declared only —
 		// see guardAssertionStatusWrite's docstring for why case-level EDIT
 		// access alone isn't a sufficient gate.
-		if (input.assertionStatus !== undefined) {
-			const citedError = rejectDeclaredAsCited(input.assertionStatus);
-			if (citedError) {
-				return { error: citedError };
-			}
-			const writeError = await guardAssertionStatusWrite(userId);
-			if (writeError) {
-				return { error: writeError };
-			}
+		const assertionStatusError = await enforceAssertionStatusRules(
+			input.assertionStatus,
+			userId
+		);
+		if (assertionStatusError) {
+			return { error: assertionStatusError };
 		}
 
 		// ADR 0004 D5: citedElementId is AWAY_GOAL-only, must reference an

--- a/lib/transforms/build-tree.ts
+++ b/lib/transforms/build-tree.ts
@@ -24,6 +24,8 @@ export interface ElementWithLinks {
 	// every other field below.
 	assertionStatus: AssertionStatus | null;
 	assumption: string | null;
+	// Element-level citation (ADR 0004 D5) — AWAY_GOAL only
+	citedElementId: string | null;
 	// Comments (optional - only included when export includes comments)
 	comments?: ExportComment[];
 	context: string[];
@@ -68,6 +70,7 @@ const TYPE_SPECIFIC_FIELDS = [
 	"moduleReferenceId",
 	"moduleEmbedType",
 	"modulePublicSummary",
+	"citedElementId",
 ] as const;
 
 /**

--- a/lib/transforms/element-response.ts
+++ b/lib/transforms/element-response.ts
@@ -51,6 +51,11 @@ export function transformToResponse(element: {
 	// export time in build-tree.ts, not here — this response mirrors the
 	// raw stored value for the canvas/JSON-editor UI).
 	assertionStatus?: AssertionStatus | null;
+	// Element-level citation (ADR 0004 D5) — AWAY_GOAL only
+	citedElementId?: string | null;
+	// Dangling-citation indicator (ADR 0004 D5) — true when citedElementId
+	// was nullified because the cited element was deleted/detached
+	citationDangling?: boolean;
 	caseId: string;
 	parentId: string | null;
 	createdAt: Date;
@@ -97,6 +102,12 @@ export function transformToResponse(element: {
 	}
 	if (element.assertionStatus) {
 		response.assertionStatus = element.assertionStatus;
+	}
+	if (element.citedElementId) {
+		response.citedElementId = element.citedElementId;
+	}
+	if (element.citationDangling) {
+		response.citationDangling = true;
 	}
 
 	return response;

--- a/lib/transforms/nested-to-flat.ts
+++ b/lib/transforms/nested-to-flat.ts
@@ -95,6 +95,13 @@ function nodeToElement(
 		// through the nested→flat step; case-import-service.ts's createElements
 		// carries it the rest of the way into the createMany rows.
 		assertionStatus: node.assertionStatus,
+		// Element-level citation (ADR 0004 D5) — preserve the cited id through
+		// the nested->flat step; case-import-service.ts's createElements
+		// carries it the rest of the way into the createMany rows (remapped
+		// through the import's idMap when the cited element is part of the
+		// SAME import payload, preserved verbatim otherwise — see that
+		// function's docstring for why).
+		citedElementId: node.citedElementId,
 	};
 
 	// Preserve comments if present

--- a/prisma/migrations/20260719010000_add_element_cited_element_id/migration.sql
+++ b/prisma/migrations/20260719010000_add_element_cited_element_id/migration.sql
@@ -1,0 +1,19 @@
+-- ADR 0004 D5: element-level citation. Additive only — nullable self-relation
+-- column + a default-false flag column, no backfill, no behaviour change for
+-- existing rows. Applicability (AWAY_GOAL only) is enforced in application
+-- code, not by the schema. ON DELETE SET NULL is a defence-in-depth safety
+-- net for the rare hard-delete path (case purge) — it mirrors the existing
+-- defeats_element_id FK below and does NOT replace the primary integrity
+-- rule, which is enforced explicitly in element-service.ts (nullify +
+-- citation_dangling flag) on the normal soft-delete/detach paths, since a
+-- bare DB-level action cannot also set the flag.
+
+-- AlterTable
+ALTER TABLE "assurance_elements" ADD COLUMN "cited_element_id" TEXT;
+ALTER TABLE "assurance_elements" ADD COLUMN "citation_dangling" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateIndex
+CREATE INDEX "assurance_elements_citedElementId_idx" ON "assurance_elements"("cited_element_id");
+
+-- AddForeignKey
+ALTER TABLE "assurance_elements" ADD CONSTRAINT "assurance_elements_cited_element_id_fkey" FOREIGN KEY ("cited_element_id") REFERENCES "assurance_elements"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260719010000_add_element_cited_element_id/migration.sql
+++ b/prisma/migrations/20260719010000_add_element_cited_element_id/migration.sql
@@ -13,7 +13,7 @@ ALTER TABLE "assurance_elements" ADD COLUMN "cited_element_id" TEXT;
 ALTER TABLE "assurance_elements" ADD COLUMN "citation_dangling" BOOLEAN NOT NULL DEFAULT false;
 
 -- CreateIndex
-CREATE INDEX "assurance_elements_citedElementId_idx" ON "assurance_elements"("cited_element_id");
+CREATE INDEX "assurance_elements_cited_element_id_idx" ON "assurance_elements"("cited_element_id");
 
 -- AddForeignKey
 ALTER TABLE "assurance_elements" ADD CONSTRAINT "assurance_elements_cited_element_id_fkey" FOREIGN KEY ("cited_element_id") REFERENCES "assurance_elements"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -420,6 +420,22 @@ model AssuranceElement {
   // overwritten) is enforced in lib/services/element-service.ts, not here.
   assertionStatus     AssertionStatus? @map("assertion_status")
 
+  // Element-level citation (ADR 0004 D5): lets an AWAY_GOAL name the specific
+  // element it cites within the referenced case (moduleReferenceId names the
+  // case; citedElementId names the element within it). Applicability
+  // (AWAY_GOAL only) is enforced in lib/schemas/element-validation.ts and
+  // lib/services/element-service.ts, not here. No onDelete override — Prisma
+  // infers SetNull for this optional self-relation (matching defeatsElementId
+  // above), which is a defence-in-depth safety net for the rare hard-delete
+  // path (case purge); the primary soft-delete/detach integrity rule
+  // (nullify + flag) is enforced explicitly in element-service.ts since it
+  // also has to set citationDangling, which a bare DB-level action can't do.
+  citedElementId      String?          @map("cited_element_id")
+  // True when citedElementId was nullified because the cited element was
+  // deleted or detached from its case (dangling-citation indicator). Cleared
+  // whenever the author explicitly sets/clears citedElementId again.
+  citationDangling    Boolean          @default(false) @map("citation_dangling")
+
   // Timestamps
   createdAt           DateTime         @default(now()) @map("created_at")
   updatedAt           DateTime         @updatedAt @map("updated_at")
@@ -438,6 +454,8 @@ model AssuranceElement {
   defeatsElement      AssuranceElement? @relation("Defeater", fields: [defeatsElementId], references: [id])
   defeatedBy          AssuranceElement[] @relation("Defeater")
   moduleReference     AssuranceCase?   @relation("ModuleReference", fields: [moduleReferenceId], references: [id])
+  citedElement        AssuranceElement? @relation("Citation", fields: [citedElementId], references: [id])
+  citedBy             AssuranceElement[] @relation("Citation")
 
   // Evidence many-to-many
   evidenceLinksFrom   EvidenceLink[]   @relation("EvidenceSource")
@@ -452,6 +470,7 @@ model AssuranceElement {
   @@index([caseId, elementType])
   @@index([caseId, deletedAt], map: "assurance_elements_case_deleted_idx")
   @@index([parentId])
+  @@index([citedElementId])
   @@map("assurance_elements")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -434,6 +434,11 @@ model AssuranceElement {
   // True when citedElementId was nullified because the cited element was
   // deleted or detached from its case (dangling-citation indicator). Cleared
   // whenever the author explicitly sets/clears citedElementId again.
+  // Deliberately excluded from the case export/import exchange format
+  // (ADR 0004 D2 precedent: derived, deployment-relative state, not
+  // author-authored content) — recomputed at import time by the
+  // citedElementId resolution step in case-import-service.ts, not carried
+  // through the export/import payload itself.
   citationDangling    Boolean          @default(false) @map("citation_dangling")
 
   // Timestamps
@@ -470,7 +475,7 @@ model AssuranceElement {
   @@index([caseId, elementType])
   @@index([caseId, deletedAt], map: "assurance_elements_case_deleted_idx")
   @@index([parentId])
-  @@index([citedElementId])
+  @@index([citedElementId], map: "assurance_elements_cited_element_id_idx")
   @@map("assurance_elements")
 }
 

--- a/src/__tests__/integration/api-elements-cited-element-id.test.ts
+++ b/src/__tests__/integration/api-elements-cited-element-id.test.ts
@@ -1,0 +1,264 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	createTestCase,
+	createTestElement,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+/**
+ * ADR 0004 D5: citedElementId lets an AWAY_GOAL name the specific element it
+ * cites within the case named by moduleReferenceId. Following the D3
+ * (assertionStatus) review lesson: `buildCreateInput`/`buildUpdateInput`
+ * (app/api/cases/[id]/elements/route.ts, app/api/elements/[id]/route.ts) are
+ * hand-maintained allowlists that silently drop unforwarded fields, so these
+ * tests exercise the ACTUAL route handlers, not just the service layer.
+ *
+ * Creating an AWAY_GOAL via the single-element POST route is not exercised
+ * here: `moduleReferenceId` (required by AwayGoalSchema) is not wired into
+ * `createElementSchema`/`buildCreateInput` today — a pre-existing gap, not
+ * introduced by this change (AWAY_GOAL elements are created via the batch
+ * path — case-batch-update-service.ts — which already handles
+ * moduleReferenceId). AWAY_GOAL fixtures here are seeded directly via the
+ * test factory; the PUT route is exercised as "the real route" per the
+ * dispatch brief.
+ */
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/services/sse-connection-manager", () => ({
+	emitSSEEvent: vi.fn(),
+	sseConnectionManager: { broadcast: vi.fn() },
+}));
+
+const NOT_APPLICABLE_PATTERN = /only applicable to AWAY_GOAL/;
+const NOT_FOUND_PATTERN = /must reference an existing element/;
+const SELF_CITATION_PATTERN = /cannot reference the element itself/;
+
+beforeEach(async () => {
+	await mockNoAuth();
+});
+
+describe("POST /api/cases/[id]/elements — citedElementId (ADR 0004 D5)", () => {
+	it("rejects citedElementId on a non-AWAY_GOAL type through the route handler", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const target = await createTestElement(testCase.id, owner.id, {
+			elementType: "GOAL",
+			name: "Existing Goal",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import("@/app/api/cases/[id]/elements/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/elements`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					type: "strategy",
+					name: "A Strategy",
+					description: "Not an AWAY_GOAL",
+					citedElementId: target.id,
+				}),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await POST(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toMatch(NOT_APPLICABLE_PATTERN);
+
+		const elements = await prisma.assuranceElement.findMany({
+			where: { caseId: testCase.id, elementType: "STRATEGY" },
+		});
+		expect(elements).toHaveLength(0);
+	});
+});
+
+describe("PUT /api/elements/[id] — citedElementId (ADR 0004 D5)", () => {
+	it("lets an author set citedElementId on an AWAY_GOAL through the route handler, persisted per a separate refetch", async () => {
+		const owner = await createTestUser();
+		const homeCase = await createTestCase(owner.id);
+		const awayCase = await createTestCase(owner.id);
+		const citedGoal = await createTestElement(awayCase.id, owner.id, {
+			elementType: "GOAL",
+			name: "Away Goal",
+		});
+		const awayGoal = await createTestElement(homeCase.id, owner.id, {
+			elementType: "AWAY_GOAL",
+			name: "Reference",
+			moduleReferenceId: awayCase.id,
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await import("@/app/api/elements/[id]/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/elements/${awayGoal.id}`,
+			{
+				method: "PUT",
+				body: JSON.stringify({ citedElementId: citedGoal.id }),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: awayGoal.id }),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.citedElementId).toBe(citedGoal.id);
+
+		// Separate refetch — proves DB persistence, not just an echoed response.
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: awayGoal.id },
+		});
+		expect(inDb?.citedElementId).toBe(citedGoal.id);
+	});
+
+	it("rejects citedElementId on a non-AWAY_GOAL type through the route handler", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const goal = await createTestElement(testCase.id, owner.id, {
+			elementType: "GOAL",
+		});
+		const otherGoal = await createTestElement(testCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+			parentId: goal.id,
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await import("@/app/api/elements/[id]/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/elements/${goal.id}`,
+			{
+				method: "PUT",
+				body: JSON.stringify({ citedElementId: otherGoal.id }),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: goal.id }),
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toMatch(NOT_APPLICABLE_PATTERN);
+
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: goal.id },
+		});
+		expect(inDb?.citedElementId).toBeNull();
+	});
+
+	it("rejects a nonexistent citedElementId target through the route handler", async () => {
+		const owner = await createTestUser();
+		const homeCase = await createTestCase(owner.id);
+		const awayCase = await createTestCase(owner.id);
+		const awayGoal = await createTestElement(homeCase.id, owner.id, {
+			elementType: "AWAY_GOAL",
+			moduleReferenceId: awayCase.id,
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await import("@/app/api/elements/[id]/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/elements/${awayGoal.id}`,
+			{
+				method: "PUT",
+				body: JSON.stringify({
+					citedElementId: "00000000-0000-0000-0000-000000000000",
+				}),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: awayGoal.id }),
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toMatch(NOT_FOUND_PATTERN);
+
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: awayGoal.id },
+		});
+		expect(inDb?.citedElementId).toBeNull();
+	});
+
+	it("rejects self-citation through the route handler", async () => {
+		const owner = await createTestUser();
+		const homeCase = await createTestCase(owner.id);
+		const awayCase = await createTestCase(owner.id);
+		const awayGoal = await createTestElement(homeCase.id, owner.id, {
+			elementType: "AWAY_GOAL",
+			moduleReferenceId: awayCase.id,
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await import("@/app/api/elements/[id]/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/elements/${awayGoal.id}`,
+			{
+				method: "PUT",
+				body: JSON.stringify({ citedElementId: awayGoal.id }),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: awayGoal.id }),
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toMatch(SELF_CITATION_PATTERN);
+
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: awayGoal.id },
+		});
+		expect(inDb?.citedElementId).toBeNull();
+	});
+
+	it("clears citationDangling when the author sets a fresh citedElementId", async () => {
+		const owner = await createTestUser();
+		const homeCase = await createTestCase(owner.id);
+		const awayCase = await createTestCase(owner.id);
+		const citedGoal = await createTestElement(awayCase.id, owner.id, {
+			elementType: "GOAL",
+		});
+		const awayGoal = await createTestElement(homeCase.id, owner.id, {
+			elementType: "AWAY_GOAL",
+			moduleReferenceId: awayCase.id,
+			citationDangling: true,
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await import("@/app/api/elements/[id]/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/elements/${awayGoal.id}`,
+			{
+				method: "PUT",
+				body: JSON.stringify({ citedElementId: citedGoal.id }),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: awayGoal.id }),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.citationDangling).toBeUndefined();
+
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: awayGoal.id },
+		});
+		expect(inDb?.citationDangling).toBe(false);
+	});
+});

--- a/src/__tests__/integration/case-batch-update-service.test.ts
+++ b/src/__tests__/integration/case-batch-update-service.test.ts
@@ -506,7 +506,7 @@ describe("applyBatchUpdate", () => {
 					citedElementId: smuggledCitedGoal.id,
 				},
 			},
-		] as ElementChange[];
+		] as unknown as ElementChange[];
 
 		expectSuccess(await applyBatchUpdate(user.id, testCase.id, changes));
 

--- a/src/__tests__/integration/case-batch-update-service.test.ts
+++ b/src/__tests__/integration/case-batch-update-service.test.ts
@@ -458,4 +458,64 @@ describe("applyBatchUpdate", () => {
 		// ...but the smuggled field did not.
 		expect(afterBatch?.assertionStatus).toBeNull();
 	});
+
+	/**
+	 * ADR 0004 D5 review fix item 2 — D3-pattern negative test (same lesson
+	 * as api-elements-cited-element-id.test.ts's header comment: hand-
+	 * maintained field allowlists silently drop unforwarded fields, so a
+	 * malicious/careless payload can't smuggle a field through by riding
+	 * along with a legitimate change). `UpdateElementData`
+	 * (lib/case/tree-diff.ts) and `buildUpdateData`'s field allowlist
+	 * (case-batch-update-service.ts) do not include citedElementId, so it is
+	 * silently dropped here even though the object smuggling it is well-
+	 * typed enough to pass a loose caller. No production change accompanies
+	 * this test — it pins existing (correct) behaviour.
+	 */
+	it("ignores a smuggled citedElementId in a batch update, applying only the allowlisted change", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+		const awayCase = await createTestCase(user.id);
+		const originalCitedGoal = await createTestElement(awayCase.id, user.id, {
+			elementType: "GOAL",
+			name: "Original Cited Goal",
+		});
+		const smuggledCitedGoal = await createTestElement(awayCase.id, user.id, {
+			elementType: "GOAL",
+			name: "Smuggled Cited Goal",
+		});
+		const awayGoal = await createTestElement(testCase.id, user.id, {
+			elementType: "AWAY_GOAL",
+			name: "Original Name",
+			moduleReferenceId: awayCase.id,
+			citedElementId: originalCitedGoal.id,
+		});
+
+		const { applyBatchUpdate } = await import(
+			"@/lib/services/case-batch-update-service"
+		);
+
+		// citedElementId is not part of UpdateElementData — smuggled here via
+		// an `as` cast to simulate a caller that bypasses the type system
+		// (e.g. a hand-built JSON payload to the batch API route).
+		const changes = [
+			{
+				type: "update",
+				elementId: awayGoal.id,
+				data: {
+					name: "Updated Name",
+					citedElementId: smuggledCitedGoal.id,
+				},
+			},
+		] as ElementChange[];
+
+		expectSuccess(await applyBatchUpdate(user.id, testCase.id, changes));
+
+		const updated = await prisma.assuranceElement.findUnique({
+			where: { id: awayGoal.id },
+		});
+		// Allowlisted change applied.
+		expect(updated?.name).toBe("Updated Name");
+		// Smuggled field had no effect — original citation is untouched.
+		expect(updated?.citedElementId).toBe(originalCitedGoal.id);
+	});
 });

--- a/src/__tests__/integration/case-export.test.ts
+++ b/src/__tests__/integration/case-export.test.ts
@@ -255,4 +255,61 @@ describe("exportCase", () => {
 			expect(evidenceNode?.assertionStatus).toBe("AS_CITED");
 		});
 	});
+
+	describe("citedElementId (ADR 0004 D5)", () => {
+		it("carries citedElementId on an AWAY_GOAL node", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			const awayCase = await createTestCase(owner.id);
+			const citedGoal = await createTestElement(awayCase.id, owner.id, {
+				elementType: "GOAL",
+				name: "Away Goal",
+			});
+			const rootGoal = await createTestElement(testCase.id, owner.id, {
+				elementType: "GOAL",
+				name: "Root Goal",
+				role: "TOP_LEVEL",
+			});
+			await createTestElement(testCase.id, owner.id, {
+				elementType: "AWAY_GOAL",
+				name: "Reference",
+				parentId: rootGoal.id,
+				moduleReferenceId: awayCase.id,
+				citedElementId: citedGoal.id,
+			});
+
+			const { exportCase } = await import("@/lib/services/case-export-service");
+			const data = expectSuccess(await exportCase(owner.id, testCase.id));
+
+			const awayGoalNode = data.tree.children.find(
+				(c: { type: string }) => c.type === "AWAY_GOAL"
+			);
+			expect(awayGoalNode?.citedElementId).toBe(citedGoal.id);
+		});
+
+		it("omits citedElementId when unset", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			const awayCase = await createTestCase(owner.id);
+			const rootGoal = await createTestElement(testCase.id, owner.id, {
+				elementType: "GOAL",
+				name: "Root Goal",
+				role: "TOP_LEVEL",
+			});
+			await createTestElement(testCase.id, owner.id, {
+				elementType: "AWAY_GOAL",
+				name: "Reference",
+				parentId: rootGoal.id,
+				moduleReferenceId: awayCase.id,
+			});
+
+			const { exportCase } = await import("@/lib/services/case-export-service");
+			const data = expectSuccess(await exportCase(owner.id, testCase.id));
+
+			const awayGoalNode = data.tree.children.find(
+				(c: { type: string }) => c.type === "AWAY_GOAL"
+			);
+			expect(awayGoalNode?.citedElementId).toBeUndefined();
+		});
+	});
 });

--- a/src/__tests__/integration/case-import.test.ts
+++ b/src/__tests__/integration/case-import.test.ts
@@ -206,6 +206,7 @@ describe("validateImportData", () => {
 	});
 
 	/**
+	/**
 	 * ADR 0004 D3, review follow-up (round 2, both reviewers independently):
 	 * `createElements` (case-import-service.ts) previously dropped
 	 * `assertionStatus` from the createMany rows, so any declared status
@@ -243,5 +244,65 @@ describe("validateImportData", () => {
 			await exportCase(importer.id, imported.caseId)
 		);
 		expect(secondExport.tree.assertionStatus).toBe("NEEDS_SUPPORT");
+	});
+
+	/**
+	 * ADR 0004 D5: citedElementId names an element in the case referenced by
+	 * moduleReferenceId — i.e. normally a DIFFERENT case from the one being
+	 * exported/imported here, so the cited id is almost never part of the
+	 * import's own idMap. Lead ruling (dispatch brief, cid 2026-07-19):
+	 * preserve the original id VERBATIM in that case rather than guessing at
+	 * a remap — there is no cross-case id-remapping table in this codebase
+	 * (moduleReferenceId itself isn't remapped either). This test proves the
+	 * verbatim-preserve path with a direct DB assertion on the imported row.
+	 */
+	it("preserves a citedElementId pointing outside the export verbatim through export -> import (round-trip fidelity)", async () => {
+		const owner = await createTestUser();
+		const homeCase = await createTestCase(owner.id);
+		const awayCase = await createTestCase(owner.id);
+		const citedGoal = await createTestElement(awayCase.id, owner.id, {
+			elementType: "GOAL",
+			name: "Away Goal",
+		});
+		const rootGoal = await createTestElement(homeCase.id, owner.id, {
+			elementType: "GOAL",
+			name: "Root Goal",
+			role: "TOP_LEVEL",
+		});
+		await createTestElement(homeCase.id, owner.id, {
+			elementType: "AWAY_GOAL",
+			name: "Reference",
+			parentId: rootGoal.id,
+			moduleReferenceId: awayCase.id,
+			citedElementId: citedGoal.id,
+		});
+
+		const { exportCase } = await import("@/lib/services/case-export-service");
+		const { importCase } = await import("@/lib/services/case-import-service");
+
+		const firstExport = expectSuccess(await exportCase(owner.id, homeCase.id));
+		const exportedAwayGoal = firstExport.tree.children.find(
+			(c: { type: string }) => c.type === "AWAY_GOAL"
+		);
+		expect(exportedAwayGoal?.citedElementId).toBe(citedGoal.id);
+
+		const importer = await createTestUser();
+		const imported = expectSuccess(await importCase(importer.id, firstExport));
+
+		// Direct DB check — proves the createMany write itself carries the
+		// (unmapped) id, not just whatever a later export happens to resolve.
+		const importedAwayGoal = await prisma.assuranceElement.findFirst({
+			where: { caseId: imported.caseId, elementType: "AWAY_GOAL" },
+		});
+		expect(importedAwayGoal?.citedElementId).toBe(citedGoal.id);
+
+		const secondExport = expectSuccess(
+			await exportCase(importer.id, imported.caseId)
+		);
+		const reexportedAwayGoal = secondExport.tree.children.find(
+			(c: { type: string }) => c.type === "AWAY_GOAL"
+		);
+		expect(reexportedAwayGoal?.citedElementId).toBe(citedGoal.id);
+	});
 	});
 });

--- a/src/__tests__/integration/case-import.test.ts
+++ b/src/__tests__/integration/case-import.test.ts
@@ -304,5 +304,59 @@ describe("validateImportData", () => {
 		);
 		expect(reexportedAwayGoal?.citedElementId).toBe(citedGoal.id);
 	});
+
+	/**
+	 * Review fix item 1 (BLOCKING, P2003 trace): a citedElementId that
+	 * resolves NOWHERE in the target DB used to hit createElements'
+	 * createMany FK (assurance_elements_cited_element_id_fkey) and roll back
+	 * prisma.$transaction — the entire import failed, not just the one
+	 * citation. The fix batch-resolves citedElementId before the insert
+	 * (idMap first, then one findMany against the target DB); anything left
+	 * unresolvable is downgraded to citedElementId: null,
+	 * citationDangling: true instead of failing the import. This test
+	 * exercises exactly that path with an id that exists nowhere in the
+	 * (fresh, per-test) target DB.
+	 */
+	it("imports successfully when citedElementId resolves nowhere in the target DB, flagging citationDangling instead of failing the whole import", async () => {
+		const owner = await createTestUser();
+		const homeCase = await createTestCase(owner.id);
+		const rootGoal = await createTestElement(homeCase.id, owner.id, {
+			elementType: "GOAL",
+			name: "Root Goal",
+			role: "TOP_LEVEL",
+		});
+		const unresolvableCitedId = crypto.randomUUID();
+		await createTestElement(homeCase.id, owner.id, {
+			elementType: "AWAY_GOAL",
+			name: "Reference",
+			parentId: rootGoal.id,
+			moduleReferenceId: homeCase.id,
+			citedElementId: unresolvableCitedId,
+		});
+
+		const { exportCase } = await import("@/lib/services/case-export-service");
+		const { importCase } = await import("@/lib/services/case-import-service");
+
+		const exported = expectSuccess(await exportCase(owner.id, homeCase.id));
+
+		const importer = await createTestUser();
+		const imported = expectSuccess(await importCase(importer.id, exported));
+
+		// The import SUCCEEDED — not rolled back — and both elements landed.
+		expect(imported.elementCount).toBe(2);
+
+		const importedAwayGoal = await prisma.assuranceElement.findFirst({
+			where: { caseId: imported.caseId, elementType: "AWAY_GOAL" },
+		});
+		expect(importedAwayGoal?.citedElementId).toBeNull();
+		expect(importedAwayGoal?.citationDangling).toBe(true);
+
+		// The unrelated goal is intact — proves this isn't a partial/silent
+		// drop of the rest of the import.
+		const importedGoal = await prisma.assuranceElement.findFirst({
+			where: { caseId: imported.caseId, elementType: "GOAL" },
+		});
+		expect(importedGoal).not.toBeNull();
+		expect(importedGoal?.name).toBe("Root Goal");
 	});
 });

--- a/src/__tests__/integration/case-import.test.ts
+++ b/src/__tests__/integration/case-import.test.ts
@@ -318,29 +318,51 @@ describe("validateImportData", () => {
 	 * (fresh, per-test) target DB.
 	 */
 	it("imports successfully when citedElementId resolves nowhere in the target DB, flagging citationDangling instead of failing the whole import", async () => {
+		// The fixture is a hand-built import JSON, not seeded via
+		// createTestElement — createTestElement writes through Prisma
+		// directly, so an unresolvable citedElementId would hit the
+		// assurance_elements_cited_element_id_fkey FK at SEED time and never
+		// reach the import path this test targets. moduleReferenceId still
+		// needs to point at a real case (a pre-existing, unrelated FK on
+		// AWAY_GOAL, not part of this fix) — an actual case covers that
+		// without touching citedElementId resolution.
 		const owner = await createTestUser();
-		const homeCase = await createTestCase(owner.id);
-		const rootGoal = await createTestElement(homeCase.id, owner.id, {
-			elementType: "GOAL",
-			name: "Root Goal",
-			role: "TOP_LEVEL",
-		});
+		const awayCase = await createTestCase(owner.id);
 		const unresolvableCitedId = crypto.randomUUID();
-		await createTestElement(homeCase.id, owner.id, {
-			elementType: "AWAY_GOAL",
-			name: "Reference",
-			parentId: rootGoal.id,
-			moduleReferenceId: homeCase.id,
-			citedElementId: unresolvableCitedId,
-		});
 
-		const { exportCase } = await import("@/lib/services/case-export-service");
+		const json = {
+			version: "1.0",
+			exportedAt: new Date().toISOString(),
+			case: {
+				name: "Dangling Citation Case",
+				description: "AWAY_GOAL cites an id absent from the target DB",
+			},
+			tree: {
+				id: "40000000-0000-4000-8000-000000000001",
+				type: "GOAL",
+				name: "Root Goal",
+				description: "Top-level goal",
+				inSandbox: false,
+				role: "TOP_LEVEL",
+				children: [
+					{
+						id: "40000000-0000-4000-8000-000000000002",
+						type: "AWAY_GOAL",
+						name: "Reference",
+						description: "Cites an element that doesn't exist anywhere",
+						inSandbox: false,
+						moduleReferenceId: awayCase.id,
+						citedElementId: unresolvableCitedId,
+						children: [],
+					},
+				],
+			},
+		};
+
 		const { importCase } = await import("@/lib/services/case-import-service");
 
-		const exported = expectSuccess(await exportCase(owner.id, homeCase.id));
-
 		const importer = await createTestUser();
-		const imported = expectSuccess(await importCase(importer.id, exported));
+		const imported = expectSuccess(await importCase(importer.id, json));
 
 		// The import SUCCEEDED — not rolled back — and both elements landed.
 		expect(imported.elementCount).toBe(2);

--- a/src/__tests__/integration/element-citation-integrity.test.ts
+++ b/src/__tests__/integration/element-citation-integrity.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import prisma from "@/lib/prisma";
+import { deleteElement, detachElement } from "@/lib/services/element-service";
+import { expectSuccess } from "../utils/assertion-helpers";
+import {
+	createTestCase,
+	createTestElement,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+/**
+ * ADR 0004 D5 integrity rule (ruled by cid + Chris, 2026-07-19): when a
+ * cited element is deleted or detached from its case, citing elements are
+ * NOT left pointing at a dangling id — citedElementId is nullified and
+ * citationDangling is set on the citing element, without blocking the
+ * deletion/detach itself. Tested both directions.
+ */
+describe("element citation integrity (ADR 0004 D5)", () => {
+	describe("deleting the cited element", () => {
+		it("nullifies citedElementId and sets citationDangling on the citing AWAY_GOAL", async () => {
+			const owner = await createTestUser();
+			const homeCase = await createTestCase(owner.id);
+			const awayCase = await createTestCase(owner.id);
+			const citedGoal = await createTestElement(awayCase.id, owner.id, {
+				elementType: "GOAL",
+			});
+			const awayGoal = await createTestElement(homeCase.id, owner.id, {
+				elementType: "AWAY_GOAL",
+				moduleReferenceId: awayCase.id,
+				citedElementId: citedGoal.id,
+			});
+
+			expectSuccess(await deleteElement(owner.id, citedGoal.id));
+
+			const inDb = await prisma.assuranceElement.findUnique({
+				where: { id: awayGoal.id },
+			});
+			expect(inDb?.citedElementId).toBeNull();
+			expect(inDb?.citationDangling).toBe(true);
+
+			// The deletion itself was not blocked.
+			const deletedGoal = await prisma.assuranceElement.findUnique({
+				where: { id: citedGoal.id },
+			});
+			expect(deletedGoal?.deletedAt).not.toBeNull();
+		});
+
+		it("nullifies citations pointing at a descendant swept up by a parent delete", async () => {
+			const owner = await createTestUser();
+			const homeCase = await createTestCase(owner.id);
+			const awayCase = await createTestCase(owner.id);
+			const parentGoal = await createTestElement(awayCase.id, owner.id, {
+				elementType: "GOAL",
+			});
+			const citedChild = await createTestElement(awayCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+				parentId: parentGoal.id,
+			});
+			const awayGoal = await createTestElement(homeCase.id, owner.id, {
+				elementType: "AWAY_GOAL",
+				moduleReferenceId: awayCase.id,
+				citedElementId: citedChild.id,
+			});
+
+			// Deleting the PARENT cascades soft-delete to citedChild too.
+			expectSuccess(await deleteElement(owner.id, parentGoal.id));
+
+			const inDb = await prisma.assuranceElement.findUnique({
+				where: { id: awayGoal.id },
+			});
+			expect(inDb?.citedElementId).toBeNull();
+			expect(inDb?.citationDangling).toBe(true);
+		});
+
+		it("does not affect citations pointing at an unrelated, still-active element", async () => {
+			const owner = await createTestUser();
+			const homeCase = await createTestCase(owner.id);
+			const awayCase = await createTestCase(owner.id);
+			const citedGoal = await createTestElement(awayCase.id, owner.id, {
+				elementType: "GOAL",
+			});
+			const unrelatedGoal = await createTestElement(awayCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+				parentId: citedGoal.id,
+			});
+			const awayGoal = await createTestElement(homeCase.id, owner.id, {
+				elementType: "AWAY_GOAL",
+				moduleReferenceId: awayCase.id,
+				citedElementId: citedGoal.id,
+			});
+
+			expectSuccess(await deleteElement(owner.id, unrelatedGoal.id));
+
+			const inDb = await prisma.assuranceElement.findUnique({
+				where: { id: awayGoal.id },
+			});
+			expect(inDb?.citedElementId).toBe(citedGoal.id);
+			expect(inDb?.citationDangling).toBe(false);
+		});
+	});
+
+	describe("detaching the cited element", () => {
+		it("nullifies citedElementId and sets citationDangling on the citing AWAY_GOAL", async () => {
+			const owner = await createTestUser();
+			const homeCase = await createTestCase(owner.id);
+			const awayCase = await createTestCase(owner.id);
+			const parentGoal = await createTestElement(awayCase.id, owner.id, {
+				elementType: "GOAL",
+			});
+			const citedClaim = await createTestElement(awayCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+				parentId: parentGoal.id,
+			});
+			const awayGoal = await createTestElement(homeCase.id, owner.id, {
+				elementType: "AWAY_GOAL",
+				moduleReferenceId: awayCase.id,
+				citedElementId: citedClaim.id,
+			});
+
+			expectSuccess(await detachElement(owner.id, citedClaim.id));
+
+			const inDb = await prisma.assuranceElement.findUnique({
+				where: { id: awayGoal.id },
+			});
+			expect(inDb?.citedElementId).toBeNull();
+			expect(inDb?.citationDangling).toBe(true);
+
+			// The detach itself was not blocked.
+			const detached = await prisma.assuranceElement.findUnique({
+				where: { id: citedClaim.id },
+			});
+			expect(detached?.inSandbox).toBe(true);
+			expect(detached?.parentId).toBeNull();
+		});
+
+		it("does not affect citations pointing at a different, still-attached element", async () => {
+			const owner = await createTestUser();
+			const homeCase = await createTestCase(owner.id);
+			const awayCase = await createTestCase(owner.id);
+			const parentGoal = await createTestElement(awayCase.id, owner.id, {
+				elementType: "GOAL",
+			});
+			const citedClaim = await createTestElement(awayCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+				parentId: parentGoal.id,
+			});
+			const otherClaim = await createTestElement(awayCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+				parentId: parentGoal.id,
+			});
+			const awayGoal = await createTestElement(homeCase.id, owner.id, {
+				elementType: "AWAY_GOAL",
+				moduleReferenceId: awayCase.id,
+				citedElementId: citedClaim.id,
+			});
+
+			expectSuccess(await detachElement(owner.id, otherClaim.id));
+
+			const inDb = await prisma.assuranceElement.findUnique({
+				where: { id: awayGoal.id },
+			});
+			expect(inDb?.citedElementId).toBe(citedClaim.id);
+			expect(inDb?.citationDangling).toBe(false);
+		});
+	});
+});

--- a/src/__tests__/utils/prisma-factories.ts
+++ b/src/__tests__/utils/prisma-factories.ts
@@ -167,6 +167,12 @@ type ElementOverrides = Partial<{
 		| "AXIOMATIC"
 		| "DEFEATED"
 		| "AS_CITED";
+	// MODULE/AWAY_GOAL — required by AwayGoalSchema/ModuleSchema when
+	// elementType is MODULE or AWAY_GOAL (lib/schemas/element-validation.ts).
+	moduleReferenceId: string;
+	// ADR 0004 D5 — AWAY_GOAL only
+	citedElementId: string | null;
+	citationDangling: boolean;
 }>;
 
 export function createTestElement(
@@ -187,6 +193,9 @@ export function createTestElement(
 			url: overrides.url,
 			inSandbox: overrides.inSandbox ?? false,
 			assertionStatus: overrides.assertionStatus,
+			moduleReferenceId: overrides.moduleReferenceId,
+			citedElementId: overrides.citedElementId,
+			citationDangling: overrides.citationDangling ?? false,
 		},
 	});
 }


### PR DESCRIPTION
## Summary

Implements ADR 0004 D5: a nullable `citedElementId` self-relation on `AssuranceElement`, so an AWAY_GOAL can name the specific goal it cites in the referenced case (previously only the case was nameable via `moduleReferenceId`). Scope is schema + validation + import/export handling; resolution UI is post-1.0.

- Prisma: nullable self-relation with `ON DELETE SET NULL` backstop (matches the `defeatsElementId` precedent) + persisted `citationDangling` flag
- Validation: AWAY_GOAL-only applicability, existence and self-citation checks (`enforceCitedElementIdRules`)
- Integrity rule: deleting/detaching a cited element nullifies citing elements and flags `citationDangling` (both directions tested, including descendant sweep)
- Import: citations are batch-resolved before the transaction; unresolvable ids are nullified and flagged at import time instead of failing the import
- Export: `citedElementId` carried on TreeNode/ElementV2 schemas; `citationDangling` deliberately excluded (derived, deployment-relative state — D2 precedent)

## Review chain

Implementation + review fix batch, then re-review: QA pass with mutation-confirmed tests (import resilience, batch-update pinning, shared guard-helper coverage on both create and update paths) and code review pass including an empirical re-run of the original import-failure reproduction, static/complexity audit clean for the change set. Rebased onto staging post-#875/#876 with both features' fields preserved; post-rebase delta re-verified (extraction-only helper for the combined assertionStatus guards). Final state: unit suite 79 files / 1166 tests green; targeted integration scope 9 files / 115 tests green; lint + typecheck clean; migrations apply cleanly from scratch.

## Notes

- The D5 migration (`20260719010000_add_element_cited_element_id`) was amended pre-push (index rename to the table's snake_case convention). It has never been deployed to a shared environment, so fresh applies are unaffected — but as a general convention, never edit an already-applied migration; add a new one.
- Known follow-up (tracked): a concurrent delete of a cited element in the window between import-time resolution and the insert transaction still fails the import wholesale; fix shape is to catch the FK violation in-transaction and downgrade to a dangling citation.