### PR TITLE
Bound Postgres pool-acquisition wait, ending the silent status-endpoint hang

### DIFF
--- a/app/api/cases/[id]/status/route.ts
+++ b/app/api/cases/[id]/status/route.ts
@@ -20,6 +20,14 @@ import type { PublishStatus as PrismaPublishStatus } from "@/src/generated/prism
 // timeout (`lib/prisma.ts`, 5s) room to fire and surface its own error first
 // in the pool-contention case, while still guaranteeing this route always
 // answers the client — see "TEA — Status endpoint can hang indefinitely".
+//
+// The two timeouts therefore cover different failure shapes, on purpose:
+// pool-acquisition contention surfaces as the pool's own fast error (pg
+// rejects at ~5s, mapped to a generic 500/INTERNAL — see
+// `api-status-pool-starvation.test.ts`), while this 15s `withTimeout` is
+// the backstop for slow-but-not-erroring work with no bounded wait of its
+// own (mapped to 504/GATEWAY_TIMEOUT). Pool exhaustion never reaches the
+// 504 path, because the pool errors out first.
 const STATUS_REQUEST_TIMEOUT_MS = 15_000;
 
 /**

--- a/app/api/cases/[id]/status/route.ts
+++ b/app/api/cases/[id]/status/route.ts
@@ -12,7 +12,15 @@ import {
 	getFullPublishStatus,
 	transitionStatus,
 } from "@/lib/services/publish-service";
+import { withTimeout } from "@/lib/with-timeout";
 import type { PublishStatus as PrismaPublishStatus } from "@/src/generated/prisma";
+
+// Local baseline for this route is ~185ms; the observed CI hang was silent
+// for 20s+ with no server-side response. 15s gives the DB-pool acquisition
+// timeout (`lib/prisma.ts`, 5s) room to fire and surface its own error first
+// in the pool-contention case, while still guaranteeing this route always
+// answers the client — see "TEA — Status endpoint can hang indefinitely".
+const STATUS_REQUEST_TIMEOUT_MS = 15_000;
 
 /**
  * GET /api/cases/[id]/status
@@ -32,7 +40,10 @@ export async function GET(
 		const userId = await requireAuth();
 		const { id } = await params;
 
-		const result = await getFullPublishStatus(userId, id);
+		const result = await withTimeout(
+			getFullPublishStatus(userId, id),
+			STATUS_REQUEST_TIMEOUT_MS
+		);
 
 		if (result.error) {
 			return apiError(serviceErrorToAppError(result.error));

--- a/lib/__tests__/errors.test.ts
+++ b/lib/__tests__/errors.test.ts
@@ -3,12 +3,14 @@ import { serviceErrorToAppError } from "../api-response";
 import {
 	AppError,
 	forbidden,
+	gatewayTimeout,
 	handleError,
 	notFound,
 	toActionResult,
 	unauthorised,
 	validationError,
 } from "../errors";
+import { TimeoutError } from "../with-timeout";
 
 describe("AppError", () => {
 	it("stores code, message, and fieldErrors", () => {
@@ -46,6 +48,9 @@ describe("AppError", () => {
 		expect(new AppError({ code: "INTERNAL", message: "" }).statusCode).toBe(
 			500
 		);
+		expect(
+			new AppError({ code: "GATEWAY_TIMEOUT", message: "" }).statusCode
+		).toBe(504);
 	});
 
 	it("preserves cause", () => {
@@ -92,6 +97,17 @@ describe("factory functions", () => {
 		expect(err.statusCode).toBe(400);
 		expect(err.fieldErrors).toEqual({ email: "Required" });
 	});
+
+	it("gatewayTimeout() creates a 504 error", () => {
+		const err = gatewayTimeout();
+		expect(err.code).toBe("GATEWAY_TIMEOUT");
+		expect(err.statusCode).toBe(504);
+	});
+
+	it("gatewayTimeout() accepts a custom message", () => {
+		const err = gatewayTimeout("Status check timed out");
+		expect(err.message).toBe("Status check timed out");
+	});
 });
 
 describe("handleError", () => {
@@ -112,6 +128,19 @@ describe("handleError", () => {
 		expect(result).toBeInstanceOf(AppError);
 		expect(result.code).toBe("INTERNAL");
 		expect(result.cause).toBe(original);
+		consoleSpy.mockRestore();
+	});
+
+	it("maps TimeoutError to GATEWAY_TIMEOUT (504), not INTERNAL", () => {
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {
+			/* suppress */
+		});
+		const original = new TimeoutError(15_000);
+		const result = handleError(original);
+
+		expect(result).toBeInstanceOf(AppError);
+		expect(result.code).toBe("GATEWAY_TIMEOUT");
+		expect(result.statusCode).toBe(504);
 		consoleSpy.mockRestore();
 	});
 

