### PR TITLE
Fix batch from the 2026-08-09 staging walkthrough

### DIFF
--- a/components/cases/__tests__/case-settings-popover.test.tsx
+++ b/components/cases/__tests__/case-settings-popover.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import useStore from "@/store/store";
@@ -14,6 +14,13 @@ vi.mock("@/providers/theme-preset-provider", () => ({
 		availablePresets: [],
 	}),
 }));
+
+// The repo-wide Radix mocks (src/__tests__/setup/component-mocks.tsx) are
+// simplified state containers that don't implement real dismiss behaviour
+// (outside click / Escape), so this whole file needs the actual primitives —
+// the dismiss-behaviour tests below would be false-green against the mocks.
+vi.unmock("@radix-ui/react-popover");
+vi.unmock("@radix-ui/react-tooltip");
 
 function resetStore(): void {
 	useStore.setState({
@@ -87,5 +94,83 @@ describe("CaseSettingsPopover — layout direction persistence", () => {
 		await user.click(topDownOption);
 
 		expect(fetch).not.toHaveBeenCalled();
+	});
+});
+
+describe("CaseSettingsPopover — dismiss on outside click / Escape", () => {
+	beforeEach(() => {
+		resetStore();
+	});
+
+	it("closes on Escape", async () => {
+		const user = userEvent.setup();
+		render(<CaseSettingsPopover />);
+
+		await user.click(await screen.findByRole("button", { name: "Settings" }));
+		await screen.findByText("Mode");
+
+		await user.keyboard("{Escape}");
+
+		await waitFor(() => {
+			expect(screen.queryByText("Mode")).not.toBeInTheDocument();
+		});
+	});
+
+	it("the trigger still toggles the popover open and closed", async () => {
+		const user = userEvent.setup();
+		render(<CaseSettingsPopover />);
+		const trigger = await screen.findByRole("button", { name: "Settings" });
+
+		await user.click(trigger);
+		await screen.findByText("Mode");
+
+		// `modal` sets `body.style.pointerEvents = "none"` while open, so a
+		// full realistic press-and-release (userEvent.click) on the trigger
+		// legitimately fails jsdom's hit-testing partway through — the same
+		// way a real browser would redirect the click elsewhere for the
+		// duration the CSS override is in effect. `fireEvent.click` exercises
+		// the trigger's actual composed onClick (open-toggle) handler without
+		// that pointer-events pre-check, which is what actually determines
+		// whether re-clicking still closes it.
+		fireEvent.click(trigger);
+		await waitFor(() => {
+			expect(screen.queryByText("Mode")).not.toBeInTheDocument();
+		});
+	});
+
+	it("closes on an outside click even when the click target stops event propagation — the exact ReactFlow-canvas scenario that defeated the pre-fix non-modal popover", async () => {
+		render(
+			<div>
+				{/* Stands in for ReactFlow's pane: d3-zoom attaches native
+				 * pointerdown/mousedown handlers there that stop propagation
+				 * for its own pan-gesture handling. A non-modal Popover's
+				 * outside-click dismiss listens on `document` in the bubble
+				 * phase, so that stopPropagation() silently swallowed the
+				 * dismiss pre-fix. */}
+				<div data-testid="canvas-pane">canvas</div>
+				<CaseSettingsPopover />
+			</div>
+		);
+		const pane = screen.getByTestId("canvas-pane");
+		pane.addEventListener("pointerdown", (e) => e.stopPropagation());
+		pane.addEventListener("mousedown", (e) => e.stopPropagation());
+
+		fireEvent.click(await screen.findByRole("button", { name: "Settings" }));
+		await screen.findByText("Mode");
+
+		// `modal` sets `document.body.style.pointerEvents = "none"` while
+		// open, so a real click over the canvas never reaches `pane` at all —
+		// confirm that's actually in effect, then dispatch where the click
+		// would really land (fireEvent skips CSS hit-testing, unlike a real
+		// browser or user-event, so we simulate the redirect explicitly).
+		expect(document.body.style.pointerEvents).toBe("none");
+		fireEvent.pointerDown(document.body);
+		fireEvent.mouseDown(document.body);
+		fireEvent.mouseUp(document.body);
+		fireEvent.click(document.body);
+
+		await waitFor(() => {
+			expect(screen.queryByText("Mode")).not.toBeInTheDocument();
+		});
 	});
 });

--- a/components/cases/__tests__/node-attributes.test.tsx
+++ b/components/cases/__tests__/node-attributes.test.tsx
@@ -1,0 +1,114 @@
+import { waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import type { Node } from "reactflow";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { recordUpdate } from "@/lib/services/history-service";
+import { toast } from "@/lib/toast";
+import { server } from "@/src/__tests__/mocks/server";
+import { renderWithAuth, screen } from "@/src/__tests__/utils/test-utils";
+import useStore from "@/store/store";
+import NodeAttributes from "../node-attributes";
+
+vi.mock("@/lib/services/history-service", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@/lib/services/history-service")>();
+	return { ...actual, recordUpdate: vi.fn() };
+});
+
+vi.mock("@/lib/toast", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/toast")>();
+	return { ...actual, toast: vi.fn() };
+});
+
+const NODE = {
+	id: "1",
+	type: "goal",
+	position: { x: 0, y: 0 },
+	data: {
+		id: 1,
+		assumption: "",
+		justification: "",
+		context: [],
+	},
+} as unknown as Node & {
+	data: {
+		assumption?: string;
+		context?: string[];
+		id: number;
+		justification?: string;
+	};
+};
+
+function resetStore(): void {
+	useStore.setState({
+		assuranceCase: {
+			id: "case-1",
+			name: "Test Case",
+			type: "assurance-case",
+			permissions: "manage",
+			createdDate: new Date().toISOString(),
+			comments: [],
+		},
+	});
+}
+
+describe("NodeAttributes — save failure handling", () => {
+	beforeEach(() => {
+		resetStore();
+		vi.mocked(toast).mockClear();
+		vi.mocked(recordUpdate).mockClear();
+	});
+
+	it("surfaces the server error and records no undo entry on failure", async () => {
+		const user = userEvent.setup();
+		server.use(
+			http.put("/api/elements/1", () =>
+				HttpResponse.json({ error: "Assumption is too long" }, { status: 400 })
+			)
+		);
+
+		renderWithAuth(
+			<NodeAttributes
+				actions={{ setAction: vi.fn(), setSelectedLink: vi.fn() }}
+				node={NODE}
+				onClose={vi.fn()}
+				setUnresolvedChanges={vi.fn()}
+			/>
+		);
+
+		await user.click(screen.getByRole("button", { name: "Update Attributes" }));
+
+		await waitFor(() =>
+			expect(toast).toHaveBeenCalledWith(
+				expect.objectContaining({
+					variant: "destructive",
+					description: "Assumption is too long",
+				})
+			)
+		);
+		expect(recordUpdate).not.toHaveBeenCalled();
+	});
+
+	it("records the undo entry on a successful save", async () => {
+		const user = userEvent.setup();
+		const onClose = vi.fn();
+		server.use(
+			http.put("/api/elements/1", () => HttpResponse.json({}, { status: 200 }))
+		);
+
+		renderWithAuth(
+			<NodeAttributes
+				actions={{ setAction: vi.fn(), setSelectedLink: vi.fn() }}
+				node={NODE}
+				onClose={onClose}
+				setUnresolvedChanges={vi.fn()}
+			/>
+		);
+
+		await user.click(screen.getByRole("button", { name: "Update Attributes" }));
+
+		await waitFor(() => expect(recordUpdate).toHaveBeenCalledTimes(1));
+		expect(toast).not.toHaveBeenCalled();
+	});
+});

