### PR TITLE
Wire assertionStatus through the batch/JSON-editor update path

### DIFF
--- a/lib/case/tree-diff.ts
+++ b/lib/case/tree-diff.ts
@@ -10,12 +10,17 @@
  * and generates link/unlink changes for evidence moves.
  */
 
-import type { CaseExportNested, TreeNode } from "@/lib/schemas/case-export";
+import type {
+	AssertionStatus,
+	CaseExportNested,
+	TreeNode,
+} from "@/lib/schemas/case-export";
 
 /**
  * Element data for creating a new element
  */
 export interface CreateElementData {
+	assertionStatus?: AssertionStatus | null;
 	assumption?: string | null;
 	context?: string[];
 	defeatsElementId?: string;
@@ -40,6 +45,7 @@ export interface CreateElementData {
  * Element data for updating an existing element
  */
 export interface UpdateElementData {
+	assertionStatus?: AssertionStatus | null;
 	assumption?: string | null;
 	context?: string[];
 	defeatsElementId?: string;
@@ -78,6 +84,7 @@ export type ElementChange =
  * Flat representation of a tree node for comparison
  */
 interface FlatElement {
+	assertionStatus?: AssertionStatus | null;
 	assumption?: string | null;
 	context?: string[];
 	defeatsElementId?: string;
@@ -175,6 +182,7 @@ function createFlatElement(
 		modifiedFromPattern: node.modifiedFromPattern,
 		isDefeater: node.isDefeater,
 		defeatsElementId: node.defeatsElementId,
+		assertionStatus: node.assertionStatus,
 	};
 }
 
@@ -264,6 +272,7 @@ const SCALAR_FIELDS = [
 	"description",
 	"inSandbox",
 	"role",
+	"assertionStatus",
 	"assumption",
 	"justification",
 	"url",
@@ -335,6 +344,7 @@ function toCreateElementData(element: FlatElement): CreateElementData {
 		modifiedFromPattern: element.modifiedFromPattern,
 		isDefeater: element.isDefeater,
 		defeatsElementId: element.defeatsElementId,
+		assertionStatus: element.assertionStatus,
 	};
 }
 

--- a/lib/schemas/batch-update.ts
+++ b/lib/schemas/batch-update.ts
@@ -1,4 +1,14 @@
 import { z } from "zod";
+import { AssertionStatusSchema } from "./case-export";
+
+/**
+ * Per-assertion status on a batch create/update payload (ADR 0004 D3).
+ * Shape only — the D3 write rule (author-declared, never machine-
+ * overwritten; AS_CITED is derived-only) is enforced in
+ * case-batch-update-service.ts via element-service.ts's shared guard, not
+ * here — mirrors lib/schemas/element.ts's assertionStatusInputSchema.
+ */
+const assertionStatusInputSchema = AssertionStatusSchema.nullable().optional();
 
 /**
  * Schema for batch update request body.
@@ -18,6 +28,7 @@ export const batchUpdateRequestSchema = z.object({
 					description: z.string(),
 					inSandbox: z.boolean(),
 					role: z.string().nullable().optional(),
+					assertionStatus: assertionStatusInputSchema,
 					assumption: z.string().nullable().optional(),
 					justification: z.string().nullable().optional(),
 					context: z.array(z.string()).optional(),
@@ -41,6 +52,7 @@ export const batchUpdateRequestSchema = z.object({
 					inSandbox: z.boolean().optional(),
 					parentId: z.string().uuid().nullable().optional(),
 					role: z.string().nullable().optional(),
+					assertionStatus: assertionStatusInputSchema,
 					assumption: z.string().nullable().optional(),
 					justification: z.string().nullable().optional(),
 					context: z.array(z.string()).optional(),

--- a/lib/services/case-batch-update-service.ts
+++ b/lib/services/case-batch-update-service.ts
@@ -11,12 +11,48 @@ import type {
 	UpdateElementData,
 } from "@/lib/case/tree-diff";
 import { prisma } from "@/lib/prisma";
+import { enforceAssertionStatusRules } from "@/lib/services/element-service";
 import { getDescendantIds } from "@/lib/utils/tree-traversal";
 import type {
 	ElementRole,
 	Prisma,
 	ElementType as PrismaElementType,
 } from "@/src/generated/prisma";
+
+/**
+ * ADR 0004 D3 write rule (author-declared, machine-proposable, never
+ * machine-overwritten; AS_CITED is derived-only): validates every create
+ * and update change that carries an assertionStatus value, reusing
+ * element-service.ts's enforceAssertionStatusRules rather than
+ * re-implementing the principal (guardAssertionStatusWrite) and value
+ * (rejectDeclaredAsCited) checks — keeps the rule single-sourced across the
+ * single-element route and this batch/JSON-editor path.
+ */
+async function validateAssertionStatusChanges(
+	userId: string,
+	creates: CreateChange[],
+	updates: UpdateChange[]
+): Promise<string | null> {
+	for (const change of creates) {
+		const error = await enforceAssertionStatusRules(
+			change.data.assertionStatus,
+			userId
+		);
+		if (error) {
+			return error;
+		}
+	}
+	for (const change of updates) {
+		const error = await enforceAssertionStatusRules(
+			change.data.assertionStatus,
+			userId
+		);
+		if (error) {
+			return error;
+		}
+	}
+	return null;
+}
 
 /**
  * Result of a batch update operation
@@ -221,6 +257,7 @@ function buildCreateData(
 		inSandbox: data.inSandbox,
 		parentId: effectiveParentId,
 		role: data.role as ElementRole | null | undefined,
+		assertionStatus: data.assertionStatus,
 		assumption: data.assumption,
 		justification: data.justification,
 		context: data.context ?? [],
@@ -310,6 +347,7 @@ function buildUpdateData(data: UpdateElementData): Record<string, unknown> {
 		"inSandbox",
 		"parentId",
 		"role",
+		"assertionStatus",
 		"assumption",
 		"justification",
 		"context",
@@ -447,6 +485,18 @@ export async function applyBatchUpdate(
 	const links = changes.filter(
 		(c): c is LinkEvidenceChange => c.type === "link_evidence"
 	);
+
+	// ADR 0004 D3 write rule: assertionStatus is author-declared only — see
+	// enforceAssertionStatusRules's docstring (element-service.ts) for why
+	// case-level EDIT access alone isn't a sufficient gate.
+	const assertionStatusError = await validateAssertionStatusChanges(
+		userId,
+		creates,
+		updates
+	);
+	if (assertionStatusError) {
+		return { error: assertionStatusError };
+	}
 
 	// Validate parent references
 	const createParentError = await validateCreateParents(creates, deletes);

--- a/lib/services/element-service.ts
+++ b/lib/services/element-service.ts
@@ -298,9 +298,11 @@ async function enforceModuleReferenceIdRules(
  * both need — extracted so the checks live in exactly one place instead of
  * being duplicated verbatim at each call site (mirrors
  * `enforceCitedElementIdRules` above, and keeps both mutation paths under
- * the cognitive-complexity budget).
+ * the cognitive-complexity budget). Exported so other write surfaces that
+ * must obey the same D3 rule (currently: case-batch-update-service.ts) can
+ * reuse it rather than re-implementing the principal/value checks.
  */
-async function enforceAssertionStatusRules(
+export async function enforceAssertionStatusRules(
 	assertionStatus: AssertionStatus | null | undefined,
 	userId: string
 ): Promise<string | undefined> {

--- a/src/__tests__/integration/case-batch-update-service.test.ts
+++ b/src/__tests__/integration/case-batch-update-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ElementChange, UpdateElementData } from "@/lib/case/tree-diff";
+import type { ElementChange } from "@/lib/case/tree-diff";
 import prisma from "@/lib/prisma";
 import {
 	expectError,
@@ -9,6 +9,7 @@ import {
 import {
 	createTestCase,
 	createTestElement,
+	createTestIntegrationWithSystemUser,
 	createTestPermission,
 	createTestUser,
 } from "../utils/prisma-factories";
@@ -21,6 +22,10 @@ vi.mock("@/lib/services/sse-connection-manager", () => ({
 	emitSSEEvent: vi.fn(),
 	sseConnectionManager: { broadcast: vi.fn() },
 }));
+
+const ASSERTION_STATUS_PERMISSION_DENIED_PATTERN =
+	/Permission denied.*assertionStatus/;
+const AS_CITED_PATTERN = /AS_CITED/;
 
 // ============================================
 // applyBatchUpdate
@@ -407,56 +412,228 @@ describe("applyBatchUpdate", () => {
 	});
 
 	/**
-	 * ADR 0004 D3, review follow-up: the batch/JSON-editor path is deliberately
-	 * NOT wired for assertionStatus (deferred to
+	 * ADR 0004 D3: the batch/JSON-editor path now carries assertionStatus
+	 * end-to-end (tree-diff.ts, case-batch-update-service.ts), enforcing the
+	 * same write rule as the single-element route via element-service.ts's
+	 * shared enforceAssertionStatusRules. Supersedes the former "PINS" test
+	 * that documented this surface as deliberately unwired (see
 	 * "TEA — assertionStatus surface completion (batch, undo-redo, UI)").
-	 * `UpdateElementData` has no `assertionStatus` field and `buildUpdateData`'s
-	 * fixed field allowlist doesn't include it, so this is structurally
-	 * impossible today. This test locks that down: a future refactor of the
-	 * field list (e.g. spreading `data` instead of allowlisting fields) could
-	 * silently open an unguarded write route that bypasses
-	 * `guardAssertionStatusWrite`/`rejectDeclaredAsCited` entirely — this test
-	 * pins the current safe behaviour so that regression fails loudly.
 	 */
-	it("PINS: a batch update payload carrying assertionStatus cannot set or alter a stored value", async () => {
-		const user = await createTestUser();
-		const testCase = await createTestCase(user.id);
-		const element = await createTestElement(testCase.id, user.id, {
-			elementType: "GOAL",
-			name: "Batch Target",
-			description: "Original description",
+	describe("assertionStatus", () => {
+		it("sets assertionStatus via a batch update and persists it", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const element = await createTestElement(testCase.id, user.id, {
+				elementType: "GOAL",
+				name: "Batch Target",
+				description: "Original description",
+			});
+			expect(element.assertionStatus).toBeNull();
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const changes: ElementChange[] = [
+				{
+					type: "update",
+					elementId: element.id,
+					data: {
+						name: "Batch Target Renamed",
+						assertionStatus: "DEFEATED",
+					},
+				},
+			];
+
+			const data = expectSuccess(
+				await applyBatchUpdate(user.id, testCase.id, changes)
+			);
+			expect(data.summary.updated).toBe(1);
+
+			const afterBatch = await prisma.assuranceElement.findUnique({
+				where: { id: element.id },
+			});
+			expect(afterBatch?.name).toBe("Batch Target Renamed");
+			expect(afterBatch?.assertionStatus).toBe("DEFEATED");
 		});
-		expect(element.assertionStatus).toBeNull();
 
-		const { applyBatchUpdate } = await import(
-			"@/lib/services/case-batch-update-service"
-		);
+		it("leaves a previously-stored assertionStatus untouched when the field is absent from a partial update", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const element = await createTestElement(testCase.id, user.id, {
+				elementType: "GOAL",
+				name: "Batch Target",
+				description: "Original description",
+				assertionStatus: "ASSUMED",
+			});
+			expect(element.assertionStatus).toBe("ASSUMED");
 
-		const changes: ElementChange[] = [
-			{
-				type: "update",
-				elementId: element.id,
-				// UpdateElementData has no assertionStatus field — this cast
-				// simulates a payload that tries to smuggle it in anyway.
-				data: {
-					name: "Batch Target Renamed",
-					assertionStatus: "DEFEATED",
-				} as unknown as UpdateElementData,
-			},
-		];
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
 
-		const data = expectSuccess(
-			await applyBatchUpdate(user.id, testCase.id, changes)
-		);
-		expect(data.summary.updated).toBe(1);
+			// data carries no assertionStatus key at all (not even null) —
+			// a partial update that only touches name.
+			const changes: ElementChange[] = [
+				{
+					type: "update",
+					elementId: element.id,
+					data: { name: "Renamed, Status Untouched" },
+				},
+			];
 
-		const afterBatch = await prisma.assuranceElement.findUnique({
-			where: { id: element.id },
+			const data = expectSuccess(
+				await applyBatchUpdate(user.id, testCase.id, changes)
+			);
+			expect(data.summary.updated).toBe(1);
+
+			const afterBatch = await prisma.assuranceElement.findUnique({
+				where: { id: element.id },
+			});
+			expect(afterBatch?.name).toBe("Renamed, Status Untouched");
+			// The stored value survives the omission — omission must never
+			// be conflated with an explicit clear (null).
+			expect(afterBatch?.assertionStatus).toBe("ASSUMED");
 		});
-		// The allowlisted field DID apply...
-		expect(afterBatch?.name).toBe("Batch Target Renamed");
-		// ...but the smuggled field did not.
-		expect(afterBatch?.assertionStatus).toBeNull();
+
+		it("explicitly clears a previously-stored assertionStatus when the field is set to null", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const element = await createTestElement(testCase.id, user.id, {
+				elementType: "GOAL",
+				name: "Batch Target",
+				description: "Original description",
+				assertionStatus: "ASSUMED",
+			});
+			expect(element.assertionStatus).toBe("ASSUMED");
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const changes: ElementChange[] = [
+				{
+					type: "update",
+					elementId: element.id,
+					data: { assertionStatus: null },
+				},
+			];
+
+			expectSuccess(await applyBatchUpdate(user.id, testCase.id, changes));
+
+			const afterBatch = await prisma.assuranceElement.findUnique({
+				where: { id: element.id },
+			});
+			expect(afterBatch?.assertionStatus).toBeNull();
+		});
+
+		it("rejects a system/machine principal batch-setting assertionStatus", async () => {
+			const owner = await createTestUser();
+			const { systemUser } = await createTestIntegrationWithSystemUser(
+				owner.id
+			);
+			const testCase = await createTestCase(owner.id);
+			// Genuine EDIT grant, same as grantIntegrationCaseAccess in production.
+			await createTestPermission(testCase.id, systemUser.id, owner.id, "EDIT");
+			const element = await createTestElement(testCase.id, owner.id, {
+				elementType: "GOAL",
+				name: "Batch Target",
+			});
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const changes: ElementChange[] = [
+				{
+					type: "update",
+					elementId: element.id,
+					data: { assertionStatus: "DEFEATED" },
+				},
+			];
+
+			expectError(
+				await applyBatchUpdate(systemUser.id, testCase.id, changes),
+				ASSERTION_STATUS_PERMISSION_DENIED_PATTERN
+			);
+
+			const afterBatch = await prisma.assuranceElement.findUnique({
+				where: { id: element.id },
+			});
+			expect(afterBatch?.assertionStatus).toBeNull();
+		});
+
+		it("rejects a hand-declared AS_CITED via a batch update", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const element = await createTestElement(testCase.id, user.id, {
+				elementType: "GOAL",
+				name: "Batch Target",
+			});
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const changes: ElementChange[] = [
+				{
+					type: "update",
+					elementId: element.id,
+					data: { assertionStatus: "AS_CITED" },
+				},
+			];
+
+			expectError(
+				await applyBatchUpdate(user.id, testCase.id, changes),
+				AS_CITED_PATTERN
+			);
+
+			const afterBatch = await prisma.assuranceElement.findUnique({
+				where: { id: element.id },
+			});
+			expect(afterBatch?.assertionStatus).toBeNull();
+		});
+
+		it("rejects a system/machine principal batch-creating an element with assertionStatus", async () => {
+			const owner = await createTestUser();
+			const { systemUser } = await createTestIntegrationWithSystemUser(
+				owner.id
+			);
+			const testCase = await createTestCase(owner.id);
+			await createTestPermission(testCase.id, systemUser.id, owner.id, "EDIT");
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const newId = `element-assertion-status-create-${Date.now()}`;
+			const changes: ElementChange[] = [
+				{
+					type: "create",
+					elementId: newId,
+					parentId: null,
+					data: {
+						id: newId,
+						type: "GOAL",
+						name: "Machine-Created Goal",
+						description: "Created by a system user",
+						inSandbox: false,
+						role: "TOP_LEVEL",
+						assertionStatus: "ASSUMED",
+					},
+				},
+			];
+
+			expectError(
+				await applyBatchUpdate(systemUser.id, testCase.id, changes),
+				ASSERTION_STATUS_PERMISSION_DENIED_PATTERN
+			);
+
+			const created = await prisma.assuranceElement.findUnique({
+				where: { id: newId },
+			});
+			expect(created).toBeNull();
+		});
 	});
 
 	/**


### PR DESCRIPTION
One of the deferred assertionStatus surfaces from the D3 follow-on. Brings the bulk/JSON-editor edit path up to the same per-claim status support the single-element route already has, enforcing the identical D3 write rule.

## What this does

- `lib/case/tree-diff.ts` — `assertionStatus` added to CreateElementData/UpdateElementData/FlatElement and the SCALAR_FIELDS diff set
- `lib/services/case-batch-update-service.ts` — new `validateAssertionStatusChanges` runs the **shared** `enforceAssertionStatusRules` guard (exported from element-service, not reimplemented) over every create and update in the batch, before the transaction opens; field carried through buildCreate/buildUpdateData
- `lib/schemas/batch-update.ts` — the nullable-enum field added to the batch zod schema (otherwise it'd be stripped pre-service)

The write rule holds on this surface exactly as on the single-element route: author-declared only (system/integration principals rejected), AS_CITED cannot be hand-declared.

## Correctness notes

- **Omission never clobbers a stored status.** A partial batch update that omits the field leaves the stored value untouched (the existing `!== undefined` allowlist); an explicit `null` clears it. This was the primary risk and is covered by tests.
- **Atomic reject.** Validation runs before the transaction, so a batch mixing a valid status change with a rejected one writes nothing.

## Review chain

QA (nanaki) mutation-confirmed all 6 new tests meaningful and the guard genuinely wired on both create and update batch loops; code review (vincent) confirmed single-sourcing, null/absent correctness, guard placement, and no bypass entry point — both PASS, zero must-fixes. Unit suite 79 files / 1166 tests green; batch + single-element integration green; lint + typecheck clean; fallow clean for the change (no new complexity).

## Scope note

This is the **batch** surface only. The undo/redo surface turned out to be client-side code (it replays API calls through the browser history store), so it's been reclassified to the frontend dispatch alongside the status badge + setter UI — not part of this PR.

## Non-blocking follow-ups (tracked)

- Permanent regression test for a mixed-validity batch (verified atomic today, no permanent pin)
- Route-level tests for the batch endpoint (pre-existing: that route has no route-level coverage; service layer is thorough)
- If a third cross-service D3-style guard appears, consider a shared validation module rather than more per-guard exports off element-service