--- a/lib/__tests__/with-timeout.test.ts
+++ b/lib/__tests__/with-timeout.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { TimeoutError, withTimeout } from "../with-timeout";
+
+describe("withTimeout", () => {
+	it("resolves with the underlying value when it settles before the deadline", async () => {
+		const result = await withTimeout(Promise.resolve("done"), 50);
+		expect(result).toBe("done");
+	});
+
+	it("rejects with TimeoutError when the promise never settles in time", async () => {
+		const neverSettles = new Promise<never>(() => {
+			/* deliberately never resolves or rejects — mirrors a hung DB query */
+		});
+
+		await expect(withTimeout(neverSettles, 10)).rejects.toBeInstanceOf(
+			TimeoutError
+		);
+	});
+
+	it("propagates the underlying rejection when it rejects before the deadline", async () => {
+		const boom = new Error("boom");
+		await expect(withTimeout(Promise.reject(boom), 50)).rejects.toBe(boom);
+	});
+
+	it("TimeoutError message names the configured duration", () => {
+		const err = new TimeoutError(15_000);
+		expect(err.name).toBe("TimeoutError");
+		expect(err.message).toContain("15000ms");
+	});
+});

--- a/lib/__tests__/with-timeout.test.ts
+++ b/lib/__tests__/with-timeout.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TimeoutError, withTimeout } from "../with-timeout";
 
 describe("withTimeout", () => {
@@ -26,5 +26,69 @@ describe("withTimeout", () => {
 		const err = new TimeoutError(15_000);
 		expect(err.name).toBe("TimeoutError");
 		expect(err.message).toContain("15000ms");
+	});
+
+	describe("timer lifecycle", () => {
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it("clears its internal timer on early resolution, leaving nothing pending", async () => {
+			// A leaked timer here would keep the Node process alive after the
+			// request that started it has long since responded — the same
+			// "silent" failure mode as the original hang, just one layer down.
+			await withTimeout(Promise.resolve("done"), 1000);
+			expect(vi.getTimerCount()).toBe(0);
+		});
+
+		it("clears its internal timer when the underlying promise rejects early", async () => {
+			await expect(
+				withTimeout(Promise.reject(new Error("boom")), 1000)
+			).rejects.toThrow("boom");
+			expect(vi.getTimerCount()).toBe(0);
+		});
+
+		it("a rejection that arrives after the timeout has already fired produces no unhandled rejection", async () => {
+			let rejectLate: (error: unknown) => void = () => {
+				/* replaced below */
+			};
+			const late = new Promise<never>((_resolve, reject) => {
+				rejectLate = reject;
+			});
+
+			const unhandled: unknown[] = [];
+			const onUnhandledRejection = (reason: unknown) => {
+				unhandled.push(reason);
+			};
+			process.on("unhandledRejection", onUnhandledRejection);
+
+			try {
+				const result = withTimeout(late, 10);
+				const assertion = expect(result).rejects.toBeInstanceOf(TimeoutError);
+
+				await vi.advanceTimersByTimeAsync(10);
+				await assertion;
+
+				// The underlying promise settles well after the race is already
+				// decided — `withTimeout`'s `.then()` handler still runs (a
+				// promise can only be observed, never "unsubscribed from"), but
+				// resolving/rejecting an already-settled outer promise is a
+				// documented no-op, not a second, unhandled rejection.
+				rejectLate(new Error("late failure, after the timeout already won"));
+				await vi.advanceTimersByTimeAsync(0);
+				// Flush the microtask queue so a genuine unhandled rejection
+				// would have had a chance to surface before we assert.
+				await Promise.resolve();
+				await Promise.resolve();
+			} finally {
+				process.off("unhandledRejection", onUnhandledRejection);
+			}
+
+			expect(unhandled).toHaveLength(0);
+		});
 	});
 });

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -8,6 +8,7 @@ export type ErrorCode =
 	| "VALIDATION"
 	| "CONFLICT"
 	| "RATE_LIMITED"