--- a/components/cases/__tests__/node-attributes.test.tsx
+++ b/components/cases/__tests__/node-attributes.test.tsx
@@ -60,8 +60,9 @@ describe("NodeAttributes — save failure handling", () => {
 		vi.mocked(recordUpdate).mockClear();
 	});
 
-	it("surfaces the server error and records no undo entry on failure", async () => {
+	it("surfaces the server error, keeps the dialog open, and records no undo entry on failure", async () => {
 		const user = userEvent.setup();
+		const onClose = vi.fn();
 		server.use(
 			http.put("/api/elements/1", () =>
 				HttpResponse.json({ error: "Assumption is too long" }, { status: 400 })
@@ -72,7 +73,7 @@ describe("NodeAttributes — save failure handling", () => {
 			<NodeAttributes
 				actions={{ setAction: vi.fn(), setSelectedLink: vi.fn() }}
 				node={NODE}
-				onClose={vi.fn()}
+				onClose={onClose}
 				setUnresolvedChanges={vi.fn()}
 			/>
 		);
@@ -88,6 +89,7 @@ describe("NodeAttributes — save failure handling", () => {
 			)
 		);
 		expect(recordUpdate).not.toHaveBeenCalled();
+		expect(onClose).not.toHaveBeenCalled();
 	});
 
 	it("records the undo entry on a successful save", async () => {

--- a/components/cases/__tests__/node-edit-dialog.test.tsx
+++ b/components/cases/__tests__/node-edit-dialog.test.tsx
@@ -2,13 +2,26 @@ import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import type { Node } from "reactflow";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ElementSlotContext } from "@/lib/plugins/slots";
 import { elementPanelSlot } from "@/lib/plugins/slots";
 import type { PluginSettingsListItem } from "@/lib/schemas/plugin";
+import { recordUpdate } from "@/lib/services/history-service";
+import { toast } from "@/lib/toast";
 import { server } from "@/src/__tests__/mocks/server";
 import { render, screen } from "@/src/__tests__/utils/test-utils";
 import NodeEditDialog from "../node-edit-dialog";
+
+vi.mock("@/lib/services/history-service", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@/lib/services/history-service")>();
+	return { ...actual, recordUpdate: vi.fn() };
+});
+
+vi.mock("@/lib/toast", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/toast")>();
+	return { ...actual, toast: vi.fn() };
+});
 
 const NODE: Node = {
 	id: "1",
@@ -232,5 +245,73 @@ describe("NodeEditDialog — form reset on node changes while open", () => {
 				"System is appropriately monitored"
 			)
 		);
+	});
+});
+
+describe("NodeEditDialog — save failure handling", () => {
+	beforeEach(() => {
+		vi.mocked(toast).mockClear();
+		vi.mocked(recordUpdate).mockClear();
+	});
+
+	it("surfaces the server error, keeps the dialog open, and records no undo entry on failure", async () => {
+		const user = userEvent.setup();
+		const onOpenChange = vi.fn();
+		mockPluginsResponse(true);
+		server.use(
+			http.put("/api/elements/1", () =>
+				HttpResponse.json({ error: "Description is required" }, { status: 400 })
+			)
+		);
+
+		render(
+			<NodeEditDialog
+				node={NODE}
+				nodeType="goal"
+				onOpenChange={onOpenChange}
+				open={true}
+			/>,
+			{ withProviders: false }
+		);
+
+		await screen.findByLabelText("Description");
+		await user.click(screen.getByRole("button", { name: "Update Goal" }));
+
+		await waitFor(() =>
+			expect(toast).toHaveBeenCalledWith(
+				expect.objectContaining({
+					variant: "destructive",
+					description: "Description is required",
+				})
+			)
+		);
+		expect(onOpenChange).not.toHaveBeenCalledWith(false);
+		expect(recordUpdate).not.toHaveBeenCalled();
+	});
+
+	it("records the undo entry and closes the dialog on a successful save", async () => {
+		const user = userEvent.setup();
+		const onOpenChange = vi.fn();
+		mockPluginsResponse(true);
+		server.use(
+			http.put("/api/elements/1", () => HttpResponse.json({}, { status: 200 }))
+		);
+
+		render(
+			<NodeEditDialog
+				node={NODE}
+				nodeType="goal"
+				onOpenChange={onOpenChange}
+				open={true}
+			/>,
+			{ withProviders: false }
+		);
+
+		await screen.findByLabelText("Description");
+		await user.click(screen.getByRole("button", { name: "Update Goal" }));
+
+		await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+		expect(recordUpdate).toHaveBeenCalledTimes(1);
+		expect(toast).not.toHaveBeenCalled();
 	});
 });

--- a/components/cases/__tests__/node-edit-dialog.test.tsx
+++ b/components/cases/__tests__/node-edit-dialog.test.tsx
@@ -138,3 +138,99 @@ describe("NodeEditDialog — element-panel slot", () => {
 		expect(screen.queryByText("Evidence")).not.toBeInTheDocument();
 	});
 });
