### PR TITLE
Store sector by stable ID, display the full name

### DIFF
--- a/components/cases/__tests__/case-information-section.sector-hydration.test.tsx
+++ b/components/cases/__tests__/case-information-section.sector-hydration.test.tsx
@@ -78,7 +78,9 @@ describe("CaseInformationSection sector hydration (real Radix Select)", () => {
 			information: {
 				description: "A worked example",
 				authors: "Ada Lovelace",
-				sector: "Financial Services",
+				// Stored value is the stable ID (10 = "Financial Services" in
+				// lib/sectors.ts), not the display name.
+				sector: "10",
 				featureImageUrl: null,
 			},
 		});
@@ -109,7 +111,8 @@ describe("CaseInformationSection sector hydration (real Radix Select)", () => {
 			information: {
 				description: "A worked example",
 				authors: "Ada Lovelace",
-				sector: "Financial Services",
+				// Stable ID, not the display name — see the note above.
+				sector: "10",
 				featureImageUrl: null,
 			},
 		});
@@ -179,7 +182,7 @@ describe("CaseInformationSection sector hydration (real Radix Select)", () => {
 			information: {
 				description: "A worked example",
 				authors: "Ada Lovelace",
-				sector: "Financial Services",
+				sector: "10",
 				featureImageUrl: null,
 			},
 		});

--- a/components/cases/case-information-section.tsx
+++ b/components/cases/case-information-section.tsx
@@ -31,7 +31,7 @@ import type {
 	CaseInformationInput,
 } from "@/lib/schemas/case-information";
 import { upsertCaseInformationSchema } from "@/lib/schemas/case-information";
-import { sectors } from "@/lib/sectors";
+import { getSectorDisplayName, sectors } from "@/lib/sectors";
 import useStore from "@/store/store";
 import { Button } from "../ui/button";
 
