### PR TITLE
fix: forward evidence URLs through element update; node-add popover outside-click dismiss

### DIFF
--- a/app/api/elements/[id]/route.ts
+++ b/app/api/elements/[id]/route.ts
@@ -52,6 +52,7 @@ function buildUpdateInput(body: Record<string, unknown>): UpdateElementInput {
 		parentId: body.parentId as string | undefined,
 		url,
 		URL: url,
+		urls: body.urls as string[] | undefined,
 		assumption: body.assumption as string | undefined,
 		justification: body.justification as string | undefined,
 		context: body.context as string[] | undefined,

--- a/components/cases/__tests__/node-add-popover.test.tsx
+++ b/components/cases/__tests__/node-add-popover.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import type { Node } from "reactflow";
+import { describe, expect, it, vi } from "vitest";
+import NodeAddPopover from "../node-add-popover";
+
+// The repo-wide Radix mocks (src/__tests__/setup/component-mocks.tsx) are
+// simplified state containers that don't implement real dismiss behaviour
+// (outside click / Escape), so this file needs the actual primitive — the
+// dismiss-behaviour tests below would be false-green against the mock.
+vi.unmock("@radix-ui/react-popover");
+
+const NODE: Node = {
+	id: "1",
+	type: "goal",
+	position: { x: 0, y: 0 },
+	data: { id: 1, name: "G1" },
+};
+
+// NodeAddPopover's `open` is externally controlled — every real caller
+// (goal-node.tsx, strategy-node.tsx, property-node.tsx) owns the boolean in
+// its own local state and flips it from the trigger's onClick, rather than
+// letting Radix manage open state itself. This harness reproduces that
+// wiring instead of driving `open` as a prop directly, since that's the
+// shape the bug actually manifests under.
+function DismissHarness() {
+	const [open, setOpen] = useState(true);
+	return (
+		<div>
+			{/* Stands in for ReactFlow's pane: d3-zoom attaches native
+			 * pointerdown/mousedown handlers there that stop propagation for
+			 * its own pan-gesture handling. */}
+			<div data-testid="canvas-pane">canvas</div>
+			<NodeAddPopover
+				node={NODE}
+				nodeType="goal"
+				onOpenChange={setOpen}
+				open={open}
+			>
+				<button type="button">Add child element</button>
+			</NodeAddPopover>
+		</div>
+	);
+}
+
+// Starts closed, so the trigger's onClick (not the `open` prop) is what
+// drives the popover open — the same wiring `DismissHarness` above uses,
+// just starting from the closed state so opening-via-trigger and
+// selecting-an-option-closes-it can both be exercised.
+function ControlledHarness() {
+	const [open, setOpen] = useState(false);
+	return (
+		<NodeAddPopover
+			node={NODE}
+			nodeType="goal"
+			onOpenChange={setOpen}
+			open={open}
+		>
+			<button onClick={() => setOpen(true)} type="button">
+				Add child element
+			</button>
+		</NodeAddPopover>
+	);
+}
+
+describe("NodeAddPopover — dismiss on outside click / Escape", () => {
+	it("closes on Escape", async () => {
+		render(<DismissHarness />);
+
+		await screen.findByText("Add Element");
+
+		fireEvent.keyDown(document, { key: "Escape" });
+
+		await waitFor(() => {
+			expect(screen.queryByText("Add Element")).not.toBeInTheDocument();
+		});
+	});
+
+	it("closes on an outside click even when the click target stops event propagation — the exact ReactFlow-canvas scenario that defeats a non-modal popover", async () => {
+		render(<DismissHarness />);
+		const pane = screen.getByTestId("canvas-pane");
+		pane.addEventListener("pointerdown", (e) => e.stopPropagation());
+		pane.addEventListener("mousedown", (e) => e.stopPropagation());
+
+		await screen.findByText("Add Element");
+
+		// `modal` sets `document.body.style.pointerEvents = "none"` while
+		// open, so a real click over the canvas never reaches `pane` at all —
+		// confirm that's actually in effect, then dispatch where the click
+		// would really land (fireEvent skips CSS hit-testing, unlike a real
+		// browser or user-event, so the redirect is simulated explicitly).
+		expect(document.body.style.pointerEvents).toBe("none");
+		fireEvent.pointerDown(document.body);
+		fireEvent.mouseDown(document.body);
+		fireEvent.mouseUp(document.body);
+		fireEvent.click(document.body);
+
+		await waitFor(() => {
+			expect(screen.queryByText("Add Element")).not.toBeInTheDocument();
+		});
+	});
+});
+
+describe("NodeAddPopover — controlled open/onOpenChange still works under modal", () => {
+	it("opens via the external trigger and closes when an option is selected", async () => {
+		const user = userEvent.setup();
+		render(<ControlledHarness />);
+
+		expect(screen.queryByText("Add Element")).not.toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Add child element" }));
+		await screen.findByText("Add Element");
+
+		await user.click(screen.getByRole("button", { name: "Add Strategy" }));
+
+		await waitFor(() => {
+			expect(screen.queryByText("Add Element")).not.toBeInTheDocument();
+		});
+	});
+});

--- a/components/cases/node-add-popover.tsx
+++ b/components/cases/node-add-popover.tsx
@@ -127,7 +127,16 @@ export default function NodeAddPopover({
 
 	return (
 		<>
-			<Popover onOpenChange={onOpenChange} open={open}>
+			{/* `modal` matters here, not just accessibility polish: ReactFlow's
+			pane (d3-zoom) has its own native pointerdown/mousedown handlers
+			that stop propagation for pan/zoom gestures. Radix's non-modal
+			outside-click dismiss listens on `document` in the bubble phase, so
+			a click on the canvas never reached it and the popover stayed open
+			— only the trigger itself could close it. `modal` disables pointer
+			events on the rest of the page while open
+			(`disableOutsidePointerEvents`), so the canvas never intercepts the
+			click in the first place. */}
+			<Popover modal onOpenChange={onOpenChange} open={open}>
 				<PopoverAnchor className="inline-flex">{children}</PopoverAnchor>
 				<PopoverContent align="start" className="w-56 p-2" side="top">
 					<div className="flex flex-col gap-1">

--- a/src/__tests__/integration/api-elements.test.ts
+++ b/src/__tests__/integration/api-elements.test.ts
@@ -1,0 +1,180 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	createTestCase,
+	createTestElement,
+	createTestPermission,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+beforeEach(async () => {
+	await mockNoAuth();
+});
+
+function putRequest(elementId: string, body: unknown): NextRequest {
+	return new NextRequest(`http://localhost:3000/api/elements/${elementId}`, {
+		method: "PUT",
+		body: JSON.stringify(body),
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+function getRequest(elementId: string): NextRequest {
+	return new NextRequest(`http://localhost:3000/api/elements/${elementId}`);
+}
+
+function importRoute() {
+	return import("@/app/api/elements/[id]/route");
+}
+
+// ============================================
+// PUT /api/elements/[id] — urls forwarding
+//
+// Regression coverage for the silent no-op: the evidence edit dialog sends
+// a validated `urls` array, but `buildUpdateInput` in the route dropped it
+// before it ever reached `updateElement`, so edits appeared to succeed while
+// the stored URLs never changed.
+//
+// The schema currently in effect on `staging` normalises entries via
+// `lenientUrlSchema` (PR #873, merged) — a scheme-less value such as
+// "example.com" is prepended with "https://" rather than rejected. Genuinely
+// malformed input (no web scheme, e.g. "mailto:x@y.z") is still rejected;
+// see lib/schemas/__tests__/element-url.test.ts for the schema's own
+// coverage of the normalisation/rejection boundary.
+// ============================================
+
+describe("PUT /api/elements/[id] — urls forwarding", () => {
+	it("stores a changed urls array (regression: urls must not be dropped)", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const evidence = await createTestElement(testCase.id, owner.id, {
+			elementType: "EVIDENCE",
+			url: "https://example.com/original",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await importRoute();
+		const response = await PUT(
+			putRequest(evidence.id, {
+				description: evidence.description,
+				urls: [
+					"https://example.com/updated-one",
+					"https://example.com/updated-two",
+				],
+			}),
+			{ params: Promise.resolve({ id: evidence.id }) }
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.urls).toEqual([
+			"https://example.com/updated-one",
+			"https://example.com/updated-two",
+		]);
+		// Legacy single-URL field stays in sync with urls[0]
+		expect(body.URL).toBe("https://example.com/updated-one");
+
+		const { GET } = await importRoute();
+		const refetched = await GET(getRequest(evidence.id), {
+			params: Promise.resolve({ id: evidence.id }),
+		});
+		const refetchedBody = await refetched.json();
+		expect(refetchedBody.urls).toEqual([
+			"https://example.com/updated-one",
+			"https://example.com/updated-two",
+		]);
+	});
+
+	it("clears urls when sent an empty array", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const evidence = await createTestElement(testCase.id, owner.id, {
+			elementType: "EVIDENCE",
+			url: "https://example.com/original",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await importRoute();
+		const response = await PUT(
+			putRequest(evidence.id, {
+				description: evidence.description,
+				urls: [],
+			}),
+			{ params: Promise.resolve({ id: evidence.id }) }
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.urls).toBeUndefined();
+		expect(body.URL).toBeUndefined();
+	});
+
+	it("leaves stored urls untouched when the field is omitted from the request", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const evidence = await createTestElement(testCase.id, owner.id, {
+			elementType: "EVIDENCE",
+			url: "https://example.com/untouched",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await importRoute();
+		const response = await PUT(
+			putRequest(evidence.id, { description: "Updated description only" }),
+			{ params: Promise.resolve({ id: evidence.id }) }
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.description).toBe("Updated description only");
+		expect(body.URL).toBe("https://example.com/untouched");
+	});
+
+	it("returns 400 for a non-web scheme that lenientUrlSchema rejects rather than mangles", async () => {
+		// "not-a-url" is no longer a valid regression fixture here: since
+		// PR #873, a scheme-less entry is normalised to "https://not-a-url"
+		// (a syntactically valid, if useless, URL) rather than rejected.
+		// "mailto:x@y.z" carries an explicit non-http(s) scheme, which
+		// lenientUrlSchema still rejects outright instead of prepending
+		// "https://" onto it.
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const evidence = await createTestElement(testCase.id, owner.id, {
+			elementType: "EVIDENCE",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await importRoute();
+		const response = await PUT(
+			putRequest(evidence.id, { urls: ["mailto:x@y.z"] }),
+			{ params: Promise.resolve({ id: evidence.id }) }
+		);
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns 404 when a VIEW-only permission holder attempts the update (anti-enumeration: same error as not-found)", async () => {
+		const owner = await createTestUser();
+		const viewer = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const evidence = await createTestElement(testCase.id, owner.id, {
+			elementType: "EVIDENCE",
+			url: "https://example.com/protected",
+		});
+		await createTestPermission(testCase.id, viewer.id, owner.id, "VIEW");
+		await mockAuth(viewer.id, viewer.username, viewer.email);
+
+		const { PUT } = await importRoute();
+		const response = await PUT(
+			putRequest(evidence.id, { urls: ["https://example.com/hijacked"] }),
+			{ params: Promise.resolve({ id: evidence.id }) }
+		);
+
+		expect(response.status).toBe(404);
+	});
+});


### PR DESCRIPTION
Two fixes, one review chain.

## fix(api): forward urls through element update (95162586)

Editing an existing evidence element's URL list was a silent no-op: the edit dialog sent the updated `urls` array, `updateElementSchema` validated it, and `buildUpdateInput` dropped it before the service call. One-line fix forwarding the validated field; `applyUrlUpdates` already handled it.

- 5 new route-level integration tests: changed array stored, empty array clears, omitted field untouched, non-web-scheme rejection (lenientUrlSchema-aware, post-#873), anti-enumeration (VIEW-only → 404, same error as not-found).
- The July draft of this fix also patched the dialog's error handling; those hunks were dropped as superseded by #884 (dialog files are untouched vs staging).

## fix(node-add-popover): dismiss on outside click over the canvas (8a39bc91)

Same mechanism as the case-settings popover fixed in #884: ReactFlow's pane handlers stop propagation of canvas pointerdown, so the non-modal Radix Popover's document-level dismiss listener never fires — only the trigger could close it. Fix is `modal` on the Popover (Radix `DropdownMenu` defaults modal and is unaffected; `Popover` defaults non-modal).

- 3 new tests (Radix unmocked, per the #884 precedent): outside-click dismiss under stopPropagation, Escape, controlled open/select wiring under `modal`.
- Reproduced failing-test-first: the outside-click test fails against the unpatched component, passes with the fix (independently re-verified in review by revert-run-restore).

## Review chain

- QA: PASS (both commits). Targeted-vs-full integration scope adjudicated with import-graph evidence (`buildUpdateInput` module-private, single call site); element-family superset 9 files / 95 tests green. Four non-blocking test-hardening follow-ups tracked separately.
- Code review: APPROVE, no blockers, no suggestions. Route input traced schema-validated end-to-end; modal semantics verified dismiss-only (no click-through, pan/zoom resumes); security grep clean.
- Fallow audit vs fresh baselines: dead code 0, complexity 0, duplication 1 false positive (blame-verified pre-existing, per-touched-file attribution).
- Lint 758 files clean; typecheck 0 errors; unit 1208/1208.

One further instance of the non-modal-popover-over-canvas pattern was found in the docs' interactive demo (quick-edit-popover) and is tracked as a follow-up, not fixed here.