+
+describe("NodeEditDialog — form reset on node changes while open", () => {
+	it("keeps unsaved edits when the host re-renders with a new `node` object for the same element", async () => {
+		const user = userEvent.setup();
+		mockPluginsResponse(true);
+
+		const { rerender } = render(
+			<NodeEditDialog
+				node={NODE}
+				nodeType="goal"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={true}
+			/>,
+			{ withProviders: false }
+		);
+
+		const description = await screen.findByLabelText("Description");
+		await user.clear(description);
+		await user.type(description, "Draft edit not yet saved");
+		expect(description).toHaveValue("Draft edit not yet saved");
+
+		// Same element (same `node.data.id`), but a brand-new object — as
+		// every host node component builds inline on each render.
+		const churnedNode: Node = {
+			...NODE,
+			data: { ...NODE.data },
+		};
+		expect(churnedNode).not.toBe(NODE);
+
+		rerender(
+			<NodeEditDialog
+				node={churnedNode}
+				nodeType="goal"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={true}
+			/>
+		);
+
+		expect(screen.getByLabelText("Description")).toHaveValue(
+			"Draft edit not yet saved"
+		);
+	});
+
+	it("reloads the form when a genuinely different element is passed in while open", async () => {
+		mockPluginsResponse(true);
+
+		const { rerender } = render(
+			<NodeEditDialog
+				node={NODE}
+				nodeType="goal"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={true}
+			/>,
+			{ withProviders: false }
+		);
+
+		await screen.findByLabelText("Description");
+		expect(screen.getByLabelText("Description")).toHaveValue(
+			"System is acceptably safe"
+		);
+
+		const otherNode: Node = {
+			id: "2",
+			type: "goal",
+			position: { x: 0, y: 0 },
+			data: {
+				id: 2,
+				name: "G2",
+				description: "System is appropriately monitored",
+			},
+		};
+
+		rerender(
+			<NodeEditDialog
+				node={otherNode}
+				nodeType="goal"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={true}
+			/>
+		);
+
+		await waitFor(() =>
+			expect(screen.getByLabelText("Description")).toHaveValue(
+				"System is appropriately monitored"
+			)
+		);
+	});
+});

--- a/components/cases/__tests__/node-edit-dialog.test.tsx
+++ b/components/cases/__tests__/node-edit-dialog.test.tsx
@@ -246,6 +246,117 @@ describe("NodeEditDialog — form reset on node changes while open", () => {
 			)
 		);
 	});