@@ -211,7 +211,9 @@ export function CaseInformationSection({
 				</div>
 				<div>
 					<h4 className="font-medium text-muted-foreground text-sm">Sector</h4>
-					<p className="text-sm">{information?.sector || "Not provided."}</p>
+					<p className="text-sm">
+						{getSectorDisplayName(information?.sector) || "Not provided."}
+					</p>
 				</div>
 				{information?.featureImageUrl && (
 					<div>
@@ -279,16 +281,26 @@ export function CaseInformationSection({
 					control={form.control}
 					name="sector"
 					render={({ field }) => {
-						// A case saved before this select existed can hold a
-						// free-text sector value that isn't in the canonical
-						// list (e.g. "Healthcare"). Tolerate it: show it as
-						// the current selection rather than crashing or
-						// silently discarding it — replacing it with a
-						// canonical choice is the user's action, not ours.
+						// The stored value is the sector's stable numeric ID
+						// (as a string — see `lib/sectors.ts`'s
+						// `getSectorById`), not its display name: renaming a
+						// sector label must never orphan cases that already
+						// selected it. A case saved before the ID migration
+						// (or one whose value was never mapped to a
+						// canonical sector) can still hold a free-text value
+						// that isn't a known ID — e.g. "Healthcare". Tolerate
+						// it: show it as the current selection rather than
+						// crashing or silently discarding it — replacing it
+						// with a canonical choice is the user's action, not
+						// ours.
 						const currentValue = field.value ?? "";
 						const isLegacyValue =
 							currentValue !== "" &&
-							!sectors.some((sector) => sector.Name === currentValue);
+							!sectors.some((sector) => String(sector.ID) === currentValue);
+						// The user must always see the full sector name, even
+						// for a legacy value — never the raw stored ID.
+						const currentDisplayValue =
+							getSectorDisplayName(currentValue) ?? currentValue;
 						return (
 							<FormItem>
 								<FormLabel>Sector</FormLabel>
@@ -332,11 +344,11 @@ export function CaseInformationSection({
 									<SelectContent>
 										{isLegacyValue && (
 											<SelectItem value={currentValue}>
-												{currentValue} (legacy value)
+												{currentDisplayValue} (legacy value)
 											</SelectItem>
 										)}
 										{sectors.map((sector) => (
-											<SelectItem key={sector.ID} value={sector.Name}>
+											<SelectItem key={sector.ID} value={String(sector.ID)}>
 												{sector.Name}
 											</SelectItem>
 										))}

--- a/components/ui/select.test.tsx
+++ b/components/ui/select.test.tsx
@@ -99,7 +99,11 @@ describe("Select", () => {
 		await user.click(option2);
 
 		expect(handleValueChange).toHaveBeenCalledWith("option2");
-		expect(trigger).toHaveTextContent("option2");
+		// The trigger shows the selected item's rendered label ("Option 2"),
+		// not its raw `value` ("option2") — matching real Radix `SelectValue`,
+		// which are allowed to differ (see the sector select's stable-ID vs
+		// display-name split).
+		expect(trigger).toHaveTextContent(OPTION_TWO_REGEX);
 		expect(trigger).toHaveAttribute("aria-expanded", "false");
 	});
 
@@ -131,7 +135,8 @@ describe("Select", () => {
 		await user.click(option3);
 
 		expect(handleValueChange).toHaveBeenCalledWith("option3");
-		expect(trigger).toHaveTextContent("option3");
+		// See the label-vs-value note in "should handle option selection".
+		expect(trigger).toHaveTextContent(/option 3/i);
 	});
 
 	it("should handle disabled state", async () => {

--- a/docs/database/schema.dbml
+++ b/docs/database/schema.dbml
@@ -465,7 +465,13 @@ Table case_information {
   caseId String [unique, not null]
   description String
   authors String
-  sector String
+  sector String [note: 'The sector\'s stable numeric ID from `lib/sectors.ts` (e.g. "15"),
+stored as a string so this column can also tolerate free text saved
+before the ID migration (`20260820000000_sector_stable_ids`) that
+couldn\'t be mapped to a canonical sector — resolve for display with
+`getSectorDisplayName`, never render this raw value. Storing the ID
+rather than the display name means relabelling a sector in
+`lib/sectors.ts` can never orphan a case that already selected it.']
   featureImageUrl String
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime [not null]

--- a/lib/__tests__/sectors.test.ts
+++ b/lib/__tests__/sectors.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { getSectorById, getSectorDisplayName, sectors } from "@/lib/sectors";
+
+describe("getSectorById", () => {
+	it("resolves a known stable ID to its Sector record", () => {
+		const sector = getSectorById("15");
+		expect(sector?.Name).toBe("Health & Social Care");
+	});
+
+	it("returns undefined for a non-numeric value", () => {
+		expect(getSectorById("Healthcare")).toBeUndefined();
+	});
+
+	it("returns undefined for an ID with no matching sector", () => {
+		expect(getSectorById("9999")).toBeUndefined();
+	});
+
+	it("returns undefined for null/undefined/empty input", () => {
+		expect(getSectorById(null)).toBeUndefined();
+		expect(getSectorById(undefined)).toBeUndefined();
+		expect(getSectorById("")).toBeUndefined();
+	});
+});
+
+describe("getSectorDisplayName", () => {
+	// The three stored-value shapes the migration and the UI's
+	// legacy-tolerance path both need to cover (issue acceptance criterion
+	// 3): a canonical stable ID, a known legacy variant already migrated to
+	// its ID, and genuinely unmappable free text left untouched.
+
+	it("resolves a canonical stable ID to the full sector name", () => {
+		const financialServices = sectors.find(
+			(sector) => sector.Name === "Financial Services"
+		);
+		expect(getSectorDisplayName(String(financialServices?.ID))).toBe(
+			"Financial Services"
+		);
+	});
+
+	it("resolves a known legacy variant's migrated ID to the canonical name (e.g. 'Healthcare' -> 'Health & Social Care')", () => {
+		const healthAndSocialCare = sectors.find(
+			(sector) => sector.Name === "Health & Social Care"
+		);
+		expect(getSectorDisplayName(String(healthAndSocialCare?.ID))).toBe(
+			"Health & Social Care"
+		);
+	});
+
+	it("falls back to the raw string for genuinely unmappable legacy free text", () => {
+		expect(getSectorDisplayName("Medical Devices")).toBe("Medical Devices");
+	});
+
+	it("returns null for null/undefined/empty input", () => {
+		expect(getSectorDisplayName(null)).toBeNull();
+		expect(getSectorDisplayName(undefined)).toBeNull();
+		expect(getSectorDisplayName("")).toBeNull();
+	});
+});

--- a/lib/sectors.ts
+++ b/lib/sectors.ts
@@ -178,3 +178,48 @@ export const sectors: Sector[] = [
 		NACEcode: "U",
 	},
 ];
+
+/**
+ * Looks up a sector by its stable numeric ID (the value now stored on
+ * `CaseInformation.sector` — see the migration
+ * `20260820000000_sector_stable_ids`). Accepts the ID as a string because
+ * that is how it travels through forms and the database column, which
+ * stays `String?` for legacy free-text compatibility.
+ */
+export function getSectorById(
+	id: string | null | undefined
+): Sector | undefined {
+	if (!id) {
+		return undefined;
+	}
+	const numericId = Number(id);
+	if (!Number.isInteger(numericId)) {
+		return undefined;
+	}
+	return sectors.find((sector) => sector.ID === numericId);
+}
+
+/**
+ * Resolves a stored `sector` value to the full display name a user should
+ * always see (Chris's hard constraint, 2026-08-18 — the ID/code is a
+ * storage detail, never UI). Handles three shapes of stored value:
+ *
+ * - A known stable ID (e.g. `"15"`) → the canonical `Name`.
+ * - Free text that predates the ID migration and was never mapped (a
+ *   genuinely unmappable legacy value) → returned verbatim, since it is
+ *   already a human-readable string and there is nothing to resolve it to.
+ * - `null`/`undefined`/`""` → `null` (no sector recorded).
+ *
+ * Also tolerant of a frozen publish snapshot's `caseInformation.sector`,
+ * which may still hold a pre-migration display-name string verbatim
+ * (snapshots are never rewritten after the fact) — the same free-text
+ * fallback covers that case.
+ */
+export function getSectorDisplayName(
+	value: string | null | undefined
+): string | null {
+	if (!value) {
+		return null;
+	}
+	return getSectorById(value)?.Name ?? value;
+}

--- a/lib/services/__tests__/discover-transforms.test.ts
+++ b/lib/services/__tests__/discover-transforms.test.ts
@@ -174,3 +174,80 @@ describe("transformPublishableItemDetailForApi — comment stripping", () => {
 		).toBe("not-an-object");
 	});
 });
+
+/**
+ * `content.caseInformation.sector` (the frozen snapshot's own copy, embedded
+ * inside the raw JSON returned to the public JSON API and the Discover
+ * detail page's Download JSON button) must resolve to the full canonical
+ * sector name exactly like the top-level `sector` field does — never the
+ * bare stable ID a post-migration snapshot stores. Blocking finding from
+ * review: `transformPublishableItemDetailForApi` was passing `content`
+ * through with only `stripComments`, leaking the raw ID.
+ */
+describe("transformPublishableItemDetailForApi — sector resolution in content", () => {
+	it("resolves a post-migration snapshot's stable-ID sector to its full name", () => {
+		const item = detailWith({
+			tree: { id: "el-1", name: "Goal", children: [] },
+			caseInformation: {
+				description: "x",
+				authors: "y",
+				sector: "15",
+			},
+		});
+
+		const result = transformPublishableItemDetailForApi(item);
+
+		expect(
+			(result.content as { caseInformation: { sector: string } })
+				.caseInformation.sector
+		).toBe("Health & Social Care");
+	});
+
+	it("passes a pre-migration snapshot's already-canonical sector name through unchanged", () => {
+		const item = detailWith({
+			tree: { id: "el-1", name: "Goal", children: [] },
+			caseInformation: {
+				description: "x",
+				authors: "y",
+				sector: "Health & Social Care",
+			},
+		});
+
+		const result = transformPublishableItemDetailForApi(item);
+
+		expect(
+			(result.content as { caseInformation: { sector: string } })
+				.caseInformation.sector
+		).toBe("Health & Social Care");
+	});
+
+	it("passes unmappable legacy free-text sector values through verbatim", () => {
+		const item = detailWith({
+			tree: { id: "el-1", name: "Goal", children: [] },
+			caseInformation: {
+				description: "x",
+				authors: "y",
+				sector: "Bespoke Legacy Sector Text",
+			},
+		});
+
+		const result = transformPublishableItemDetailForApi(item);
+
+		expect(
+			(result.content as { caseInformation: { sector: string } })
+				.caseInformation.sector
+		).toBe("Bespoke Legacy Sector Text");
+	});
+
+	it("leaves content with no caseInformation.sector key untouched", () => {
+		const content = {
+			tree: { id: "el-1", name: "Goal", children: [] },
+			caseInformation: { description: "x", authors: "y" },
+		};
+		const item = detailWith(content);
+
+		const result = transformPublishableItemDetailForApi(item);
+
+		expect(result.content).toStrictEqual(content);
+	});
+});

--- a/lib/services/discover-service.ts
+++ b/lib/services/discover-service.ts
@@ -3,6 +3,7 @@ import {
 	type PublishedSnapshotMeta,
 	publishedSnapshotMetaSchema,
 } from "@/lib/schemas/publishable-item";
+import { getSectorDisplayName } from "@/lib/sectors";
 import type { PublishableItemType } from "@/src/generated/prisma";
 import type { ServiceResult } from "@/types/service";
 
@@ -70,7 +71,14 @@ function toSummary(record: PublishedRecord): PublishableItemSummary {
 			record.description ??
 			meta.case?.description ??
 			null,
-		sector: meta.caseInformation?.sector ?? null,
+		// The frozen snapshot's `sector` may hold a stable ID (post-migration
+		// publishes) or a pre-migration display-name string (older, never
+		// rewritten, snapshots) — this single choke point resolves either
+		// shape to the full sector name every Discover surface renders, so
+		// no downstream component needs to know the storage detail (Chris's
+		// hard constraint, 2026-08-18: the user must always see the full
+		// name).
+		sector: getSectorDisplayName(meta.caseInformation?.sector),
 		authors: meta.caseInformation?.authors ?? null,
 		featureImageUrl: meta.caseInformation?.featureImageUrl ?? null,
 		publishedAt: record.createdAt,

--- a/lib/services/discover-transforms.ts
+++ b/lib/services/discover-transforms.ts
@@ -9,6 +9,7 @@
  */
 
 import type { PublishableItemTypeResponse } from "@/lib/schemas/publishable-item";
+import { getSectorDisplayName } from "@/lib/sectors";
 import type {
 	PublishableItemDetail,
 	PublishableItemSummary,
@@ -61,6 +62,62 @@ function stripComments(value: unknown): unknown {
 	return value;
 }
 
+/**
+ * Resolves `content.caseInformation.sector` to the full canonical display
+ * name before a frozen snapshot's `content` is ever served (Chris's hard
+ * constraint, 2026-08-18 — the stable ID is a storage detail, never
+ * UI/API surface). `discover-service.ts`'s `toSummary` already does this
+ * for the top-level summary `sector` field via `getSectorDisplayName`; this
+ * is the equivalent choke point for the embedded snapshot `content` that
+ * `transformPublishableItemDetailForApi` passes through — otherwise a
+ * post-migration snapshot serves the bare stable ID (e.g. `"15"`) inside
+ * `content.caseInformation.sector` even though the top-level `sector` field
+ * next to it is already resolved.
+ *
+ * Handles both stored shapes via `getSectorDisplayName` itself: a
+ * post-migration stable ID resolves to its `Name`; a pre-migration snapshot
+ * that already stored a display name, or genuinely unmappable legacy free
+ * text, passes through verbatim (there is nothing to resolve it to).
+ *
+ * Non-destructive and defensive, matching `readSnapshotMeta` in
+ * `discover-service.ts`: never mutates the stored snapshot, and any shape
+ * that doesn't match `{ caseInformation: { sector } }` (missing, malformed,
+ * non-object) is returned unchanged rather than throwing.
+ */
+function resolveSectorInContent(content: unknown): unknown {
+	if (
+		content === null ||
+		typeof content !== "object" ||
+		Array.isArray(content)
+	) {
+		return content;
+	}
+	const record = content as Record<string, unknown>;
+	const caseInformation = record.caseInformation;
+	if (
+		caseInformation === null ||
+		typeof caseInformation !== "object" ||
+		Array.isArray(caseInformation)
+	) {
+		return content;
+	}
+	const caseInfoRecord = caseInformation as Record<string, unknown>;
+	if (!("sector" in caseInfoRecord)) {
+		return content;
+	}
+	const sector = caseInfoRecord.sector;
+	if (sector !== null && typeof sector !== "string") {
+		return content;
+	}
+	return {
+		...record,
+		caseInformation: {
+			...caseInfoRecord,
+			sector: getSectorDisplayName(sector),
+		},
+	};
+}
+
 /** Transform a single published item summary for API response. */
 export function transformPublishableItemForApi(
 	item: PublishableItemSummary
@@ -87,17 +144,19 @@ export function transformPublishableItemsForApi(
 
 /**
  * Transform a published item's full detail (summary + frozen content) for
- * API response. `content` is stripped of comments (`stripComments`) here —
- * the single choke point both the public JSON API
- * (`GET /api/public/discover/[slug]`) and the Discover detail page's
- * Download JSON button (via `actions/discover.ts`'s `fetchPublishedItemBySlug`)
- * pass through, so both surfaces get the strip for free.
+ * API response. `content` is stripped of comments (`stripComments`) and has
+ * its embedded `caseInformation.sector` resolved to the full display name
+ * (`resolveSectorInContent`) here — the single choke point both the public
+ * JSON API (`GET /api/public/discover/[slug]`) and the Discover detail
+ * page's Download JSON button (via `actions/discover.ts`'s
+ * `fetchPublishedItemBySlug`) pass through, so both surfaces get both fixes
+ * for free.
  */
 export function transformPublishableItemDetailForApi(
 	item: PublishableItemDetail
 ): PublishableItemDetailResponse {
 	return {
 		...transformPublishableItemForApi(item),
-		content: stripComments(item.content),
+		content: stripComments(resolveSectorInContent(item.content)),
 	};
 }

--- a/prisma/migrations/20260820000000_sector_stable_ids/migration.sql
+++ b/prisma/migrations/20260820000000_sector_stable_ids/migration.sql
@@ -1,0 +1,68 @@
+-- Migrate `case_information.sector` from a free-text display name to the
+-- sector's stable numeric ID (as a string) from `lib/sectors.ts`.
+--
+-- Rationale: the column previously stored the display name verbatim, so
+-- relabelling a sector orphaned every case that had already selected it
+-- into the "(legacy value)" tolerance path. Drift had already happened in
+-- practice — the dev seed stored "Healthcare" while the canonical list
+-- calls it "Health & Social Care" (see the sector-stable-id issue and
+-- [[TEA — Staging walkthrough of the walkthrough-defect fixes (PRs
+-- 890-891+)]] story 3 in the vault).
+--
+-- The stable ID is used (not the ISIC/NACE code) because those codes are
+-- not unique across the 20 sectors — three are bespoke composites and
+-- codes M, O and N are each reused across two different sectors.
+--
+-- Covers: (1) every current canonical name, verbatim, and (2) the one
+-- known legacy variant ("Healthcare"). Any other stored value is left
+-- untouched — genuinely unmappable free text stays on the UI's existing
+-- legacy-tolerance path (case-information-section.tsx), which continues to
+-- display it labelled "(legacy value)" rather than losing user data.
+--
+-- `PublishedAssuranceCase.content` (frozen publish snapshots) is
+-- deliberately NOT touched here: snapshots are point-in-time and frozen by
+-- design (never rewritten after publish), and `discover-service.ts`'s
+-- `getSectorDisplayName` already resolves either a stable ID or a
+-- pre-migration name string at read time, so old snapshots keep rendering
+-- correctly without a JSON rewrite.
+--
+-- Guarded on the table's existence (`to_regclass`) rather than a bare
+-- `UPDATE "case_information" ...`: `publishing-schema-migration.test.ts`
+-- reconstructs a pre-`20260716000000_publishing_schema_and_state_model`
+-- database state by applying every OTHER migration in order (including
+-- this one, which sorts after it chronologically) before that one
+-- migration — the one that actually creates `case_information` — is
+-- applied. A bare reference would fail migrate deploy in that scenario;
+-- this migration is a genuine no-op until the table exists, and in every
+-- real deployment (where migrations always apply in full, in order) that
+-- is immediately true.
+DO $$
+BEGIN
+	IF to_regclass('public.case_information') IS NOT NULL THEN
+		-- Canonical names -> stable ID.
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '1'  WHERE "sector" = 'Agriculture, Forestry & Fishing'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '2'  WHERE "sector" = 'Mining, Quarrying & Extraction'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '3'  WHERE "sector" = 'Energy Production & Supply'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '4'  WHERE "sector" = 'Utilities & Environmental Services'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '5'  WHERE "sector" = 'Construction & Civil Engineering'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '6'  WHERE "sector" = 'Manufacturing & Industrial Production'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '7'  WHERE "sector" = 'Wholesale & Retail Trade'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '8'  WHERE "sector" = 'Transportation & Logistics'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '9'  WHERE "sector" = 'Information, Communication & Media'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '10' WHERE "sector" = 'Financial Services'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '11' WHERE "sector" = 'Real-Estate & Property Management'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '12' WHERE "sector" = 'Professional, Scientific & Technical Services'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '13' WHERE "sector" = 'Public Administration, Defence & Security'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '14' WHERE "sector" = 'Education & Training'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '15' WHERE "sector" = 'Health & Social Care'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '16' WHERE "sector" = 'Accommodation, Food Service & Tourism'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '17' WHERE "sector" = 'Arts, Entertainment & Creative Industries'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '18' WHERE "sector" = 'Legal Services & Justice'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '19' WHERE "sector" = 'Personal & Other Community Services'$sql$;
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '20' WHERE "sector" = 'Extraterrestrial & International Organisations'$sql$;
+
+		-- Known legacy variant -> canonical ID.
+		EXECUTE $sql$UPDATE "case_information" SET "sector" = '15' WHERE "sector" = 'Healthcare'$sql$;
+	END IF;
+END
+$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -850,6 +850,13 @@ model CaseInformation {
 
   description     String?
   authors         String?  @db.VarChar(255)
+  /// The sector's stable numeric ID from `lib/sectors.ts` (e.g. "15"),
+  /// stored as a string so this column can also tolerate free text saved
+  /// before the ID migration (`20260820000000_sector_stable_ids`) that
+  /// couldn't be mapped to a canonical sector — resolve for display with
+  /// `getSectorDisplayName`, never render this raw value. Storing the ID
+  /// rather than the display name means relabelling a sector in
+  /// `lib/sectors.ts` can never orphan a case that already selected it.
   sector          String?  @db.VarChar(100)
   featureImageUrl String?  @map("feature_image_url") @db.VarChar(2000)
 

--- a/prisma/seed/dev-seed.ts
+++ b/prisma/seed/dev-seed.ts
@@ -14,6 +14,7 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import argon2 from "argon2";
 import { Pool } from "pg";
 import { prisma as appPrisma } from "../../lib/prisma";
+import { sectors } from "../../lib/sectors";
 import { upsertCaseInformation } from "../../lib/services/case-information-service";
 import {
 	DARTER_INTEGRATION_NAME,
@@ -22,6 +23,15 @@ import {
 } from "../../lib/services/darter-integration-service";
 import { publishAssuranceCase } from "../../lib/services/publish-service";
 import { PrismaClient } from "../../src/generated/prisma";
+
+const HEALTH_AND_SOCIAL_CARE_SECTOR_ID = sectors.find(
+	(sector) => sector.Name === "Health & Social Care"
+)?.ID;
+if (!HEALTH_AND_SOCIAL_CARE_SECTOR_ID) {
+	throw new Error(
+		"Seed data assumes a 'Health & Social Care' sector exists in lib/sectors.ts"
+	);
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -838,7 +848,10 @@ async function main() {
 			description:
 				"A worked example assurance case covering ML trustworthiness, used to exercise sharing, comments and publishing in local development.",
 			authors: "Chris Burr",
-			sector: "Healthcare",
+			// Stored by stable ID, not display name (fixes the "Healthcare" vs
+			// canonical "Health & Social Care" drift this seed used to carry —
+			// see the sector-stable-id migration).
+			sector: String(HEALTH_AND_SOCIAL_CARE_SECTOR_ID),
 		}
 	);
 	if ("error" in caseInformationResult) {

--- a/src/__tests__/integration/discover-service.test.ts
+++ b/src/__tests__/integration/discover-service.test.ts
@@ -45,6 +45,22 @@ describe("getPublishedItems", () => {
 		expect(item?.featureImageUrl).toBe("https://example.com/feature.png");
 	});
 
+	it("resolves a stored stable sector ID to its full canonical name (never the raw ID)", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCaseWithGoal(owner.id, "ID Sector Case");
+		await createTestCaseInformation(testCase.id, {
+			description: "Sector stored by ID",
+			// 15 = "Health & Social Care" in lib/sectors.ts.
+			sector: "15",
+		});
+		await publishAssuranceCase(owner.id, testCase.id);
+
+		const items = expectSuccess(await getPublishedItems());
+		const item = items.find((i) => i.title === "ID Sector Case");
+
+		expect(item?.sector).toBe("Health & Social Care");
+	});
+
 	it("falls back to the case's own description when there is no case information", async () => {
 		const owner = await createTestUser();
 		const testCase = await createTestCaseWithGoal(owner.id, "Bare Case");

--- a/src/__tests__/mocks/radix-ui-mocks.tsx
+++ b/src/__tests__/mocks/radix-ui-mocks.tsx
@@ -947,6 +947,15 @@ export const MockDropdownMenuItemIndicator = ({
 
 // Select Mock with state management
 interface SelectContextValue {
+	// Maps each mounted item's `value` to its rendered label (`children`) —
+	// real Radix's `SelectValue` displays the selected item's rendered
+	// content, not its raw `value`, which matters once a consumer's item
+	// `value` differs from its display label (e.g. a stable ID stored
+	// under a human-readable name). A ref, not state: items register on
+	// mount as a side effect, and `MockSelectValue` reads it on whatever
+	// render already happens from a value/open change — no extra
+	// re-render needed to propagate a registration.
+	itemLabels: React.MutableRefObject<Map<string, ReactNode>>;
 	open: boolean;
 	setOpen: (open: boolean) => void;
 	setValue: (value: string) => void;
@@ -970,6 +979,7 @@ export const MockSelectRoot = ({
 }: SelectRootProps) => {
 	const [internalValue, setInternalValue] = useState(defaultValue ?? "");
 	const [open, setOpen] = useState(false);
+	const itemLabels = useRef(new Map<string, ReactNode>());
 	const isControlled = controlledValue !== undefined;
 	const currentValue = isControlled ? controlledValue : internalValue;
 
@@ -988,6 +998,7 @@ export const MockSelectRoot = ({
 				setValue: handleValueChange,
 				open,
 				setOpen,
+				itemLabels,
 			}}
 		>
 			{children}
@@ -1029,7 +1040,10 @@ MockSelectTrigger.displayName = "MockSelectTrigger";
 
 export const MockSelectValue = ({ placeholder }: { placeholder?: string }) => {
 	const context = React.useContext(SelectContext);
-	return <span>{context?.value || placeholder}</span>;
+	const label = context
+		? context.itemLabels.current.get(context.value)
+		: undefined;
+	return <span>{label || context?.value || placeholder}</span>;
 };
 
 interface SelectIconProps {
@@ -1087,6 +1101,13 @@ export const MockSelectItem = ({
 }: MockSelectItemProps) => {
 	const context = React.useContext(SelectContext);
 	const isSelected = context?.value === value;
+
+	// Register this item's rendered label against its value so
+	// `MockSelectValue` can display the label rather than the raw value —
+	// see the `itemLabels` doc comment on `SelectContextValue`.
+	useEffect(() => {
+		context?.itemLabels.current.set(value, children);
+	}, [context, value, children]);
 
 	const handleClick = () => {
 		if (!disabled) {


### PR DESCRIPTION
## Problem

The sector field stored the display-name string, so any rewording of a label orphans stored values into "(legacy value)" status — drift had already happened (seed wrote "Healthcare"; the canonical list says "Health & Social Care").

## Change

- Sector is stored as the stable numeric ID from `lib/sectors.ts` (as a string; column type unchanged for legacy tolerance). The user always sees the full sector name — the ID is a storage detail and never reaches any UI or API surface.
- New helpers `getSectorById` / `getSectorDisplayName`; every render site resolves through them, and published-snapshot content is resolved at the API/Download-JSON choke point (`resolveSectorInContent`), covering pre-migration (name), post-migration (ID), and unmappable legacy free-text snapshots.
- **Data migration** (`20260820000000_sector_stable_ids`): maps all 20 canonical names + the known "Healthcare" legacy variant to IDs. Idempotent (re-run is a no-op); unmappable free text and NULLs untouched. Rehearsed against representative pre-migration data including the re-run case.
- `dev-seed.ts` seeds by ID (fixes the "Healthcare" drift).
- Shared Radix Select test mock fixed: `SelectValue` now renders the selected item's label (matching real Radix), previously masked while value === label everywhere.

## Knowingly excluded

- The legacy `Release` model's `sector` column (zero live references; pre-Django-purge remnant) is untouched.
- The Select mock resolves labels only after the dropdown has opened once — a latent gap vs real Radix; no current test is affected.

## Verification

- Unit 1297/1297, integration 882/882 on the final commit; lint + typecheck clean.
- Migration rehearsed on a scratch DB: canonical→ID, legacy variant→ID, free text/NULL untouched, already-migrated values stable across a second run.
- Sector surfaces checked end-to-end: editor select (real-Radix hydration tests), read-only pane, Discover list/detail (real-Postgres integration tests), and the public detail JSON / Download JSON payload (`content.caseInformation.sector` always a full name).