### PR TITLE
fix: evidence URL last-row removal; docs quick-edit popover dismiss; PUT route test hardening

### DIFF
--- a/components/cases/__tests__/node-add-popover.test.tsx
+++ b/components/cases/__tests__/node-add-popover.test.tsx
@@ -119,3 +119,57 @@ describe("NodeAddPopover — controlled open/onOpenChange still works under moda
 		});
 	});
 });
+
+// Focus restoration (review follow-up, PR #885 G3): NOT the same regression
+// vector here as the other modal popovers. Radix's modal PopoverContent only
+// restores focus via `context.triggerRef.current?.focus()` — and
+// `context.triggerRef` is populated exclusively by `<PopoverTrigger>`.
+// NodeAddPopover wires its `children` through `<PopoverAnchor>` instead (the
+// component is externally controlled — every real caller, e.g. goal-node.tsx,
+// opens it from its own `onClick`, not Radix's), which is purely a popper
+// positioning primitive and never touches `triggerRef`. So
+// `triggerRef.current` stays `null` for the lifetime of this component, the
+// optional-chained `.focus()` call is a no-op, and — because
+// `onCloseAutoFocus` also calls `event.preventDefault()` unconditionally —
+// FocusScope's own "focus the previously-focused element" fallback never
+// runs either. Net effect: dismissing this popover restores focus to
+// nothing; the browser's default (the focused node was removed) takes over.
+//
+// Verified this is a real behavioural fact, not a jsdom limitation: an
+// identical harness against QuickEditPopover (components/docs/curriculum/
+// enhanced/dialogs/quick-edit-popover.tsx — a real `<PopoverTrigger>`) DOES
+// land focus back on its trigger button under jsdom. Asserting "focus
+// returns to the trigger" against NodeAddPopover would therefore be
+// asserting something the component doesn't do — a test that's always
+// falsely red, not a true regression guard. Per the brief: documenting why
+// here rather than shipping either a false-failing test or a vacuous one
+// that asserts nothing meaningful. The alternative locked in below is the
+// one thing that IS true and worth guarding: the trigger stays mounted,
+// unbroken and re-clickable after a dismiss cycle (no stale-ref crash, no
+// focus trap on a removed node). Wiring `<PopoverTrigger>` properly (so
+// focus restoration starts working) is production code and out of scope for
+// this test-only commit — worth a follow-up issue.
+describe("NodeAddPopover — trigger survives a dismiss cycle (focus restoration does not apply — see comment above)", () => {
+	it("leaves the trigger mounted and reusable after dismissing via Escape", async () => {
+		const user = userEvent.setup();
+		render(<ControlledHarness />);
+
+		const trigger = screen.getByRole("button", { name: "Add child element" });
+		await user.click(trigger);
+		await screen.findByText("Add Element");
+
+		fireEvent.keyDown(document, { key: "Escape" });
+
+		await waitFor(() => {
+			expect(screen.queryByText("Add Element")).not.toBeInTheDocument();
+		});
+		expect(trigger).toBeInTheDocument();
+
+		// Reopening still works — the dismiss cycle didn't leave the trigger
+		// (or its wiring to `open`/`onOpenChange`) in a broken state.
+		await user.click(trigger);
+		await waitFor(() => {
+			expect(screen.getByText("Add Element")).toBeInTheDocument();
+		});
+	});
+});

--- a/components/cases/__tests__/node-edit-dialog.test.tsx
+++ b/components/cases/__tests__/node-edit-dialog.test.tsx
@@ -426,3 +426,107 @@ describe("NodeEditDialog — save failure handling", () => {
 		expect(toast).not.toHaveBeenCalled();
 	});
 });