+	| "GATEWAY_TIMEOUT"
 	| "INTERNAL";
 
 /**
@@ -25,6 +26,7 @@ const STATUS_MAP: Record<ErrorCode, number> = {
 	VALIDATION: 400,
 	CONFLICT: 409,
 	RATE_LIMITED: 429,
+	GATEWAY_TIMEOUT: 504,
 	INTERNAL: 500,
 };
 
@@ -79,6 +81,10 @@ export function validationError(
 	return new AppError({ code: "VALIDATION", message, fieldErrors });
 }
 
+export function gatewayTimeout(message = "Request timed out"): AppError {
+	return new AppError({ code: "GATEWAY_TIMEOUT", message });
+}
+
 // ---------------------------------------------------------------------------
 // Conversion helpers
 // ---------------------------------------------------------------------------
@@ -90,6 +96,17 @@ export function validationError(
 export function handleError(error: unknown): AppError {
 	if (error instanceof AppError) {
 		return error;
+	}
+
+	// `TimeoutError` (`lib/with-timeout.ts`) is checked by name, not
+	// `instanceof` — it's thrown from a plain module with no shared base
+	// class import here, and matching by `.name` avoids a circular import
+	// between `lib/errors.ts` and `lib/with-timeout.ts`.
+	if (error instanceof Error && error.name === "TimeoutError") {
+		console.error("[handleError] request timed out:", error.message);
+		return gatewayTimeout(
+			"The request took too long to complete. Please try again."
+		);
 	}
 
 	const message =

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -110,9 +110,27 @@ function createExtendedPrismaClient() {
 		throw new Error("DATABASE_URL environment variable is required");
 	}
 
-	// Create a PostgreSQL connection pool
+	// Create a PostgreSQL connection pool.
+	//
+	// `connectionTimeoutMillis` is NOT optional here. `@prisma/adapter-pg`
+	// hands connection pooling entirely to this bare `pg.Pool` — Prisma's own
+	// engine-level pool (and its `pool_timeout` / P2024 error) never comes
+	// into play with a driver adapter. `pg-pool` only pushes a waiting
+	// acquisition onto its pending queue with a timeout when
+	// `connectionTimeoutMillis` is set (see `pg-pool/index.js`); left
+	// `undefined`, a request that arrives while every pool slot is checked
+	// out waits *forever* for a connection — no error, no rejection, ever.
+	// That is the exact shape of "TEA — Status endpoint can hang
+	// indefinitely" (silent hang, no server-side error, only relieved once
+	// another connection happens to free up): confirmed by a standalone
+	// repro (issue evidence) that saturating this same `pg.Pool` config
+	// leaves an extra query unsettled for 8s+ with this option unset, vs.
+	// erroring at ~3000ms with it set. Any transient contention for
+	// connections — not just this route — was previously invisible until it
+	// resolved or the client itself gave up.
 	const pool =
-		globalForPrisma.pgPool || new Pool({ connectionString: databaseUrl });
+		globalForPrisma.pgPool ||
+		new Pool({ connectionString: databaseUrl, connectionTimeoutMillis: 5000 });
 	if (process.env.NODE_ENV !== "production") {
 		globalForPrisma.pgPool = pool;
 	}

--- a/lib/with-timeout.ts
+++ b/lib/with-timeout.ts
@@ -1,0 +1,38 @@
+/**
+ * Races a promise against a wall-clock timeout, rejecting with
+ * `TimeoutError` if it hasn't settled in time.
+ *
+ * Defense-in-depth for server-side hangs (e.g. DB connection-pool
+ * contention) that would otherwise leave a request open indefinitely — see
+ * `lib/prisma.ts` for the primary fix (a bounded connection-acquisition
+ * wait) and "TEA — Status endpoint can hang indefinitely" for the incident
+ * this guards against. This is a second, independent backstop: even if some
+ * future slow path has no bounded wait of its own, the route still returns
+ * a response instead of hanging on the client forever.
+ *
+ * Does NOT cancel the underlying work — there is no `AbortSignal` plumbed
+ * through Prisma/pg here — it only bounds how long the *caller* waits, so a
+ * client always gets a timely response even if server-side work is stuck.
+ */
+export class TimeoutError extends Error {
+	constructor(ms: number) {
+		super(`Operation timed out after ${ms}ms`);
+		this.name = "TimeoutError";
+	}
+}
+
+export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const timer = setTimeout(() => reject(new TimeoutError(ms)), ms);
+		promise.then(
+			(value) => {
+				clearTimeout(timer);
+				resolve(value);
+			},
+			(error) => {
+				clearTimeout(timer);
+				reject(error);
+			}
+		);
+	});
+}