+
+	it("discards an unsaved draft on a parent-driven close/reopen cycle (reopen is never told apart from staying open by Radix's onOpenChange, which only fires for internally-driven changes)", async () => {
+		const user = userEvent.setup();
+		mockPluginsResponse(true);
+
+		const { rerender } = render(
+			<NodeEditDialog
+				node={NODE}
+				nodeType="goal"
+				onOpenChange={() => {
+					// no-op — this test drives `open` directly, as the parent
+					// would, rather than routing through Radix's callback.
+				}}
+				open={true}
+			/>,
+			{ withProviders: false }
+		);
+
+		const description = await screen.findByLabelText("Description");
+		await user.clear(description);
+		await user.type(description, "Draft edit not yet saved");
+		expect(description).toHaveValue("Draft edit not yet saved");
+
+		// Parent-driven close: flips the controlled `open` prop directly,
+		// the way a parent would in response to state elsewhere in the
+		// app — never via the dialog's own onOpenChange.
+		rerender(
+			<NodeEditDialog
+				node={NODE}
+				nodeType="goal"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={false}
+			/>
+		);
+
+		// Parent-driven reopen of the same element.
+		rerender(
+			<NodeEditDialog
+				node={NODE}
+				nodeType="goal"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={true}
+			/>
+		);
+
+		await waitFor(() =>
+			expect(screen.getByLabelText("Description")).toHaveValue(
+				"System is acceptably safe"
+			)
+		);
+		expect(
+			screen.queryByDisplayValue("Draft edit not yet saved")
+		).not.toBeInTheDocument();
+	});
+
+	it("reloads over an unsaved draft when a different element's data.id arrives while the dialog stays open", async () => {
+		const user = userEvent.setup();
+		mockPluginsResponse(true);
+
+		const { rerender } = render(
+			<NodeEditDialog
+				node={NODE}
+				nodeType="goal"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={true}
+			/>,
+			{ withProviders: false }
+		);
+
+		const description = await screen.findByLabelText("Description");
+		await user.clear(description);
+		await user.type(description, "Draft edit not yet saved");
+		expect(description).toHaveValue("Draft edit not yet saved");
+
+		const otherNode: Node = {
+			id: "2",
+			type: "goal",
+			position: { x: 0, y: 0 },
+			data: {
+				id: 2,
+				name: "G2",
+				description: "System is appropriately monitored",
+			},
+		};
+
+		rerender(
+			<NodeEditDialog
+				node={otherNode}
+				nodeType="goal"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={true}
+			/>
+		);
+
+		await waitFor(() =>
+			expect(screen.getByLabelText("Description")).toHaveValue(
+				"System is appropriately monitored"
+			)
+		);
+		expect(
+			screen.queryByDisplayValue("Draft edit not yet saved")
+		).not.toBeInTheDocument();
+	});
 });
 
 describe("NodeEditDialog — save failure handling", () => {

--- a/components/cases/case-settings-popover.tsx
+++ b/components/cases/case-settings-popover.tsx
@@ -91,7 +91,15 @@ export function CaseSettingsPopover() {
 	}
 
 	return (
-		<Popover>
+		// `modal` matters here, not just accessibility polish: ReactFlow's pane
+		// (d3-zoom) has its own native pointerdown/mousedown handlers that stop
+		// propagation for pan/zoom gestures. Radix's non-modal outside-click
+		// dismiss listens on `document` in the bubble phase, so a click on the
+		// canvas never reached it and the popover stayed open — only the
+		// trigger button itself could close it. `modal` disables pointer events
+		// on the rest of the page while open (`disableOutsidePointerEvents`),
+		// so the canvas never intercepts the click in the first place.
+		<Popover modal>
 			<ActionTooltip label="Settings">
 				<PopoverTrigger asChild>
 					<Button className="rounded-full p-3" size="icon" type="button">

--- a/components/cases/node-attributes.tsx
+++ b/components/cases/node-attributes.tsx
@@ -8,6 +8,7 @@ import { useForm } from "react-hook-form";
 import type { Node } from "reactflow";
 import { Form } from "@/components/ui/form";
 import {
+	getNodeMutationErrorMessage,
 	type ReactFlowNode,
 	updateAssuranceCase,
 	updateAssuranceCaseNode,
@@ -17,6 +18,7 @@ import {
 	elementAttributesFormSchema,
 } from "@/lib/schemas/element";
 import { recordUpdate } from "@/lib/services/history-service";
+import { toast } from "@/lib/toast";
 import useStore from "@/store/store";
 import { Button } from "../ui/button";
 import AddAttributeButtons from "./add-attribute-buttons";
@@ -105,7 +107,7 @@ const NodeAttributes: React.FC<NodeAttributesProps> = ({
 			updateItem
 		);
 
-		if (updated) {
+		if (updated === true) {
 			// Record update operation for undo/redo
 			const afterData = { ...beforeData, ...updateItem };
 			recordUpdate(node.data.id, node.type, beforeData, afterData);
@@ -122,7 +124,17 @@ const NodeAttributes: React.FC<NodeAttributesProps> = ({
 				setLoading(false);
 				onClose();
 			}
+			return;
 		}
+		toast({
+			variant: "destructive",
+			title: "Failed to update attributes",
+			description: getNodeMutationErrorMessage(
+				updated,
+				"Something went wrong trying to update this element's attributes."
+			),
+		});
+		setLoading(false);
 	}
 
 	const readOnly = !!(

--- a/components/cases/node-edit-dialog.tsx
+++ b/components/cases/node-edit-dialog.tsx
@@ -2,7 +2,14 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2, Lock, Minus, Plus, PlusIcon, Trash2 } from "lucide-react";
-import { useCallback, useEffect, useId, useMemo, useState } from "react";
+import {
+	useCallback,
+	useEffect,
+	useId,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { type UseFormReturn, useFieldArray, useForm } from "react-hook-form";
 import type { Node } from "reactflow";
 import type { DiagramNodeType } from "@/components/shared/nodes/node-config";
@@ -406,6 +413,11 @@ export default function NodeEditDialog({
 		name: "urls",
 	});
 
+	// Subscribing to `isDirty` here (rather than only inside the effect below)
+	// makes react-hook-form's formState Proxy track it, so the effect sees
+	// up-to-date values as the user types.
+	const { isDirty } = form.formState;
+
 	// Context management
 	const contextValues = form.watch("context") || [];
 	const [itemIds, setItemIds] = useState<string[]>(() =>
@@ -443,6 +455,12 @@ export default function NodeEditDialog({
 		);
 	};
 
+	// The id of the node whose data is currently loaded into the form. Used
+	// (not `node` object identity — host node components rebuild that object
+	// inline on every render, e.g. `goal-node.tsx`) to tell a genuine element
+	// change apart from an unrelated re-render of the currently-open node.
+	const loadedNodeIdRef = useRef(node.data?.id);
+
 	const resetFormToNode = useCallback(
 		(n: Node) => {
 			const contextData = (n.data?.context as string[]) ?? [];
@@ -458,6 +476,7 @@ export default function NodeEditDialog({
 			});
 			setItemIds(contextData.map((_, i) => `${componentId}-reset-${i}`));
 			setNewContextValue("");
+			loadedNodeIdRef.current = n.data?.id;
 		},
 		[form, componentId]
 	);
@@ -469,12 +488,22 @@ export default function NodeEditDialog({
 		onOpenChange(nextOpen);
 	};
 
-	// Re-reset when node changes while dialog is already open
+	// Re-reset only for a genuine element change while the dialog stays open
+	// (a different `node.data.id`), never merely because the host re-rendered
+	// and passed a new `node` object for the *same* element — and never while
+	// the user has unsaved edits, so an in-flight change is never silently
+	// discarded.
 	useEffect(() => {
-		if (open) {
-			resetFormToNode(node);
+		if (!open) {
+			return;
 		}
-	}, [node, open, resetFormToNode]);
+		const currentNodeId = node.data?.id;
+		const isGenuineElementChange = currentNodeId !== loadedNodeIdRef.current;
+		if (!isGenuineElementChange || isDirty) {
+			return;
+		}
+		resetFormToNode(node);
+	}, [node, open, resetFormToNode, isDirty]);
 
 	const handleClose = () => handleOpenChange(false);
 

--- a/components/cases/node-edit-dialog.tsx
+++ b/components/cases/node-edit-dialog.tsx
@@ -47,12 +47,16 @@ import {
 	type AuthorAssertionStatusValue,
 	isAuthorAssertionStatusValue,
 } from "@/lib/assertion-status";
-import { updateAssuranceCaseNode } from "@/lib/case";
+import {
+	getNodeMutationErrorMessage,
+	updateAssuranceCaseNode,
+} from "@/lib/case";
 import {
 	type NodeEditFormInput,
 	nodeEditFormSchema,
 } from "@/lib/schemas/element";
 import { recordUpdate } from "@/lib/services/history-service";
+import { toast } from "@/lib/toast";
 import useStore from "@/store/store";
 
 type FormValues = NodeEditFormInput;
@@ -524,7 +528,7 @@ export default function NodeEditDialog({
 			updateItem
 		);
 
-		if (updated) {
+		if (updated === true) {
 			recordUpdate(node.data.id as number, node.type || "unknown", beforeData, {
 				...beforeData,
 				...updateItem,
@@ -533,6 +537,14 @@ export default function NodeEditDialog({
 			handleClose();
 			return;
 		}
+		toast({
+			variant: "destructive",
+			title: `Failed to update ${nodeTypeLabel.toLowerCase()}`,
+			description: getNodeMutationErrorMessage(
+				updated,
+				"Something went wrong trying to update this element."
+			),
+		});
 		setLoading(false);
 	};
 

--- a/components/cases/node-edit-dialog.tsx
+++ b/components/cases/node-edit-dialog.tsx
@@ -492,18 +492,33 @@ export default function NodeEditDialog({
 		onOpenChange(nextOpen);
 	};
 
-	// Re-reset only for a genuine element change while the dialog stays open
-	// (a different `node.data.id`), never merely because the host re-rendered
-	// and passed a new `node` object for the *same* element — and never while
-	// the user has unsaved edits, so an in-flight change is never silently
-	// discarded.
+	// Tracks whether the dialog was open on the previous render, so a
+	// closed→open transition (reopen) can be told apart from staying open
+	// across re-renders.
+	const wasOpenRef = useRef(open);
+
+	// Re-reset when the dialog is reopened, or a genuine element change
+	// arrives while it stays open (a different `node.data.id`) — both always
+	// reload, even over an unsaved draft, since that draft either belongs to
+	// a stale close/reopen cycle or to a *different* element entirely. Only a
+	// same-element re-render while the dialog stays open and the user is
+	// actively editing is guarded by `isDirty`, so an in-flight change is
+	// never silently discarded by unrelated identity churn.
 	useEffect(() => {
+		const justOpened = open && !wasOpenRef.current;
+		wasOpenRef.current = open;
+
 		if (!open) {
 			return;
 		}
 		const currentNodeId = node.data?.id;
+		// Currently unreachable in production: each dialog instance mounts
+		// 1:1 with a single node id (`${nodeType}-${item.id}` in
+		// convert-case.ts), so `node.data.id` never changes under a live
+		// dialog. Kept as defensive correctness in case that mounting
+		// invariant ever changes.
 		const isGenuineElementChange = currentNodeId !== loadedNodeIdRef.current;
-		if (!isGenuineElementChange || isDirty) {
+		if (!(justOpened || isGenuineElementChange) && isDirty) {
 			return;
 		}
 		resetFormToNode(node);
@@ -511,6 +526,14 @@ export default function NodeEditDialog({
 
 	const handleClose = () => handleOpenChange(false);
 
+	// Trade-off (accepted): `buildUpdatePayload` sends a full snapshot of the
+	// form's attribute fields, not a diff. Now that a dirty draft can survive
+	// longer (reopen no longer discards it — see the effect above), the
+	// window in which a field the user never touched could have been changed
+	// concurrently elsewhere and then get overwritten by this stale snapshot
+	// on save is correspondingly longer too. Accepted because the
+	// alternative — silently discarding the user's in-flight edit, which is
+	// the bug this fix addresses — is worse.
 	const handleSubmit = async (values: FormValues) => {
 		// Auto-add any unsaved draft context text
 		if (newContextValue.trim()) {

--- a/components/shared/nodes/__tests__/node-options-menu.test.tsx
+++ b/components/shared/nodes/__tests__/node-options-menu.test.tsx
@@ -4,7 +4,7 @@ import { HttpResponse, http } from "msw";
 import type React from "react";
 import type { Node } from "reactflow";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { recordDelete } from "@/lib/services/history-service";
+import { recordDelete, recordDetach } from "@/lib/services/history-service";
 import { toast } from "@/lib/toast";
 import { server } from "@/src/__tests__/mocks/server";
 import { renderWithReactFlow, screen } from "@/src/__tests__/utils/test-utils";
@@ -67,6 +67,15 @@ async function openDeleteConfirmation(
 	await user.click(await screen.findByRole("button", { name: "Delete" }));
 }
 
+async function openDetachConfirmation(
+	user: ReturnType<typeof userEvent.setup>
+) {
+	const trigger = screen.getByRole("button");
+	await user.click(trigger);
+	await user.click(await screen.findByText("Detach"));
+	await user.click(await screen.findByRole("button", { name: "Detach" }));
+}
+
 describe("NodeOptionsMenu — delete failure handling", () => {
 	beforeEach(() => {
 		resetStore();
@@ -119,5 +128,44 @@ describe("NodeOptionsMenu — delete failure handling", () => {
 
 		await waitFor(() => expect(recordDelete).toHaveBeenCalledTimes(1));
 		expect(toast).not.toHaveBeenCalled();
+	});
+});
+
+describe("NodeOptionsMenu — detach failure handling", () => {
+	beforeEach(() => {
+		resetStore();
+		vi.mocked(toast).mockClear();
+		vi.mocked(recordDetach).mockClear();
+	});
+
+	it("surfaces the server error, keeps the detach-confirmation dialog open, and records no undo entry on failure", async () => {
+		const user = userEvent.setup();
+		server.use(
+			http.post("/api/elements/1/detach", () =>
+				HttpResponse.json(
+					{ error: "Strategy has dependent claims" },
+					{
+						status: 400,
+					}
+				)
+			)
+		);
+
+		renderWithReactFlow(<NodeOptionsMenu node={NODE} nodeType="strategy" />);
+
+		await openDetachConfirmation(user);
+
+		await waitFor(() =>
+			expect(toast).toHaveBeenCalledWith(
+				expect.objectContaining({
+					variant: "destructive",
+					description: "Strategy has dependent claims",
+				})
+			)
+		);
+		expect(recordDetach).not.toHaveBeenCalled();
+		expect(
+			screen.getByRole("heading", { name: "Detach S1?" })
+		).toBeInTheDocument();
 	});
 });

--- a/components/shared/nodes/__tests__/node-options-menu.test.tsx
+++ b/components/shared/nodes/__tests__/node-options-menu.test.tsx
@@ -74,7 +74,7 @@ describe("NodeOptionsMenu — delete failure handling", () => {
 		vi.mocked(recordDelete).mockClear();
 	});
 
-	it("surfaces the server error and records no undo entry on failure", async () => {
+	it("surfaces the server error, keeps the delete-confirmation dialog open, and records no undo entry on failure", async () => {
 		const user = userEvent.setup();
 		server.use(
 			http.delete("/api/elements/1", () =>
@@ -100,6 +100,9 @@ describe("NodeOptionsMenu — delete failure handling", () => {
 			)
 		);
 		expect(recordDelete).not.toHaveBeenCalled();
+		expect(
+			screen.getByRole("heading", { name: "Delete S1?" })
+		).toBeInTheDocument();
 	});
 
 	it("records the undo entry on a successful delete", async () => {

--- a/components/shared/nodes/__tests__/node-options-menu.test.tsx
+++ b/components/shared/nodes/__tests__/node-options-menu.test.tsx
@@ -1,0 +1,120 @@
+import { waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import type React from "react";
+import type { Node } from "reactflow";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { recordDelete } from "@/lib/services/history-service";
+import { toast } from "@/lib/toast";
+import { server } from "@/src/__tests__/mocks/server";
+import { renderWithReactFlow, screen } from "@/src/__tests__/utils/test-utils";
+import useStore from "@/store/store";
+import NodeOptionsMenu from "../node-options-menu";
+
+// The repo-wide reactflow mock (src/__tests__/setup/component-mocks.tsx)
+// doesn't stub `useNodes`/`useEdges`, which this component (and the
+// always-mounted MoveElementDialog it renders) calls directly. Provide a
+// minimal local replacement — only what this render tree actually uses.
+vi.mock("reactflow", () => ({
+	ReactFlowProvider: ({ children }: { children: React.ReactNode }) => children,
+	useNodes: () => [],
+	useEdges: () => [],
+}));
+
+vi.mock("@/lib/services/history-service", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@/lib/services/history-service")>();
+	return { ...actual, recordDelete: vi.fn(), recordDetach: vi.fn() };
+});
+
+vi.mock("@/lib/toast", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/toast")>();
+	return { ...actual, toast: vi.fn() };
+});
+
+const NODE: Node = {
+	id: "1",
+	type: "strategy",
+	position: { x: 0, y: 0 },
+	data: {
+		id: 1,
+		type: "strategy",
+		name: "S1",
+		description: "Strategy under test",
+	},
+};
+
+function resetStore(): void {
+	useStore.setState({
+		assuranceCase: {
+			id: "case-1",
+			name: "Test Case",
+			type: "assurance-case",
+			permissions: "manage",
+			createdDate: new Date().toISOString(),
+			comments: [],
+		},
+		orphanedElements: [],
+	});
+}
+
+async function openDeleteConfirmation(
+	user: ReturnType<typeof userEvent.setup>
+) {
+	const trigger = screen.getByRole("button");
+	await user.click(trigger);
+	await user.click(await screen.findByText("Delete"));
+	await user.click(await screen.findByRole("button", { name: "Delete" }));
+}
+
+describe("NodeOptionsMenu — delete failure handling", () => {
+	beforeEach(() => {
+		resetStore();
+		vi.mocked(toast).mockClear();
+		vi.mocked(recordDelete).mockClear();
+	});
+
+	it("surfaces the server error and records no undo entry on failure", async () => {
+		const user = userEvent.setup();
+		server.use(
+			http.delete("/api/elements/1", () =>
+				HttpResponse.json(
+					{ error: "Strategy has dependent claims" },
+					{
+						status: 400,
+					}
+				)
+			)
+		);
+
+		renderWithReactFlow(<NodeOptionsMenu node={NODE} nodeType="strategy" />);
+
+		await openDeleteConfirmation(user);
+
+		await waitFor(() =>
+			expect(toast).toHaveBeenCalledWith(
+				expect.objectContaining({
+					variant: "destructive",
+					description: "Strategy has dependent claims",
+				})
+			)
+		);
+		expect(recordDelete).not.toHaveBeenCalled();
+	});
+
+	it("records the undo entry on a successful delete", async () => {
+		const user = userEvent.setup();
+		server.use(
+			http.delete("/api/elements/1", () =>
+				HttpResponse.json({}, { status: 200 })
+			)
+		);
+
+		renderWithReactFlow(<NodeOptionsMenu node={NODE} nodeType="strategy" />);
+
+		await openDeleteConfirmation(user);
+
+		await waitFor(() => expect(recordDelete).toHaveBeenCalledTimes(1));
+		expect(toast).not.toHaveBeenCalled();
+	});
+});

--- a/components/shared/nodes/node-options-menu.tsx
+++ b/components/shared/nodes/node-options-menu.tsx
@@ -31,6 +31,7 @@ import {
 import {
 	deleteAssuranceCaseNode,
 	detachCaseElement,
+	getNodeMutationErrorMessage,
 	type ReactFlowNode,
 	removeAssuranceCaseNode,
 } from "@/lib/case";
@@ -41,6 +42,7 @@ import {
 } from "@/lib/element-compatibility";
 import type { AssuranceCaseResponse } from "@/lib/services/case-response-types";
 import { recordDelete, recordDetach } from "@/lib/services/history-service";
+import { toast } from "@/lib/toast";
 import useStore from "@/store/store";
 import { AttachElementDialog } from "./attach-element-dialog";
 import { MoveElementDialog } from "./move-element-dialog";
@@ -340,11 +342,21 @@ export default function NodeOptionsMenu({
 			node.data.id as string,
 			""
 		);
-		if (deleted) {
+		if (deleted === true) {
 			processDeleteResult(node, assuranceCase, setAssuranceCase);
+			setLoading(false);
+			setDeleteDialogOpen(false);
+			return;
 		}
+		toast({
+			variant: "destructive",
+			title: "Failed to delete element",
+			description: getNodeMutationErrorMessage(
+				deleted,
+				"Something went wrong trying to delete this element."
+			),
+		});
 		setLoading(false);
-		setDeleteDialogOpen(false);
 	};
 
 	return (

--- a/components/shared/nodes/node-options-menu.tsx
+++ b/components/shared/nodes/node-options-menu.tsx
@@ -227,8 +227,9 @@ function ConfirmationDialogs({
 						    synchronously on click *before* our async handler's
 						    request resolves — regardless of outcome. `preventDefault`
 						    stops that built-in close so the handler's own
-						    `setDetachDialogOpen(false)` (success only) is what
-						    governs visibility, keeping the dialog open on failure. */}
+						    `setDetachDialogOpen(false)` (success only; a failed
+						    detach toasts instead) is what governs visibility,
+						    keeping the dialog open on failure. */}
 						<AlertDialogAction
 							disabled={loading}
 							onClick={(e) => {
@@ -346,9 +347,20 @@ export default function NodeOptionsMenu({
 				setAssuranceCase,
 				setOrphanedElements
 			);
+			setLoading(false);
+			setDetachDialogOpen(false);
+			return;
 		}
+		const errorMessage =
+			"error" in result && typeof result.error === "string"
+				? result.error
+				: "Something went wrong trying to detach this element.";
+		toast({
+			variant: "destructive",
+			title: "Failed to detach element",
+			description: errorMessage,
+		});
 		setLoading(false);
-		setDetachDialogOpen(false);
 	};
 
 	const handleDelete = async () => {

--- a/components/shared/nodes/node-options-menu.tsx
+++ b/components/shared/nodes/node-options-menu.tsx
@@ -222,7 +222,20 @@ function ConfirmationDialogs({
 					</AlertDialogHeader>
 					<AlertDialogFooter>
 						<AlertDialogCancel disabled={loading}>Cancel</AlertDialogCancel>
-						<AlertDialogAction disabled={loading} onClick={onConfirmDetach}>
+						{/* AlertDialogAction is Radix's `Dialog.Close` under the hood
+						    (@radix-ui/react-alert-dialog), so it closes the dialog
+						    synchronously on click *before* our async handler's
+						    request resolves — regardless of outcome. `preventDefault`
+						    stops that built-in close so the handler's own
+						    `setDetachDialogOpen(false)` (success only) is what
+						    governs visibility, keeping the dialog open on failure. */}
+						<AlertDialogAction
+							disabled={loading}
+							onClick={(e) => {
+								e.preventDefault();
+								onConfirmDetach();
+							}}
+						>
 							{loading ? "Detaching..." : "Detach"}
 						</AlertDialogAction>
 					</AlertDialogFooter>
@@ -240,10 +253,16 @@ function ConfirmationDialogs({
 					</AlertDialogHeader>
 					<AlertDialogFooter>
 						<AlertDialogCancel disabled={loading}>Cancel</AlertDialogCancel>
+						{/* See the Detach action above: prevent Radix's built-in
+						    close so a failed delete leaves the confirmation open
+						    instead of vanishing under the error toast. */}
 						<AlertDialogAction
 							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 							disabled={loading}
-							onClick={onConfirmDelete}
+							onClick={(e) => {
+								e.preventDefault();
+								onConfirmDelete();
+							}}
 						>
 							{loading ? "Deleting..." : "Delete"}
 						</AlertDialogAction>

--- a/lib/case/api.ts
+++ b/lib/case/api.ts
@@ -12,6 +12,23 @@ import type {
 } from "./types";
 
 /**
+ * Extracts a user-facing message from an `updateAssuranceCaseNode` /
+ * `deleteAssuranceCaseNode` result. These return `true` on success or
+ * `{ error: string }` on failure — never `false` — so callers must check
+ * `=== true` rather than truthiness, and use this helper (rather than
+ * assuming a particular shape) to surface the failure.
+ */
+export function getNodeMutationErrorMessage(
+	result: boolean | { error: string },
+	fallback: string
+): string {
+	if (typeof result === "object" && result !== null && "error" in result) {
+		return result.error || fallback;
+	}
+	return fallback;
+}
+
+/**
  * Creates a new assurance case node by sending a POST request to the specified API endpoint.
  * Note: Authentication is handled via NextAuth session cookies, not the token parameter.
  */

--- a/lib/case/index.ts
+++ b/lib/case/index.ts
@@ -11,6 +11,7 @@ export {
 	deleteAssuranceCaseNode,
 	detachCaseElement,
 	getAssuranceCaseNode,
+	getNodeMutationErrorMessage,
 	moveCaseElement,
 	updateAssuranceCaseNode,
 	updateElementComment,

--- a/lib/plugins/health/__tests__/health-badge.test.tsx
+++ b/lib/plugins/health/__tests__/health-badge.test.tsx
@@ -234,23 +234,48 @@ describe("HealthBadge — score→band via plugin settings", () => {
 });
 
 describe("HealthBadge — staleness", () => {
-	it("shows the quiet stale treatment when lastEvaluatedAt is outside the validity window", async () => {
+	// ADR 0002 v2 §3: health ⊥ freshness — "green-but-stale is preserved".
+	// Staleness must ANNOTATE the band colour, never replace it, so a stale
+	// claim's last-known health stays readable at a glance.
+	it.each([
+		{ score: 1, band: "pass" as const, bandClass: "bg-success" },
+		{ score: 0.5, band: "degraded" as const, bandClass: "bg-warning" },
+		{ score: 0, band: "fail" as const, bandClass: "bg-destructive" },
+	])("keeps the $band band colour ($bandClass) when stale, and adds a non-colour stale marker", async ({
+		score,
+		bandClass,
+	}) => {
 		mockHealthResponse(CLAIM_CONTEXT.elementId, {
-			score: 1,
+			score,
 			lastEvaluatedAt: hoursAgo(72), // 3 days ago, window is 24h
 			validityWindowSeconds: DAY_SECONDS,
 		});
 		render(<HealthBadge {...CLAIM_CONTEXT} />, { withProviders: false });
 
+		const dot = await screen.findByTestId("health-badge-dot");
+		await waitFor(() => expect(dot).toHaveClass(bandClass));
+		// The stale marker is a shape/ring cue, not a colour swap — the
+		// band colour class above must survive alongside it.
+		expect(dot).toHaveClass("ring-2");
+		expect(dot).not.toHaveClass("bg-muted-foreground");
+	});
+
+	it("names both the band and the staleness in the label (aria-label and tooltip)", async () => {
+		mockHealthResponse(CLAIM_CONTEXT.elementId, {
+			score: 1,
+			lastEvaluatedAt: hoursAgo(72),
+			validityWindowSeconds: DAY_SECONDS,
+		});
+		render(<HealthBadge {...CLAIM_CONTEXT} />, { withProviders: false });
+
+		const dot = await screen.findByTestId("health-badge-dot");
 		await waitFor(() =>
-			expect(screen.getByTestId("health-badge-dot")).toHaveClass(
-				"bg-muted-foreground"
+			expect(dot).toHaveAttribute(
+				"aria-label",
+				expect.stringContaining("passing")
 			)
 		);
-		expect(screen.getByTestId("health-badge-dot")).toHaveAttribute(
-			"aria-label",
-			expect.stringContaining("Health: stale")
-		);
+		expect(dot).toHaveAttribute("aria-label", expect.stringContaining("stale"));
 	});
 
 	it("does not show stale for a score within the validity window", async () => {
@@ -264,6 +289,7 @@ describe("HealthBadge — staleness", () => {
 		await waitFor(() =>
 			expect(screen.getByTestId("health-badge-dot")).toHaveClass("bg-success")
 		);
+		expect(screen.getByTestId("health-badge-dot")).not.toHaveClass("ring-2");
 	});
 });
 

--- a/lib/plugins/health/health-badge.tsx
+++ b/lib/plugins/health/health-badge.tsx
@@ -26,7 +26,23 @@ const BAND_LABELS: Record<HealthBand, string> = {
 	fail: "Health: failing",
 };
 
-const STALE_DOT_CLASS = "bg-muted-foreground";
+/** The band word alone, for composing into the stale label below. */
+const BAND_WORDS: Record<HealthBand, string> = {
+	pass: "passing",
+	degraded: "degraded",
+	fail: "failing",
+};
+
+/**
+ * Stale marker (ADR 0002 v2 §3 — "green-but-stale is preserved"): health and
+ * freshness are orthogonal, so staleness must never REPLACE the band colour,
+ * only annotate it. A ring keeps the dot's fill on its band colour and adds
+ * a second, concentric shape around it — a geometry cue, not a colour one,
+ * so it reads even without colour vision. `ring-offset-background` keeps the
+ * gap between dot and ring visible against either theme.
+ */
+const STALE_RING_CLASSES =
+	"ring-2 ring-muted-foreground/70 ring-offset-1 ring-offset-background";
 
 /**
  * The `element-badge` slot's health state dot (ADR 0002 v2 §3 — "the state
@@ -56,9 +72,13 @@ export function HealthBadge({
 
 	const stale = isHealthStale(health);
 	const band = deriveHealthBand(health.score, bandScores);
-	const dotClassName = stale ? STALE_DOT_CLASS : BAND_DOT_CLASSES[band];
+	const dotClassName = cn(
+		"inline-block size-2 rounded-full",
+		BAND_DOT_CLASSES[band],
+		stale && STALE_RING_CLASSES
+	);
 	const label = stale
-		? `Health: stale (last evaluated ${formatRelativeToNow(health.lastEvaluatedAt)})`
+		? `Health: ${BAND_WORDS[band]} — stale (last evaluated ${formatRelativeToNow(health.lastEvaluatedAt)})`
 		: BAND_LABELS[band];
 
 	return (
@@ -67,7 +87,7 @@ export function HealthBadge({
 				<TooltipTrigger asChild>
 					<output
 						aria-label={label}
-						className={cn("inline-block size-2 rounded-full", dotClassName)}
+						className={dotClassName}
 						data-testid="health-badge-dot"
 					/>
 				</TooltipTrigger>


### PR DESCRIPTION
Four user-facing fixes found during the 2026-08-09 staging validation walkthrough, plus two follow-on defects caught in review.

## Fixes

1. **Node edit dialog no longer loses unsaved edits** (`3b89b750`, `4d75c761`) — the dialog's form was reset whenever its host node re-rendered (the node prop is rebuilt on every render), so background updates — including the SSE echo of the user's own previous save — silently discarded in-progress edits. The reset is now keyed on the element id and an open-transition: unsaved edits survive re-render churn, while a reopen or a genuine element change always loads fresh.
2. **Failed saves are no longer dressed up as successes** (`d614d46e`) — `updateAssuranceCaseNode`/`deleteAssuranceCaseNode` return `true | {error}` (never `false`), so truthy checks treated every server rejection as success: undo recorded, dialog closed, no feedback. All three call sites now check `=== true`, surface the server's message via toast, and keep the dialog open on failure.
3. **Case settings menu dismisses on outside click** (`b20f1b46`) — the ReactFlow pane's own pointer handlers stop propagation, so the non-modal Radix Popover's document-level dismiss listener never fired. The popover is now `modal` while open.
4. **Stale health badge keeps its band colour** (`69044165`) — the stale branch replaced both the dot colour and the label, hiding the last-known health reading. It now composes: band fill + a muted ring, with tooltip/aria-label carrying both facts ("Health: passing — stale (last evaluated …)"), per ADR 0002 §3's health ⊥ freshness rule.
5. **Delete/detach confirmations no longer close before the request resolves** (`4d75c761`, `26fa6365`) — `AlertDialogAction` is Radix's `Dialog.Close` and closed the confirmation synchronously regardless of outcome; both actions now `preventDefault` and visibility is governed by the handlers (close on success, toast + stay open on failure).

## Review chain

Implemented and fix-rounded by the frontend track; QA review (PASS after fix round — two reset-guard edge cases found by probe, both fixed and pinned by tests that fail against the pre-fix code) and code review (APPROVE — includes the fallow audit; two flagged attribution false-positives traced to stale baselines, to be regenerated separately). Post-review deltas verified hunk-by-hunk against the review prescriptions.

Evidence on the final tree: unit 1196/1196 (one pre-existing suite failure from the un-generated Prisma client in the sandbox, identical on base), lint clean (756 files), typecheck delta 0 vs the pre-existing baseline.

Follow-ups tracked separately: node-add popover has the same non-modal dismiss bug (same fix pattern); fallow dead-code/styling/dupes baselines need regenerating.