+
+describe("NodeEditDialog — evidence URL removal", () => {
+	const EVIDENCE_NODE: Node = {
+		id: "3",
+		type: "evidence",
+		position: { x: 0, y: 0 },
+		data: {
+			id: 3,
+			name: "E1",
+			description: "Test results for the acceptance suite",
+			urls: ["https://example.com/evidence"],
+		},
+	};
+
+	it("shows the remove button on the last remaining URL row", async () => {
+		mockPluginsResponse(true);
+
+		render(
+			<NodeEditDialog
+				node={EVIDENCE_NODE}
+				nodeType="evidence"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={true}
+			/>,
+			{ withProviders: false }
+		);
+
+		await screen.findByDisplayValue("https://example.com/evidence");
+		expect(
+			screen.getByRole("button", { name: "Remove URL" })
+		).toBeInTheDocument();
+	});
+
+	it("removing the last URL then saving clears urls server-side", async () => {
+		const user = userEvent.setup();
+		const onOpenChange = vi.fn();
+		mockPluginsResponse(true);
+
+		let capturedBody: Record<string, unknown> | undefined;
+		server.use(
+			http.put("/api/elements/3", async ({ request }) => {
+				capturedBody = (await request.json()) as Record<string, unknown>;
+				return HttpResponse.json({}, { status: 200 });
+			})
+		);
+
+		render(
+			<NodeEditDialog
+				node={EVIDENCE_NODE}
+				nodeType="evidence"
+				onOpenChange={onOpenChange}
+				open={true}
+			/>,
+			{ withProviders: false }
+		);
+
+		await screen.findByDisplayValue("https://example.com/evidence");
+		await user.click(screen.getByRole("button", { name: "Remove URL" }));
+
+		expect(
+			screen.queryByDisplayValue("https://example.com/evidence")
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Remove URL" })
+		).not.toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Update Evidence" }));
+
+		await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+		expect(capturedBody).toEqual(
+			expect.objectContaining({ urls: [], URL: "" })
+		);
+	});
+
+	it("re-adding a URL after removing the last row works via the Add URL button", async () => {
+		const user = userEvent.setup();
+		mockPluginsResponse(true);
+
+		render(
+			<NodeEditDialog
+				node={EVIDENCE_NODE}
+				nodeType="evidence"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={true}
+			/>,
+			{ withProviders: false }
+		);
+
+		await screen.findByDisplayValue("https://example.com/evidence");
+		await user.click(screen.getByRole("button", { name: "Remove URL" }));
+		expect(
+			screen.queryByPlaceholderText("https://example.com/evidence")
+		).not.toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Add URL" }));
+		expect(
+			screen.getByPlaceholderText("https://example.com/evidence")
+		).toHaveValue("");
+	});
+});