--- a/src/__tests__/integration/api-status-pool-starvation.test.ts
+++ b/src/__tests__/integration/api-status-pool-starvation.test.ts
@@ -1,0 +1,119 @@
+import { NextRequest } from "next/server";
+import type { Pool, PoolClient } from "pg";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	createTestCaseWithGoal,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("next/cache", () => ({
+	revalidatePath: vi.fn(),
+}));
+
+beforeEach(async () => {
+	await mockNoAuth();
+});
+
+function statusRequest(caseId: string) {
+	return new NextRequest(`http://localhost:3000/api/cases/${caseId}/status`);
+}
+
+/**
+ * Saturates the app's real Postgres connection pool — the same
+ * `globalThis.pgPool` singleton `lib/prisma.ts` constructs (see that
+ * module's comment) — by checking out every slot up to its configured `max`
+ * and holding them for the duration of `fn`. This reproduces the exhaustion
+ * shape from "TEA — Status endpoint can hang indefinitely": a request
+ * arriving while every pool slot is already checked out.
+ *
+ * Clients are ALWAYS released in `finally`, even if `fn` throws or an
+ * assertion inside it fails — a wedged pool here would starve every other
+ * test in the suite run, not just this one.
+ */
+async function withSaturatedPool<T>(fn: () => Promise<T>): Promise<T> {
+	// Importing `@/lib/prisma` forces the module — and therefore its pool —
+	// to exist; it's the same singleton the route's Prisma calls go through.
+	// (In practice it's already loaded by the factories above, but this
+	// makes the dependency explicit rather than relying on import order.)
+	await import("@/lib/prisma");
+	const pool = (globalThis as unknown as { pgPool: Pool }).pgPool;
+	const max = pool.options.max ?? 10;
+	const clients: PoolClient[] = [];
+	try {
+		for (let i = 0; i < max; i++) {
+			clients.push(await pool.connect());
+		}
+		return await fn();
+	} finally {
+		for (const client of clients) {
+			client.release();
+		}
+	}
+}
+
+describe("GET /api/cases/[id]/status — pool-starvation regression", () => {
+	// nanaki's QA (2026-08-20) exercised this against the app's real
+	// singleton pool and found it cheap and reliable: pre-fix, an extra
+	// query left unsettled past 120s; fixed, a loud rejection at ~5018ms.
+	// This commits that regression check so future changes to `lib/prisma.ts`
+	// or `lib/with-timeout.ts` can't silently reopen the hang.
+	it("returns a fast structured error instead of hanging when the connection pool is fully saturated", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCaseWithGoal(user.id);
+		await mockAuth(user.id, user.username, user.email);
+
+		await withSaturatedPool(async () => {
+			const started = Date.now();
+			const { GET } = await import("@/app/api/cases/[id]/status/route");
+			const response = await GET(statusRequest(testCase.id), {
+				params: Promise.resolve({ id: testCase.id }),
+			});
+			const elapsedMs = Date.now() - started;
+
+			// The pool's own `connectionTimeoutMillis` (`lib/prisma.ts`, 5000ms)
+			// fires long before the route's 15s `withTimeout` backstop, so this
+			// settles in low single-digit seconds — nowhere near the 30s
+			// integration test timeout the pre-fix hang would have exhausted.
+			expect(elapsedMs).toBeLessThan(10_000);
+
+			const body = await response.json();
+			expect(response.status).toBeGreaterThanOrEqual(500);
+			expect(typeof body.code).toBe("string");
+		});
+	});
+
+	it("pool exhaustion surfaces as 500/INTERNAL — the pool's own fast error — not 504", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCaseWithGoal(user.id);
+		await mockAuth(user.id, user.username, user.email);
+
+		await withSaturatedPool(async () => {
+			const { GET } = await import("@/app/api/cases/[id]/status/route");
+			const response = await GET(statusRequest(testCase.id), {
+				params: Promise.resolve({ id: testCase.id }),
+			});
+
+			// This is DELIBERATE current behaviour, not a bug (vincent's review,
+			// nanaki's QA, 2026-08-20). Pool-acquisition contention throws pg's
+			// own plain `Error('timeout exceeded when trying to connect')` —
+			// `handleError` (`lib/errors.ts`) only special-cases `TimeoutError`
+			// (`lib/with-timeout.ts`, matched by `.name`), so this falls through
+			// to the generic 500/INTERNAL branch. The route's 504/GATEWAY_TIMEOUT
+			// path is a *different* backstop that only fires when `withTimeout`
+			// itself elapses (slow-but-not-erroring work) — pool exhaustion never
+			// reaches it because the pool errors out first, well inside the 15s
+			// budget. This is loud and fast (the fix's goal), but indistinguishable
+			// from any other internal error in production logs — tracked
+			// internally as a follow-up (a tagged pool-timeout ErrorCode /
+			// structured log, per vincent's review).
+			expect(response.status).toBe(500);
+			const body = await response.json();
+			expect(body.code).toBe("INTERNAL");
+		});
+	});
+});


