### PR TITLE
Serve local-storage uploads through a route handler (fixes 404-until-restart on standalone builds)

### DIFF
--- a/app/uploads/[...path]/route.ts
+++ b/app/uploads/[...path]/route.ts
@@ -68,6 +68,36 @@ function notFound(): NextResponse {
 	return new NextResponse(null, { status: 404 });
 }
 
+function serverError(): NextResponse {
+	return new NextResponse(null, { status: 500 });
+}
+
+/**
+ * Opens a read stream and waits for it to actually open (or fail) before
+ * returning. `stat()` succeeding is not a guarantee the file is still there
+ * by the time we read it — it can be deleted, or become unreadable, in the
+ * window between the two calls. Resolving/rejecting on the stream's `open`/
+ * `error` event (rather than handing back a lazily-opened stream) lets the
+ * caller still choose a clean status code for that race, because nothing has
+ * been written to the response yet.
+ */
+async function openReadStream(
+	filePath: string
+): Promise<ReturnType<typeof createReadStream>> {
+	return await new Promise((resolvePromise, rejectPromise) => {
+		const readStream = createReadStream(filePath);
+		const onError = (err: unknown) => {
+			readStream.destroy();
+			rejectPromise(err);
+		};
+		readStream.once("error", onError);
+		readStream.once("open", () => {
+			readStream.off("error", onError);
+			resolvePromise(readStream);
+		});
+	});
+}
+
 export async function GET(_request: NextRequest, { params }: RouteParams) {
 	const { path: segments } = await params;
 	const filePath = resolveSafePath(segments);
@@ -87,18 +117,48 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
 		return notFound();
 	}
 
+	let nodeStream: Awaited<ReturnType<typeof openReadStream>>;
+	try {
+		nodeStream = await openReadStream(filePath);
+	} catch (err) {
+		// Opening still failed even though stat() just succeeded — most
+		// commonly the file was deleted in between. Nothing has been sent to
+		// the client yet, so we can still return a clean status instead of
+		// letting the stream surface an unhandled error later.
+		const code = (err as NodeJS.ErrnoException).code;
+		return code === "ENOENT" ? notFound() : serverError();
+	}
+
+	// From here on the stream is open and NextResponse below commits status
+	// 200 — headers are sent as soon as the framework starts consuming the
+	// body, so a failure past this point (e.g. a mid-read disk error) can no
+	// longer change the status code. Without an error listener, that failure
+	// would be an unhandled 'error' event; the best we can do is destroy the
+	// stream so the connection aborts/truncates instead of hanging or
+	// crashing the process.
+	nodeStream.on("error", (err) => {
+		// No structured logger exists in this codebase yet (CLAUDE.md names
+		// one; other server code paths without one use console.error too) —
+		// this is the same prevailing pattern, not a deviation introduced
+		// here.
+		console.error("[uploads] stream error after response started:", err);
+		nodeStream.destroy();
+	});
+
 	const contentType = getMimeTypeFromExtension(extname(filePath));
-	const stream = Readable.toWeb(
-		createReadStream(filePath)
-	) as ReadableStream<Uint8Array>;
+	const stream = Readable.toWeb(nodeStream) as ReadableStream<Uint8Array>;
 
 	return new NextResponse(stream, {
 		status: 200,
 		headers: {
 			"Content-Type": contentType,
 			"Content-Length": String(fileStat.size),
-			// Uploaded filenames are randomUUID-based, so a given URL's
-			// content never changes; safe to cache aggressively.
+			"X-Content-Type-Options": "nosniff",
+			// Every upload is written under a freshly-minted URL (a random
+			// UUID on the /information/image path, a caseId+timestamp on the
+			// screenshot local-fallback path) — whichever scheme, a given
+			// URL's content never changes, so it's safe to cache
+			// aggressively.
 			"Cache-Control": "public, max-age=31536000, immutable",
 		},
 	});

