### PR TITLE
fix(test-infra): invocation-scoped integration test databases

### DIFF
--- a/src/__tests__/integration/publishing-schema-migration.test.ts
+++ b/src/__tests__/integration/publishing-schema-migration.test.ts
@@ -84,8 +84,19 @@ function setUpTmpProject(): void {
 	);
 }
 
-describe("publishing-schema-and-state-model migration", () => {
-	afterAll(async () => {
+/**
+ * Drops the scratch database, retrying on transient failure. Under full-suite
+ * parallel load `DROP DATABASE … WITH (FORCE)` (which itself has to wait for
+ * and terminate other backends) can be slow enough to blow past a tight
+ * timeout even though nothing is actually wrong — that's the CI-only flake
+ * on this file (see the issue's 2026-08-11 note: `afterAll` timed out at 30s
+ * four times under parallel load, always green in isolation at 12–27s). A
+ * couple of short retries absorb that contention without masking a real
+ * failure (each attempt still surfaces its error on the final try).
+ */
+async function dropScratchDatabaseWithRetries(): Promise<void> {
+	const maxAttempts = 3;
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 		const adminPool = new Pool({
 			connectionString: INTEGRATION_TEST_ADMIN_DATABASE_URL,
 		});
@@ -93,11 +104,29 @@ describe("publishing-schema-and-state-model migration", () => {
 			await adminPool.query(
 				`DROP DATABASE IF EXISTS "${scratchDbName}" WITH (FORCE)`
 			);
+			return;
+		} catch (error) {
+			if (attempt === maxAttempts) {
+				throw error;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
 		} finally {
 			await adminPool.end();
 		}
+	}
+}
+
+describe("publishing-schema-and-state-model migration", () => {
+	// Raised from 30s: under full-suite parallel load this teardown competes
+	// with three other worker databases' worth of connection/DDL contention
+	// on the same Postgres instance — 12–27s in isolation, occasionally over
+	// 30s under load (issue's 2026-08-11 note). The retried drop above
+	// absorbs most of that; the higher ceiling covers what's left without
+	// papering over a genuinely stuck teardown.
+	afterAll(async () => {
+		await dropScratchDatabaseWithRetries();
 		fs.rmSync(tmpDir, { recursive: true, force: true });
-	}, 30_000);
+	}, 60_000);
 
 	it("maps legacy READY_TO_PUBLISH rows to DRAFT and backfills a unique slug, before rebuilding the enum", async () => {
 		const allMigrations = fs

--- a/src/__tests__/scripts/setup-test-db.ts
+++ b/src/__tests__/scripts/setup-test-db.ts
@@ -3,20 +3,30 @@
 // Gives each vitest fork-pool worker its own throwaway Postgres database
 // cloned from a migrated template, instead of every worker sharing one
 // `tea_test` database (see the design note linked from the issue for the
-// full rationale). Sequence, every run:
+// full rationale). Worker database names are scoped to THIS invocation
+// (`tea_test_p<pid>_w<n>`, pid = this process's own pid) so that two
+// overlapping `vitest run` invocations against the same Postgres never
+// collide on the same database names — see the issue's reproduction
+// findings (2026-08-12) for the collision this replaces. Sequence, every
+// run:
 //
-//   1. Force-drop any stray `tea_test_w*` databases left by a prior run
-//      (a crashed run leaves open connections; FORCE terminates them, which
-//      is what eliminates the deadlock-on-shared-TRUNCATE failure mode).
-//   2. Create the `tea_test_template` database if it doesn't exist yet, and
-//      apply migrations to it (idempotent — safe to run every time).
-//   3. Clone `tea_test_w1..wN` from the template, SEQUENTIALLY (Postgres
-//      does not allow concurrent `CREATE DATABASE … TEMPLATE` against the
-//      same source database).
+//   1. Force-drop stray `tea_test_p*_w*` databases left by a prior run —
+//      but ONLY those whose embedded pid is no longer a running process.
+//      A crashed run leaves its worker databases behind; a concurrently
+//      RUNNING invocation's databases must survive this sweep, which is
+//      exactly what the old fixed-name scheme got wrong.
+//   2. Ensure the `tea_test_template` database exists, is migrated to HEAD,
+//      and is not contaminated by a migration applied on another branch
+//      that isn't on disk here (see `ensureTemplateDatabase`).
+//   3. Clone this invocation's `tea_test_p<pid>_w1..wN` from the template,
+//      SEQUENTIALLY (Postgres does not allow concurrent
+//      `CREATE DATABASE … TEMPLATE` against the same source database).
 //
-// Teardown drops the worker databases (the template is left in place so the
-// next run doesn't pay for a fresh clone slot / re-migrate from scratch).
+// Teardown drops only THIS invocation's worker databases (never a blanket
+// sweep — that was the collision bug) — the template is left in place so
+// the next run doesn't pay for a fresh clone slot / re-migrate from scratch.
 import { execSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import { Pool } from "pg";
 import {
@@ -24,11 +34,17 @@ import {
 	INTEGRATION_TEST_TEMPLATE_DATABASE,
 	INTEGRATION_TEST_WORKER_COUNT,
 	INTEGRATION_TEST_WORKER_DATABASE_PATTERN,
+	parseWorkerDatabaseName,
+	setInvocationId,
 	workerDatabaseName,
 } from "./test-db-config";
 
 // Resolve project root from this file's location (src/__tests__/scripts/)
 const PROJECT_ROOT = path.resolve(import.meta.dirname, "../../..");
+const MIGRATIONS_DIR = path.join(PROJECT_ROOT, "prisma/migrations");
+
+/** Postgres error code for "relation does not exist" — a fresh, unmigrated database. */
+const PG_UNDEFINED_TABLE = "42P01";
 
 function databaseUrlFor(databaseName: string): string {
 	const url = new URL(INTEGRATION_TEST_ADMIN_DATABASE_URL);
@@ -61,34 +77,139 @@ async function forceDropDatabase(
 }
 
 /**
- * Drops every database matching the worker-database naming scheme, whatever N
- * was last run with. `logPrefix` only distinguishes the two call sites in the
- * console (the startup sweep clears crash strays; the teardown sweep is
- * routine end-of-run cleanup) — same statement either way.
+ * Whether a process with this pid is still running. Used to decide whether a
+ * `tea_test_p<pid>_w*` database belongs to a crashed run (safe to force-drop)
+ * or a currently-running invocation (must be left alone) — the distinction
+ * the old fixed-name scheme couldn't make, which is what let two overlapping
+ * invocations destroy each other's databases (see the issue's reproduction
+ * findings, 2026-08-12). Runs on the same host as the pid it's checking:
+ * both the vitest process and this globalSetup run on the developer/CI
+ * machine, not inside the Postgres container, so the pid namespace matches.
  */
-async function dropAllWorkerDatabases(
-	adminPool: Pool,
-	logPrefix: string
-): Promise<void> {
+function isInvocationProcessAlive(pid: number): boolean {
+	try {
+		// Signal 0 sends nothing; it only checks the process exists and is
+		// signalable. Throws if not.
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ESRCH") {
+			return false; // no such process — the invocation that owned it is gone
+		}
+		// EPERM (exists, but owned by another user) or anything else: we can't
+		// prove it's dead, so err on the side of NOT dropping a database that
+		// might still be in use.
+		return true;
+	}
+}
+
+/**
+ * Startup-only sweep: force-drops worker databases left by crashed runs.
+ * Deliberately does NOT touch a database whose embedded invocation pid is
+ * still alive — that's what makes this safe to run while another invocation
+ * is mid-suite against the same Postgres.
+ */
+async function dropStrayWorkerDatabases(adminPool: Pool): Promise<void> {
 	const result = await adminPool.query<{ datname: string }>(
 		"SELECT datname FROM pg_database WHERE datname ~ $1",
 		[INTEGRATION_TEST_WORKER_DATABASE_PATTERN.source]
 	);
 	for (const row of result.rows) {
-		if (!INTEGRATION_TEST_WORKER_DATABASE_PATTERN.test(row.datname)) {
-			// Defence in depth: the SQL regex above should already guarantee this.
+		const parsed = parseWorkerDatabaseName(row.datname);
+		if (!parsed) {
+			// Defence in depth: the SQL regex above should already guarantee a match.
 			continue;
 		}
-		console.log(`${logPrefix} ${row.datname}`);
+		const pid = Number.parseInt(parsed.invocationId, 10);
+		if (isInvocationProcessAlive(pid)) {
+			continue; // belongs to a currently-running invocation — leave it alone
+		}
+		console.log(
+			`Force-dropping stray database ${row.datname} (owning pid ${pid} is not running)`
+		);
 		await forceDropDatabase(adminPool, row.datname);
 	}
 }
 
+/**
+ * Teardown-only: drops exactly this invocation's own worker databases. Never
+ * a blanket sweep by pattern — that's what let two overlapping invocations
+ * drop each other's databases under the old fixed-name scheme.
+ */
+async function dropInvocationWorkerDatabases(
+	adminPool: Pool,
+	invocationId: string
+): Promise<void> {
+	for (let poolId = 1; poolId <= INTEGRATION_TEST_WORKER_COUNT; poolId++) {
+		const name = workerDatabaseName(poolId, invocationId);
+		console.log(`Dropping worker database ${name}`);
+		await forceDropDatabase(adminPool, name);
+	}
+}
+
+/** Migration directory names actually present on disk (excludes `migration_lock.toml`). */
+function migrationsOnDisk(): Set<string> {
+	return new Set(
+		fs
+			.readdirSync(MIGRATIONS_DIR, { withFileTypes: true })
+			.filter((entry) => entry.isDirectory())
+			.map((entry) => entry.name)
+	);
+}
+
+/** Migration names Prisma has recorded as applied against the template. */
+async function appliedTemplateMigrations(): Promise<string[]> {
+	const templatePool = new Pool({
+		connectionString: databaseUrlFor(INTEGRATION_TEST_TEMPLATE_DATABASE),
+	});
+	try {
+		const result = await templatePool.query<{ migration_name: string }>(
+			"SELECT migration_name FROM _prisma_migrations WHERE finished_at IS NOT NULL"
+		);
+		return result.rows.map((row) => row.migration_name);
+	} catch (error) {
+		// Fresh, never-migrated template: the Prisma bookkeeping table doesn't
+		// exist yet. Nothing applied, so nothing can be contaminated.
+		if ((error as NodeJS.ErrnoException).code === PG_UNDEFINED_TABLE) {
+			return [];
+		}
+		throw error;
+	} finally {
+		await templatePool.end();
+	}
+}
+
+/**
+ * True if the template has a migration applied that doesn't exist in
+ * `prisma/migrations/` on this checkout — i.e. it was migrated forward by a
+ * DIFFERENT branch's run (`prisma migrate deploy` only ever moves a database
+ * forward, so it can't self-heal an over-applied template). See the issue's
+ * cross-branch contamination finding, 2026-08-12.
+ */
+async function templateIsContaminated(): Promise<boolean> {
+	const applied = await appliedTemplateMigrations();
+	if (applied.length === 0) {
+		return false;
+	}
+	const onDisk = migrationsOnDisk();
+	return applied.some((name) => !onDisk.has(name));
+}
+
 async function ensureTemplateDatabase(adminPool: Pool): Promise<void> {
-	const exists = await databaseExists(
+	let exists = await databaseExists(
 		adminPool,
 		INTEGRATION_TEST_TEMPLATE_DATABASE
 	);
+
+	if (exists && (await templateIsContaminated())) {
+		console.log(
+			`${INTEGRATION_TEST_TEMPLATE_DATABASE} has a migration applied that isn't in prisma/migrations/ on this branch (likely left over from another branch's run) — rebuilding it`
+		);
+		await forceDropDatabase(adminPool, INTEGRATION_TEST_TEMPLATE_DATABASE);
+		exists = false;
+	}
+
 	if (!exists) {
 		await adminPool.query(
 			`CREATE DATABASE "${INTEGRATION_TEST_TEMPLATE_DATABASE}"`
@@ -110,13 +231,16 @@ async function ensureTemplateDatabase(adminPool: Pool): Promise<void> {
 	console.log(`Migrations applied to ${INTEGRATION_TEST_TEMPLATE_DATABASE}`);
 }
 
-async function createWorkerDatabases(adminPool: Pool): Promise<void> {
+async function createWorkerDatabases(
+	adminPool: Pool,
+	invocationId: string
+): Promise<void> {
 	// Sequential on purpose: Postgres refuses concurrent `CREATE DATABASE …
 	// TEMPLATE` calls against the same source ("source database is being
 	// accessed by other users"), so cloning must happen one at a time here in
 	// global setup rather than letting workers self-clone.
 	for (let poolId = 1; poolId <= INTEGRATION_TEST_WORKER_COUNT; poolId++) {
-		const name = workerDatabaseName(poolId);
+		const name = workerDatabaseName(poolId, invocationId);
 		await adminPool.query(
 			`CREATE DATABASE "${name}" TEMPLATE "${INTEGRATION_TEST_TEMPLATE_DATABASE}"`
 		);
@@ -125,14 +249,21 @@ async function createWorkerDatabases(adminPool: Pool): Promise<void> {
 }
 
 export async function setup() {
+	// This process's own pid scopes every database name this invocation
+	// creates. Set BEFORE anything spawns worker processes, and before
+	// process.env is captured for them — `setInvocationId` mutates
+	// `process.env`, which vitest's fork-pool workers inherit at spawn time.
+	const invocationId = String(process.pid);
+	setInvocationId(invocationId);
+
 	const adminPool = new Pool({
 		connectionString: INTEGRATION_TEST_ADMIN_DATABASE_URL,
 	});
 
 	try {
-		await dropAllWorkerDatabases(adminPool, "Force-dropping stray database");
+		await dropStrayWorkerDatabases(adminPool);
 		await ensureTemplateDatabase(adminPool);
-		await createWorkerDatabases(adminPool);
+		await createWorkerDatabases(adminPool, invocationId);
 	} catch (error) {
 		await adminPool.end();
 		throw error;
@@ -140,7 +271,7 @@ export async function setup() {
 
 	return async function teardown() {
 		try {
-			await dropAllWorkerDatabases(adminPool, "Dropping worker database");
+			await dropInvocationWorkerDatabases(adminPool, invocationId);
 		} finally {
 			await adminPool.end();
 		}

--- a/src/__tests__/scripts/test-db-config.test.ts
+++ b/src/__tests__/scripts/test-db-config.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Unit tests for the pure per-invocation worker-database naming logic in
+ * test-db-config.ts — no Postgres required. Covers the two things the
+ * integration-only evidence in the parent fix couldn't cheaply exercise:
+ * validation failure modes (bad pool id, missing/malformed invocation id)
+ * and the parse/format round-trip the stray-sweep and teardown code depends
+ * on to recover an invocation id from a database name.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	currentInvocationId,
+	INTEGRATION_TEST_WORKER_COUNT,
+	INTEGRATION_TEST_WORKER_DATABASE_PATTERN,
+	parseWorkerDatabaseName,
+	setInvocationId,
+	workerDatabaseName,
+} from "./test-db-config";
+
+const ENV_VAR = "INTEGRATION_TEST_INVOCATION_ID";
+const ENV_VAR_NAME_PATTERN = /INTEGRATION_TEST_INVOCATION_ID/;
+const NOT_A_PID_PATTERN = /"not-a-pid"/;
+const INVALID_WORKER_ID_PATTERN = /Invalid vitest worker id/;
+
+describe("test-db-config", () => {
+	afterEach(() => {
+		delete process.env[ENV_VAR];
+	});
+
+	describe("setInvocationId / currentInvocationId", () => {
+		it("round-trips a numeric pid through the environment", () => {
+			setInvocationId(48_213);
+			expect(currentInvocationId()).toBe("48213");
+		});
+
+		it("accepts a string pid", () => {
+			setInvocationId("999");
+			expect(currentInvocationId()).toBe("999");
+		});
+
+		it("throws, naming the bad value, when unset", () => {
+			delete process.env[ENV_VAR];
+			expect(() => currentInvocationId()).toThrow(ENV_VAR_NAME_PATTERN);
+		});
+
+		it("throws when set to a non-numeric value rather than silently accepting it", () => {
+			process.env[ENV_VAR] = "not-a-pid";
+			expect(() => currentInvocationId()).toThrow(NOT_A_PID_PATTERN);
+		});
+
+		it("throws on an empty string (falsy, must not fall through to the falsy-default branch)", () => {
+			process.env[ENV_VAR] = "";
+			expect(() => currentInvocationId()).toThrow();
+		});
+	});
+
+	describe("workerDatabaseName", () => {
+		it("formats a worker database name scoped to an explicit invocation id", () => {
+			expect(workerDatabaseName(2, "48213")).toBe("tea_test_p48213_w2");
+		});
+
+		it("accepts a numeric-string pool id", () => {
+			expect(workerDatabaseName("3", "1")).toBe("tea_test_p1_w3");
+		});
+
+		it("falls back to currentInvocationId() when no invocation id is passed", () => {
+			setInvocationId(555);
+			expect(workerDatabaseName(1)).toBe("tea_test_p555_w1");
+		});
+
+		it("rejects a pool id of 0", () => {
+			expect(() => workerDatabaseName(0, "1")).toThrow(
+				INVALID_WORKER_ID_PATTERN
+			);
+		});
+
+		it("rejects a pool id above INTEGRATION_TEST_WORKER_COUNT", () => {
+			expect(() =>
+				workerDatabaseName(INTEGRATION_TEST_WORKER_COUNT + 1, "1")
+			).toThrow(INVALID_WORKER_ID_PATTERN);
+		});
+
+		it("accepts the boundary values 1 and INTEGRATION_TEST_WORKER_COUNT", () => {
+			expect(workerDatabaseName(1, "1")).toBe("tea_test_p1_w1");
+			expect(workerDatabaseName(INTEGRATION_TEST_WORKER_COUNT, "1")).toBe(
+				`tea_test_p1_w${INTEGRATION_TEST_WORKER_COUNT}`
+			);
+		});
+
+		// Number.parseInt("1.5", 10) truncates to 1 rather than failing to
+		// parse, so this does NOT throw — it silently resolves to worker 1.
+		// That's real behaviour, not a bug this test suite should paper over:
+		// flagged in QA (2026-08-12) as a pre-existing gap in the "fails
+		// loudly on a bad id" guarantee the surrounding code comments claim.
+		// Low real-world risk (VITEST_POOL_ID is vitest-generated, never
+		// hand-typed), but documented here so a future change to the
+		// truncating-vs-strict parsing choice is deliberate, not accidental.
+		it("does NOT reject a non-integer numeric-string pool id — parseInt truncation (documented gap)", () => {
+			expect(workerDatabaseName("1.5", "1")).toBe("tea_test_p1_w1");
+		});
+
+		it("rejects a non-numeric pool id", () => {
+			expect(() => workerDatabaseName("abc", "1")).toThrow(
+				INVALID_WORKER_ID_PATTERN
+			);
+		});
+	});
+
+	describe("parseWorkerDatabaseName / INTEGRATION_TEST_WORKER_DATABASE_PATTERN round-trip", () => {
+		it("recovers the invocation id and pool id from a name it produced", () => {
+			const name = workerDatabaseName(3, "48213");
+			expect(parseWorkerDatabaseName(name)).toEqual({
+				invocationId: "48213",
+				poolId: 3,
+			});
+		});
+
+		it("returns null for a name that doesn't match the scheme at all", () => {
+			expect(parseWorkerDatabaseName("tea_test_template")).toBeNull();
+			expect(parseWorkerDatabaseName("some_other_database")).toBeNull();
+		});
+
+		it("returns null for the OLD pre-fix fixed-name scheme (tea_test_w1) — must not be treated as a match", () => {
+			expect(parseWorkerDatabaseName("tea_test_w1")).toBeNull();
+		});
+
+		it("returns null for a name with a non-numeric invocation id", () => {
+			expect(parseWorkerDatabaseName("tea_test_pABC_w1")).toBeNull();
+		});
+
+		it("agrees with the exported pattern constant on what matches", () => {
+			const matching = "tea_test_p1_w1";
+			const nonMatching = "tea_test_p1_w1_extra";
+			expect(INTEGRATION_TEST_WORKER_DATABASE_PATTERN.test(matching)).toBe(
+				true
+			);
+			expect(parseWorkerDatabaseName(matching)).not.toBeNull();
+			expect(INTEGRATION_TEST_WORKER_DATABASE_PATTERN.test(nonMatching)).toBe(
+				false
+			);
+			expect(parseWorkerDatabaseName(nonMatching)).toBeNull();
+		});
+	});
+});

--- a/src/__tests__/scripts/test-db-config.ts
+++ b/src/__tests__/scripts/test-db-config.ts
@@ -5,11 +5,12 @@
 
 /**
  * Number of parallel vitest forks the integration project is allowed to run.
- * Also the number of `tea_test_w*` worker databases created in globalSetup.
- * Connection budget: each worker opens its own Prisma pool (default 10) plus
- * a 1-connection cleanup pool, so N=4 costs ~44 connections against a default
- * `max_connections` of 100. Tune only with measurement, and keep this the
- * single place both files read from.
+ * Also the number of `tea_test_p<pid>_w*` worker databases created in
+ * globalSetup for a given invocation. Connection budget: each worker opens
+ * its own Prisma pool (default 10) plus a 1-connection cleanup pool, so N=4
+ * costs ~44 connections against a default `max_connections` of 100. Tune
+ * only with measurement, and keep this the single place both files read
+ * from.
  */
 export const INTEGRATION_TEST_WORKER_COUNT = 4;
 
@@ -20,24 +21,82 @@ export const INTEGRATION_TEST_ADMIN_DATABASE_URL =
 /** Migrated template that every worker database is cloned from. */
 export const INTEGRATION_TEST_TEMPLATE_DATABASE = "tea_test_template";
 
-/** Prefix for per-worker throwaway databases: `tea_test_w1`, `tea_test_w2`, … */
-const INTEGRATION_TEST_WORKER_DATABASE_PREFIX = "tea_test_w";
+/** Prefix for per-worker throwaway databases, before the invocation/worker suffix. */
+const INTEGRATION_TEST_WORKER_DATABASE_PREFIX = "tea_test_p";
 
-/** Matches exactly the worker databases this scheme owns — used for force-drop and assertions. */
-export const INTEGRATION_TEST_WORKER_DATABASE_PATTERN = /^tea_test_w[0-9]+$/;
+/**
+ * Matches exactly the worker databases this scheme owns —
+ * `tea_test_p<invocationId>_w<poolId>`, e.g. `tea_test_p48213_w2`. Used for
+ * force-drop, the stray-database sweep, and assertions. Capture groups let
+ * callers recover the invocation id and worker id from a matched name (see
+ * `parseWorkerDatabaseName`) — group order must stay `(invocationId)(poolId)`.
+ */
+export const INTEGRATION_TEST_WORKER_DATABASE_PATTERN =
+	/^tea_test_p([0-9]+)_w([0-9]+)$/;
+
+/**
+ * The environment variable that carries this vitest invocation's identity
+ * (its root process's PID) from globalSetup, where it is first computed, to
+ * every worker fork, where `setup.integration.tsx` reads it to build the
+ * same worker-database name globalSetup already created. Node's
+ * `child_process.fork` (vitest's "forks" pool) inherits `process.env` from
+ * the process that calls it, and globalSetup sets this before workers are
+ * spawned — see `setup-test-db.ts` for the write side and the acceptance-run
+ * evidence on the issue for verification that the inheritance holds.
+ */
+const INTEGRATION_TEST_INVOCATION_ID_ENV_VAR = "INTEGRATION_TEST_INVOCATION_ID";
+
+/** Matches a bare PID — used to validate `INTEGRATION_TEST_INVOCATION_ID_ENV_VAR`. */
+const NUMERIC_PID_PATTERN = /^[0-9]+$/;
+
+/**
+ * Reads the current invocation id set by globalSetup. Fails loudly (rather
+ * than silently falling back to a shared/default name, which is exactly the
+ * bug this scheme fixes) if it's missing or not a bare PID.
+ */
+export function currentInvocationId(): string {
+	const id = process.env[INTEGRATION_TEST_INVOCATION_ID_ENV_VAR];
+	if (!(id && NUMERIC_PID_PATTERN.test(id))) {
+		throw new Error(
+			`${INTEGRATION_TEST_INVOCATION_ID_ENV_VAR} must be set to a numeric PID before worker database names can be resolved (expected setup-test-db.ts's globalSetup to set it before any worker process starts), got ${JSON.stringify(id)}`
+		);
+	}
+	return id;
+}
+
+/** Sets the invocation id env var — called once, by globalSetup, before workers are spawned. */
+export function setInvocationId(id: string | number): void {
+	process.env[INTEGRATION_TEST_INVOCATION_ID_ENV_VAR] = String(id);
+}
 
 /**
  * Validates and formats a vitest worker/pool id into its worker database
- * name. Rejects anything outside `1..INTEGRATION_TEST_WORKER_COUNT` so a bad
- * or unset `VITEST_POOL_ID` fails loudly here, naming the bad value, instead
- * of surfacing later as an opaque "database does not exist" from pg.
+ * name, scoped to the current invocation (`currentInvocationId()`, or an
+ * explicit override for globalSetup's own use before workers exist). Rejects
+ * a pool id outside `1..INTEGRATION_TEST_WORKER_COUNT` so a bad or unset
+ * `VITEST_POOL_ID` fails loudly here, naming the bad value, instead of
+ * surfacing later as an opaque "database does not exist" from pg.
  */
-export function workerDatabaseName(poolId: string | number): string {
+export function workerDatabaseName(
+	poolId: string | number,
+	invocationId: string = currentInvocationId()
+): string {
 	const id = typeof poolId === "number" ? poolId : Number.parseInt(poolId, 10);
 	if (!Number.isInteger(id) || id < 1 || id > INTEGRATION_TEST_WORKER_COUNT) {
 		throw new Error(
 			`Invalid vitest worker id ${JSON.stringify(poolId)}: expected an integer between 1 and ${INTEGRATION_TEST_WORKER_COUNT} (INTEGRATION_TEST_WORKER_COUNT), got ${id}`
 		);
 	}
-	return `${INTEGRATION_TEST_WORKER_DATABASE_PREFIX}${id}`;
+	return `${INTEGRATION_TEST_WORKER_DATABASE_PREFIX}${invocationId}_w${id}`;
+}
+
+/** Recovers `{ invocationId, poolId }` from a worker database name, or `null` if it doesn't match. */
+export function parseWorkerDatabaseName(
+	databaseName: string
+): { invocationId: string; poolId: number } | null {
+	const match = INTEGRATION_TEST_WORKER_DATABASE_PATTERN.exec(databaseName);
+	if (!(match?.[1] && match[2])) {
+		return null;
+	}
+	return { invocationId: match[1], poolId: Number.parseInt(match[2], 10) };
 }

--- a/src/__tests__/setup.integration.tsx
+++ b/src/__tests__/setup.integration.tsx
@@ -9,7 +9,11 @@ import { workerDatabaseName } from "./scripts/test-db-config";
 // load before test files in each vitest fork — so this override always lands
 // first. `VITEST_POOL_ID` is vitest's 1-indexed fork id; it's stable for the
 // lifetime of the worker process, so every test file the worker picks up
-// shares the same worker-scoped database.
+// shares the same worker-scoped database. `workerDatabaseName` also scopes
+// the name to this invocation (`INTEGRATION_TEST_INVOCATION_ID`, read from
+// the environment globalSetup set it in — inherited by this fork at spawn
+// time), so two overlapping `vitest run` invocations never land on the same
+// database name.
 const workerId = process.env.VITEST_POOL_ID ?? "1";
 const baseDatabaseUrl = process.env.DATABASE_URL;
 if (!baseDatabaseUrl) {


### PR DESCRIPTION
## Summary

Fixes the long-standing integration-test flake (FK violations / vanished databases when two test invocations overlap) plus two adjacent failure modes found during root-causing. Test infrastructure only — no product code, no test assertions changed.

1. **Invocation-scoped worker databases** — worker DB names now embed the owning process's PID (`tea_test_p<pid>_w<n>`), so concurrent invocations cannot see each other's databases. The startup stray-sweep only drops databases whose owning PID is provably dead; teardown drops only the invocation's own databases.
2. **Template staleness check** — global setup rebuilds `tea_test_template` when it carries a migration not present on the checked-out branch (cross-branch contamination previously caused deterministic wall-of-red failures after switching branches).
3. **Teardown resilience** — `publishing-schema-migration.test.ts` gains drop retries and a 60s afterAll timeout, addressing the CI-only teardown flake seen under full-suite parallel load.

Plus 18 new unit tests covering the naming/validation logic (no DB required).

## Verification

- Collision reproducer: two overlapping invocations, previously 55/82 failures on demand — now both green (2 independent trials + QA's own reproduction)
- Template contamination self-heal exercised and green
- 5 consecutive full-suite integration runs green (53 files / 918 tests each)
- Crashed-run cleanup live-tested (kill -9 mid-run; strays dropped on next run; zero residue)
- Unit 1258/1258 and integration 918/918 green on the final SHA; lint + typecheck clean; fallow audit clean (0 dead code / complexity / duplication regressions)
- CI needs no changes: the test job runs on the runner VM (PID liveness check valid) with a disposable Postgres service

## Known non-blocking notes (tracked on the internal issue)

- Template-rebuild racing a concurrent invocation's clone is a narrow, untested gap (precondition: already-contaminated template)
- PID reuse can leave a stray DB unswept (fails safe: disk leak, never drops a live DB)
- Stale `tea_test_w*` naming survives in one docstring