### PR TITLE
assertionStatus UI — status badge, edit-dialog setter, and undo/redo

### DIFF
--- a/components/cases/__tests__/node-edit-dialog-assertion-status.test.ts
+++ b/components/cases/__tests__/node-edit-dialog-assertion-status.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { AUTHOR_ASSERTION_STATUS_VALUES } from "@/lib/assertion-status";
+import { getInitialAssertionStatus } from "../node-edit-dialog";
+
+/**
+ * Pins the write-side of ADR 0004 D5: `AS_CITED` is derived-only and must
+ * never be offered as an author choice in the setter, even though the badge
+ * (assertion-status-badge.test.tsx) displays it. Covers both halves of that
+ * rule — the initial-value resolver never surfaces `AS_CITED`, and the
+ * setter's option set excludes it entirely.
+ */
+describe("getInitialAssertionStatus", () => {
+	it("falls back to ASSERTED for a node whose assertionStatus is AS_CITED", () => {
+		expect(getInitialAssertionStatus({ assertionStatus: "AS_CITED" })).toBe(
+			"ASSERTED"
+		);
+	});
+
+	it("falls back to ASSERTED for null", () => {
+		expect(getInitialAssertionStatus({ assertionStatus: null })).toBe(
+			"ASSERTED"
+		);
+	});
+
+	it("falls back to ASSERTED for undefined", () => {
+		expect(getInitialAssertionStatus({ assertionStatus: undefined })).toBe(
+			"ASSERTED"
+		);
+	});
+
+	it("falls back to ASSERTED for an invalid string", () => {
+		expect(
+			getInitialAssertionStatus({ assertionStatus: "NOT_A_REAL_STATUS" })
+		).toBe("ASSERTED");
+	});
+
+	it("returns one of the five author-declarable values for a valid status", () => {
+		expect(getInitialAssertionStatus({ assertionStatus: "DEFEATED" })).toBe(
+			"DEFEATED"
+		);
+	});
+});
+
+describe("AUTHOR_ASSERTION_STATUS_VALUES", () => {
+	it("does not contain AS_CITED", () => {
+		expect(AUTHOR_ASSERTION_STATUS_VALUES).not.toContain("AS_CITED");
+	});
+
+	it("contains exactly the five author-declarable values", () => {
+		expect([...AUTHOR_ASSERTION_STATUS_VALUES].sort()).toEqual(
+			["ASSERTED", "ASSUMED", "AXIOMATIC", "DEFEATED", "NEEDS_SUPPORT"].sort()
+		);
+	});
+});

--- a/components/cases/goal-node.tsx
+++ b/components/cases/goal-node.tsx
@@ -3,7 +3,11 @@
 import { Plus } from "lucide-react";
 import { memo, useState } from "react";
 import type { NodeProps } from "reactflow";
-import { BaseNode, NodeActionGroup } from "@/components/shared/nodes";
+import {
+	BaseNode,
+	getAssertionStatusIndicator,
+	NodeActionGroup,
+} from "@/components/shared/nodes";
 import ActionTooltip from "@/components/ui/action-tooltip";
 import { useElementBadgeSlot } from "@/hooks/use-element-badge-slot";
 import useStore from "@/store/store";
@@ -23,6 +27,14 @@ function GoalNode({ data, ...props }: NodeProps) {
 		elementId: String(data.id),
 		elementType: "goal",
 	});