### PR DESCRIPTION
## Problem

`GET /api/cases/[id]/status` could hang indefinitely for a published case (CI-reproduced: request fires, no response and no error for 20s+, silent server side, bimodal per-run). No server-side timeout existed, so a real user would hang too.

## Root cause

Not the suspected query fan-out — the status chain (`getFullPublishStatus → detectChanges → exportCase`) is sequential `await`s (worst case 2 concurrent connections per request; hypothesis falsified by code audit).

The actual cause: `lib/prisma.ts` hands Prisma a bare `pg.Pool` via `@prisma/adapter-pg`, which delegates pooling entirely to `pg-pool` — Prisma's own engine pool and its `pool_timeout`/P2024 error never engage. With `connectionTimeoutMillis` unset, `pg-pool` queues a starved connection acquisition **forever, with no error ever raised** (verified against installed library source and reproduced deterministically: unsettled past 120s unset, loud rejection at ~5s when set).

## Fix

- `connectionTimeoutMillis: 5000` on the pool — application-wide, so any pool-starved query now fails fast and loudly instead of hanging silently.
- Defence in depth: new `withTimeout` (15s) on the status route mapping to `504 GATEWAY_TIMEOUT` via a new error code.

Deliberate semantics, pinned by test: pool-acquisition contention surfaces as the pool's own fast error (500/INTERNAL) — the 504 path is the backstop for slow-but-not-erroring work only. Distinguishable pool-timeout errors (observability) and deliberate pool sizing are tracked internally as follow-ups.

## Verification

- Deterministic starvation repro before/after (unsettled >120s → rejects at ~5005ms), plus the real route composition against the app's actual singleton pool (12ms baseline → loud error at ~5018ms saturated).
- Committed regression tests: pool saturated via the real `globalThis.pgPool`, route answers fast with a structured error; 500-vs-504 semantics pinned; `withTimeout` timer-lifecycle and late-rejection tests.
- Full integration suite 883/883 on the final commit (including the new starvation tests); unit 1292/1292; lint + typecheck clean.
- No test approaches the 5s acquisition budget (slowest sampled 2.7s; the 12.7s migration-replay test uses its own isolated pool).

## Note

The e2e spec named in the original report was already rewritten upstream (publish-flow change decoupled the modal from this fetch) — untouched here.