### PR TITLE
Support AWAY_GOAL via the single-element route + close the citedElementId import race

### DIFF
--- a/app/api/cases/[id]/elements/route.ts
+++ b/app/api/cases/[id]/elements/route.ts
@@ -69,6 +69,10 @@ function buildCreateInput(
 		// createElementSchema; applicability/existence/self-citation checks
 		// live in element-service.ts (createElement), not here.
 		citedElementId: body.citedElementId as string | null | undefined,
+		// Module reference (MODULE/AWAY_GOAL) — validated by
+		// createElementSchema; applicability/requiredness/existence checks
+		// live in element-service.ts (createElement), not here.
+		moduleReferenceId: body.moduleReferenceId as string | null | undefined,
 	};
 }
 

--- a/app/api/elements/[id]/route.ts
+++ b/app/api/elements/[id]/route.ts
@@ -64,6 +64,10 @@ function buildUpdateInput(body: Record<string, unknown>): UpdateElementInput {
 		// updateElementSchema; applicability/existence/self-citation checks
 		// live in element-service.ts (updateElement), not here.
 		citedElementId: body.citedElementId as string | null | undefined,
+		// Module reference (MODULE/AWAY_GOAL) — validated by
+		// updateElementSchema; applicability/existence checks live in
+		// element-service.ts (updateElement), not here.
+		moduleReferenceId: body.moduleReferenceId as string | null | undefined,
 	};
 }
 

