### PR TITLE
fix(cases): preserve unsaved case-information fields; sector select + author tag entry

### DIFF
--- a/components/cases/__tests__/case-details.test.tsx
+++ b/components/cases/__tests__/case-details.test.tsx
@@ -7,6 +7,7 @@ import CaseDetails from "../case-details";
 // behaviour has its own dedicated test in case-information-section.test.tsx.
 vi.mock("@/hooks/use-case-information", () => ({
 	useCaseInformation: () => ({
+		forCaseId: "case-1",
 		information: null,
 		loading: false,
 		saving: false,

--- a/components/cases/__tests__/case-information-section.test.tsx
+++ b/components/cases/__tests__/case-information-section.test.tsx
@@ -11,6 +11,11 @@ vi.mock("@/hooks/use-case-information", () => ({
 const mockedUseCaseInformation = vi.mocked(useCaseInformation);
 const SAVE_BUTTON_PATTERN = /save/i;
 const SAVE_CASE_INFORMATION_BUTTON_PATTERN = /save case information/i;
+const FINANCIAL_SERVICES_OPTION_PATTERN = /^financial services$/i;
+const FINANCIAL_SERVICES_PATTERN = /financial services/i;
+const HEALTHCARE_LEGACY_OPTION_PATTERN = /healthcare \(legacy value\)/i;
+const AUTHOR_HELPER_TEXT_PATTERN = /press enter to add an author as a tag/i;
+const REMOVE_ADA_LOVELACE_PATTERN = /remove ada lovelace/i;
 
 function stubHook(overrides: Partial<ReturnType<typeof useCaseInformation>>) {
 	mockedUseCaseInformation.mockReturnValue({
@@ -97,5 +102,117 @@ describe("CaseInformationSection", () => {
 		expect(save).toHaveBeenCalledWith(
 			expect.objectContaining({ description: "Updated description" })
 		);
+	});
+
+	it("keeps unsaved Authors and Sector edits intact across a feature-image upload response", async () => {
+		const uploadFeatureImage = vi.fn().mockResolvedValue(true);
+		const baseHookReturn = {
+			information: {
+				description: "Original description",
+				authors: "Grace Hopper",
+				sector: "Defence",
+				featureImageUrl: null,
+			},
+			loading: false,
+			saving: false,
+			uploadingImage: false,
+			save: vi.fn().mockResolvedValue(true),
+			uploadFeatureImage,
+			removeFeatureImage: vi.fn().mockResolvedValue(true),
+		};
+		stubHook(baseHookReturn);
+		const user = userEvent.setup();
+
+		const { rerender } = render(
+			<CaseInformationSection canEdit={true} caseId="case-1" />
+		);
+		await screen.findByTestId("case-information-form");
+
+		// Edit both fields without saving.
+		const authorsInput = screen.getByPlaceholderText("e.g. Ada Lovelace");
+		await user.type(authorsInput, "Ada Lovelace{Enter}");
+		expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+
+		await user.click(screen.getByRole("combobox"));
+		await user.click(
+			screen.getByRole("option", { name: FINANCIAL_SERVICES_OPTION_PATTERN })
+		);
+		expect(screen.getByRole("combobox")).toHaveTextContent(
+			FINANCIAL_SERVICES_PATTERN
+		);
+
+		// Simulate the upload response: `useCaseInformation` sets `information`
+		// from the *previous* (pre-upload) server-side authors/sector plus the
+		// new feature image URL — this is exactly what wiped the form before
+		// the fix, because the component used to `reset()` the whole form
+		// whenever `information` changed.
+		mockedUseCaseInformation.mockReturnValue({
+			...baseHookReturn,
+			information: {
+				...baseHookReturn.information,
+				featureImageUrl: "https://example.com/uploaded.png",
+			},
+		});
+		rerender(<CaseInformationSection canEdit={true} caseId="case-1" />);
+
+		expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+		expect(screen.getByRole("combobox")).toHaveTextContent(
+			FINANCIAL_SERVICES_PATTERN
+		);
+	});
+
+	it("tolerates a legacy free-text sector value not in the canonical list", async () => {
+		stubHook({
+			information: {
+				description: "Original description",
+				authors: "Grace Hopper",
+				sector: "Healthcare",
+				featureImageUrl: null,
+			},
+		});
+		const user = userEvent.setup();
+
+		render(<CaseInformationSection canEdit={true} caseId="case-1" />);
+		await screen.findByTestId("case-information-form");
+
+		const trigger = screen.getByRole("combobox");
+		expect(trigger).toHaveTextContent("Healthcare");
+
+		await user.click(trigger);
+		expect(
+			screen.getByRole("option", { name: HEALTHCARE_LEGACY_OPTION_PATTERN })
+		).toBeInTheDocument();
+	});
+
+	it("adds and removes author chips via Enter and the remove button, with helper text present", async () => {
+		stubHook({
+			information: {
+				description: "Original description",
+				authors: "",
+				sector: "",
+				featureImageUrl: null,
+			},
+		});
+		const user = userEvent.setup();
+
+		render(<CaseInformationSection canEdit={true} caseId="case-1" />);
+		await screen.findByTestId("case-information-form");
+
+		expect(screen.getByText(AUTHOR_HELPER_TEXT_PATTERN)).toBeInTheDocument();
+
+		const authorsInput = screen.getByPlaceholderText("e.g. Ada Lovelace");
+		await user.type(authorsInput, "Ada Lovelace{Enter}");
+		await user.type(authorsInput, "Grace Hopper{Enter}");
+
+		const tagList = screen.getByTestId("authors-tag-list");
+		expect(tagList).toHaveTextContent("Ada Lovelace");
+		expect(tagList).toHaveTextContent("Grace Hopper");
+
+		await user.click(
+			screen.getByRole("button", { name: REMOVE_ADA_LOVELACE_PATTERN })
+		);
+
+		expect(screen.queryByText("Ada Lovelace")).not.toBeInTheDocument();
+		expect(tagList).toHaveTextContent("Grace Hopper");
 	});
 });

--- a/components/cases/__tests__/case-information-section.test.tsx
+++ b/components/cases/__tests__/case-information-section.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useCaseInformation } from "@/hooks/use-case-information";
+import useStore from "@/store/store";
 import { CaseInformationSection } from "../case-information-section";
 
 vi.mock("@/hooks/use-case-information", () => ({
@@ -19,6 +20,7 @@ const REMOVE_ADA_LOVELACE_PATTERN = /remove ada lovelace/i;
 
 function stubHook(overrides: Partial<ReturnType<typeof useCaseInformation>>) {
 	mockedUseCaseInformation.mockReturnValue({
+		forCaseId: "case-1",
 		information: null,
 		loading: false,
 		saving: false,
@@ -33,6 +35,10 @@ function stubHook(overrides: Partial<ReturnType<typeof useCaseInformation>>) {
 describe("CaseInformationSection", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		useStore.setState({ caseInformationFocusField: null });
 	});
 
 	it("shows a loading skeleton while the record is being fetched", () => {
@@ -107,6 +113,7 @@ describe("CaseInformationSection", () => {
 	it("keeps unsaved Authors and Sector edits intact across a feature-image upload response", async () => {
 		const uploadFeatureImage = vi.fn().mockResolvedValue(true);
 		const baseHookReturn = {
+			forCaseId: "case-1",
 			information: {
 				description: "Original description",
 				authors: "Grace Hopper",
@@ -214,5 +221,237 @@ describe("CaseInformationSection", () => {
 
 		expect(screen.queryByText("Ada Lovelace")).not.toBeInTheDocument();
 		expect(tagList).toHaveTextContent("Grace Hopper");
+	});
+
+	it("ignores an empty or whitespace-only draft and de-duplicates a repeated name", async () => {
+		stubHook({
+			information: {
+				description: "",
+				authors: "",
+				sector: "",
+				featureImageUrl: null,
+			},
+		});
+		const user = userEvent.setup();
+
+		render(<CaseInformationSection canEdit={true} caseId="case-1" />);
+		await screen.findByTestId("case-information-form");
+
+		const authorsInput = screen.getByPlaceholderText("e.g. Ada Lovelace");
+
+		// Whitespace-only draft: no chip added.
+		await user.type(authorsInput, "   {Enter}");
+		expect(screen.queryByTestId("authors-tag-list")).not.toBeInTheDocument();
+
+		// Duplicate name: no second chip.
+		await user.type(authorsInput, "Ada Lovelace{Enter}");
+		await user.type(authorsInput, "Ada Lovelace{Enter}");
+
+		const tagList = screen.getByTestId("authors-tag-list");
+		expect(
+			tagList.querySelectorAll('[aria-label="Remove Ada Lovelace"]')
+		).toHaveLength(1);
+	});
+
+	it("keeps unsaved Authors and Sector edits intact across a feature-image removal response", async () => {
+		const removeFeatureImage = vi.fn().mockResolvedValue(true);
+		const baseHookReturn = {
+			forCaseId: "case-1",
+			information: {
+				description: "Original description",
+				authors: "Grace Hopper",
+				sector: "Defence",
+				featureImageUrl: "https://example.com/existing.png",
+			},
+			loading: false,
+			saving: false,
+			uploadingImage: false,
+			save: vi.fn().mockResolvedValue(true),
+			uploadFeatureImage: vi.fn().mockResolvedValue(true),
+			removeFeatureImage,
+		};
+		stubHook(baseHookReturn);
+		const user = userEvent.setup();
+
+		const { rerender } = render(
+			<CaseInformationSection canEdit={true} caseId="case-1" />
+		);
+		await screen.findByTestId("case-information-form");
+
+		const authorsInput = screen.getByPlaceholderText("e.g. Ada Lovelace");
+		await user.type(authorsInput, "Ada Lovelace{Enter}");
+		expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+
+		// Simulate the remove response: `information` loses its feature image
+		// but otherwise reflects the previous server-side authors/sector.
+		mockedUseCaseInformation.mockReturnValue({
+			...baseHookReturn,
+			information: {
+				...baseHookReturn.information,
+				featureImageUrl: null,
+			},
+		});
+		rerender(<CaseInformationSection canEdit={true} caseId="case-1" />);
+
+		expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+		expect(screen.getByText("Grace Hopper")).toBeInTheDocument();
+	});
+
+	it("focuses the Authors control when the publish flow requests it", async () => {
+		stubHook({
+			information: {
+				description: "",
+				authors: "",
+				sector: "",
+				featureImageUrl: null,
+			},
+		});
+		useStore.setState({ caseInformationFocusField: "authors" });
+
+		render(<CaseInformationSection canEdit={true} caseId="case-1" />);
+		await screen.findByTestId("case-information-form");
+
+		await waitFor(() => {
+			expect(document.activeElement).toBe(
+				screen.getByPlaceholderText("e.g. Ada Lovelace")
+			);
+		});
+	});
+
+	it("focuses the Sector control when the publish flow requests it", async () => {
+		stubHook({
+			information: {
+				description: "",
+				authors: "",
+				sector: "",
+				featureImageUrl: null,
+			},
+		});
+		useStore.setState({ caseInformationFocusField: "sector" });
+
+		render(<CaseInformationSection canEdit={true} caseId="case-1" />);
+		await screen.findByTestId("case-information-form");
+
+		await waitFor(() => {
+			expect(document.activeElement).toBe(screen.getByRole("combobox"));
+		});
+	});
+
+	it("fully resets to the new case's values on a case switch, discarding unsaved edits and never showing a stale record", async () => {
+		const caseOneReturn = {
+			forCaseId: "case-1",
+			information: {
+				description: "Case one description",
+				authors: "Grace Hopper",
+				sector: "Defence",
+				featureImageUrl: null,
+			},
+			loading: false,
+			saving: false,
+			uploadingImage: false,
+			save: vi.fn().mockResolvedValue(true),
+			uploadFeatureImage: vi.fn().mockResolvedValue(true),
+			removeFeatureImage: vi.fn().mockResolvedValue(true),
+		};
+		mockedUseCaseInformation.mockReturnValue(caseOneReturn);
+		const user = userEvent.setup();
+
+		const { rerender } = render(
+			<CaseInformationSection canEdit={true} caseId="case-1" />
+		);
+		await screen.findByTestId("case-information-form");
+
+		const descriptionField = screen.getByLabelText("Description");
+		await user.clear(descriptionField);
+		await user.type(descriptionField, "Unsaved edit for case one");
+		expect(descriptionField).toHaveValue("Unsaved edit for case one");
+
+		// caseId has switched but the fetch for case-2 hasn't resolved yet:
+		// `forCaseId` still names case-1, even though `loading` is already
+		// false again in this stub. The provenance guard must not hydrate
+		// here — a purely `loading`-based guard would wrongly fire.
+		mockedUseCaseInformation.mockReturnValue({
+			...caseOneReturn,
+			loading: false,
+		});
+		rerender(<CaseInformationSection canEdit={true} caseId="case-2" />);
+
+		expect(screen.getByLabelText("Description")).toHaveValue(
+			"Unsaved edit for case one"
+		);
+
+		// case-2's record has now arrived, with matching provenance.
+		mockedUseCaseInformation.mockReturnValue({
+			...caseOneReturn,
+			forCaseId: "case-2",
+			information: {
+				description: "Case two description",
+				authors: "Ada Lovelace",
+				sector: "Healthcare",
+				featureImageUrl: null,
+			},
+		});
+		rerender(<CaseInformationSection canEdit={true} caseId="case-2" />);
+
+		expect(screen.getByLabelText("Description")).toHaveValue(
+			"Case two description"
+		);
+		expect(
+			screen.queryByText("Unsaved edit for case one")
+		).not.toBeInTheDocument();
+		expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+		expect(screen.queryByText("Grace Hopper")).not.toBeInTheDocument();
+	});
+
+	it("renders two chips for a legacy comma-joined authors value on initial load", async () => {
+		stubHook({
+			information: {
+				description: "",
+				authors: "Ada Lovelace, Grace Hopper",
+				sector: "",
+				featureImageUrl: null,
+			},
+		});
+
+		render(<CaseInformationSection canEdit={true} caseId="case-1" />);
+		await screen.findByTestId("case-information-form");
+
+		const tagList = screen.getByTestId("authors-tag-list");
+		expect(tagList).toHaveTextContent("Ada Lovelace");
+		expect(tagList).toHaveTextContent("Grace Hopper");
+	});
+
+	it("replaces a legacy sector value with a canonical selection and drops the legacy option from the list", async () => {
+		stubHook({
+			information: {
+				description: "",
+				authors: "",
+				sector: "Healthcare",
+				featureImageUrl: null,
+			},
+		});
+		const user = userEvent.setup();
+
+		render(<CaseInformationSection canEdit={true} caseId="case-1" />);
+		await screen.findByTestId("case-information-form");
+
+		const trigger = screen.getByRole("combobox");
+		expect(trigger).toHaveTextContent("Healthcare");
+
+		await user.click(trigger);
+		expect(
+			screen.getByRole("option", { name: HEALTHCARE_LEGACY_OPTION_PATTERN })
+		).toBeInTheDocument();
+
+		await user.click(
+			screen.getByRole("option", { name: FINANCIAL_SERVICES_OPTION_PATTERN })
+		);
+
+		expect(trigger).toHaveTextContent(FINANCIAL_SERVICES_PATTERN);
+
+		await user.click(trigger);
+		expect(
+			screen.queryByRole("option", { name: HEALTHCARE_LEGACY_OPTION_PATTERN })
+		).not.toBeInTheDocument();
 	});
 });

--- a/components/cases/authors-tag-input.tsx
+++ b/components/cases/authors-tag-input.tsx
@@ -13,6 +13,13 @@ import {
 
 interface AuthorsTagInputProps {
 	disabled?: boolean;
+	/**
+	 * Forwarded by `FormControl` (`components/ui/form.tsx`) so the field's
+	 * `FormLabel` associates with the real text input, not this component's
+	 * outer wrapper — without it, `getByLabel("Authors")` (and screen readers)
+	 * can't find a control to label.
+	 */
+	id?: string;
 	onChange: (value: string) => void;
 	placeholder?: string;
 	value: string;
@@ -47,6 +54,7 @@ export function AuthorsTagInput({
 	value,
 	onChange,
 	disabled,
+	id,
 	placeholder = "e.g. Ada Lovelace",
 }: AuthorsTagInputProps) {
 	const [draft, setDraft] = useState("");
@@ -88,6 +96,7 @@ export function AuthorsTagInput({
 				<Input
 					aria-describedby="authors-tag-input-help"
 					disabled={disabled}
+					id={id}
 					onChange={(event) => setDraft(event.target.value)}
 					onKeyDown={onKeyDown}
 					placeholder={placeholder}

--- a/components/cases/authors-tag-input.tsx
+++ b/components/cases/authors-tag-input.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { InfoIcon, X } from "lucide-react";
+import { type KeyboardEvent, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface AuthorsTagInputProps {
+	disabled?: boolean;
+	onChange: (value: string) => void;
+	placeholder?: string;
+	value: string;
+}
+
+/**
+ * Splits the stored comma-joined authors string into display chips. Kept
+ * deliberately simple (no migration, ADR 0003 §1): a legacy single-author
+ * value with no comma loads as one chip, and a value that already contains
+ * commas — from the old free-text field, or from a previous save of this
+ * component — splits unambiguously on the comma.
+ */
+function parseAuthors(value: string): string[] {
+	return value
+		.split(",")
+		.map((name) => name.trim())
+		.filter(Boolean);
+}
+
+function serialiseAuthors(authors: string[]): string {
+	return authors.join(", ");
+}
+
+/**
+ * Tag-style entry for the case-information "Authors" field (ADR 0003 §1).
+ * Type a name, press Enter to add it as a removable chip; Backspace on an
+ * empty draft removes the last chip. The underlying value stays a single
+ * comma-joined string — the schema and database field are unchanged, so no
+ * migration is needed (Chris's constraint, publish completion pane brief).
+ */
+export function AuthorsTagInput({
+	value,
+	onChange,
+	disabled,
+	placeholder = "e.g. Ada Lovelace",
+}: AuthorsTagInputProps) {
+	const [draft, setDraft] = useState("");
+	const authors = parseAuthors(value);
+
+	const addAuthor = () => {
+		const name = draft.trim();
+		if (!name) {
+			return;
+		}
+		if (authors.includes(name)) {
+			setDraft("");
+			return;
+		}
+		onChange(serialiseAuthors([...authors, name]));
+		setDraft("");
+	};
+
+	const removeAuthor = (name: string) => {
+		onChange(serialiseAuthors(authors.filter((author) => author !== name)));
+	};
+
+	const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+		if (event.key === "Enter") {
+			event.preventDefault();
+			addAuthor();
+		} else if (
+			event.key === "Backspace" &&
+			draft === "" &&
+			authors.length > 0
+		) {
+			removeAuthor(authors.at(-1) as string);
+		}
+	};
+
+	return (
+		<div className="space-y-2">
+			<div className="flex items-center gap-1.5">
+				<Input
+					aria-describedby="authors-tag-input-help"
+					disabled={disabled}
+					onChange={(event) => setDraft(event.target.value)}
+					onKeyDown={onKeyDown}
+					placeholder={placeholder}
+					value={draft}
+				/>
+				<TooltipProvider>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<button
+								aria-label="How author entry works"
+								className="shrink-0 text-muted-foreground hover:text-foreground"
+								type="button"
+							>
+								<InfoIcon className="h-4 w-4" />
+							</button>
+						</TooltipTrigger>
+						<TooltipContent className="max-w-xs">
+							Type a name and press Enter to add it as a tag. Click the × on a
+							tag, or press Backspace with an empty input, to remove it.
+						</TooltipContent>
+					</Tooltip>
+				</TooltipProvider>
+			</div>
+			<p className="text-muted-foreground text-xs" id="authors-tag-input-help">
+				Press Enter to add an author as a tag.
+			</p>
+			{authors.length > 0 && (
+				<div className="flex flex-wrap gap-1.5" data-testid="authors-tag-list">
+					{authors.map((author) => (
+						<Badge
+							className="gap-1 py-1 pr-1 pl-2.5"
+							key={author}
+							variant="secondary"
+						>
+							{author}
+							<button
+								aria-label={`Remove ${author}`}
+								className="rounded-full p-0.5 hover:bg-muted-foreground/20"
+								disabled={disabled}
+								onClick={() => removeAuthor(author)}
+								type="button"
+							>
+								<X className="h-3 w-3" />
+							</button>
+						</Badge>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/components/cases/authors-tag-input.tsx
+++ b/components/cases/authors-tag-input.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { InfoIcon, X } from "lucide-react";
-import { type KeyboardEvent, useState } from "react";
+import { forwardRef, type KeyboardEvent, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import {
@@ -12,6 +12,15 @@ import {
 } from "@/components/ui/tooltip";
 
 interface AuthorsTagInputProps {
+	/**
+	 * Injected by `FormControl` (`components/ui/form.tsx`) via Radix `Slot`
+	 * when this field has a validation error — merged with our own helper
+	 * text id below so both are announced, rather than one silently
+	 * overwriting the other.
+	 */
+	"aria-describedby"?: string;
+	/** Injected by `FormControl` — forwarded to the real text input. */
+	"aria-invalid"?: boolean | "false" | "true";
 	disabled?: boolean;
 	/**
 	 * Forwarded by `FormControl` (`components/ui/form.tsx`) so the field's
@@ -24,6 +33,8 @@ interface AuthorsTagInputProps {
 	placeholder?: string;
 	value: string;
 }
+
+const HELP_TEXT_ID = "authors-tag-input-help";
 
 /**
  * Splits the stored comma-joined authors string into display chips. Kept
@@ -49,102 +60,126 @@ function serialiseAuthors(authors: string[]): string {
  * empty draft removes the last chip. The underlying value stays a single
  * comma-joined string — the schema and database field are unchanged, so no
  * migration is needed (Chris's constraint, publish completion pane brief).
+ *
+ * Wrapped in `forwardRef` and attaches the ref to the real text input so
+ * react-hook-form's `setFocus("authors")` — the publish-gate "focus the
+ * missing field" flow (ADR 0003 §2) — can actually focus this control
+ * instead of silently no-oping.
  */
-export function AuthorsTagInput({
-	value,
-	onChange,
-	disabled,
-	id,
-	placeholder = "e.g. Ada Lovelace",
-}: AuthorsTagInputProps) {
-	const [draft, setDraft] = useState("");
-	const authors = parseAuthors(value);
+export const AuthorsTagInput = forwardRef<
+	HTMLInputElement,
+	AuthorsTagInputProps
+>(
+	(
+		{
+			value,
+			onChange,
+			disabled,
+			id,
+			placeholder = "e.g. Ada Lovelace",
+			"aria-describedby": ariaDescribedBy,
+			"aria-invalid": ariaInvalid,
+		},
+		ref
+	) => {
+		const [draft, setDraft] = useState("");
+		const authors = parseAuthors(value);
+		const describedBy = [ariaDescribedBy, HELP_TEXT_ID]
+			.filter(Boolean)
+			.join(" ");
 
-	const addAuthor = () => {
-		const name = draft.trim();
-		if (!name) {
-			return;
-		}
-		if (authors.includes(name)) {
+		const addAuthor = () => {
+			const name = draft.trim();
+			if (!name) {
+				return;
+			}
+			if (authors.includes(name)) {
+				setDraft("");
+				return;
+			}
+			onChange(serialiseAuthors([...authors, name]));
 			setDraft("");
-			return;
-		}
-		onChange(serialiseAuthors([...authors, name]));
-		setDraft("");
-	};
+		};
 
-	const removeAuthor = (name: string) => {
-		onChange(serialiseAuthors(authors.filter((author) => author !== name)));
-	};
+		const removeAuthor = (name: string) => {
+			onChange(serialiseAuthors(authors.filter((author) => author !== name)));
+		};
 
-	const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-		if (event.key === "Enter") {
-			event.preventDefault();
-			addAuthor();
-		} else if (
-			event.key === "Backspace" &&
-			draft === "" &&
-			authors.length > 0
-		) {
-			removeAuthor(authors.at(-1) as string);
-		}
-	};
+		const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+			if (event.key === "Enter") {
+				event.preventDefault();
+				addAuthor();
+			} else if (
+				event.key === "Backspace" &&
+				draft === "" &&
+				authors.length > 0
+			) {
+				removeAuthor(authors.at(-1) as string);
+			}
+		};
 
-	return (
-		<div className="space-y-2">
-			<div className="flex items-center gap-1.5">
-				<Input
-					aria-describedby="authors-tag-input-help"
-					disabled={disabled}
-					id={id}
-					onChange={(event) => setDraft(event.target.value)}
-					onKeyDown={onKeyDown}
-					placeholder={placeholder}
-					value={draft}
-				/>
-				<TooltipProvider>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<button
-								aria-label="How author entry works"
-								className="shrink-0 text-muted-foreground hover:text-foreground"
-								type="button"
-							>
-								<InfoIcon className="h-4 w-4" />
-							</button>
-						</TooltipTrigger>
-						<TooltipContent className="max-w-xs">
-							Type a name and press Enter to add it as a tag. Click the × on a
-							tag, or press Backspace with an empty input, to remove it.
-						</TooltipContent>
-					</Tooltip>
-				</TooltipProvider>
-			</div>
-			<p className="text-muted-foreground text-xs" id="authors-tag-input-help">
-				Press Enter to add an author as a tag.
-			</p>
-			{authors.length > 0 && (
-				<div className="flex flex-wrap gap-1.5" data-testid="authors-tag-list">
-					{authors.map((author) => (
-						<Badge
-							className="gap-1 py-1 pr-1 pl-2.5"
-							key={author}
-							variant="secondary"
-						>
-							{author}
-							<button
-								aria-label={`Remove ${author}`}
-								className="rounded-full p-0.5 hover:bg-muted-foreground/20"
-								disabled={disabled}
-								onClick={() => removeAuthor(author)}
-								type="button"
-							>
-								<X className="h-3 w-3" />
-							</button>
-						</Badge>
-					))}
+		return (
+			<div className="space-y-2">
+				<div className="flex items-center gap-1.5">
+					<Input
+						aria-describedby={describedBy}
+						aria-invalid={ariaInvalid}
+						disabled={disabled}
+						id={id}
+						onChange={(event) => setDraft(event.target.value)}
+						onKeyDown={onKeyDown}
+						placeholder={placeholder}
+						ref={ref}
+						value={draft}
+					/>
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									aria-label="How author entry works"
+									className="shrink-0 text-muted-foreground hover:text-foreground"
+									type="button"
+								>
+									<InfoIcon className="h-4 w-4" />
+								</button>
+							</TooltipTrigger>
+							<TooltipContent className="max-w-xs">
+								Type a name and press Enter to add it as a tag. Click the × on a
+								tag, or press Backspace with an empty input, to remove it.
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
 				</div>
-			)}
-		</div>
-	);
-}
+				<p className="text-muted-foreground text-xs" id={HELP_TEXT_ID}>
+					Press Enter to add an author as a tag.
+				</p>
+				{authors.length > 0 && (
+					<div
+						className="flex flex-wrap gap-1.5"
+						data-testid="authors-tag-list"
+					>
+						{authors.map((author) => (
+							<Badge
+								className="gap-1 py-1 pr-1 pl-2.5"
+								key={author}
+								variant="secondary"
+							>
+								{author}
+								<button
+									aria-label={`Remove ${author}`}
+									className="rounded-full p-0.5 hover:bg-muted-foreground/20"
+									disabled={disabled}
+									onClick={() => removeAuthor(author)}
+									type="button"
+								>
+									<X className="h-3 w-3" />
+								</button>
+							</Badge>
+						))}
+					</div>
+				)}
+			</div>
+		);
+	}
+);
+AuthorsTagInput.displayName = "AuthorsTagInput";

--- a/components/cases/case-information-section.tsx
+++ b/components/cases/case-information-section.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2 } from "lucide-react";
 import Image from "next/image";
-import { useEffect, useRef } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { AuthorsTagInput } from "@/components/cases/authors-tag-input";
 import {
@@ -54,6 +54,7 @@ export function CaseInformationSection({
 	canEdit,
 }: CaseInformationSectionProps) {
 	const {
+		forCaseId,
 		information,
 		loading,
 		saving,
@@ -82,11 +83,30 @@ export function CaseInformationSection({
 	// not yet saved (the "upload wipes unsaved fields" bug: uploading an
 	// image replaced `information` with the last-saved server values, and
 	// this effect used to reset the whole form to match, clobbering in-flight
-	// edits to Authors/Sector). Keyed on caseId so switching to a different
-	// case still re-hydrates the form.
-	const hydratedCaseIdRef = useRef<string | undefined>(undefined);
+	// edits to Authors/Sector).
+	//
+	// Gated on `forCaseId === caseId` rather than on `loading` alone —
+	// `useCaseInformation` reports `forCaseId`, the caseId the current
+	// `information` was actually fetched for, so hydration can't fire against
+	// a stale record that happens to still be in state when `loading` flips
+	// false on a fast case switch (the same-tick staleness window a purely
+	// timing-based guard couldn't see). Keyed on `forCaseId` so switching to a
+	// different case still re-hydrates the form once its own record arrives.
+	//
+	// Deliberately **state**, not a ref: `reset()` re-renders every
+	// `Controller`-backed field (react-hook-form gives each one a fresh
+	// `field.ref` closure per render, so Radix/our components re-attach their
+	// DOM ref as part of that commit). The focus effect below needs to run
+	// *after* that reattachment lands, and a ref write doesn't trigger a
+	// re-run of anything — only a state change reliably schedules the extra
+	// render that separates "hydrate" from "focus" into two commits. Calling
+	// `setFocus` in the very same effect flush as `reset()` silently no-ops
+	// (`setFocus`'s search for the field's DOM ref lands mid-reattachment).
+	const [hydratedForCaseId, setHydratedForCaseId] = useState<
+		string | undefined
+	>(undefined);
 	useEffect(() => {
-		if (loading || hydratedCaseIdRef.current === caseId) {
+		if (loading || forCaseId !== caseId || hydratedForCaseId === forCaseId) {
 			return;
 		}
 		reset({
@@ -95,23 +115,31 @@ export function CaseInformationSection({
 			sector: information?.sector ?? "",
 			featureImageUrl: information?.featureImageUrl ?? "",
 		});
-		hydratedCaseIdRef.current = caseId;
-	}, [information, reset, caseId, loading]);
+		setHydratedForCaseId(forCaseId);
+	}, [information, reset, caseId, forCaseId, loading, hydratedForCaseId]);
 
 	// The feature image is the one field a background upload/remove legitimately
 	// needs to push into the form after initial hydration — sync just that
 	// field (never the others) so it reflects the freshly uploaded URL.
 	useEffect(() => {
-		if (loading || hydratedCaseIdRef.current !== caseId) {
+		if (loading || hydratedForCaseId !== caseId) {
 			return;
 		}
 		setValue("featureImageUrl", information?.featureImageUrl ?? "");
-	}, [information?.featureImageUrl, setValue, caseId, loading]);
+	}, [
+		information?.featureImageUrl,
+		setValue,
+		caseId,
+		loading,
+		hydratedForCaseId,
+	]);
 
 	// The publish flow (ADR 0003 §2) sends the user here with a specific
 	// missing field named — focus it once the fetched values have synced in,
 	// then clear the request so a later manual open of this sheet doesn't
-	// re-focus anything.
+	// re-focus anything. Gated on `hydratedForCaseId === caseId` (not just
+	// `loading`) so this only fires on the commit *after* the hydration
+	// effect's `reset()` has settled — see the comment above.
 	const caseInformationFocusField = useStore(
 		(state) => state.caseInformationFocusField
 	);
@@ -119,7 +147,11 @@ export function CaseInformationSection({
 		(state) => state.setCaseInformationFocusField
 	);
 	useEffect(() => {
-		if (loading || !(canEdit && caseInformationFocusField)) {
+		if (
+			loading ||
+			hydratedForCaseId !== caseId ||
+			!(canEdit && caseInformationFocusField)
+		) {
 			return;
 		}
 		if (caseInformationFocusField in getValues()) {
@@ -128,6 +160,8 @@ export function CaseInformationSection({
 		setCaseInformationFocusField(null);
 	}, [
 		loading,
+		hydratedForCaseId,
+		caseId,
 		canEdit,
 		caseInformationFocusField,
 		getValues,
@@ -233,6 +267,7 @@ export function CaseInformationSection({
 							<FormControl>
 								<AuthorsTagInput
 									onChange={field.onChange}
+									ref={field.ref}
 									value={field.value ?? ""}
 								/>
 							</FormControl>
@@ -262,7 +297,7 @@ export function CaseInformationSection({
 									value={currentValue || undefined}
 								>
 									<FormControl>
-										<SelectTrigger>
+										<SelectTrigger ref={field.ref}>
 											<SelectValue placeholder="Select a sector" />
 										</SelectTrigger>
 									</FormControl>

--- a/components/cases/case-information-section.tsx
+++ b/components/cases/case-information-section.tsx
@@ -3,8 +3,9 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2 } from "lucide-react";
 import Image from "next/image";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
+import { AuthorsTagInput } from "@/components/cases/authors-tag-input";
 import {
 	Form,
 	FormControl,
@@ -14,7 +15,13 @@ import {
 	FormMessage,
 } from "@/components/ui/form";
 import { ImageUpload } from "@/components/ui/image-upload";
-import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
@@ -24,6 +31,7 @@ import type {
 	CaseInformationInput,
 } from "@/lib/schemas/case-information";
 import { upsertCaseInformationSchema } from "@/lib/schemas/case-information";
+import { sectors } from "@/lib/sectors";
 import useStore from "@/store/store";
 import { Button } from "../ui/button";
 
@@ -64,18 +72,41 @@ export function CaseInformationSection({
 			featureImageUrl: "",
 		},
 	});
-	const { reset, setFocus, getValues } = form;
+	const { reset, setValue, setFocus, getValues } = form;
 
-	// Sync fetched values into the form once they arrive (the form mounts
-	// before the fetch resolves).
+	// Sync fetched values into the form once, when the record for this case
+	// first arrives (the form mounts before the fetch resolves). Deliberately
+	// does NOT re-run on every `information` change — `information` is also
+	// updated by feature-image upload/remove and by a successful save, and a
+	// full `reset()` on those would overwrite whatever the user has typed but
+	// not yet saved (the "upload wipes unsaved fields" bug: uploading an
+	// image replaced `information` with the last-saved server values, and
+	// this effect used to reset the whole form to match, clobbering in-flight
+	// edits to Authors/Sector). Keyed on caseId so switching to a different
+	// case still re-hydrates the form.
+	const hydratedCaseIdRef = useRef<string | undefined>(undefined);
 	useEffect(() => {
+		if (loading || hydratedCaseIdRef.current === caseId) {
+			return;
+		}
 		reset({
 			description: information?.description ?? "",
 			authors: information?.authors ?? "",
 			sector: information?.sector ?? "",
 			featureImageUrl: information?.featureImageUrl ?? "",
 		});
-	}, [information, reset]);
+		hydratedCaseIdRef.current = caseId;
+	}, [information, reset, caseId, loading]);
+
+	// The feature image is the one field a background upload/remove legitimately
+	// needs to push into the form after initial hydration — sync just that
+	// field (never the others) so it reflects the freshly uploaded URL.
+	useEffect(() => {
+		if (loading || hydratedCaseIdRef.current !== caseId) {
+			return;
+		}
+		setValue("featureImageUrl", information?.featureImageUrl ?? "");
+	}, [information?.featureImageUrl, setValue, caseId, loading]);
 
 	// The publish flow (ADR 0003 §2) sends the user here with a specific
 	// missing field named — focus it once the fetched values have synced in,
@@ -200,9 +231,8 @@ export function CaseInformationSection({
 						<FormItem>
 							<FormLabel>Authors</FormLabel>
 							<FormControl>
-								<Input
-									placeholder="e.g. Ada Lovelace"
-									{...field}
+								<AuthorsTagInput
+									onChange={field.onChange}
 									value={field.value ?? ""}
 								/>
 							</FormControl>
@@ -213,19 +243,46 @@ export function CaseInformationSection({
 				<FormField
 					control={form.control}
 					name="sector"
-					render={({ field }) => (
-						<FormItem>
-							<FormLabel>Sector</FormLabel>
-							<FormControl>
-								<Input
-									placeholder="e.g. Healthcare"
-									{...field}
-									value={field.value ?? ""}
-								/>
-							</FormControl>
-							<FormMessage />
-						</FormItem>
-					)}
+					render={({ field }) => {
+						// A case saved before this select existed can hold a
+						// free-text sector value that isn't in the canonical
+						// list (e.g. "Healthcare"). Tolerate it: show it as
+						// the current selection rather than crashing or
+						// silently discarding it — replacing it with a
+						// canonical choice is the user's action, not ours.
+						const currentValue = field.value ?? "";
+						const isLegacyValue =
+							currentValue !== "" &&
+							!sectors.some((sector) => sector.Name === currentValue);
+						return (
+							<FormItem>
+								<FormLabel>Sector</FormLabel>
+								<Select
+									onValueChange={field.onChange}
+									value={currentValue || undefined}
+								>
+									<FormControl>
+										<SelectTrigger>
+											<SelectValue placeholder="Select a sector" />
+										</SelectTrigger>
+									</FormControl>
+									<SelectContent>
+										{isLegacyValue && (
+											<SelectItem value={currentValue}>
+												{currentValue} (legacy value)
+											</SelectItem>
+										)}
+										{sectors.map((sector) => (
+											<SelectItem key={sector.ID} value={sector.Name}>
+												{sector.Name}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+								<FormMessage />
+							</FormItem>
+						);
+					}}
 				/>
 				<div className="space-y-2">
 					<span className="font-medium text-sm">Feature image</span>

--- a/components/publishing/__tests__/status-modal-wrapper.test.tsx
+++ b/components/publishing/__tests__/status-modal-wrapper.test.tsx
@@ -24,6 +24,7 @@ function stubCaseInformation(
 	overrides: Partial<ReturnType<typeof useCaseInformation>>
 ) {
 	mockedUseCaseInformation.mockReturnValue({
+		forCaseId: CASE_ID,
 		information: null,
 		loading: false,
 		saving: false,

--- a/components/publishing/__tests__/status-modal.test.tsx
+++ b/components/publishing/__tests__/status-modal.test.tsx
@@ -21,6 +21,7 @@ function stubCaseInformation(
 	overrides: Partial<ReturnType<typeof useCaseInformation>>
 ) {
 	mockedUseCaseInformation.mockReturnValue({
+		forCaseId: "case-1",
 		information: null,
 		loading: false,
 		saving: false,

--- a/e2e/publish-journey.spec.ts
+++ b/e2e/publish-journey.spec.ts
@@ -41,7 +41,10 @@ const CASE_INFO = {
 	description:
 		"A worked example built for end-to-end publish-journey coverage.",
 	authors: "E2E Test Suite",
-	sector: "Technology",
+	// Must be a canonical value from `lib/sectors.ts` (ADR 0003 §1) — the
+	// Sector field is a Radix Select, not free text, so an arbitrary string
+	// can't be chosen.
+	sector: "Information, Communication & Media",
 };
 const NEW_STRATEGY_DESCRIPTION = "New strategy added for divergence coverage";
 
@@ -100,8 +103,19 @@ test.describe("ADR 0003 — publish journey", () => {
 		// its own "Description" label.
 		const infoForm = page.getByTestId("case-information-form");
 		await infoForm.getByLabel("Description").fill(CASE_INFO.description);
+
+		// Authors is a tag input (AuthorsTagInput): typing text alone never
+		// commits it — press Enter to add the chip, then assert it rendered.
 		await infoForm.getByLabel("Authors").fill(CASE_INFO.authors);
-		await infoForm.getByLabel("Sector").fill(CASE_INFO.sector);
+		await infoForm.getByLabel("Authors").press("Enter");
+		await expect(
+			infoForm.getByTestId("authors-tag-list").getByText(CASE_INFO.authors)
+		).toBeVisible();
+
+		// Sector is a Radix Select, not free text: open it and choose the
+		// canonical option.
+		await infoForm.getByLabel("Sector").click();
+		await page.getByRole("option", { name: CASE_INFO.sector }).click();
 
 		await Promise.all([
 			page.waitForResponse(

--- a/hooks/__tests__/use-case-information.test.ts
+++ b/hooks/__tests__/use-case-information.test.ts
@@ -34,6 +34,26 @@ describe("useCaseInformation", () => {
 		expect(result.current.information?.description).toBe("A worked example");
 	});
 
+	it("reports forCaseId matching the caseId the record was fetched for", async () => {
+		server.use(
+			http.get(INFORMATION_PATH, () =>
+				HttpResponse.json({
+					description: "A worked example",
+					authors: "Ada Lovelace",
+					sector: "Healthcare",
+					featureImageUrl: null,
+				})
+			)
+		);
+
+		const { result } = renderHook(() => useCaseInformation(CASE_ID));
+
+		expect(result.current.forCaseId).toBeUndefined();
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.forCaseId).toBe(CASE_ID);
+	});
+
 	it("resolves to null information when the case has none yet", async () => {
 		server.use(http.get(INFORMATION_PATH, () => HttpResponse.json(null)));
 

--- a/hooks/use-case-information.ts
+++ b/hooks/use-case-information.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { CaseInformationData } from "@/lib/schemas/case-information";
 // Reusing the service's snapshot shape rather than hand-declaring a parallel
 // type: it already names exactly the four case-information fields (ADR 0003
@@ -9,6 +9,15 @@ import type { CaseInformationSnapshot } from "@/lib/services/case-information-se
 import { toast } from "@/lib/toast";
 
 interface UseCaseInformationReturn {
+	/**
+	 * The caseId that `information` was fetched for. Consumers that hydrate
+	 * local state from `information` (e.g. a form's `reset()`) should gate on
+	 * `forCaseId === caseId` rather than on `loading` alone — `loading` only
+	 * says a request finished, not which case it was for, and a fast
+	 * caseId-switch can otherwise land a stale record against the new case in
+	 * the same tick.
+	 */
+	forCaseId: string | undefined;
 	information: CaseInformationSnapshot | null;
 	loading: boolean;
 	removeFeatureImage: () => Promise<boolean>;
@@ -29,29 +38,52 @@ export function useCaseInformation(
 ): UseCaseInformationReturn {
 	const [information, setInformation] =
 		useState<CaseInformationSnapshot | null>(null);
+	const [forCaseId, setForCaseId] = useState<string | undefined>(undefined);
 	const [loading, setLoading] = useState(true);
 	const [saving, setSaving] = useState(false);
 	const [uploadingImage, setUploadingImage] = useState(false);
 
+	// Tracks the most recently *requested* caseId so an in-flight fetch that
+	// resolves after a later caseId change (e.g. a fast case switch) doesn't
+	// stamp its result with the wrong provenance — the response is ignored
+	// once a newer request has superseded it.
+	const latestRequestedCaseIdRef = useRef<string | undefined>(undefined);
+
 	const fetchInformation = useCallback(async () => {
-		if (!caseId) {
+		const requestedCaseId = caseId;
+		latestRequestedCaseIdRef.current = requestedCaseId;
+
+		if (!requestedCaseId) {
 			setLoading(false);
+			setInformation(null);
+			setForCaseId(undefined);
 			return;
 		}
 
 		setLoading(true);
 		try {
-			const response = await fetch(`/api/cases/${caseId}/information`);
+			const response = await fetch(`/api/cases/${requestedCaseId}/information`);
+			if (latestRequestedCaseIdRef.current !== requestedCaseId) {
+				return;
+			}
 			if (!response.ok) {
 				setInformation(null);
+				setForCaseId(requestedCaseId);
 				return;
 			}
 			const data = await response.json();
 			setInformation(data);
+			setForCaseId(requestedCaseId);
 		} catch {
+			if (latestRequestedCaseIdRef.current !== requestedCaseId) {
+				return;
+			}
 			setInformation(null);
+			setForCaseId(requestedCaseId);
 		} finally {
-			setLoading(false);
+			if (latestRequestedCaseIdRef.current === requestedCaseId) {
+				setLoading(false);
+			}
 		}
 	}, [caseId]);
 
@@ -187,6 +219,7 @@ export function useCaseInformation(
 	}, [caseId]);
 
 	return {
+		forCaseId,
 		information,
 		loading,
 		saving,

--- a/lib/sectors.ts
+++ b/lib/sectors.ts
@@ -1,0 +1,178 @@
+/**
+ * Canonical sector list for case information (ADR 0003 §1). Recovered from
+ * git history — this lived as the `sectors` export in `config/index.ts`
+ * until commit ee15d369 removed it as (then) dead code. It backs the
+ * publish-completion pane's Sector select, replacing a free-text input.
+ *
+ * 20 broad sectors mapped to ISIC/NACE classification codes, chosen for
+ * plain-English recognisability over exhaustive standards coverage.
+ */
+export interface Sector {
+	Description: string;
+	ID: number;
+	ISICcode: string;
+	NACEcode: string;
+	Name: string;
+}
+
+export const sectors: Sector[] = [
+	{
+		ID: 1,
+		Name: "Agriculture, Forestry & Fishing",
+		Description:
+			"Growing crops, raising animals, managing forests and catching fish to supply food and raw materials.",
+		ISICcode: "A",
+		NACEcode: "A",
+	},
+	{
+		ID: 2,
+		Name: "Mining, Quarrying & Extraction",
+		Description:
+			"Digging or drilling the earth for minerals, metals, stone, oil and gas that feed industry and energy systems.",
+		ISICcode: "B",
+		NACEcode: "B",
+	},
+	{
+		ID: 3,
+		Name: "Energy Production & Supply",
+		Description:
+			"Generating and distributing electricity, heat, oil, gas and renewable power that keep homes, businesses and transport running.",
+		ISICcode: "D",
+		NACEcode: "D",
+	},
+	{
+		ID: 4,
+		Name: "Utilities & Environmental Services",
+		Description:
+			"Delivering clean water, treating wastewater, collecting rubbish and recycling, and cleaning up pollution.",
+		ISICcode: "E",
+		NACEcode: "E",
+	},
+	{
+		ID: 5,
+		Name: "Construction & Civil Engineering",
+		Description:
+			"Building and maintaining houses, offices, roads, bridges and other physical infrastructure.",
+		ISICcode: "F",
+		NACEcode: "F",
+	},
+	{
+		ID: 6,
+		Name: "Manufacturing & Industrial Production",
+		Description: "Turning raw or semi-processed materials into finished goods.",
+		ISICcode: "C",
+		NACEcode: "C",
+	},
+	{
+		ID: 7,
+		Name: "Wholesale & Retail Trade",
+		Description:
+			"Buying goods in bulk and selling them on to shops or directly to consumers in stores and online.",
+		ISICcode: "G",
+		NACEcode: "G",
+	},
+	{
+		ID: 8,
+		Name: "Transportation & Logistics",
+		Description:
+			"Moving people and goods by road, rail, air, sea and pipelines, plus warehousing and delivery services.",
+		ISICcode: "H",
+		NACEcode: "H",
+	},
+	{
+		ID: 9,
+		Name: "Information, Communication & Media",
+		Description:
+			"Creating, processing and transmitting data, software, news, entertainment and telecoms services.",
+		ISICcode: "J",
+		NACEcode: "J",
+	},
+	{
+		ID: 10,
+		Name: "Financial Services",
+		Description:
+			"Managing money through banking, investment, insurance, pensions and related advisory activities.",
+		ISICcode: "K",
+		NACEcode: "K",
+	},
+	{
+		ID: 11,
+		Name: "Real-Estate & Property Management",
+		Description:
+			"Buying, selling, renting and looking after land and buildings for living, working or investment.",
+		ISICcode: "L",
+		NACEcode: "L",
+	},
+	{
+		ID: 12,
+		Name: "Professional, Scientific & Technical Services",
+		Description:
+			"Providing expert knowledge such as engineering design, R&D, consulting, accountancy and advertising.",
+		ISICcode: "M",
+		NACEcode: "M",
+	},
+	{
+		ID: 13,
+		Name: "Public Administration, Defence & Security",
+		Description:
+			"Government bodies that make policy, deliver public services and protect national safety.",
+		ISICcode: "O",
+		NACEcode: "O",
+	},
+	{
+		ID: 14,
+		Name: "Education & Training",
+		Description:
+			"Schools, colleges, universities and lifelong learning organisations that teach skills and capabilities.",
+		ISICcode: "P",
+		NACEcode: "P",
+	},
+	{
+		ID: 15,
+		Name: "Health & Social Care",
+		Description:
+			"Hospitals, clinics, care homes and community services that maintain physical and mental well-being.",
+		ISICcode: "Q",
+		NACEcode: "Q",
+	},
+	{
+		ID: 16,
+		Name: "Accommodation, Food Service & Tourism",
+		Description:
+			"Hotels, restaurants, cafés and travel operators that host, feed and entertain visitors.",
+		ISICcode: "I, N",
+		NACEcode: "I, N",
+	},
+	{
+		ID: 17,
+		Name: "Arts, Entertainment & Creative Industries",
+		Description:
+			"Producing culture and leisure activities such as music, film, gaming, museums and live events.",
+		ISICcode: "R",
+		NACEcode: "R",
+	},
+	{
+		ID: 18,
+		Name: "Legal Services & Justice",
+		Description:
+			"Solicitors, barristers, courts and mediation bodies that advise on and enforce the law.",
+		ISICcode: "M, O",
+		NACEcode: "M, O",
+	},
+	{
+		ID: 19,
+		Name: "Personal & Other Community Services",
+		Description:
+			"Everyday support such as hairdressing, dry-cleaning, household repairs, gyms and charities.",
+		ISICcode: "N, S, T",
+		NACEcode: "N, S, T",
+	},
+	{
+		ID: 20,
+		Name: "Extraterrestrial & International Organisations",
+		Description:
+			"Embassies, UN agencies, the International Space Station and other bodies operating outside national jurisdictions.",
+		ISICcode: "U",
+		NACEcode: "U",
+	},
+];

--- a/src/__tests__/mocks/radix-ui-mocks.tsx
+++ b/src/__tests__/mocks/radix-ui-mocks.tsx
@@ -995,11 +995,14 @@ export const MockSelectRoot = ({
 	);
 };
 
-export const MockSelectTrigger = ({
-	children,
-	asChild: _asChild,
-	...props
-}: MockTriggerProps) => {
+type MockSelectTriggerProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+	asChild?: boolean;
+};
+
+export const MockSelectTrigger = React.forwardRef<
+	HTMLButtonElement,
+	MockSelectTriggerProps
+>(({ children, asChild: _asChild, ...props }, ref) => {
 	const context = React.useContext(SelectContext);
 
 	const handleClick = () => {
@@ -1013,6 +1016,7 @@ export const MockSelectTrigger = ({
 			aria-haspopup="listbox"
 			data-state={context?.open ? "open" : "closed"}
 			onClick={handleClick}
+			ref={ref}
 			role="combobox"
 			type="button"
 			{...props}
@@ -1020,7 +1024,8 @@ export const MockSelectTrigger = ({
 			{children}
 		</button>
 	);
-};
+});
+MockSelectTrigger.displayName = "MockSelectTrigger";
 
 export const MockSelectValue = ({ placeholder }: { placeholder?: string }) => {
 	const context = React.useContext(SelectContext);


### PR DESCRIPTION
## Summary

Fixes the three completion-pane defects from the 2026-08-12 staging walkthrough (findings 1–3).

- **Bug fix (data loss):** uploading a feature image wiped unsaved Author(s)/Sector text — the form-reset effect re-fired on every server-state change and clobbered in-flight edits when the upload response landed. Hydration is now provenance-based (the hook reports which case its data belongs to; the form hydrates once per case) with a narrow image-only sync for uploads/removals. Regression test verified to fail on the pre-fix component.
- **Focus-flow repair:** fixing the above exposed a pre-existing bug — the publish gate's "focus the missing field" mechanism raced the hydration reset and silently no-oped for every field. Focus now fires on the commit after hydration settles, refs are forwarded through both new controls, and two tests assert `document.activeElement`. (A repo-wide test-mock gap that masked this ref class is also fixed.)
- **Sector:** free text → select bound to the canonical 20-sector list (restored to `lib/sectors.ts`); legacy out-of-list values are displayed and selectable until the user replaces them with a canonical choice.
- **Author(s):** tag-style multi-entry (Enter adds a chip) with helper text and an info tooltip; values stored as the existing comma-joined string — no schema or migration change. Legacy values load as chips.
- Journey e2e updated to drive the new controls (chip entry, select option) with a canonical sector value.

## Review chain

- QA: PASS — headline regression test confirmed genuine (fails on pre-fix code); three test-gap findings, all implemented (case-switch reset, legacy comma-split load, legacy-sector remediation).
- Code review: initial REQUEST-CHANGES (lost `field.ref` forwarding broke the missing-field focus flow) — fixed, focused re-review APPROVE. Accessibility attributes now forwarded and merged.
- Suite on final commit: lint/typecheck clean, unit 1276/1276, integration green vs real Postgres, e2e journey+publishing 7/7.