--- a/app/uploads/[...path]/route.ts
+++ b/app/uploads/[...path]/route.ts
@@ -1,0 +1,105 @@
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { extname, resolve, sep } from "node:path";
+import { Readable } from "node:stream";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { getMimeTypeFromExtension } from "@/lib/services/blob-storage-service";
+
+/**
+ * Serves locally-stored uploads (self-hosted / `USE_LOCAL_STORAGE=true`
+ * deployments) at runtime.
+ *
+ * Next's standalone production server serves `public/` from a filesystem
+ * path set it computes once at startup, so files written to
+ * `public/uploads/` *after* the process has started 404 until the next
+ * restart — verified empirically (file present on disk, URL 404, restart
+ * flips it to 200). This route handler is a fallback: Next's static-file
+ * check runs before app routing and still wins for anything present at
+ * startup (unchanged behaviour), but for a path that check misses, the
+ * request falls through to here and we stream the file straight off disk,
+ * so uploads work without a restart.
+ *
+ * Not run through the envelope pattern (`apiSuccess`/`apiError`) — like the
+ * SSE and health routes, this serves a binary payload, not JSON.
+ */
+
+const UPLOAD_ROOT = resolve(process.cwd(), "public", "uploads");
+
+interface RouteParams {
+	params: Promise<{ path: string[] }>;
+}
+
+/**
+ * Resolves the requested path segments to an absolute filesystem path,
+ * rejecting anything that could escape `UPLOAD_ROOT` — traversal segments
+ * (`..`, `.`), empty segments, and segments carrying a raw separator or NUL
+ * byte (which would only appear via a doubly-encoded or malformed path,
+ * since Next has already URL-decoded each segment by this point). Returns
+ * `null` for anything rejected, and re-checks containment on the resolved
+ * path as a second, independent guard.
+ */
+function resolveSafePath(segments: string[]): string | null {
+	if (segments.length === 0) {
+		return null;
+	}
+
+	for (const segment of segments) {
+		if (
+			!segment ||
+			segment === "." ||
+			segment === ".." ||
+			segment.includes("/") ||
+			segment.includes("\\") ||
+			segment.includes("\0")
+		) {
+			return null;
+		}
+	}
+
+	const candidate = resolve(UPLOAD_ROOT, ...segments);
+	const isWithinRoot =
+		candidate === UPLOAD_ROOT || candidate.startsWith(UPLOAD_ROOT + sep);
+
+	return isWithinRoot ? candidate : null;
+}
+
+function notFound(): NextResponse {
+	return new NextResponse(null, { status: 404 });
+}
+
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+	const { path: segments } = await params;
+	const filePath = resolveSafePath(segments);
+
+	if (!filePath) {
+		return notFound();
+	}
+
+	let fileStat: Awaited<ReturnType<typeof stat>>;
+	try {
+		fileStat = await stat(filePath);
+	} catch {
+		return notFound();
+	}
+
+	if (!fileStat.isFile()) {
+		return notFound();
+	}
+
+	const contentType = getMimeTypeFromExtension(extname(filePath));
+	const stream = Readable.toWeb(
+		createReadStream(filePath)
+	) as ReadableStream<Uint8Array>;
+
+	return new NextResponse(stream, {
+		status: 200,
+		headers: {
+			"Content-Type": contentType,
+			"Content-Length": String(fileStat.size),
+			// Uploaded filenames are randomUUID-based, so a given URL's
+			// content never changes; safe to cache aggressively.
+			"Cache-Control": "public, max-age=31536000, immutable",
+		},
+	});
+}

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -68,4 +68,26 @@ describe("middleware route matcher", () => {
 			expect(re.test(path)).toBe(true);
 		}
 	});
+
+	it("exempts every route under uploads from session auth, regardless of extension", async () => {
+		const re = await getMatcherRegex();
+		const uploadPaths = [
+			"/uploads",
+			"/uploads/cases/123/case-information/abc.png",
+			// .gif and .webp aren't in the file-extension exemption list
+			// below, so without a dedicated `uploads` exemption these two
+			// (both in ALLOWED_MIME_TYPES, lib/services/file-storage-service.ts)
+			// would 307-redirect to /login same as any other protected route.
+			"/uploads/cases/123/case-information/abc.gif",
+			"/uploads/cases/123/case-information/abc.webp",
+		];
+		for (const path of uploadPaths) {
+			expect(re.test(path)).toBe(false);
+		}
+	});
+
+	it("boundary-anchors uploads — a hypothetical /uploadsfoo stays protected", async () => {
+		const re = await getMatcherRegex();
+		expect(re.test("/uploadsfoo")).toBe(true);
+	});
 });

