### PR TITLE
fix: correct local Docker entrypoint and move build out of the memory cap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,8 +129,10 @@ Risk-tiered, integration-heavy ("testing trophy", not pyramid):
 ## Local development
 
 - Docker dev stack: `docker-compose -f docker-compose.local.yml up -d --build`.
-  **Never `docker-compose down -v`** — it wipes the local database volume. To
-  pick up new npm packages, remove only `assuranceplatform_node_modules_dev`.
+  **Never `docker-compose down -v`** — it wipes the local database volume. The
+  image bakes source and dependencies in at build time (no source bind
+  mount), so `--build` alone picks up new npm packages and source changes;
+  there is no separate volume to clear.
 - Docs run in production mode inside Docker (Nextra 4 dev-mode crash); for hot
   reload run `pnpm dev` on the host against Docker's Postgres.
 - Seed test users: `chris`, `alice`, `bob`, `charlie` (password from the

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,32 +1,64 @@
 # syntax=docker/dockerfile:1
+#
+# Local development image for docker-compose.local.yml.
+#
+# Multi-stage on purpose: `pnpm build` (and its Nextra + Next.js compile,
+# measured at ~12.7GB peak RSS on a clean build) now runs during `docker
+# build`, which is a separate BuildKit process NOT subject to the compose
+# service's `mem_limit`. Only the running server is memory-capped at runtime.
+# This replaces the previous design, which ran `pnpm run build` inside the
+# running container's `command:` — sharing its cgroup with `mem_limit` and
+# getting OOM-killed (exit 137) at 6g.
+#
+# Rebuild after every source change:
+#   docker compose -f docker-compose.local.yml up -d --build
+# Docker's layer cache keys the rebuild to file content (the `COPY . .` layer
+# below): unchanged source -> cached, near-instant `--build`; changed source
+# -> that layer and everything after it (prisma generate, pnpm build) reruns.
+# There is no BUILD_ID-existence check to silently go stale.
 
-FROM node:20-alpine
+FROM node:20-alpine AS deps
 
-# Install dependencies needed for compatibility and native modules (argon2)
 RUN apk add --no-cache libc6-compat python3 make g++
 
 WORKDIR /app
 
-# Copy package files and patches (pnpm needs patches during install)
 COPY package.json pnpm-lock.yaml ./
 COPY patches/ ./patches/
 
-# Install dependencies with pnpm store cache for faster rebuilds
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
     corepack enable pnpm && pnpm i --frozen-lockfile
 
-# Copy source code
+FROM node:20-alpine AS builder
+
+RUN apk add --no-cache libc6-compat python3 make g++
+
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# Generate Prisma clients (DATABASE_URL not needed for generate, but config requires it)
-RUN DATABASE_URL="postgresql://placeholder:placeholder@localhost:5432/placeholder" \
-    npx prisma generate --schema=prisma/schema.prisma
+# Dummy DATABASE_URL: only needed to satisfy Prisma config validation and
+# Next.js static analysis at build time, not a real connection. The real URL
+# is supplied at container runtime via env_file/environment (see compose).
+ENV DATABASE_URL="postgresql://placeholder:placeholder@localhost:5432/placeholder"
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 
-# Note: Documentation is now built as part of Next.js (Nextra integration)
-# No separate tea-docs build step needed
+RUN npx prisma generate --schema=prisma/schema.prisma
+RUN corepack enable pnpm && pnpm build
 
-# Expose port
+FROM node:20-alpine AS runner
+
+RUN apk add --no-cache libc6-compat
+
+WORKDIR /app
+
+# Full builder tree (source, devDependencies, prisma CLI, tsx, full .next
+# output), not the trimmed `.next/standalone` bundle: the dev seed script
+# (prisma/seed/dev-seed.ts) needs tsx + the project's own service modules,
+# which standalone's dependency tracing does not include.
+COPY --from=builder /app ./
+
 EXPOSE 3000
 
-# Start development server
-CMD ["sh", "-c", "corepack enable pnpm && pnpm dev"]
+CMD ["sh", "-c", "npx prisma migrate deploy && npx tsx prisma/seed/dev-seed.ts && npx next start"]

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -33,21 +33,32 @@ services:
     environment:
       # Override DATABASE_URL to use Docker network hostname
       - DATABASE_URL=postgresql://tea_user:tea_password@postgres:5432/tea_dev
-      # Increase Node.js memory limit for Next.js dev server
-      - NODE_OPTIONS=--max-old-space-size=4096
-    volumes:
-      - .:/app
-      - app_next:/app/.next
-      - node_modules_dev:/app/node_modules
+      # V8 heap cap for the running Next.js server. Kept well under mem_limit
+      # (below) so V8's own GC pressure valve kicks in before the kernel
+      # OOM-killer does - a heap cap close to or above the cgroup limit lets
+      # V8 grow toward it and get killed (exit 137) instead of collecting.
+      - NODE_OPTIONS=--max-old-space-size=1536
     networks:
       - tea_dev_network
-    # Memory limit (requires docker-compose v2)
-    mem_limit: 6g
-    memswap_limit: 6g
-    # Run in production mode to avoid Nextra dev compilation crashes
-    # For hot reload, run `pnpm dev` on localhost instead
+    # Runtime memory limit only. The Next.js/Nextra production build (measured
+    # ~12.7GB peak RSS) now runs during `docker build` (Dockerfile.dev), which
+    # is not subject to this limit. Measured peak RSS for migrate + seed +
+    # `next start` + several requests, with NODE_OPTIONS capped at 1536m
+    # above: ~472MiB (cgroup memory.peak = 495042560 bytes), so 2g leaves
+    # comfortable headroom on both the heap cap and the container limit;
+    # raise either if the app itself needs more.
+    mem_limit: 2g
+    memswap_limit: 2g
+    # Run in production mode to avoid Nextra dev compilation crashes.
+    # For hot reload, run `pnpm dev` on the host against this stack's Postgres.
+    #
+    # No bind mount of source: this image bakes the checked-out source in at
+    # `docker build` time (see Dockerfile.dev). After any source change,
+    # recreate with `docker compose -f docker-compose.local.yml up -d --build`
+    # to get a fresh build - Docker's layer cache makes this a fast no-op when
+    # nothing changed and a real rebuild when something did.
     command:
-      sh -c "npx prisma migrate deploy && npx tsx prisma/seed/dev-seed.ts && if [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build && pnpm start; else npm run build && npm start; fi"
+      sh -c "npx prisma migrate deploy && npx tsx prisma/seed/dev-seed.ts && npx next start"
 
 networks:
   tea_dev_network:
@@ -55,7 +66,3 @@ networks:
 
 volumes:
   postgres_data:
-  app_next:
-  # Named volume for container's node_modules (Linux binaries, separate from host's macOS binaries)
-  # Clear when dependencies change: docker volume rm assuranceplatform_node_modules_dev
-  node_modules_dev:


### PR DESCRIPTION
## Summary

Fixes two coupled defects in the local Docker stack (`docker-compose.local.yml` + `Dockerfile.dev`):

1. **Broken entrypoint for standalone output.** The compose command ran `pnpm start` (`node server.js` at `/app`), but `next.config.mjs` produces `output: standalone` for non-dev builds, so a genuinely fresh container failed with `Cannot find module '/app/server.js'`.
2. **In-container builds OOM-killed at `mem_limit: 6g`.** A clean production build peaks ~12.7GB RSS; the old command ran the build inside the running container's cgroup, so fresh builds died (exit 137).

## Changes

- `Dockerfile.dev` rewritten as a three-stage build (`deps` → `builder` → `runner`): the production build now runs during `docker build`, outside the compose memory limit.
- Compose command reduced to `migrate deploy` → dev seed → `npx next start`; whole-repo bind mount and build-cache volumes dropped — rebuilds are keyed to Docker's content-addressed layer cache, so a source change genuinely rebuilds and an unchanged tree is a fast no-op (no stale builds can silently serve).
- Runtime `mem_limit` lowered 6g → 2g (runtime only), with `NODE_OPTIONS=--max-old-space-size=1536` kept safely under the cgroup cap. Measured peak across migrate + seed + start + requests: ~472MiB.
- `CLAUDE.md` local-stack instructions updated to match (rebuild via `up -d --build`; stale volume-clearing advice removed).

## Verification

- Fresh `up -d --build` from empty volumes: migrations + seed complete, app serves, built image traced to the exact source commit.
- Edit-then-rebuild demonstrated with a temporary marker in the health route (served only after `--build`).
- Independent QA on an isolated stack: `/`, `/login`, `/docs` 200; `/dashboard` 307 auth redirect; sampled `/_next/static` chunks all 200 with a 404 negative control; logs clean apart from Next's known cosmetic `next start`-with-standalone warning (verified harmless — the image ships the full build tree).
- Memory under smoke load: ~264MiB of the 2GiB cap.

## Notes

- Local dev workflow change: source edits now require `docker compose -f docker-compose.local.yml up -d --build` (as the repo docs already instructed) — the live-edit bind mount is gone.
- Diff touches no TS/JS source (compose, Dockerfile, docs only).