+	const assertionBadge = getAssertionStatusIndicator(data.assertionStatus);
+	const topRightActions =
+		assertionBadge || badgeSlot ? (
+			<div className="flex items-center gap-1.5">
+				{assertionBadge}
+				{badgeSlot}
+			</div>
+		) : null;
 
 	const addPopover = (
 		<NodeAddPopover
@@ -76,7 +88,7 @@ function GoalNode({ data, ...props }: NodeProps) {
 				name={data.name}
 				nodeType="goal"
 				selected={props.selected}
-				topRightActions={badgeSlot}
+				topRightActions={topRightActions}
 			/>
 
 			{/* Edit Dialog */}

--- a/components/cases/goal-node.tsx
+++ b/components/cases/goal-node.tsx
@@ -3,14 +3,9 @@
 import { Plus } from "lucide-react";
 import { memo, useState } from "react";
 import type { NodeProps } from "reactflow";
-import {
-	BaseNode,
-	getAssertionStatusIndicator,
-	NodeActionGroup,
-} from "@/components/shared/nodes";
+import { BaseNode, NodeActionGroup } from "@/components/shared/nodes";
 import ActionTooltip from "@/components/ui/action-tooltip";
-import { useElementBadgeSlot } from "@/hooks/use-element-badge-slot";
-import useStore from "@/store/store";
+import { useNodeTopRightActions } from "@/hooks/use-node-top-right-actions";
 import NodeAddPopover from "./node-add-popover";
 import NodeEditDialog from "./node-edit-dialog";
 import ToggleButton from "./toggle-button";
@@ -18,23 +13,10 @@ import ToggleButton from "./toggle-button";
 function GoalNode({ data, ...props }: NodeProps) {
 	const [editDialogOpen, setEditDialogOpen] = useState(false);
 	const [addPopoverOpen, setAddPopoverOpen] = useState(false);
-	const { assuranceCase } = useStore();
 
 	const node = { data, position: { x: 0, y: 0 }, ...props };
 
-	const badgeSlot = useElementBadgeSlot({
-		caseId: assuranceCase?.id?.toString() ?? "",
-		elementId: String(data.id),
-		elementType: "goal",
-	});
-	const assertionBadge = getAssertionStatusIndicator(data.assertionStatus);
-	const topRightActions =
-		assertionBadge || badgeSlot ? (
-			<div className="flex items-center gap-1.5">
-				{assertionBadge}
-				{badgeSlot}
-			</div>
-		) : null;
+	const topRightActions = useNodeTopRightActions(data, "goal");
 
 	const addPopover = (
 		<NodeAddPopover

--- a/components/cases/node-edit-dialog.tsx
+++ b/components/cases/node-edit-dialog.tsx
@@ -24,9 +24,22 @@ import {
 	FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { useElementPanelSlot } from "@/hooks/use-element-panel-slot";
+import {
+	ASSERTION_STATUS_LABELS,
+	AUTHOR_ASSERTION_STATUS_VALUES,
+	type AuthorAssertionStatusValue,
+	isAuthorAssertionStatusValue,
+} from "@/lib/assertion-status";
 import { updateAssuranceCaseNode } from "@/lib/case";
 import {
 	type NodeEditFormInput,
@@ -40,6 +53,20 @@ type FormValues = NodeEditFormInput;
 // Helper to check if element type supports attributes
 const supportsAttributes = (nodeType: DiagramNodeType): boolean =>
 	["goal", "strategy", "property"].includes(nodeType);
+
+/**
+ * Resolves a node's current `assertionStatus` to one of the five
+ * author-declarable values for the Select's initial value. Falls back to
+ * "ASSERTED" for `null`/`undefined` (unset means ASSERTED) and for
+ * `AS_CITED` (derived-only — never offered as a choice here, so a node that
+ * currently carries it shows the default rather than an invalid selection).
+ */
+function getInitialAssertionStatus(
+	nodeData: Record<string, unknown>
+): AuthorAssertionStatusValue {
+	const value = nodeData?.assertionStatus;
+	return isAuthorAssertionStatusValue(value) ? value : "ASSERTED";
+}
 
 /**
  * Converts node data URLs to field array format.
@@ -71,6 +98,9 @@ function buildUpdatePayload(
 		updateItem.assumption = values.assumption || "";
 		updateItem.justification = values.justification || "";
 		updateItem.context = values.context || [];
+		// Per-assertion status (ADR 0004 D3) — always one of the five
+		// author-declarable values; the Select never offers AS_CITED.
+		updateItem.assertionStatus = values.assertionStatus || "ASSERTED";
 	}
 
 	if (nodeType === "evidence") {
@@ -122,6 +152,61 @@ function TextFieldSection({
 							{...field}
 						/>
 					</FormControl>
+					<FormMessage />
+				</FormItem>
+			)}
+		/>
+	);
+}
+
+interface AssertionStatusSectionProps {
+	form: UseFormReturn<FormValues>;
+	readOnly: boolean;
+}
+
+/**
+ * The assertion-status setter (ADR 0004 D3). Offers exactly the five
+ * author-declarable values — `AS_CITED` is derived-only (computed by the
+ * server from a cited element's own status) and must never appear as a
+ * choice here, so `AUTHOR_ASSERTION_STATUS_VALUES` (not the full six-value
+ * enum) drives this list.
+ */
+function AssertionStatusSection({
+	form,
+	readOnly,
+}: AssertionStatusSectionProps) {
+	return (
+		<FormField
+			control={form.control}
+			name="assertionStatus"
+			render={({ field }) => (
+				<FormItem>
+					<FormLabel className="flex items-center gap-2">
+						Assertion status
+						{readOnly && (
+							<span className="text-muted-foreground" title="Read Only">
+								<Lock className="h-3 w-3" />
+							</span>
+						)}
+					</FormLabel>
+					<Select
+						disabled={readOnly}
+						onValueChange={field.onChange}
+						value={field.value}
+					>
+						<FormControl>
+							<SelectTrigger>
+								<SelectValue />
+							</SelectTrigger>
+						</FormControl>
+						<SelectContent>
+							{AUTHOR_ASSERTION_STATUS_VALUES.map((value) => (
+								<SelectItem key={value} value={value}>
+									{ASSERTION_STATUS_LABELS[value]}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
 					<FormMessage />
 				</FormItem>
 			)}
@@ -310,6 +395,9 @@ export default function NodeEditDialog({
 			justification: (node.data?.justification as string) ?? "",
 			context: (node.data?.context as string[]) ?? [],
 			urls: getInitialUrls(node.data as Record<string, unknown>),
+			assertionStatus: getInitialAssertionStatus(
+				node.data as Record<string, unknown>
+			),
 		},
 	});
 
@@ -364,6 +452,9 @@ export default function NodeEditDialog({
 				justification: (n.data?.justification as string) ?? "",
 				context: contextData,
 				urls: getInitialUrls(n.data as Record<string, unknown>),
+				assertionStatus: getInitialAssertionStatus(
+					n.data as Record<string, unknown>
+				),
 			});
 			setItemIds(contextData.map((_, i) => `${componentId}-reset-${i}`));
 			setNewContextValue("");
@@ -451,6 +542,7 @@ export default function NodeEditDialog({
 							placeholder="Type your justification here (optional)."
 							readOnly={readOnly}
 						/>
+						<AssertionStatusSection form={form} readOnly={readOnly} />
 						<ContextSection
 							contextItems={contextItems}
 							newContextValue={newContextValue}

--- a/components/cases/node-edit-dialog.tsx
+++ b/components/cases/node-edit-dialog.tsx
@@ -61,7 +61,7 @@ const supportsAttributes = (nodeType: DiagramNodeType): boolean =>
  * `AS_CITED` (derived-only — never offered as a choice here, so a node that
  * currently carries it shows the default rather than an invalid selection).
  */
-function getInitialAssertionStatus(
+export function getInitialAssertionStatus(
 	nodeData: Record<string, unknown>
 ): AuthorAssertionStatusValue {
 	const value = nodeData?.assertionStatus;

--- a/components/cases/property-node.tsx
+++ b/components/cases/property-node.tsx
@@ -3,14 +3,9 @@
 import { Plus } from "lucide-react";
 import { memo, useState } from "react";
 import type { NodeProps } from "reactflow";
-import {
-	BaseNode,
-	getAssertionStatusIndicator,
-	NodeActionGroup,
-} from "@/components/shared/nodes";
+import { BaseNode, NodeActionGroup } from "@/components/shared/nodes";
 import ActionTooltip from "@/components/ui/action-tooltip";
-import { useElementBadgeSlot } from "@/hooks/use-element-badge-slot";
-import useStore from "@/store/store";
+import { useNodeTopRightActions } from "@/hooks/use-node-top-right-actions";
 import NodeAddPopover from "./node-add-popover";
 import NodeEditDialog from "./node-edit-dialog";
 import ToggleButton from "./toggle-button";
@@ -18,23 +13,10 @@ import ToggleButton from "./toggle-button";
 function PropertyNode({ data, ...props }: NodeProps) {
 	const [editDialogOpen, setEditDialogOpen] = useState(false);
 	const [addPopoverOpen, setAddPopoverOpen] = useState(false);
-	const { assuranceCase } = useStore();
 
 	const node = { data, position: { x: 0, y: 0 }, ...props };
 
-	const badgeSlot = useElementBadgeSlot({
-		caseId: assuranceCase?.id?.toString() ?? "",
-		elementId: String(data.id),
-		elementType: "property",
-	});
-	const assertionBadge = getAssertionStatusIndicator(data.assertionStatus);
-	const topRightActions =
-		assertionBadge || badgeSlot ? (
-			<div className="flex items-center gap-1.5">
-				{assertionBadge}
-				{badgeSlot}
-			</div>
-		) : null;
+	const topRightActions = useNodeTopRightActions(data, "property");
 
 	const addPopover = (
 		<NodeAddPopover

--- a/components/cases/property-node.tsx
+++ b/components/cases/property-node.tsx
@@ -3,7 +3,11 @@
 import { Plus } from "lucide-react";
 import { memo, useState } from "react";
 import type { NodeProps } from "reactflow";
-import { BaseNode, NodeActionGroup } from "@/components/shared/nodes";
+import {
+	BaseNode,
+	getAssertionStatusIndicator,
+	NodeActionGroup,
+} from "@/components/shared/nodes";
 import ActionTooltip from "@/components/ui/action-tooltip";
 import { useElementBadgeSlot } from "@/hooks/use-element-badge-slot";
 import useStore from "@/store/store";
@@ -23,6 +27,14 @@ function PropertyNode({ data, ...props }: NodeProps) {
 		elementId: String(data.id),
 		elementType: "property",
 	});
+	const assertionBadge = getAssertionStatusIndicator(data.assertionStatus);
+	const topRightActions =
+		assertionBadge || badgeSlot ? (
+			<div className="flex items-center gap-1.5">
+				{assertionBadge}
+				{badgeSlot}
+			</div>
+		) : null;
 
 	const addPopover = (
 		<NodeAddPopover
@@ -74,7 +86,7 @@ function PropertyNode({ data, ...props }: NodeProps) {
 				name={data.name}
 				nodeType="property"
 				selected={props.selected}
-				topRightActions={badgeSlot}
+				topRightActions={topRightActions}
 			/>
 
 			{/* Edit Dialog */}

--- a/components/cases/strategy-node.tsx
+++ b/components/cases/strategy-node.tsx
@@ -3,7 +3,11 @@
 import { Plus } from "lucide-react";
 import { memo, useState } from "react";
 import type { NodeProps } from "reactflow";
-import { BaseNode, NodeActionGroup } from "@/components/shared/nodes";
+import {
+	BaseNode,
+	getAssertionStatusIndicator,
+	NodeActionGroup,
+} from "@/components/shared/nodes";
 import ActionTooltip from "@/components/ui/action-tooltip";
 import { useElementBadgeSlot } from "@/hooks/use-element-badge-slot";
 import useStore from "@/store/store";
@@ -23,6 +27,14 @@ function StrategyNode({ data, ...props }: NodeProps) {
 		elementId: String(data.id),
 		elementType: "strategy",
 	});
+	const assertionBadge = getAssertionStatusIndicator(data.assertionStatus);
+	const topRightActions =
+		assertionBadge || badgeSlot ? (
+			<div className="flex items-center gap-1.5">
+				{assertionBadge}
+				{badgeSlot}
+			</div>
+		) : null;
 
 	const addPopover = (
 		<NodeAddPopover
@@ -74,7 +86,7 @@ function StrategyNode({ data, ...props }: NodeProps) {
 				name={data.name}
 				nodeType="strategy"
 				selected={props.selected}
-				topRightActions={badgeSlot}
+				topRightActions={topRightActions}
 			/>
 
 			{/* Edit Dialog */}

--- a/components/cases/strategy-node.tsx
+++ b/components/cases/strategy-node.tsx
@@ -3,14 +3,9 @@
 import { Plus } from "lucide-react";
 import { memo, useState } from "react";
 import type { NodeProps } from "reactflow";
-import {
-	BaseNode,
-	getAssertionStatusIndicator,
-	NodeActionGroup,
-} from "@/components/shared/nodes";
+import { BaseNode, NodeActionGroup } from "@/components/shared/nodes";
 import ActionTooltip from "@/components/ui/action-tooltip";
-import { useElementBadgeSlot } from "@/hooks/use-element-badge-slot";
-import useStore from "@/store/store";
+import { useNodeTopRightActions } from "@/hooks/use-node-top-right-actions";
 import NodeAddPopover from "./node-add-popover";
 import NodeEditDialog from "./node-edit-dialog";
 import ToggleButton from "./toggle-button";
@@ -18,23 +13,10 @@ import ToggleButton from "./toggle-button";
 function StrategyNode({ data, ...props }: NodeProps) {
 	const [editDialogOpen, setEditDialogOpen] = useState(false);
 	const [addPopoverOpen, setAddPopoverOpen] = useState(false);
-	const { assuranceCase } = useStore();
 
 	const node = { data, position: { x: 0, y: 0 }, ...props };
 
-	const badgeSlot = useElementBadgeSlot({
-		caseId: assuranceCase?.id?.toString() ?? "",
-		elementId: String(data.id),
-		elementType: "strategy",
-	});
-	const assertionBadge = getAssertionStatusIndicator(data.assertionStatus);
-	const topRightActions =
-		assertionBadge || badgeSlot ? (
-			<div className="flex items-center gap-1.5">
-				{assertionBadge}
-				{badgeSlot}
-			</div>
-		) : null;
+	const topRightActions = useNodeTopRightActions(data, "strategy");
 
 	const addPopover = (
 		<NodeAddPopover

--- a/components/shared/nodes/__tests__/assertion-status-badge.test.tsx
+++ b/components/shared/nodes/__tests__/assertion-status-badge.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { getAssertionStatusIndicator } from "../assertion-status-badge";
+
+/**
+ * Pins the badge-side of ADR 0004 D5's read/write asymmetry: the badge
+ * DISPLAYS all six statuses including the derived `AS_CITED`; only the
+ * setter (node-edit-dialog-assertion-status.test.ts) excludes it from
+ * what an author can choose. `ASSERTED` is the unremarkable default, so it
+ * — like absent/invalid data — renders no badge at all.
+ */
+describe("getAssertionStatusIndicator", () => {
+	it("returns null for the default ASSERTED status", () => {
+		expect(getAssertionStatusIndicator("ASSERTED")).toBeNull();
+	});
+
+	it("returns null for null", () => {
+		expect(getAssertionStatusIndicator(null)).toBeNull();
+	});
+
+	it("returns null for undefined", () => {
+		expect(getAssertionStatusIndicator(undefined)).toBeNull();
+	});
+
+	it("returns null for an invalid value", () => {
+		expect(getAssertionStatusIndicator("NOT_A_REAL_STATUS")).toBeNull();
+	});
+
+	it.each([
+		"NEEDS_SUPPORT",
+		"ASSUMED",
+		"AXIOMATIC",
+		"DEFEATED",
+		"AS_CITED",
+	] as const)("returns a badge for %s", (status) => {
+		expect(getAssertionStatusIndicator(status)).not.toBeNull();
+	});
+
+	it("returns a badge for AS_CITED even though the setter excludes it", () => {
+		// AS_CITED is derived-only (ADR 0004 D5) and never author-selectable
+		// (see AUTHOR_ASSERTION_STATUS_VALUES / getInitialAssertionStatus), but
+		// it is still a real, displayable status once the server has derived
+		// it — the badge must show it like any other non-default status.
+		expect(getAssertionStatusIndicator("AS_CITED")).not.toBeNull();
+	});
+});

--- a/components/shared/nodes/assertion-status-badge.tsx
+++ b/components/shared/nodes/assertion-status-badge.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/lib/assertion-status";
 import { cn } from "@/lib/utils";
 
-export interface AssertionStatusBadgeProps {
+interface AssertionStatusBadgeProps {
 	className?: string;
 	/** The element's per-assertion status (ADR 0004 D3). */
 	status: AssertionStatusValue;
@@ -57,7 +57,7 @@ const STATUS_CLASSES: Record<AssertionStatusValue, string> = {
  * all (see `useElementBadgeSlot`'s docstring for why that distinction
  * matters to `BaseNode`'s `topRightActions` guard).
  */
-export function AssertionStatusBadge({
+function AssertionStatusBadge({
 	status,
 	className,
 }: AssertionStatusBadgeProps) {

--- a/components/shared/nodes/assertion-status-badge.tsx
+++ b/components/shared/nodes/assertion-status-badge.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Badge } from "@/components/ui/badge";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+	ASSERTION_STATUS_DESCRIPTIONS,
+	ASSERTION_STATUS_LABELS,
+	type AssertionStatusValue,
+	isAssertionStatusValue,
+} from "@/lib/assertion-status";
+import { cn } from "@/lib/utils";
+
+export interface AssertionStatusBadgeProps {
+	className?: string;
+	/** The element's per-assertion status (ADR 0004 D3). */
+	status: AssertionStatusValue;
+}
+
+/**
+ * Tailwind classes per status, following the same
+ * `bg-<token>/10 text-<token> ring-<token>/20` convention as
+ * `components/publishing/status-badge.tsx` and `components/cases/trash-list.tsx`
+ * — semantic tokens only, no hardcoded colours.
+ *
+ * `AS_CITED` (derived) and the default `ASSERTED` share the neutral
+ * muted-foreground treatment: neither is an author call to action, unlike
+ * the other four.
+ */
+const STATUS_CLASSES: Record<AssertionStatusValue, string> = {
+	ASSERTED:
+		"bg-muted-foreground/10 text-muted-foreground ring-muted-foreground/20",
+	NEEDS_SUPPORT: "bg-warning/10 text-warning ring-warning/20",
+	ASSUMED: "bg-info/10 text-info ring-info/20",
+	AXIOMATIC: "bg-secondary text-secondary-foreground ring-secondary/40",
+	DEFEATED: "bg-destructive/10 text-destructive ring-destructive/20",
+	AS_CITED:
+		"bg-muted-foreground/10 text-muted-foreground ring-muted-foreground/20",
+};
+
+/**
+ * A small badge showing an element's per-assertion status (ADR 0004 D3) —
+ * the author's declared stance on the claim, or `AS_CITED` when the server
+ * has derived it from a cited element (ADR 0004 D5). Status is never
+ * colour-only: the label text is always visible on the badge itself, so the
+ * signal survives greyscale rendering and colour-vision differences; the
+ * tooltip repeats it in fuller words for hover users.
+ *
+ * Callers should not render this for the default `ASSERTED` status — see
+ * `getAssertionStatusIndicator` below, which callers use instead of this
+ * component directly so the "nothing to show" case produces no element at
+ * all (see `useElementBadgeSlot`'s docstring for why that distinction
+ * matters to `BaseNode`'s `topRightActions` guard).
+ */
+export function AssertionStatusBadge({
+	status,
+	className,
+}: AssertionStatusBadgeProps) {
+	const label = ASSERTION_STATUS_LABELS[status];
+	const description = ASSERTION_STATUS_DESCRIPTIONS[status];
+
+	return (
+		<TooltipProvider>
+			<Tooltip delayDuration={200}>
+				<TooltipTrigger asChild>
+					<Badge
+						aria-label={`Assertion status: ${label}`}
+						className={cn(
+							"rounded-full border-none px-2 py-0.5 font-medium text-[10px] ring-1 ring-inset",
+							STATUS_CLASSES[status],
+							className
+						)}
+						variant="outline"
+					>
+						{label}
+					</Badge>
+				</TooltipTrigger>
+				<TooltipContent>{description}</TooltipContent>
+			</Tooltip>
+		</TooltipProvider>
+	);
+}
+
+/**
+ * Derives the `topRightActions` badge for a node's raw `assertionStatus`
+ * data field. Returns `null` — not a component that renders null — for
+ * `undefined`/`null`/an invalid value, and for the default `ASSERTED`:
+ * ASSERTED is the unremarkable default, so only the other five statuses are
+ * worth a badge (confirmed against the acceptance criteria: "a non-default
+ * assertionStatus shows as a badge").
+ */
+export function getAssertionStatusIndicator(status: unknown): ReactNode | null {
+	if (!isAssertionStatusValue(status) || status === "ASSERTED") {
+		return null;
+	}
+	return <AssertionStatusBadge status={status} />;
+}

--- a/components/shared/nodes/index.ts
+++ b/components/shared/nodes/index.ts
@@ -13,6 +13,10 @@ export {
 } from "./animations";
 
 // Components
+export {
+	AssertionStatusBadge,
+	getAssertionStatusIndicator,
+} from "./assertion-status-badge";
 export { default as AttributeSection } from "./attribute-section";
 export { default as BaseNode } from "./base-node";
 export { default as NodeActionGroup } from "./node-action-group";

--- a/components/shared/nodes/index.ts
+++ b/components/shared/nodes/index.ts
@@ -13,10 +13,7 @@ export {
 } from "./animations";
 
 // Components
-export {
-	AssertionStatusBadge,
-	getAssertionStatusIndicator,
-} from "./assertion-status-badge";
+export { getAssertionStatusIndicator } from "./assertion-status-badge";
 export { default as AttributeSection } from "./attribute-section";
 export { default as BaseNode } from "./base-node";
 export { default as NodeActionGroup } from "./node-action-group";

--- a/hooks/use-node-top-right-actions.tsx
+++ b/hooks/use-node-top-right-actions.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { getAssertionStatusIndicator } from "@/components/shared/nodes";
+import type { ElementType } from "@/lib/plugins/slots";
+import useStore from "@/store/store";
+import { useElementBadgeSlot } from "./use-element-badge-slot";
+
+/**
+ * Combines the two things a canvas node shows in `BaseNode`'s
+ * `topRightActions` slot — the per-assertion status badge (ADR 0004 D3) and
+ * the `element-badge` plugin slot (ADR 0002 v2 §2.3) — into the single node
+ * `goal-node.tsx`/`strategy-node.tsx`/`property-node.tsx` pass through.
+ *
+ * Was three verbatim copies of this composition (one per node type,
+ * introduced alongside the assertionStatus badge); extracted here so the
+ * three node components only differ in `elementType`/`nodeType`. Behaviour
+ * is unchanged: `null` when both the assertion badge and the plugin slot are
+ * absent, so `BaseNode`'s `topRightActions && <div>...</div>` guard still
+ * renders no wrapper at all (see `useElementBadgeSlot`'s docstring for why
+ * that distinction matters).
+ */
+export function useNodeTopRightActions(
+	data: Record<string, unknown>,
+	elementType: ElementType
+): ReactNode | null {
+	const { assuranceCase } = useStore();
+
+	const badgeSlot = useElementBadgeSlot({
+		caseId: assuranceCase?.id?.toString() ?? "",
+		elementId: String(data.id),
+		elementType,
+	});
+	const assertionBadge = getAssertionStatusIndicator(data.assertionStatus);
+
+	if (!(assertionBadge || badgeSlot)) {
+		return null;
+	}
+
+	return (
+		<div className="flex items-center gap-1.5">
+			{assertionBadge}
+			{badgeSlot}
+		</div>
+	);
+}

--- a/lib/assertion-status.ts
+++ b/lib/assertion-status.ts
@@ -1,0 +1,83 @@
+/**
+ * Per-assertion status (ADR 0004 D3) — shared client-side vocabulary.
+ *
+ * Single source of truth for the UI's badge labels/colours and for the
+ * setter's allowed values. Mirrors `AssertionStatusSchema`
+ * (lib/schemas/case-export.ts), which mirrors the Prisma `AssertionStatus`
+ * enum.
+ */
+
+import { z } from "zod";
+import { AssertionStatusSchema } from "@/lib/schemas/case-export";
+
+export type AssertionStatusValue = z.infer<typeof AssertionStatusSchema>;
+
+export const ASSERTION_STATUS_VALUES = AssertionStatusSchema.options;
+
+/**
+ * The five author-declarable values (ADR 0004 D3). `AS_CITED` is
+ * DERIVED-ONLY — the server computes it transitively from the cited
+ * claim's own status, and rejects a hand-declared `AS_CITED`
+ * (`element-service.ts`'s `rejectDeclaredAsCited`). Deliberately
+ * hand-listed rather than derived from `ASSERTION_STATUS_VALUES` by
+ * filtering: the setter's allowed-value list is a security-relevant
+ * allowlist, not a byproduct of the full enum minus one entry.
+ */
+export const AuthorAssertionStatusSchema = z.enum([
+	"ASSERTED",
+	"NEEDS_SUPPORT",
+	"ASSUMED",
+	"AXIOMATIC",
+	"DEFEATED",
+]);
+
+export type AuthorAssertionStatusValue = z.infer<
+	typeof AuthorAssertionStatusSchema
+>;
+
+export const AUTHOR_ASSERTION_STATUS_VALUES =
+	AuthorAssertionStatusSchema.options;
+
+/** Short label shown on the badge and in the setter's dropdown. */
+export const ASSERTION_STATUS_LABELS: Record<AssertionStatusValue, string> = {
+	ASSERTED: "Asserted",
+	NEEDS_SUPPORT: "Needs support",
+	ASSUMED: "Assumed",
+	AXIOMATIC: "Axiomatic",
+	DEFEATED: "Defeated",
+	AS_CITED: "As cited",
+};
+
+/** Longer, plain-English description shown on hover. */
+export const ASSERTION_STATUS_DESCRIPTIONS: Record<
+	AssertionStatusValue,
+	string
+> = {
+	ASSERTED: "The author's stated position — the default status.",
+	NEEDS_SUPPORT: "Flagged by the author as needing further support.",
+	ASSUMED: "Taken as given by the author rather than argued for.",
+	AXIOMATIC: "Treated by the author as self-evidently true in this case.",
+	DEFEATED: "Marked by the author as refuted or withdrawn.",
+	AS_CITED:
+		"Computed automatically from the status of the claim this element cites — not set directly by an author.",
+};
+
+/** Type guard for narrowing an unknown value (e.g. React Flow node data). */
+export function isAssertionStatusValue(
+	value: unknown
+): value is AssertionStatusValue {
+	return (
+		typeof value === "string" &&
+		(ASSERTION_STATUS_VALUES as readonly string[]).includes(value)
+	);
+}
+
+/** Type guard for the five author-declarable values. */
+export function isAuthorAssertionStatusValue(
+	value: unknown
+): value is AuthorAssertionStatusValue {
+	return (
+		typeof value === "string" &&
+		(AUTHOR_ASSERTION_STATUS_VALUES as readonly string[]).includes(value)
+	);
+}

--- a/lib/assertion-status.ts
+++ b/lib/assertion-status.ts
@@ -12,7 +12,7 @@ import { AssertionStatusSchema } from "@/lib/schemas/case-export";
 
 export type AssertionStatusValue = z.infer<typeof AssertionStatusSchema>;
 
-export const ASSERTION_STATUS_VALUES = AssertionStatusSchema.options;
+const ASSERTION_STATUS_VALUES = AssertionStatusSchema.options;
 
 /**
  * The five author-declarable values (ADR 0004 D3). `AS_CITED` is

--- a/lib/schemas/element.ts
+++ b/lib/schemas/element.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { AuthorAssertionStatusSchema } from "@/lib/assertion-status";
 import { lenientUrlSchema, optionalString, optionalUrlSchema } from "./base";
 import { AssertionStatusSchema } from "./case-export";
 
@@ -177,6 +178,12 @@ export const nodeEditFormSchema = z.object({
 	justification: z.string().optional(),
 	context: z.array(z.string()).optional(),
 	urls: z.array(z.object({ value: z.string() })),
+	// Per-assertion status (ADR 0004 D3). The five author-declarable values
+	// only — `AS_CITED` is derived-only and must never be offered in this
+	// form's Select (components/cases/node-edit-dialog.tsx). "Unset" is
+	// represented by the explicit "ASSERTED" option, not by omitting the
+	// field, since the Select always needs a concrete value to display.
+	assertionStatus: AuthorAssertionStatusSchema.optional(),
 });
 
 export type NodeEditFormInput = z.input<typeof nodeEditFormSchema>;

--- a/lib/services/__tests__/history-service.test.ts
+++ b/lib/services/__tests__/history-service.test.ts
@@ -4,10 +4,12 @@ import type { HistoryCommand } from "@/types/history";
 import {
 	applyRedo,
 	applyUndo,
+	createSnapshot,
 	generateOperationDescription,
 	recordAttach,
 	recordDetach,
 	recordMove,
+	recordUpdate,
 } from "../history-service";
 
 // ---------------------------------------------------------------------------
@@ -245,6 +247,69 @@ describe("recordAttach", () => {
 });
 
 // ---------------------------------------------------------------------------
+// createSnapshot -- assertionStatus (ADR 0004 D3)
+// ---------------------------------------------------------------------------
+
+describe("createSnapshot", () => {
+	it("captures assertionStatus from the source data", () => {
+		const snapshot = createSnapshot({
+			id: "elem-1",
+			type: "property_claim",
+			name: "Claim",
+			description: "A claim",
+			assertionStatus: "NEEDS_SUPPORT",
+		});
+
+		expect(snapshot.assertionStatus).toBe("NEEDS_SUPPORT");
+	});
+
+	it("leaves assertionStatus undefined when the source data omits it", () => {
+		const snapshot = createSnapshot({
+			id: "elem-2",
+			type: "goal",
+			name: "Goal",
+			description: "A goal",
+		});
+
+		expect(snapshot.assertionStatus).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// recordUpdate + applyUndo/applyRedo -- assertionStatus end-to-end round-trip
+// ---------------------------------------------------------------------------
+
+describe("assertionStatus undo/redo round-trip", () => {
+	beforeEach(() => {
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockOkResponse()));
+	});
+
+	it("replays the pre-change status on undo and the post-change status on redo", async () => {
+		recordUpdate(
+			"elem-96",
+			"property_claim",
+			{ name: "Claim", description: "Desc", assertionStatus: "ASSERTED" },
+			{ name: "Claim", description: "Desc", assertionStatus: "DEFEATED" }
+		);
+
+		const { undoStack } = useHistoryStore.getState();
+		const command = undoStack[0]!.commands[0]!;
+
+		await applyUndo(command);
+		const undoCall = (fetch as unknown as ReturnType<typeof vi.fn>).mock
+			.calls[0]!;
+		const undoBody = JSON.parse(undoCall[1].body as string);
+		expect(undoBody.assertionStatus).toBe("ASSERTED");
+
+		await applyRedo(command);
+		const redoCall = (fetch as unknown as ReturnType<typeof vi.fn>).mock
+			.calls[1]!;
+		const redoBody = JSON.parse(redoCall[1].body as string);
+		expect(redoBody.assertionStatus).toBe("DEFEATED");
+	});
+});
+
+// ---------------------------------------------------------------------------
 // applyUndo -- move
 // ---------------------------------------------------------------------------
 
@@ -393,6 +458,34 @@ describe('applyUndo("update")', () => {
 		await applyUndo(command);
 
 		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("carries assertionStatus (ADR 0004 D3) in the replayed PUT body", async () => {
+		const command: HistoryCommand = {
+			type: "update",
+			elementId: "elem-94",
+			elementType: "property_claim",
+			before: {
+				id: "elem-94",
+				elementType: "property_claim",
+				name: "Claim",
+				description: "Before description",
+				assertionStatus: "ASSERTED",
+			},
+			after: {
+				id: "elem-94",
+				elementType: "property_claim",
+				name: "Claim",
+				description: "After description",
+				assertionStatus: "DEFEATED",
+			},
+		};
+
+		await applyUndo(command);
+
+		const call = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!;
+		const body = JSON.parse(call[1].body as string);
+		expect(body.assertionStatus).toBe("ASSERTED");
 	});
 });
 
@@ -728,6 +821,34 @@ describe('applyRedo("update")', () => {
 		await applyRedo(command);
 
 		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("carries assertionStatus (ADR 0004 D3) in the replayed PUT body", async () => {
+		const command: HistoryCommand = {
+			type: "update",
+			elementId: "elem-95",
+			elementType: "property_claim",
+			before: {
+				id: "elem-95",
+				elementType: "property_claim",
+				name: "Claim",
+				description: "Before description",
+				assertionStatus: "ASSERTED",
+			},
+			after: {
+				id: "elem-95",
+				elementType: "property_claim",
+				name: "Claim",
+				description: "After description",
+				assertionStatus: "DEFEATED",
+			},
+		};
+
+		await applyRedo(command);
+
+		const call = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!;
+		const body = JSON.parse(call[1].body as string);
+		expect(body.assertionStatus).toBe("DEFEATED");
 	});
 });
 

--- a/lib/services/case-fetch-service.ts
+++ b/lib/services/case-fetch-service.ts
@@ -94,6 +94,10 @@ function buildGoalStructure(
 		assumption: goal.assumption ?? "",
 		justification: goal.justification ?? "",
 		inSandbox: goal.inSandbox,
+		// Per-assertion status (ADR 0004 D3); omitted (not forced to
+		// "ASSERTED") when unset, matching element-response.ts's convention —
+		// the badge/setter treat undefined the same as the default.
+		assertionStatus: goal.assertionStatus ?? undefined,
 	};
 }
 
@@ -124,6 +128,8 @@ function buildStrategyStructure(
 		justification: strategy.justification ?? "",
 		context: strategy.context || [],
 		inSandbox: strategy.inSandbox,
+		// Per-assertion status (ADR 0004 D3) — see buildGoalStructure comment.
+		assertionStatus: strategy.assertionStatus ?? undefined,
 	};
 }
 
@@ -185,6 +191,8 @@ function buildPropertyClaimStructure(
 		justification: claim.justification ?? "",
 		context: claim.context || [],
 		inSandbox: claim.inSandbox,
+		// Per-assertion status (ADR 0004 D3) — see buildGoalStructure comment.
+		assertionStatus: claim.assertionStatus ?? undefined,
 	};
 }
 

--- a/lib/services/case-response-types.ts
+++ b/lib/services/case-response-types.ts
@@ -12,7 +12,21 @@ import type { CommentResponse } from "./comment-service";
 // and PUBLISHED are the only two states now.
 export type PublishStatusType = "DRAFT" | "PUBLISHED";
 
+// Per-assertion status (ADR 0004 D3), mirroring the Prisma `AssertionStatus`
+// enum and `AssertionStatusSchema` (lib/schemas/case-export.ts). Kept as a
+// plain string union here rather than imported from generated Prisma types,
+// matching this file's convention (see PublishStatusType above) of
+// UI-facing response types staying independent of the Prisma client.
+export type AssertionStatusResponseType =
+	| "ASSERTED"
+	| "NEEDS_SUPPORT"
+	| "ASSUMED"
+	| "AXIOMATIC"
+	| "DEFEATED"
+	| "AS_CITED";
+
 export interface GoalResponse {
+	assertionStatus?: AssertionStatusResponseType;
 	assumption?: string;
 	assuranceCaseId: string;
 	comments?: CommentResponse[];
@@ -34,6 +48,7 @@ export interface GoalResponse {
 }
 
 export interface StrategyResponse {
+	assertionStatus?: AssertionStatusResponseType;
 	assumption?: string;
 	comments?: CommentResponse[];
 	context?: string[];
@@ -53,6 +68,7 @@ export interface StrategyResponse {
 }
 
 export interface PropertyClaimResponse {
+	assertionStatus?: AssertionStatusResponseType;
 	assumption?: string;
 	claimType: string;
 	comments?: CommentResponse[];

--- a/lib/services/history-service.ts
+++ b/lib/services/history-service.ts
@@ -35,6 +35,7 @@ export async function applyUndo(command: HistoryCommand): Promise<void> {
 						justification: command.before.justification,
 						context: command.before.context,
 						inSandbox: command.before.inSandbox,
+						assertionStatus: command.before.assertionStatus,
 					}),
 				});
 			}
@@ -110,6 +111,7 @@ export async function applyRedo(command: HistoryCommand): Promise<void> {
 						justification: command.after.justification,
 						context: command.after.context,
 						inSandbox: command.after.inSandbox,
+						assertionStatus: command.after.assertionStatus,
 					}),
 				});
 			}
@@ -211,6 +213,9 @@ export function createSnapshot(data: Record<string, unknown>): ElementSnapshot {
 		justification: data.justification as string | undefined,
 		context: data.context as string[] | undefined,
 		inSandbox: data.inSandbox as boolean | undefined,
+		// Per-assertion status (ADR 0004 D3) — undo/redo must round-trip this
+		// like any other author-editable field.
+		assertionStatus: data.assertionStatus as string | undefined,
 	};
 }
 

--- a/src/__tests__/integration/case-crud.test.ts
+++ b/src/__tests__/integration/case-crud.test.ts
@@ -6,6 +6,7 @@ import {
 import { expectError, expectSuccess } from "../utils/assertion-helpers";
 import {
 	createTestCase,
+	createTestElement,
 	createTestPermission,
 	createTestUser,
 } from "../utils/prisma-factories";
@@ -125,6 +126,63 @@ describe("case-fetch-service", () => {
 
 			const data = expectSuccess(result);
 			expect(data.permissions).toBe("manage");
+		});
+	});
+
+	describe("fetchCaseFromPrisma — assertionStatus read-carry (ADR 0004 D3)", () => {
+		it("carries assertionStatus through to the goal, strategy, and property claim in the response", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id, {
+				name: "Assertion Status Case",
+			});
+			const goal = await createTestElement(testCase.id, user.id, {
+				elementType: "GOAL",
+				name: "G1",
+				role: "TOP_LEVEL",
+				assertionStatus: "NEEDS_SUPPORT",
+			});
+			const strategy = await createTestElement(testCase.id, user.id, {
+				elementType: "STRATEGY",
+				name: "S1",
+				parentId: goal.id,
+				assertionStatus: "ASSUMED",
+			});
+			await createTestElement(testCase.id, user.id, {
+				elementType: "PROPERTY_CLAIM",
+				name: "P1",
+				parentId: strategy.id,
+				assertionStatus: "DEFEATED",
+			});
+
+			const result = await fetchCaseFromPrisma(testCase.id, user.id);
+			const data = expectSuccess(result);
+
+			const fetchedGoal = data.goals?.[0];
+			expect(fetchedGoal?.assertionStatus).toBe("NEEDS_SUPPORT");
+
+			const fetchedStrategy = fetchedGoal?.strategies?.[0];
+			expect(fetchedStrategy?.assertionStatus).toBe("ASSUMED");
+
+			const fetchedClaim = fetchedStrategy?.propertyClaims?.[0];
+			expect(fetchedClaim?.assertionStatus).toBe("DEFEATED");
+		});
+
+		it("omits assertionStatus when unset (null), leaving it undefined rather than forcing ASSERTED", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id, {
+				name: "Unset Assertion Status Case",
+			});
+			await createTestElement(testCase.id, user.id, {
+				elementType: "GOAL",
+				name: "G1",
+				role: "TOP_LEVEL",
+				// assertionStatus omitted — column default (null/unset)
+			});
+
+			const result = await fetchCaseFromPrisma(testCase.id, user.id);
+			const data = expectSuccess(result);
+
+			expect(data.goals?.[0]?.assertionStatus).toBeUndefined();
 		});
 	});
 

--- a/types/history.ts
+++ b/types/history.ts
@@ -21,6 +21,9 @@ export type OperationType =
  */
 // Captures arbitrary element fields for history snapshots (undo/redo)
 export interface ElementSnapshot {
+	// Per-assertion status (ADR 0004 D3); nullable, null/undefined means the
+	// default ASSERTED.
+	assertionStatus?: string | null;
 	assumption?: string | null;
 	context?: string[];
 	description: string;


### PR DESCRIPTION
Makes the per-claim assertionStatus field (ADR 0004 D3) visible and settable in the case builder. The field was already persisted, validated, and API-settable; this is the browser half.

## What this adds

- **Status badge** on goal/strategy/property nodes — shows the author's stance on a claim (needs-support, assumed, axiomatic, defeated, or cited-from-elsewhere). The unremarkable default (asserted) shows no badge; the others do. Accessible: a visible text label (never colour-alone), an aria-label, and a tooltip; correct in light and dark themes.
- **Setter** in the node edit dialog — an author picks from the **five author-declarable** statuses. `AS_CITED` is derived by the system, so it is structurally excluded from the choices (a hand-listed allowlist, not a filter) — the badge still displays it when the server has set it.
- **Read-carry** — the field now travels server → browser through the case-fetch pipeline (service builders + response types; the store/convert-case hops were already pass-through).
- **Undo/redo** now captures and replays the field.

The D3 write rule holds end to end: the setter offers only declarable values, and the server independently rejects a hand-declared `AS_CITED` regardless of client (defence in depth, already tested).

## Review chain

QA (nanaki) mutation-confirmed the read-carry and undo/redo tests and verified node.data reachability; code review (vincent) confirmed the AS_CITED exclusion is structural, the badge/setter vocabularies are single-sourced and can't drift, no Prisma leak in the read path, and shadcn/token/accessibility compliance — both PASS, zero must-fixes. A follow-up round then extracted a duplicated node block into a shared hook, dropped three needless exports (fallow-clean, no baseline bump), and added the two tests the reviewers wanted (the AS_CITED-exclusion proof and the badge show/hide logic). Delta personally verified. Final: unit 81 files / 1188 tests green; read-carry integration green; typecheck + lint + fallow clean.

## Note for reviewers

The setter is scoped to goal/strategy/property nodes (matches the badge scope); easy to widen later. Visual acceptance is best done on staging — automated review covers the logic, accessibility attributes, and theming tokens, but not the rendered look.

Base note: branched off staging; independent of #879 (the batch surface) — different files, no conflict.