--- a/middleware.ts
+++ b/middleware.ts
@@ -100,7 +100,10 @@ export const config = {
 		 *   `/login` even for files that existed at build time (the file
 		 *   extension list happened to cover `.png`/`.jpg`/`.jpeg` but not
 		 *   every `ALLOWED_MIME_TYPES` extension); a bare `uploads` prefix
-		 *   here covers all of them without relying on an extension list.)
+		 *   here covers all of them without relying on an extension list.
+		 *   This exemption is extension-independent by construction: anything
+		 *   a future writer places under `public/uploads` becomes publicly
+		 *   readable, regardless of what it is.)
 		 *
 		 * Each of the five `api/*` prefixes above is boundary-anchored
 		 * (`(?:/|$)`) rather than a bare string prefix — otherwise a

--- a/middleware.ts
+++ b/middleware.ts
@@ -90,6 +90,17 @@ export const config = {
 		 * - _next/image (image optimization files)
 		 * - favicon.ico (favicon file)
 		 * - public folder
+		 * - uploads (locally-stored user uploads — served via the
+		 *   `/uploads/[...path]` route handler at runtime, or straight off
+		 *   `public/` for anything present at build time; these are the same
+		 *   URLs Azure Blob Storage returns in production, which are public
+		 *   by URL, so this exemption keeps both storage backends behaving
+		 *   the same way. Without it, uploads whose extension isn't in the
+		 *   `.*\.ext$` list below — `.gif`, `.webp` — were 307-redirected to
+		 *   `/login` even for files that existed at build time (the file
+		 *   extension list happened to cover `.png`/`.jpg`/`.jpeg` but not
+		 *   every `ALLOWED_MIME_TYPES` extension); a bare `uploads` prefix
+		 *   here covers all of them without relying on an extension list.)
 		 *
 		 * Each of the five `api/*` prefixes above is boundary-anchored
 		 * (`(?:/|$)`) rather than a bare string prefix — otherwise a
@@ -100,6 +111,6 @@ export const config = {
 		 * existing route under any of the five prefixes relies on the
 		 * looser match, so all five are anchored the same way.
 		 */
-		"/((?!api/auth(?:/|$)|api/cron(?:/|$)|api/machine(?:/|$)|api/health(?:/|$)|api/public(?:/|$)|api/users/register|_next/static|_next/image|favicon.ico|images|data|.*\\.png$|.*\\.jpg$|.*\\.jpeg$|.*\\.svg$|.*\\.json$|.*\\.html$).*)",
+		"/((?!api/auth(?:/|$)|api/cron(?:/|$)|api/machine(?:/|$)|api/health(?:/|$)|api/public(?:/|$)|api/users/register|_next/static|_next/image|favicon.ico|images|data|uploads(?:/|$)|.*\\.png$|.*\\.jpg$|.*\\.jpeg$|.*\\.svg$|.*\\.json$|.*\\.html$).*)",
 	],
 };