--- a/components/cases/node-edit-dialog.tsx
+++ b/components/cases/node-edit-dialog.tsx
@@ -343,10 +343,12 @@ function UrlsSection({
 										{...inputField}
 									/>
 								</FormControl>
-								{!readOnly && fields.length > 1 && (
+								{!readOnly && (
 									<Button
+										aria-label="Remove URL"
 										onClick={() => onRemove(index)}
 										size="icon"
+										title="Remove URL"
 										type="button"
 										variant="outline"
 									>

--- a/components/docs/curriculum/enhanced/dialogs/__tests__/quick-edit-popover.test.tsx
+++ b/components/docs/curriculum/enhanced/dialogs/__tests__/quick-edit-popover.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { QuickEditPopover } from "../quick-edit-popover";
+
+// The repo-wide Radix mocks (src/__tests__/setup/component-mocks.tsx) are
+// simplified state containers that don't implement real dismiss behaviour
+// (outside click / Escape), so this file needs the actual primitive — the
+// dismiss-behaviour tests below would be false-green against the mock.
+vi.unmock("@radix-ui/react-popover");
+
+// Stands in for ReactFlow's pane: d3-zoom attaches native
+// pointerdown/mousedown handlers there that stop propagation for its own
+// pan-gesture handling — the same wiring node-action-toolbar.tsx sits inside
+// of via enhanced-interactive-case-viewer.tsx's canvas.
+function Harness({ onSave = vi.fn() }: { onSave?: (value: string) => void }) {
+	return (
+		<div>
+			<div data-testid="canvas-pane">canvas</div>
+			<QuickEditPopover
+				description="Existing description"
+				isDarkMode={false}
+				onSave={onSave}
+			/>
+		</div>
+	);
+}
+
+async function openPopover(user: ReturnType<typeof userEvent.setup>) {
+	await user.click(screen.getByRole("button"));
+	await screen.findByLabelText("Description");
+}
+
+describe("QuickEditPopover — dismiss on outside click / Escape", () => {
+	it("closes on Escape", async () => {
+		const user = userEvent.setup();
+		render(<Harness />);
+
+		await openPopover(user);
+
+		fireEvent.keyDown(document, { key: "Escape" });
+
+		await waitFor(() => {
+			expect(screen.queryByLabelText("Description")).not.toBeInTheDocument();
+		});
+	});
+
+	it("closes on an outside click even when the click target stops event propagation — the exact ReactFlow-canvas scenario that defeats a non-modal popover", async () => {
+		const user = userEvent.setup();
+		render(<Harness />);
+		const pane = screen.getByTestId("canvas-pane");
+		pane.addEventListener("pointerdown", (e) => e.stopPropagation());
+		pane.addEventListener("mousedown", (e) => e.stopPropagation());
+
+		await openPopover(user);
+
+		// `modal` sets `document.body.style.pointerEvents = "none"` while
+		// open, so a real click over the canvas never reaches `pane` at all —
+		// confirm that's actually in effect, then dispatch where the click
+		// would really land (fireEvent skips CSS hit-testing, unlike a real
+		// browser or user-event, so the redirect is simulated explicitly).
+		expect(document.body.style.pointerEvents).toBe("none");
+		fireEvent.pointerDown(document.body);
+		fireEvent.mouseDown(document.body);
+		fireEvent.mouseUp(document.body);
+		fireEvent.click(document.body);
+
+		await waitFor(() => {
+			expect(screen.queryByLabelText("Description")).not.toBeInTheDocument();
+		});
+	});
+});
+
+describe("QuickEditPopover — controlled open/onOpenChange still works under modal", () => {
+	it("opens via the trigger and closes again on Save, calling onSave with the edited value", async () => {
+		const user = userEvent.setup();
+		const onSave = vi.fn();
+		render(<Harness onSave={onSave} />);
+
+		expect(screen.queryByLabelText("Description")).not.toBeInTheDocument();
+
+		await openPopover(user);
+
+		const textarea = screen.getByLabelText("Description");
+		await user.clear(textarea);
+		await user.type(textarea, "Updated description");
+
+		await user.click(screen.getByRole("button", { name: "Save" }));
+
+		await waitFor(() => {
+			expect(screen.queryByLabelText("Description")).not.toBeInTheDocument();
+		});
+		expect(onSave).toHaveBeenCalledWith("Updated description");
+	});
+
+	it("opens via the trigger and closes again on Cancel without calling onSave", async () => {
+		const user = userEvent.setup();
+		const onSave = vi.fn();
+		render(<Harness onSave={onSave} />);
+
+		await openPopover(user);
+
+		await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+		await waitFor(() => {
+			expect(screen.queryByLabelText("Description")).not.toBeInTheDocument();
+		});
+		expect(onSave).not.toHaveBeenCalled();
+	});
+});

--- a/components/docs/curriculum/enhanced/dialogs/quick-edit-popover.tsx
+++ b/components/docs/curriculum/enhanced/dialogs/quick-edit-popover.tsx
@@ -77,7 +77,18 @@ export const QuickEditPopover = ({
 	};
 
 	return (
-		<Popover onOpenChange={setIsOpen} open={isOpen}>
+		// `modal` matters here, not just accessibility polish: this popover is
+		// mounted (via node-action-toolbar.tsx) inside
+		// enhanced-interactive-case-viewer.tsx's ReactFlow canvas, whose pane
+		// (d3-zoom) has its own native pointerdown/mousedown handlers that stop
+		// propagation for pan/zoom gestures. Radix's non-modal outside-click
+		// dismiss listens on `document` in the bubble phase, so a click on the
+		// canvas never reached it and the popover stayed open — only the
+		// trigger itself could close it. `modal` disables pointer events on
+		// the rest of the page while open (`disableOutsidePointerEvents`), so
+		// the canvas never intercepts the click in the first place. Same
+		// pattern as case-settings-popover.tsx and node-add-popover.tsx.
+		<Popover modal onOpenChange={setIsOpen} open={isOpen}>
 			<Tooltip>
 				<TooltipTrigger asChild>
 					<PopoverTrigger asChild>

--- a/src/__tests__/integration/api-elements.test.ts
+++ b/src/__tests__/integration/api-elements.test.ts
@@ -2,15 +2,20 @@ import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
 import {
+	addTeamMember,
 	createTestCase,
 	createTestElement,
 	createTestPermission,
+	createTestTeam,
+	createTestTeamPermission,
 	createTestUser,
 } from "../utils/prisma-factories";
 
 vi.mock("@/lib/auth/validate-session", () => ({
 	validateSession: vi.fn().mockResolvedValue(null),
 }));
+
+const NONEXISTENT_ID = "00000000-0000-0000-0000-000000000000";
 
 beforeEach(async () => {
 	await mockNoAuth();
@@ -114,6 +119,65 @@ describe("PUT /api/elements/[id] — urls forwarding", () => {
 		expect(body.URL).toBeUndefined();
 	});
 
+	it("urls wins unconditionally over url/URL when all three are present in one body", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const evidence = await createTestElement(testCase.id, owner.id, {
+			elementType: "EVIDENCE",
+			url: "https://example.com/original",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await importRoute();
+		const response = await PUT(
+			putRequest(evidence.id, {
+				description: evidence.description,
+				urls: ["https://example.com/urls-wins"],
+				url: "https://example.com/url-loses",
+				URL: "https://example.com/URL-loses",
+			}),
+			{ params: Promise.resolve({ id: evidence.id }) }
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.urls).toEqual(["https://example.com/urls-wins"]);
+		expect(body.URL).toBe("https://example.com/urls-wins");
+
+		const { GET } = await importRoute();
+		const refetched = await GET(getRequest(evidence.id), {
+			params: Promise.resolve({ id: evidence.id }),
+		});
+		const refetchedBody = await refetched.json();
+		expect(refetchedBody.urls).toEqual(["https://example.com/urls-wins"]);
+	});
+
+	it("an explicit empty urls array still wins over a present url/URL, clearing rather than falling back", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const evidence = await createTestElement(testCase.id, owner.id, {
+			elementType: "EVIDENCE",
+			url: "https://example.com/original",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await importRoute();
+		const response = await PUT(
+			putRequest(evidence.id, {
+				description: evidence.description,
+				urls: [],
+				url: "https://example.com/url-loses",
+				URL: "https://example.com/URL-loses",
+			}),
+			{ params: Promise.resolve({ id: evidence.id }) }
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.urls).toBeUndefined();
+		expect(body.URL).toBeUndefined();
+	});
+
 	it("leaves stored urls untouched when the field is omitted from the request", async () => {
 		const owner = await createTestUser();
 		const testCase = await createTestCase(owner.id);
@@ -176,5 +240,145 @@ describe("PUT /api/elements/[id] — urls forwarding", () => {
 		);
 
 		expect(response.status).toBe(404);
+	});
+});
+
+// ============================================
+// PUT /api/elements/[id] — anti-enumeration hardening
+//
+// nanaki's G3 review of PR #885: the VIEW-only-permission 404 and a
+// genuine not-found 404 both currently return the literal string
+// "Element not found" (element-service.ts:847 for the not-found branch,
+// :857 for the no-permission branch) — but that's two separate string
+// literals that happen to match today. A future edit to either message
+// alone would keep both responses at 404 while making their bodies
+// diverge, handing an attacker an enumeration oracle even though the
+// status code still looks identical. Asserting body equality (not just
+// status) is what would catch that drift.
+// ============================================
+
+describe("PUT /api/elements/[id] — anti-enumeration hardening", () => {
+	it("returns a byte-identical body for a VIEW-only-permission 404 and a genuinely-not-found 404", async () => {
+		const owner = await createTestUser();
+		const viewer = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const evidence = await createTestElement(testCase.id, owner.id, {
+			elementType: "EVIDENCE",
+			url: "https://example.com/protected",
+		});
+		await createTestPermission(testCase.id, viewer.id, owner.id, "VIEW");
+		await mockAuth(viewer.id, viewer.username, viewer.email);
+
+		const { PUT } = await importRoute();
+		const viewOnlyResponse = await PUT(
+			putRequest(evidence.id, { urls: ["https://example.com/hijacked"] }),
+			{ params: Promise.resolve({ id: evidence.id }) }
+		);
+		const nonexistentResponse = await PUT(
+			putRequest(NONEXISTENT_ID, { urls: ["https://example.com/hijacked"] }),
+			{ params: Promise.resolve({ id: NONEXISTENT_ID }) }
+		);
+
+		expect(viewOnlyResponse.status).toBe(404);
+		expect(viewOnlyResponse.status).toBe(nonexistentResponse.status);
+		const viewOnlyBody = await viewOnlyResponse.json();
+		const nonexistentBody = await nonexistentResponse.json();
+		expect(viewOnlyBody).toEqual(nonexistentBody);
+	});
+});
+
+// ============================================
+// PUT /api/elements/[id] — permission matrix backfill
+//
+// nanaki's G3 review of PR #885: the existing coverage in this file only
+// exercised owner (implicit ADMIN) and VIEW-via-direct-share. Backfilling
+// the remaining cases from the repo's secured-endpoint convention
+// (CLAUDE.md "Testing") that were genuinely missing across all four
+// api-elements*.test.ts files for THIS route: COMMENT-level via direct
+// share, EDIT via a team grant, unauthenticated, and a genuinely
+// nonexistent element id.
+// ============================================
+
+describe("PUT /api/elements/[id] — permission matrix backfill", () => {
+	it("returns 404 for a COMMENT-level permission holder (COMMENT < EDIT, same anti-enumeration error as not-found)", async () => {
+		const owner = await createTestUser();
+		const commenter = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const evidence = await createTestElement(testCase.id, owner.id, {
+			elementType: "EVIDENCE",
+			url: "https://example.com/protected",
+		});
+		await createTestPermission(testCase.id, commenter.id, owner.id, "COMMENT");
+		await mockAuth(commenter.id, commenter.username, commenter.email);
+
+		const { PUT } = await importRoute();
+		const response = await PUT(
+			putRequest(evidence.id, { urls: ["https://example.com/hijacked"] }),
+			{ params: Promise.resolve({ id: evidence.id }) }
+		);
+
+		expect(response.status).toBe(404);
+		const body = await response.json();
+		expect(body.error).toBe("Element not found");
+	});
+
+	it("succeeds for a user with EDIT access via a team grant (not a direct share)", async () => {
+		const owner = await createTestUser();
+		const teamMember = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const evidence = await createTestElement(testCase.id, owner.id, {
+			elementType: "EVIDENCE",
+			url: "https://example.com/original",
+		});
+		const team = await createTestTeam(owner.id);
+		await addTeamMember(team.id, teamMember.id);
+		await createTestTeamPermission(testCase.id, team.id, owner.id, "EDIT");
+		await mockAuth(teamMember.id, teamMember.username, teamMember.email);
+
+		const { PUT } = await importRoute();
+		const response = await PUT(
+			putRequest(evidence.id, {
+				description: evidence.description,
+				urls: ["https://example.com/via-team-grant"],
+			}),
+			{ params: Promise.resolve({ id: evidence.id }) }
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.urls).toEqual(["https://example.com/via-team-grant"]);
+	});
+
+	it("returns 401 with no session", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const evidence = await createTestElement(testCase.id, owner.id, {
+			elementType: "EVIDENCE",
+		});
+
+		const { PUT } = await importRoute();
+		const response = await PUT(
+			putRequest(evidence.id, {
+				description: "Attempted unauthenticated edit",
+			}),
+			{ params: Promise.resolve({ id: evidence.id }) }
+		);
+
+		expect(response.status).toBe(401);
+	});
+
+	it("returns 404 for a genuinely nonexistent element id", async () => {
+		const owner = await createTestUser();
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await importRoute();
+		const response = await PUT(
+			putRequest(NONEXISTENT_ID, { description: "Does not matter" }),
+			{ params: Promise.resolve({ id: NONEXISTENT_ID }) }
+		);
+
+		expect(response.status).toBe(404);
+		const body = await response.json();
+		expect(body.error).toBe("Element not found");
 	});
 });


### PR DESCRIPTION
Three small polish items, one review chain, one commit each.

## fix(cases): allow removing the last evidence URL row (85652dbd)

The evidence edit dialog hid the remove button when only one URL row remained (a guard from January, when URL edits were silently dropped anyway — #885 made the gap visible). The guard is removed: the list may now go empty, "Add URL" is the way back in, and saving with no rows sends `urls: []` — the clear-all path the API already supports. The previously icon-only remove button also gains an accessible name (`aria-label`/`title`).

- 3 new dialog tests: remove button on the last row, remove-then-save clears server-side (payload-level), re-add after empty works.
- Zero-rows submit traced in review: the accompanying empty `URL: ""` is transformed to undefined at schema parse, so nothing downstream can store it.

## fix(docs): quick-edit popover does not dismiss on outside click (85ea413d)

Third instance of the non-modal-Radix-Popover-over-a-ReactFlow-canvas pattern (after #884's case-settings popover and #885's node-add popover): the canvas stops pointerdown propagation, defeating the document-level dismiss listener. Fix is `modal` on the Popover with an adapted mechanism comment. Surface: the curriculum docs' interactive demo.

- 4 new tests (Radix unmocked): outside-click-under-stopPropagation, Escape, controlled open wiring for Save and Cancel.
- Reproduced failing-test-first; independently re-verified in review.

## test(elements): PUT route hardening and popover follow-ups (b54d02c4)

Test-only commit closing the coverage follow-ups from #885's review:

- Anti-enumeration: VIEW-only 404 body asserted byte-identical to a genuine not-found (catches future message drift that keeps the status code).
- `urls`-vs-`url` precedence: two tests pinning that `urls` wins unconditionally, including the empty-array clear-all case.
- PUT permission-matrix backfill: COMMENT-level denied, EDIT via a team grant (fixture verified to exercise the team path exclusively), unauthenticated 401, nonexistent id 404.
- Focus restoration for the node-add popover was found to be genuinely inert (trigger wired via `PopoverAnchor`, not `PopoverTrigger` — confirmed against a working control) and is documented with a substitute dismiss-cycle guard; the production wiring fix is tracked as a follow-up issue.

## Review chain

- QA: PASS (all three commits). Independent fail-proofs: guard restored → exactly the 3 new dialog tests fail; modal removed → exactly the outside-click test fails; perturbation proofs for the body-equivalence and precedence tests (message drift / branch flip each break exactly the expected tests). Suite counts double-run and reconciled: unit 1216/1216, element-family integration 102/102.
- Code review: APPROVE, no blockers. Team-grant fixture, zero-rows submit path, and demo-canvas interactions all traced; security grep clean.
- Fallow audit vs current baselines: dead code 0, complexity 0, duplication 0; one advisory styling flag blame-proven pre-existing (Jan 2026).
- Lint 759 files clean; typecheck 0 errors.