--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -141,6 +141,11 @@ const ERROR_MAPPINGS: Array<{
 	// element type, nonexistent target, self-citation) is a validation
 	// failure (400), not a 500.
 	{ pattern: /^citedElementId /, factory: () => validationError("") },
+	// `element-service.ts`'s `rejectModuleReferenceIdIfNotApplicable` /
+	// `rejectMissingModuleReferenceId` / `validateModuleReferenceId`: a bad
+	// `moduleReferenceId` (wrong element type, missing on a required type,
+	// nonexistent target case) is a validation failure (400), not a 500.
+	{ pattern: /^moduleReferenceId /, factory: () => validationError("") },
 	// Lifecycle/state-guard errors from the integration registry service —
 	// the integration or token exists and is owned by the caller, but its
 	// current status makes the requested action a no-op or a terminal-state

--- a/lib/schemas/case-export.ts
+++ b/lib/schemas/case-export.ts
@@ -121,6 +121,20 @@ export const ElementV2Schema = z
 			.nullable()
 			.optional()
 			.describe("ID of the element cited by an AWAY_GOAL (ADR 0004 D5)"),
+		// Module reference — MODULE (required) and AWAY_GOAL (required) name
+		// the case they reference/cite into. Nullable/optional here (like
+		// citedElementId above) for import leniency with pre-existing exports
+		// that never carried the field — requiredness for MODULE/AWAY_GOAL is
+		// enforced by the DB foreign key and element-service.ts on the
+		// author-facing mutation routes, not by this exchange-format schema.
+		moduleReferenceId: z
+			.string()
+			.uuid()
+			.nullable()
+			.optional()
+			.describe(
+				"ID of the case referenced by a MODULE, or cited by an AWAY_GOAL"
+			),
 		inSandbox: z
 			.boolean()
 			.default(false)

--- a/lib/schemas/element.ts
+++ b/lib/schemas/element.ts
@@ -47,6 +47,12 @@ export const createElementSchema = z.object({
 	// Element-level citation (ADR 0004 D5) — AWAY_GOAL only; applicability,
 	// existence, and self-citation are enforced in element-service.ts.
 	citedElementId: z.string().uuid().nullable().optional(),
+	// Module reference — MODULE and AWAY_GOAL only; required for both on
+	// create (mirrors the batch path's AwayGoalSchema/ModuleSchema in
+	// lib/schemas/element-validation.ts). Only shape is validated here;
+	// applicability, requiredness, and existence are enforced in
+	// element-service.ts, matching the citedElementId pattern above.
+	moduleReferenceId: z.string().uuid().nullable().optional(),
 });
 
 export type CreateElementSchemaInput = z.input<typeof createElementSchema>;
@@ -80,6 +86,11 @@ export const updateElementSchema = z.object({
 	// Element-level citation (ADR 0004 D5) — AWAY_GOAL only; applicability,
 	// existence, and self-citation are enforced in element-service.ts.
 	citedElementId: z.string().uuid().nullable().optional(),
+	// Module reference — MODULE and AWAY_GOAL only. No requiredness check on
+	// update (mirrors the batch update path, case-batch-update-service.ts,
+	// which allows changing/clearing it without a required-field guard);
+	// applicability and existence are still enforced in element-service.ts.
+	moduleReferenceId: z.string().uuid().nullable().optional(),
 
 	// Sandbox flag
 	inSandbox: z.boolean().optional(),

--- a/lib/services/case-import-service.ts
+++ b/lib/services/case-import-service.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import type { CaseExportV2, ElementV2 } from "@/lib/schemas/case-export";
 import { detectAndValidate } from "@/lib/schemas/version-detection";
+import { Prisma } from "@/src/generated/prisma";
 
 export type ImportResult =
 	| {
@@ -181,6 +182,11 @@ async function createCaseWithPermission(
  * One findMany for the whole batch (not one query per element), run BEFORE
  * the transaction opens — keeps the transaction short per CLAUDE.md and
  * avoids doing this lookup once per createElements call.
+ *
+ * Also reused (a second time, with a fresh query) by createElements' resolve-
+ * window race backstop: if an id resolved here is deleted before the insert
+ * actually runs, re-calling this same function after that P2003 correctly
+ * comes back without it — see createElements' docstring.
  */
 async function resolveExternalCitedElementIds(
 	elements: ElementV2[],
@@ -248,7 +254,140 @@ function resolveImportedCitedElementId(
 }
 
 /**
+ * Foreign key constraint name for `citedElementId` (see the ADR 0004 D5
+ * migration, `assurance_elements_cited_element_id_fkey`). Anchoring the P2003
+ * catch below to this exact constraint name — rather than treating any
+ * P2003 from this insert as recoverable — matters because the same
+ * `createMany` call also carries `caseId`, `parentId`, `defeatsElementId`,
+ * and `moduleReferenceId` foreign keys: a P2003 on any of THOSE means real
+ * corrupt/inconsistent import data and must still fail the whole import
+ * loudly, not be silently downgraded.
+ */
+const CITED_ELEMENT_ID_FK_CONSTRAINT =
+	"assurance_elements_cited_element_id_fkey";
+
+/**
+ * True when `error` is the specific FK violation this module knows how to
+ * recover from: a `citedElementId` that pointed at a real row when
+ * `resolveExternalCitedElementIds` checked it, but was deleted before this
+ * `createMany` actually ran (the resolve-window race — see `createElements`'
+ * docstring). Matches on the Postgres constraint name Prisma echoes into the
+ * error message (verified against a live P2003: `error.message` contains
+ * "Foreign key constraint violated on the constraint: `<name>`"), not on
+ * `error.meta`'s shape, which is adapter-internal and not a stable contract.
+ */
+function isCitedElementIdForeignKeyError(error: unknown): boolean {
+	return (
+		error instanceof Prisma.PrismaClientKnownRequestError &&
+		error.code === "P2003" &&
+		error.message.includes(CITED_ELEMENT_ID_FK_CONSTRAINT)
+	);
+}
+
+/**
+ * Builds the createMany row for one element, resolving its citedElementId
+ * against the given (already-resolved) external-id set. Extracted from
+ * createElements so the resolve-window race backstop there can rebuild rows
+ * a second time, against a freshly re-resolved set, without duplicating the
+ * per-row field mapping.
+ */
+function buildElementRow(
+	el: ElementV2,
+	idMap: Map<string, string>,
+	resolvedExternalCitedElementIds: Set<string>,
+	caseId: string,
+	userId: string
+) {
+	const newId = idMap.get(el.id);
+	if (!newId) {
+		return null;
+	}
+
+	// Element-level citation (ADR 0004 D5) — see
+	// resolveImportedCitedElementId's docstring for the
+	// remap-else-preserve-verbatim-else-flag-dangling decision.
+	const { citedElementId, citationDangling } = resolveImportedCitedElementId(
+		el.citedElementId,
+		idMap,
+		resolvedExternalCitedElementIds
+	);
+
+	return {
+		id: newId,
+		caseId,
+		elementType: el.elementType,
+		role: el.role,
+		parentId: el.parentId ? (idMap.get(el.parentId) ?? null) : null,
+		name: el.name,
+		description: el.description,
+		assumption: el.assumption,
+		justification: el.justification,
+		context: el.context ?? [],
+		url: el.url,
+		level: el.level,
+		inSandbox: el.inSandbox,
+		fromPattern: el.fromPattern ?? false,
+		modifiedFromPattern: el.modifiedFromPattern ?? false,
+		// Per-assertion status (ADR 0004 D3) — lead ruling: import
+		// PRESERVES a declared status rather than dropping it. This is a
+		// direct createMany write (not through createElement/updateElement),
+		// so it intentionally bypasses guardAssertionStatusWrite/
+		// rejectDeclaredAsCited: import is a bulk data-load operation, not
+		// an author declaring a NEW status, and the source data already
+		// passed through export's own AS_CITED derivation.
+		assertionStatus: el.assertionStatus,
+		citedElementId,
+		citationDangling,
+		// Module reference (MODULE/AWAY_GOAL) — names a CASE, not an element
+		// in this import's own payload, so (unlike citedElementId) there is
+		// nothing in idMap to remap it through; preserved verbatim. A value
+		// that doesn't resolve in the target DB fails this createMany loudly
+		// via the module_reference_id foreign key — deliberately NOT given
+		// the citedElementId FK's soft-degrade treatment below, since it was
+		// never flagged as needing one (see nested-to-flat.ts for the same
+		// note at the point this value is first carried through).
+		moduleReferenceId: el.moduleReferenceId,
+		createdById: userId,
+	};
+}
+
+function buildElementRows(
+	sortedElements: ElementV2[],
+	idMap: Map<string, string>,
+	resolvedExternalCitedElementIds: Set<string>,
+	caseId: string,
+	userId: string
+) {
+	return sortedElements
+		.map((el) =>
+			buildElementRow(
+				el,
+				idMap,
+				resolvedExternalCitedElementIds,
+				caseId,
+				userId
+			)
+		)
+		.filter((d) => d !== null);
+}
+
+/**
  * Creates all elements in the correct order (parents before children).
+ *
+ * Resolve-window race backstop: `resolveExternalCitedElementIds` (called by
+ * `importCase` before this function runs) confirms each external
+ * citedElementId exists, but that check and this insert are not atomic —
+ * the cited element can be deleted in between. Before this fix, that raced
+ * insert would throw a raw P2003 on `assurance_elements_cited_element_id_fkey`
+ * and roll back the ENTIRE import (case, unrelated elements, everything),
+ * for a single citation that should just degrade to dangling like the
+ * already-unresolvable case review fix item 1 handles. The catch below is
+ * the backstop: on exactly that FK error, re-resolve the external
+ * citedElementIds against the DB (this time the raced-away id correctly
+ * comes back unresolved), rebuild the rows, and retry the insert once. A
+ * P2003 on any OTHER foreign key (caseId, parentId, defeatsElementId,
+ * moduleReferenceId) — or a second failure on retry — is not this module's
+ * to recover from and propagates, failing the import as before.
  */
 async function createElements(
 	caseId: string,
@@ -260,55 +399,32 @@ async function createElements(
 	// Sort elements topologically so parents are created before children
 	const sortedElements = topologicalSort(elements);
 
-	const data = sortedElements
-		.map((el) => {
-			const newId = idMap.get(el.id);
-			if (!newId) {
-				return null;
-			}
+	const data = buildElementRows(
+		sortedElements,
+		idMap,
+		resolvedExternalCitedElementIds,
+		caseId,
+		userId
+	);
 
-			// Element-level citation (ADR 0004 D5) — see
-			// resolveImportedCitedElementId's docstring for the
-			// remap-else-preserve-verbatim-else-flag-dangling decision.
-			const { citedElementId, citationDangling } =
-				resolveImportedCitedElementId(
-					el.citedElementId,
-					idMap,
-					resolvedExternalCitedElementIds
-				);
+	try {
+		await prisma.assuranceElement.createMany({ data });
+	} catch (error) {
+		if (!isCitedElementIdForeignKeyError(error)) {
+			throw error;
+		}
 
-			return {
-				id: newId,
-				caseId,
-				elementType: el.elementType,
-				role: el.role,
-				parentId: el.parentId ? (idMap.get(el.parentId) ?? null) : null,
-				name: el.name,
-				description: el.description,
-				assumption: el.assumption,
-				justification: el.justification,
-				context: el.context ?? [],
-				url: el.url,
-				level: el.level,
-				inSandbox: el.inSandbox,
-				fromPattern: el.fromPattern ?? false,
-				modifiedFromPattern: el.modifiedFromPattern ?? false,
-				// Per-assertion status (ADR 0004 D3) — lead ruling: import
-				// PRESERVES a declared status rather than dropping it. This is a
-				// direct createMany write (not through createElement/updateElement),
-				// so it intentionally bypasses guardAssertionStatusWrite/
-				// rejectDeclaredAsCited: import is a bulk data-load operation, not
-				// an author declaring a NEW status, and the source data already
-				// passed through export's own AS_CITED derivation.
-				assertionStatus: el.assertionStatus,
-				citedElementId,
-				citationDangling,
-				createdById: userId,
-			};
-		})
-		.filter((d) => d !== null);
-
-	await prisma.assuranceElement.createMany({ data });
+		const reResolvedExternalCitedElementIds =
+			await resolveExternalCitedElementIds(elements, idMap);
+		const retryData = buildElementRows(
+			sortedElements,
+			idMap,
+			reResolvedExternalCitedElementIds,
+			caseId,
+			userId
+		);
+		await prisma.assuranceElement.createMany({ data: retryData });
+	}
 
 	return data.length;
 }

--- a/lib/services/element-service.ts
+++ b/lib/services/element-service.ts
@@ -4,7 +4,10 @@ import type {
 	CreateElementSchemaOutput,
 	UpdateElementSchemaOutput,
 } from "@/lib/schemas/element";
-import { fieldAppliesTo } from "@/lib/schemas/element-validation";
+import {
+	fieldAppliesTo,
+	fieldRequiredFor,
+} from "@/lib/schemas/element-validation";
 import { transformToResponse } from "@/lib/transforms/element-response";
 import {
 	getDeletedDescendantIds,
@@ -53,6 +56,8 @@ export interface ElementResponse {
 	inSandbox: boolean;
 	justification?: string;
 	level?: number;
+	// Module reference (MODULE/AWAY_GOAL only) — names the referenced case
+	moduleReferenceId?: string | null;
 	name: string;
 	propertyClaimId?: string | string[] | null;
 	strategyId?: string | null;
@@ -189,6 +194,101 @@ async function enforceCitedElementIdRules(
 		return applicabilityError;
 	}
 	return await validateCitedElementId(citedElementId, ownElementId);
+}
+
+/**
+ * `moduleReferenceId` is applicable to MODULE and AWAY_GOAL only
+ * (FIELD_APPLICABILITY, lib/schemas/element-validation.ts). Checked whenever
+ * the field is explicitly present in the input, mirroring
+ * `rejectCitedElementIdIfNotApplicable` above — a silent drop is a worse UX
+ * than an explicit rejection, and the single-element route has no
+ * discriminated-union schema (unlike the batch path's AwayGoalSchema/
+ * ModuleSchema) to lean on for this.
+ */
+function rejectModuleReferenceIdIfNotApplicable(
+	elementType: string,
+	moduleReferenceId: string | null | undefined
+): string | undefined {
+	if (moduleReferenceId === undefined) {
+		return;
+	}
+	if (!fieldAppliesTo("moduleReferenceId", elementType)) {
+		return "moduleReferenceId is only applicable to MODULE and AWAY_GOAL elements";
+	}
+	return;
+}
+
+/**
+ * `moduleReferenceId` is required for MODULE and AWAY_GOAL on create
+ * (REQUIRED_FIELDS, lib/schemas/element-validation.ts — the same rule the
+ * batch path enforces via AwayGoalSchema/ModuleSchema's non-optional
+ * `z.string().uuid()`). Create-only: the batch UPDATE path
+ * (case-batch-update-service.ts) allows changing/clearing the field without
+ * a requiredness guard, so `updateElement` below does not call this.
+ */
+function rejectMissingModuleReferenceId(
+	elementType: string,
+	moduleReferenceId: string | null | undefined
+): string | undefined {
+	if (!fieldRequiredFor("moduleReferenceId", elementType)) {
+		return;
+	}
+	if (!moduleReferenceId) {
+		return "moduleReferenceId is required for MODULE and AWAY_GOAL elements";
+	}
+	return;
+}
+
+/**
+ * `moduleReferenceId` must reference an existing, non-trashed case.
+ * Mirrors `validateCitedElementId`'s existence check (ADR 0004 D5) — the
+ * batch path relies on the DB foreign key to reject a bad reference (which
+ * would surface as an opaque 500), so this route holds itself to the
+ * stricter, already-established precedent instead.
+ */
+async function validateModuleReferenceId(
+	moduleReferenceId: string | null | undefined
+): Promise<string | undefined> {
+	if (!moduleReferenceId) {
+		return;
+	}
+	const target = await prisma.assuranceCase.findFirst({
+		where: { id: moduleReferenceId, deletedAt: null },
+		select: { id: true },
+	});
+	if (!target) {
+		return "moduleReferenceId must reference an existing case";
+	}
+	return;
+}
+
+/**
+ * Runs the moduleReferenceId guards (applicability, then — create only —
+ * requiredness, then existence) in the order createElement and updateElement
+ * both need. Mirrors `enforceCitedElementIdRules`'s extraction rationale.
+ */
+async function enforceModuleReferenceIdRules(
+	elementType: string,
+	moduleReferenceId: string | null | undefined,
+	options: { requireOnCreate: boolean }
+): Promise<string | undefined> {
+	const applicabilityError = rejectModuleReferenceIdIfNotApplicable(
+		elementType,
+		moduleReferenceId
+	);
+	if (applicabilityError) {
+		return applicabilityError;
+	}
+	if (options.requireOnCreate) {
+		const requiredError = rejectMissingModuleReferenceId(
+			elementType,
+			moduleReferenceId
+		);
+		if (requiredError) {
+			return requiredError;
+		}
+	}
+	return await validateModuleReferenceId(moduleReferenceId);
 }
 
 /**
@@ -496,6 +596,10 @@ async function createElementInDatabase(
 			// and self-citation are validated in createElement before this
 			// function is called.
 			citedElementId: input.citedElementId,
+			// Module reference (MODULE/AWAY_GOAL) — applicability, requiredness,
+			// and existence are validated in createElement before this function
+			// is called.
+			moduleReferenceId: input.moduleReferenceId,
 			createdById: userId,
 		},
 		include: {
@@ -549,6 +653,15 @@ export async function createElement(
 
 	if (elementType === "GOAL" && (await caseHasGoal(caseId))) {
 		return { error: "A case can only have one goal claim" };
+	}
+
+	const moduleReferenceIdError = await enforceModuleReferenceIdRules(
+		elementType,
+		input.moduleReferenceId,
+		{ requireOnCreate: true }
+	);
+	if (moduleReferenceIdError) {
+		return { error: moduleReferenceIdError };
 	}
 
 	const citedElementIdError = await enforceCitedElementIdRules(
@@ -670,6 +783,9 @@ function buildUpdateData(input: UpdateElementInput): Record<string, unknown> {
 		// longer describes the current state, declared or not.
 		updateData.citationDangling = false;
 	}
+	if (input.moduleReferenceId !== undefined) {
+		updateData.moduleReferenceId = input.moduleReferenceId;
+	}
 
 	return updateData;
 }
@@ -748,6 +864,19 @@ export async function updateElement(
 		);
 		if (assertionStatusError) {
 			return { error: assertionStatusError };
+		}
+
+		// moduleReferenceId is MODULE/AWAY_GOAL-only and must reference an
+		// existing case. No requiredness check on update — mirrors the batch
+		// update path (case-batch-update-service.ts), see
+		// enforceModuleReferenceIdRules's docstring.
+		const moduleReferenceIdError = await enforceModuleReferenceIdRules(
+			existing.elementType,
+			input.moduleReferenceId,
+			{ requireOnCreate: false }
+		);
+		if (moduleReferenceIdError) {
+			return { error: moduleReferenceIdError };
 		}
 
 		// ADR 0004 D5: citedElementId is AWAY_GOAL-only, must reference an

--- a/lib/transforms/element-response.ts
+++ b/lib/transforms/element-response.ts
@@ -56,6 +56,8 @@ export function transformToResponse(element: {
 	// Dangling-citation indicator (ADR 0004 D5) — true when citedElementId
 	// was nullified because the cited element was deleted/detached
 	citationDangling?: boolean;
+	// Module reference (MODULE/AWAY_GOAL only) — names the referenced case
+	moduleReferenceId?: string | null;
 	caseId: string;
 	parentId: string | null;
 	createdAt: Date;
@@ -108,6 +110,9 @@ export function transformToResponse(element: {
 	}
 	if (element.citationDangling) {
 		response.citationDangling = true;
+	}
+	if (element.moduleReferenceId) {
+		response.moduleReferenceId = element.moduleReferenceId;
 	}
 
 	return response;

--- a/lib/transforms/nested-to-flat.ts
+++ b/lib/transforms/nested-to-flat.ts
@@ -102,6 +102,17 @@ function nodeToElement(
 		// SAME import payload, preserved verbatim otherwise — see that
 		// function's docstring for why).
 		citedElementId: node.citedElementId,
+		// Module reference (MODULE/AWAY_GOAL) — preserve verbatim through the
+		// nested->flat step. Unlike citedElementId, this is never remapped
+		// through the import's idMap: it names a CASE, not an element in this
+		// import's own payload, so there is nothing in idMap to look it up
+		// against (idMap only maps element ids). A moduleReferenceId that
+		// doesn't resolve in the target DB fails loudly via the DB foreign key
+		// (assurance_elements_module_reference_id_fkey) — deliberately NOT
+		// given the citedElementId FK's soft-degrade treatment (ADR 0004 D5
+		// review fix item 1 / the resolve-window race fix), since it was never
+		// flagged as needing one.
+		moduleReferenceId: node.moduleReferenceId,
 	};
 
 	// Preserve comments if present

--- a/src/__tests__/integration/api-elements-cited-element-id.test.ts
+++ b/src/__tests__/integration/api-elements-cited-element-id.test.ts
@@ -16,14 +16,18 @@ import {
  * hand-maintained allowlists that silently drop unforwarded fields, so these
  * tests exercise the ACTUAL route handlers, not just the service layer.
  *
- * Creating an AWAY_GOAL via the single-element POST route is not exercised
- * here: `moduleReferenceId` (required by AwayGoalSchema) is not wired into
- * `createElementSchema`/`buildCreateInput` today — a pre-existing gap, not
- * introduced by this change (AWAY_GOAL elements are created via the batch
- * path — case-batch-update-service.ts — which already handles
- * moduleReferenceId). AWAY_GOAL fixtures here are seeded directly via the
- * test factory; the PUT route is exercised as "the real route" per the
- * dispatch brief.
+ * Creating an AWAY_GOAL via the single-element POST route used to be
+ * untestable here: `moduleReferenceId` (required by AwayGoalSchema) wasn't
+ * wired into `createElementSchema`/`buildCreateInput`, so AWAY_GOAL elements
+ * could only be created via the batch path (case-batch-update-service.ts).
+ * That gap is closed (moduleReferenceId route wiring dispatch) — the first
+ * test below now creates a real AWAY_GOAL end to end through this route,
+ * with both moduleReferenceId and citedElementId set in the same request.
+ * moduleReferenceId's own dedicated coverage (required-field rejection,
+ * applicability, existence) lives in
+ * api-elements-module-reference-id.test.ts; the rest of this file still
+ * seeds AWAY_GOAL fixtures directly via the test factory where the point of
+ * the test is citedElementId behaviour specifically.
  */
 
 vi.mock("@/lib/auth/validate-session", () => ({
@@ -44,6 +48,48 @@ beforeEach(async () => {
 });
 
 describe("POST /api/cases/[id]/elements — citedElementId (ADR 0004 D5)", () => {
+	it("creates an AWAY_GOAL end to end with moduleReferenceId and citedElementId, persisted per a separate refetch", async () => {
+		const owner = await createTestUser();
+		const homeCase = await createTestCase(owner.id);
+		const awayCase = await createTestCase(owner.id);
+		const citedGoal = await createTestElement(awayCase.id, owner.id, {
+			elementType: "GOAL",
+			name: "Away Goal",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import("@/app/api/cases/[id]/elements/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${homeCase.id}/elements`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					type: "away_goal",
+					name: "Reference",
+					description: "Cites a specific element in another case",
+					moduleReferenceId: awayCase.id,
+					citedElementId: citedGoal.id,
+				}),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await POST(req, {
+			params: Promise.resolve({ id: homeCase.id }),
+		});
+
+		expect(response.status).toBe(201);
+		const body = await response.json();
+		expect(body.moduleReferenceId).toBe(awayCase.id);
+		expect(body.citedElementId).toBe(citedGoal.id);
+
+		// Separate refetch — proves DB persistence, not just an echoed response.
+		const inDb = await prisma.assuranceElement.findFirst({
+			where: { caseId: homeCase.id, elementType: "AWAY_GOAL" },
+		});
+		expect(inDb?.moduleReferenceId).toBe(awayCase.id);
+		expect(inDb?.citedElementId).toBe(citedGoal.id);
+	});
+
 	it("rejects citedElementId on a non-AWAY_GOAL type through the route handler", async () => {
 		const owner = await createTestUser();
 		const testCase = await createTestCase(owner.id);

--- a/src/__tests__/integration/api-elements-module-reference-id.test.ts
+++ b/src/__tests__/integration/api-elements-module-reference-id.test.ts
@@ -1,0 +1,247 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	createTestCase,
+	createTestElement,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+/**
+ * moduleReferenceId route wiring — "AWAY_GOAL cannot be created via the
+ * single-element route" (moduleReferenceId gap). Before this fix,
+ * `moduleReferenceId` was not part of `createElementSchema`/
+ * `buildCreateInput`/`updateElementSchema` at all: the batch path
+ * (case-batch-update-service.ts, via AwayGoalSchema/ModuleSchema in
+ * lib/schemas/element-validation.ts) already required and persisted it, but
+ * the single-element POST/PUT routes had no way to carry it through, so an
+ * AWAY_GOAL created via POST would hit the Prisma element-validation
+ * extension's "Element validation failed" and surface as an opaque 500 —
+ * this is the exact gap api-elements-cited-element-id.test.ts's docstring
+ * flagged as making a route-level AWAY_GOAL creation test impossible during
+ * ADR 0004 D5 (its deviation 1). These tests exercise the real route
+ * handlers end to end, following that file's convention.
+ */
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/services/sse-connection-manager", () => ({
+	emitSSEEvent: vi.fn(),
+	sseConnectionManager: { broadcast: vi.fn() },
+}));
+
+const NOT_APPLICABLE_PATTERN = /only applicable to MODULE and AWAY_GOAL/;
+const REQUIRED_PATTERN = /moduleReferenceId is required/;
+const NOT_FOUND_PATTERN = /must reference an existing case/;
+
+beforeEach(async () => {
+	await mockNoAuth();
+});
+
+describe("POST /api/cases/[id]/elements — moduleReferenceId", () => {
+	it("creates an AWAY_GOAL with moduleReferenceId, persisted per a separate refetch", async () => {
+		const owner = await createTestUser();
+		const homeCase = await createTestCase(owner.id);
+		const awayCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import("@/app/api/cases/[id]/elements/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${homeCase.id}/elements`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					type: "away_goal",
+					name: "Reference",
+					description: "Cites another case",
+					moduleReferenceId: awayCase.id,
+				}),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await POST(req, {
+			params: Promise.resolve({ id: homeCase.id }),
+		});
+
+		expect(response.status).toBe(201);
+		const body = await response.json();
+		expect(body.moduleReferenceId).toBe(awayCase.id);
+
+		// Separate refetch — proves DB persistence, not just an echoed response.
+		const inDb = await prisma.assuranceElement.findFirst({
+			where: { caseId: homeCase.id, elementType: "AWAY_GOAL" },
+		});
+		expect(inDb?.moduleReferenceId).toBe(awayCase.id);
+	});
+
+	it("rejects creating an AWAY_GOAL without moduleReferenceId (400, not a 500)", async () => {
+		const owner = await createTestUser();
+		const homeCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import("@/app/api/cases/[id]/elements/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${homeCase.id}/elements`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					type: "away_goal",
+					name: "Reference",
+					description: "Missing its case reference",
+				}),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await POST(req, {
+			params: Promise.resolve({ id: homeCase.id }),
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toMatch(REQUIRED_PATTERN);
+
+		const elements = await prisma.assuranceElement.findMany({
+			where: { caseId: homeCase.id, elementType: "AWAY_GOAL" },
+		});
+		expect(elements).toHaveLength(0);
+	});
+
+	it("rejects moduleReferenceId on a type it doesn't apply to", async () => {
+		const owner = await createTestUser();
+		const homeCase = await createTestCase(owner.id);
+		const awayCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import("@/app/api/cases/[id]/elements/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${homeCase.id}/elements`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					type: "strategy",
+					name: "A Strategy",
+					description: "Not a MODULE or AWAY_GOAL",
+					moduleReferenceId: awayCase.id,
+				}),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await POST(req, {
+			params: Promise.resolve({ id: homeCase.id }),
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toMatch(NOT_APPLICABLE_PATTERN);
+
+		const elements = await prisma.assuranceElement.findMany({
+			where: { caseId: homeCase.id, elementType: "STRATEGY" },
+		});
+		expect(elements).toHaveLength(0);
+	});
+
+	it("rejects a nonexistent moduleReferenceId target case", async () => {
+		const owner = await createTestUser();
+		const homeCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import("@/app/api/cases/[id]/elements/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${homeCase.id}/elements`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					type: "away_goal",
+					name: "Reference",
+					description: "Cites a case that doesn't exist",
+					moduleReferenceId: "00000000-0000-0000-0000-000000000000",
+				}),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await POST(req, {
+			params: Promise.resolve({ id: homeCase.id }),
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toMatch(NOT_FOUND_PATTERN);
+
+		const elements = await prisma.assuranceElement.findMany({
+			where: { caseId: homeCase.id, elementType: "AWAY_GOAL" },
+		});
+		expect(elements).toHaveLength(0);
+	});
+});
+
+describe("PUT /api/elements/[id] — moduleReferenceId", () => {
+	it("lets an author change moduleReferenceId on an AWAY_GOAL, persisted per a separate refetch", async () => {
+		const owner = await createTestUser();
+		const homeCase = await createTestCase(owner.id);
+		const awayCaseA = await createTestCase(owner.id);
+		const awayCaseB = await createTestCase(owner.id);
+		const awayGoal = await createTestElement(homeCase.id, owner.id, {
+			elementType: "AWAY_GOAL",
+			name: "Reference",
+			moduleReferenceId: awayCaseA.id,
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await import("@/app/api/elements/[id]/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/elements/${awayGoal.id}`,
+			{
+				method: "PUT",
+				body: JSON.stringify({ moduleReferenceId: awayCaseB.id }),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: awayGoal.id }),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.moduleReferenceId).toBe(awayCaseB.id);
+
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: awayGoal.id },
+		});
+		expect(inDb?.moduleReferenceId).toBe(awayCaseB.id);
+	});
+
+	it("rejects moduleReferenceId on a non-MODULE/AWAY_GOAL type through the route handler", async () => {
+		const owner = await createTestUser();
+		const homeCase = await createTestCase(owner.id);
+		const awayCase = await createTestCase(owner.id);
+		const goal = await createTestElement(homeCase.id, owner.id, {
+			elementType: "GOAL",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await import("@/app/api/elements/[id]/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/elements/${goal.id}`,
+			{
+				method: "PUT",
+				body: JSON.stringify({ moduleReferenceId: awayCase.id }),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: goal.id }),
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toMatch(NOT_APPLICABLE_PATTERN);
+
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: goal.id },
+		});
+		expect(inDb?.moduleReferenceId).toBeNull();
+	});
+});

--- a/src/__tests__/integration/case-import.test.ts
+++ b/src/__tests__/integration/case-import.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import prisma from "@/lib/prisma";
 import {
 	expectError,
@@ -380,5 +380,225 @@ describe("validateImportData", () => {
 		});
 		expect(importedGoal).not.toBeNull();
 		expect(importedGoal?.name).toBe("Root Goal");
+	});
+
+	/**
+	 * Resolve-window race (the backstop the P2003 catch in
+	 * case-import-service.ts's createElements exists for): unlike the test
+	 * above, this citedElementId genuinely EXISTS — and resolves successfully
+	 * — when resolveExternalCitedElementIds checks it. It is then deleted
+	 * before the createMany insert actually runs, simulated here by spying on
+	 * prisma.assuranceElement.findMany (which resolveExternalCitedElementIds
+	 * calls) to delete the row, for real, immediately after confirming it
+	 * exists — the exact window described in the issue. The insert that
+	 * follows hits a REAL Postgres P2003 on
+	 * assurance_elements_cited_element_id_fkey (not a mocked error shape);
+	 * the catch re-resolves, finds the id gone, and retries once with it
+	 * nulled + flagged, instead of rolling back the whole import.
+	 */
+	it("degrades a citedElementId to dangling when the cited element is deleted between resolve and insert (resolve-window race)", async () => {
+		const owner = await createTestUser();
+		const awayCase = await createTestCase(owner.id);
+		const citedGoal = await createTestElement(awayCase.id, owner.id, {
+			elementType: "GOAL",
+			name: "Away Goal",
+		});
+
+		const json = {
+			version: "1.0",
+			exportedAt: new Date().toISOString(),
+			case: {
+				name: "Race Window Case",
+				description: "AWAY_GOAL cites an element deleted mid-import",
+			},
+			tree: {
+				id: "50000000-0000-4000-8000-000000000001",
+				type: "GOAL",
+				name: "Root Goal",
+				description: "Top-level goal",
+				inSandbox: false,
+				role: "TOP_LEVEL",
+				children: [
+					{
+						id: "50000000-0000-4000-8000-000000000002",
+						type: "AWAY_GOAL",
+						name: "Reference",
+						description: "Cites an element that vanishes mid-import",
+						inSandbox: false,
+						moduleReferenceId: awayCase.id,
+						citedElementId: citedGoal.id,
+						children: [],
+					},
+				],
+			},
+		};
+
+		const { importCase } = await import("@/lib/services/case-import-service");
+
+		const originalFindMany = prisma.assuranceElement.findMany.bind(
+			prisma.assuranceElement
+		);
+		let deletedMidImport = false;
+		// Cast: mockImplementation's real Prisma type wants a `PrismaPromise`
+		// return, not a plain `Promise` — an implementation detail the mock
+		// doesn't need to satisfy to behave correctly at runtime (it just needs
+		// to resolve to the same array `originalFindMany` would have).
+		const findManySpy = vi
+			.spyOn(prisma.assuranceElement, "findMany")
+			.mockImplementation((async (args) => {
+				const result = await originalFindMany(args);
+				const idFilter = (args as { where?: { id?: { in?: string[] } } })?.where
+					?.id?.in;
+				if (
+					!deletedMidImport &&
+					Array.isArray(idFilter) &&
+					idFilter.includes(citedGoal.id)
+				) {
+					deletedMidImport = true;
+					await prisma.assuranceElement.delete({
+						where: { id: citedGoal.id },
+					});
+				}
+				return result;
+			}) as typeof prisma.assuranceElement.findMany);
+
+		try {
+			const importer = await createTestUser();
+			const imported = expectSuccess(await importCase(importer.id, json));
+
+			// The import SUCCEEDED — not rolled back by the raced FK violation —
+			// and the race was actually triggered (not a no-op assertion).
+			expect(deletedMidImport).toBe(true);
+			expect(imported.elementCount).toBe(2);
+
+			const importedAwayGoal = await prisma.assuranceElement.findFirst({
+				where: { caseId: imported.caseId, elementType: "AWAY_GOAL" },
+			});
+			expect(importedAwayGoal?.citedElementId).toBeNull();
+			expect(importedAwayGoal?.citationDangling).toBe(true);
+			// moduleReferenceId is an UNRELATED foreign key (a real case, never
+			// deleted) — proves the retry rebuilt the full row, not just the
+			// citedElementId field.
+			expect(importedAwayGoal?.moduleReferenceId).toBe(awayCase.id);
+
+			// The unrelated goal is intact — proves this isn't a partial/silent
+			// drop of the rest of the import.
+			const importedGoal = await prisma.assuranceElement.findFirst({
+				where: { caseId: imported.caseId, elementType: "GOAL" },
+			});
+			expect(importedGoal).not.toBeNull();
+			expect(importedGoal?.name).toBe("Root Goal");
+		} finally {
+			findManySpy.mockRestore();
+		}
+	});
+
+	/**
+	 * The P2003 catch in createElements is anchored to the exact
+	 * `assurance_elements_cited_element_id_fkey` constraint name specifically
+	 * so it does NOT swallow a P2003 on a DIFFERENT foreign key on the same
+	 * createMany insert. moduleReferenceId is a convenient other FK to exploit
+	 * here: it isn't part of the resolve-before-insert machinery at all, so a
+	 * value that never existed reaches the insert unresolved and must fail
+	 * the whole import loudly, same as before this fix.
+	 */
+	it("still fails the whole import on a P2003 from an unrelated foreign key (moduleReferenceId)", async () => {
+		const nonExistentCaseId = crypto.randomUUID();
+
+		const json = {
+			version: "1.0",
+			exportedAt: new Date().toISOString(),
+			case: {
+				name: "Bad Module Reference Case",
+				description: "AWAY_GOAL references a case that doesn't exist",
+			},
+			tree: {
+				id: "60000000-0000-4000-8000-000000000001",
+				type: "GOAL",
+				name: "Root Goal",
+				description: "Top-level goal",
+				inSandbox: false,
+				role: "TOP_LEVEL",
+				children: [
+					{
+						id: "60000000-0000-4000-8000-000000000002",
+						type: "AWAY_GOAL",
+						name: "Reference",
+						description: "References a nonexistent case",
+						inSandbox: false,
+						moduleReferenceId: nonExistentCaseId,
+						children: [],
+					},
+				],
+			},
+		};
+
+		const { importCase } = await import("@/lib/services/case-import-service");
+
+		const importer = await createTestUser();
+		expectError(await importCase(importer.id, json));
+
+		// Nothing from this failed import landed — proves the P2003 catch
+		// didn't mask (and thus didn't half-succeed) an unrelated FK failure.
+		const elements = await prisma.assuranceElement.findMany({
+			where: { name: "Root Goal" },
+		});
+		expect(elements).toHaveLength(0);
+	});
+
+	/**
+	 * moduleReferenceId gap: before this fix, nodeToElement
+	 * (lib/transforms/nested-to-flat.ts) never carried moduleReferenceId from
+	 * the nested tree into the flat ElementV2 row, and ElementV2Schema
+	 * (lib/schemas/case-export.ts) didn't even declare the field — so ANY
+	 * import (nested or flat) silently dropped it, and a re-imported AWAY_GOAL
+	 * lost the case it referenced. Unlike citedElementId, moduleReferenceId
+	 * names a CASE (not an element in this import's own payload), so it is
+	 * preserved verbatim rather than remapped through idMap — there is no
+	 * cross-case id-remapping table here either.
+	 */
+	it("preserves an AWAY_GOAL's moduleReferenceId through export -> import (round-trip fidelity)", async () => {
+		const owner = await createTestUser();
+		const homeCase = await createTestCase(owner.id);
+		const awayCase = await createTestCase(owner.id);
+		const rootGoal = await createTestElement(homeCase.id, owner.id, {
+			elementType: "GOAL",
+			name: "Root Goal",
+			role: "TOP_LEVEL",
+		});
+		await createTestElement(homeCase.id, owner.id, {
+			elementType: "AWAY_GOAL",
+			name: "Reference",
+			parentId: rootGoal.id,
+			moduleReferenceId: awayCase.id,
+		});
+
+		const { exportCase } = await import("@/lib/services/case-export-service");
+		const { importCase } = await import("@/lib/services/case-import-service");
+
+		const firstExport = expectSuccess(await exportCase(owner.id, homeCase.id));
+		const exportedAwayGoal = firstExport.tree.children.find(
+			(c: { type: string }) => c.type === "AWAY_GOAL"
+		);
+		expect(exportedAwayGoal?.moduleReferenceId).toBe(awayCase.id);
+
+		const importer = await createTestUser();
+		const imported = expectSuccess(await importCase(importer.id, firstExport));
+
+		// Direct DB check — proves the createMany write itself carries the
+		// (unmapped) case id, not just whatever a later export happens to
+		// resolve.
+		const importedAwayGoal = await prisma.assuranceElement.findFirst({
+			where: { caseId: imported.caseId, elementType: "AWAY_GOAL" },
+		});
+		expect(importedAwayGoal?.moduleReferenceId).toBe(awayCase.id);
+
+		const secondExport = expectSuccess(
+			await exportCase(importer.id, imported.caseId)
+		);
+		const reexportedAwayGoal = secondExport.tree.children.find(
+			(c: { type: string }) => c.type === "AWAY_GOAL"
+		);
+		expect(reexportedAwayGoal?.moduleReferenceId).toBe(awayCase.id);
 	});
 });


### PR DESCRIPTION
Two related fixes on the case-model surface, both building on ADR 0004 D5 (#877, merged).

## 1. AWAY_GOAL creatable via the single-element route (moduleReferenceId gap)

Previously an AWAY_GOAL could only be created through the batch/JSON-editor path — the single-element create route silently failed because `moduleReferenceId` (required for AWAY_GOAL/MODULE) was never wired through the schema, route input, or service. This wires it through create and update, mirroring the D5 `citedElementId` pattern exactly:

- `createElementSchema`/`updateElementSchema`, `buildCreateInput`/`buildUpdateInput`, service guards (`enforceModuleReferenceIdRules`: applicability always, requiredness on create only, existence check), response transform, and `ERROR_MAPPINGS` anchor
- Import carry-through: `moduleReferenceId` is now preserved through export→import (previously dropped)
- The route-level AWAY_GOAL create-and-refetch test that was **impossible** to write during D5 now passes

Applicability/requiredness semantics match the batch path byte-for-byte (verified in review).

## 2. citedElementId import resolve-window race

The D5 import fix resolved the deterministic unresolvable-citation case. This closes the residual race: a cited element deleted between import-time resolution and the insert. The insert now catches the foreign-key violation **anchored to the specific constraint** (`assurance_elements_cited_element_id_fkey`), re-resolves, and retries once — degrading only that citation to null + `citationDangling`. Any *other* FK violation still fails the whole import loudly.

## Review chain

QA (mutation-confirmed the new tests, including proving the negative unrelated-FK test) and code review (verified FK-anchor specificity against real constraint names; ruled the catch/retry sound under the current import model) — both PASS, zero must-fixes. Final: unit 79 files / 1166 tests green; targeted integration 31 + 82 regression green; lint + typecheck clean.

## Known scope notes (tracked follow-ups, not blocking)

- **Import is not atomic** — the import `$transaction` callback uses the global client, not the transaction-scoped one, so a mid-import failure can leave a partial write. Pre-existing, tracked separately. The retry-once above is safe because `createMany` is a single atomic INSERT at realistic sizes; a caveat for very large imports (>~3,600 elements) is recorded on that issue.
- **Test-discrimination hardening** — a moduleReferenceId PUT-existence test and a P2003 anchor-specificity test, both test-only additions, tracked as fast-follow.

Base note: branched off the D5 head, which is now merged to staging (#877, merge commit), so the diff here is exactly these two commits.