--- a/src/__tests__/integration/api-uploads-route.test.ts
+++ b/src/__tests__/integration/api-uploads-route.test.ts
@@ -1,0 +1,124 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it } from "vitest";
+
+const UPLOAD_ROOT = join(process.cwd(), "public", "uploads");
+
+// Subdirectory scoped to this test file so cleanup can't collide with a
+// concurrent worker or leftover files from other suites.
+const TEST_SUBDIR = `route-test-${randomUUID()}`;
+const TEST_DIR = join(UPLOAD_ROOT, TEST_SUBDIR);
+
+async function writeUploadedFile(
+	filename: string,
+	contents: Buffer
+): Promise<string> {
+	await mkdir(TEST_DIR, { recursive: true });
+	await writeFile(join(TEST_DIR, filename), contents);
+	return `/uploads/${TEST_SUBDIR}/${filename}`;
+}
+
+function buildRequest(urlPath: string) {
+	return new NextRequest(`http://localhost:3000${urlPath}`);
+}
+
+afterEach(async () => {
+	await rm(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("GET /uploads/[...path]", () => {
+	it("streams a file written to disk at runtime, with the correct bytes and content type", async () => {
+		const contents = Buffer.from([1, 2, 3, 4, 5]);
+		const url = await writeUploadedFile("runtime.png", contents);
+
+		const { GET } = await import("@/app/uploads/[...path]/route");
+		const response = await GET(buildRequest(url), {
+			params: Promise.resolve({ path: [TEST_SUBDIR, "runtime.png"] }),
+		});
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toBe("image/png");
+
+		const body = Buffer.from(await response.arrayBuffer());
+		expect(body.equals(contents)).toBe(true);
+	});
+
+	it("sets the content type from the extension for a non-PNG upload", async () => {
+		const contents = Buffer.from([9, 9, 9]);
+		const url = await writeUploadedFile("runtime.webp", contents);
+
+		const { GET } = await import("@/app/uploads/[...path]/route");
+		const response = await GET(buildRequest(url), {
+			params: Promise.resolve({ path: [TEST_SUBDIR, "runtime.webp"] }),
+		});
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toBe("image/webp");
+	});
+
+	it("returns 404 for a file that does not exist", async () => {
+		const { GET } = await import("@/app/uploads/[...path]/route");
+		const response = await GET(
+			buildRequest(`/uploads/${TEST_SUBDIR}/does-not-exist.png`),
+			{
+				params: Promise.resolve({
+					path: [TEST_SUBDIR, "does-not-exist.png"],
+				}),
+			}
+		);
+
+		expect(response.status).toBe(404);
+	});
+
+	it("returns 404 for an empty path", async () => {
+		const { GET } = await import("@/app/uploads/[...path]/route");
+		const response = await GET(buildRequest("/uploads/"), {
+			params: Promise.resolve({ path: [] }),
+		});
+
+		expect(response.status).toBe(404);
+	});
+
+	it("rejects a traversal attempt via a literal '..' segment", async () => {
+		const { GET } = await import("@/app/uploads/[...path]/route");
+		const response = await GET(buildRequest("/uploads/../../etc/passwd"), {
+			params: Promise.resolve({ path: ["..", "..", "etc", "passwd"] }),
+		});
+
+		expect(response.status).toBe(404);
+	});
+
+	it("rejects a traversal attempt smuggled inside a single segment", async () => {
+		const { GET } = await import("@/app/uploads/[...path]/route");
+		const response = await GET(
+			buildRequest("/uploads/..%2f..%2fetc%2fpasswd"),
+			{
+				params: Promise.resolve({ path: ["../../etc/passwd"] }),
+			}
+		);
+
+		expect(response.status).toBe(404);
+	});
+
+	it("rejects an absolute-path segment", async () => {
+		const { GET } = await import("@/app/uploads/[...path]/route");
+		const response = await GET(buildRequest("/uploads//etc/passwd"), {
+			params: Promise.resolve({ path: ["/etc/passwd"] }),
+		});
+
+		expect(response.status).toBe(404);
+	});
+
+	it("does not serve a directory", async () => {
+		await mkdir(TEST_DIR, { recursive: true });
+
+		const { GET } = await import("@/app/uploads/[...path]/route");
+		const response = await GET(buildRequest(`/uploads/${TEST_SUBDIR}`), {
+			params: Promise.resolve({ path: [TEST_SUBDIR] }),
+		});
+
+		expect(response.status).toBe(404);
+	});
+});

--- a/src/__tests__/integration/api-uploads-route.test.ts
+++ b/src/__tests__/integration/api-uploads-route.test.ts
@@ -2,7 +2,23 @@ import { randomUUID } from "node:crypto";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { NextRequest } from "next/server";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	return {
+		...actual,
+		// Wrapping (not replacing) the real implementation keeps every other
+		// test in this file exercising real disk I/O; only the one test that
+		// overrides this with `mockImplementationOnce` sees different
+		// behaviour.
+		stat: vi.fn(actual.stat),
+	};
+});
+
+const { stat: mockedStat } = await import("node:fs/promises");
+const { stat: actualStat } =
+	await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
 
 const UPLOAD_ROOT = join(process.cwd(), "public", "uploads");
 
@@ -81,6 +97,12 @@ describe("GET /uploads/[...path]", () => {
 		expect(response.status).toBe(404);
 	});
 
+	// Next's router collapses literal and percent-encoded dot-segments
+	// before a request ever reaches this handler, so this exact input is
+	// unreachable over real HTTP on the Next version this app runs. This
+	// test guards `resolveSafePath`'s own defensive contract (it must not
+	// rely on the router for safety), not an exploit that is actually
+	// reachable in production.
 	it("rejects a traversal attempt via a literal '..' segment", async () => {
 		const { GET } = await import("@/app/uploads/[...path]/route");
 		const response = await GET(buildRequest("/uploads/../../etc/passwd"), {
@@ -117,6 +139,55 @@ describe("GET /uploads/[...path]", () => {
 		const { GET } = await import("@/app/uploads/[...path]/route");
 		const response = await GET(buildRequest(`/uploads/${TEST_SUBDIR}`), {
 			params: Promise.resolve({ path: [TEST_SUBDIR] }),
+		});
+
+		expect(response.status).toBe(404);
+	});
+
+	it("streams a file nested at realistic production path depth (caseId/case-information/file)", async () => {
+		const contents = Buffer.from([7, 7, 7, 7]);
+		const caseId = randomUUID();
+		const nestedDir = join(TEST_DIR, caseId, "case-information");
+		await mkdir(nestedDir, { recursive: true });
+		await writeFile(join(nestedDir, "evidence.png"), contents);
+
+		const { GET } = await import("@/app/uploads/[...path]/route");
+		const response = await GET(
+			buildRequest(
+				`/uploads/${TEST_SUBDIR}/${caseId}/case-information/evidence.png`
+			),
+			{
+				params: Promise.resolve({
+					path: [TEST_SUBDIR, caseId, "case-information", "evidence.png"],
+				}),
+			}
+		);
+
+		expect(response.status).toBe(200);
+		const body = Buffer.from(await response.arrayBuffer());
+		expect(body.equals(contents)).toBe(true);
+	});
+
+	it("returns 404, not an unhandled stream error, if the file is deleted between stat() and the read starting", async () => {
+		const contents = Buffer.from([1, 2, 3]);
+		const url = await writeUploadedFile("race.png", contents);
+		const filePath = join(TEST_DIR, "race.png");
+
+		// stat() still sees the file (so the route proceeds past the
+		// existence check), but the file is gone by the time the route
+		// opens a read stream — reproducing the stat-then-read race a
+		// concurrent delete could cause.
+		vi.mocked(mockedStat).mockImplementationOnce(async (target) => {
+			const result = await actualStat(
+				target as Parameters<typeof actualStat>[0]
+			);
+			await rm(filePath);
+			return result;
+		});
+
+		const { GET } = await import("@/app/uploads/[...path]/route");
+		const response = await GET(buildRequest(url), {
+			params: Promise.resolve({ path: [TEST_SUBDIR, "race.png"] }),
 		});
 
 		expect(response.status).toBe(404);


### PR DESCRIPTION
## Problem

With `USE_LOCAL_STORAGE=true`, uploads are written under `public/uploads/`, but the Next standalone production server snapshots `public/` at startup — files created at runtime 404 until the process restarts (verified empirically: file on disk, URL 404, restart flips it to 200). Affects any self-hoster on the documented standalone build.

## Fix

- New `GET /uploads/[...path]` route handler that streams files from disk: per-segment validation plus an independent resolved-path containment check, open/error-gated streaming (clean 404/500 on the stat-then-read race instead of a connection reset), `nosniff`, immutable caching (every write mints a fresh URL).
- Middleware: `/uploads` exemption made path-based rather than extension-based, preserving the existing public-by-URL posture (the old extension list accidentally excluded `.gif`/`.webp`). Boundary-anchored; commented that anything placed under `public/uploads` is publicly readable by construction.

## Notes for reviewers

- The literal-`..`-segment test guards the resolver's own defensive contract; Next's router collapses dot-segments before routing, so that input is unreachable over real HTTP (the `%2f`-smuggled variant *does* reach the handler and is rejected — verified over real HTTP).
- Known excluded: no Range-request support (uploads are inline images today).

## Verification

- 10/10 route tests (incl. realistic 3-segment depth and the stat-then-read race), 6/6 middleware tests, full integration suite 889/889 reproduced independently twice, lint + typecheck clean.
- Manual repro on the standalone server: runtime-written file served 200 byte-for-byte (checksum-matched) with no restart; pre-existing build-time assets unaffected.