### PR TITLE
Give the fallow CI gate a real environment and honest attribution

### DIFF
--- a/.fallow-baseline.health.json
+++ b/.fallow-baseline.health.json
@@ -1,5 +1,10 @@
 {
   "finding_counts": {
+    "actions/cases.ts": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
     "app/(authenticated)/dashboard/page.tsx": {
       "crap_moderate": {
         "count": 1
@@ -94,7 +99,28 @@
         "count": 1
       }
     },
+    "app/api/cases/[id]/elements/route.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
     "app/api/cases/[id]/image/route.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/information/image/route.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/information/route.ts": {
       "crap_moderate": {
         "count": 1
       }
@@ -108,7 +134,28 @@
       }
     },
     "app/api/cases/[id]/permissions/route.ts": {
-      "complexity_moderate": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/publish/route.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/route.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/status/route.ts": {
+      "crap_high": {
         "count": 1
       }
     },
@@ -178,8 +225,51 @@
         "count": 1
       }
     },
+    "app/api/elements/[id]/route.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
     "app/api/health/route.ts": {
       "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/integrations/[id]/case-grants/[caseId]/route.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/integrations/[id]/case-grants/route.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/integrations/[id]/route.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/integrations/[id]/tokens/[tokenId]/rotate/route.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/integrations/[id]/tokens/[tokenId]/route.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/integrations/[id]/tokens/route.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/integrations/route.ts": {
+      "crap_moderate": {
         "count": 1
       }
     },
@@ -188,13 +278,43 @@
         "count": 1
       }
     },
+    "app/api/machine/health/elements/[id]/evidence/route.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
     "app/api/teams/[id]/members/[userId]/route.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/teams/[id]/members/route.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "app/api/teams/[id]/route.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/teams/route.ts": {
       "crap_moderate": {
         "count": 1
       }
     },
     "app/api/templates/route.ts": {
       "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/user/plugins/route.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/users/me/route.ts": {
+      "crap_high": {
         "count": 1
       }
     },
@@ -238,6 +358,9 @@
       },
       "crap_high": {
         "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
       }
     },
     "components/cases/case-card.tsx": {
@@ -259,8 +382,18 @@
         "count": 3
       }
     },
+    "components/cases/case-information-section.tsx": {
+      "complexity_moderate": {
+        "count": 1
+      }
+    },
     "components/cases/case-list.tsx": {
       "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/cases/case-settings-popover.tsx": {
+      "crap_high": {
         "count": 1
       }
     },
@@ -314,25 +447,33 @@
     },
     "components/cases/header.tsx": {
       "crap_moderate": {
-        "count": 1
+        "count": 3
+      }
+    },
+    "components/cases/json-editor-toolbar.tsx": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 2
       }
     },
     "components/cases/json-view-panel.tsx": {
       "complexity_high": {
         "count": 1
       },
-      "crap_moderate": {
-        "count": 1
-      }
-    },
-    "components/cases/node-attributes.tsx": {
-      "complexity_high": {
+      "crap_critical": {
         "count": 1
       },
       "crap_high": {
         "count": 1
       },
       "crap_moderate": {
+        "count": 3
+      }
+    },
+    "components/cases/node-attributes.tsx": {
+      "complexity_moderate": {
         "count": 1
       }
     },
@@ -342,13 +483,15 @@
       }
     },
     "components/cases/node-edit-dialog.tsx": {
-      "complexity_critical": {
+      "complexity_high": {
         "count": 1
       },
-      "crap_critical": {
+      "crap_high": {
         "count": 1
-      },
-      "crap_moderate": {
+      }
+    },
+    "components/cases/notes-feed.tsx": {
+      "crap_high": {
         "count": 1
       }
     },
@@ -697,9 +840,68 @@
         "count": 1
       }
     },
+    "components/modals/_import-modal/github-import-tab.tsx": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/modals/_import-modal/google-drive-import-tab.tsx": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/modals/_import-modal/use-case-import.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "components/modals/_share-modal/document-export-section.tsx": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/modals/_share-modal/google-backup-section.tsx": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/modals/_share-modal/image-export-section.tsx": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/modals/_share-modal/json-export-section.tsx": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/modals/case-create-modal.tsx": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
     "components/modals/delete-element-modal.tsx": {
       "crap_moderate": {
         "count": 1
+      }
+    },
+    "components/modals/migration-modal.tsx": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/modals/permissions-modal.tsx": {
+      "crap_high": {
+        "count": 2
       }
     },
     "components/navigation/desktop-nav.tsx": {
@@ -721,14 +923,19 @@
       }
     },
     "components/publishing/status-modal.tsx": {
-      "complexity_high": {
-        "count": 1
-      },
-      "crap_high": {
+      "complexity_moderate": {
         "count": 1
       }
     },
     "components/shared/nodes/animations.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/shared/nodes/attach-element-dialog.tsx": {
+      "crap_high": {
+        "count": 1
+      },
       "crap_moderate": {
         "count": 1
       }
@@ -750,6 +957,12 @@
       }
     },
     "components/shared/nodes/move-element-dialog.tsx": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
       "crap_moderate": {
         "count": 1
       }
@@ -759,7 +972,38 @@
         "count": 1
       }
     },
-    "components/shared/nodes/node-options-menu.tsx": {
+    "components/sharing/_case-sharing/use-case-permissions.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/sharing/case-sharing-dialog.tsx": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/teams/create-team-dialog.tsx": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/teams/invite-member-dialog.tsx": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/teams/team-card.tsx": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/teams/team-member-list.tsx": {
+      "crap_high": {
+        "count": 1
+      },
       "crap_moderate": {
         "count": 1
       }
@@ -774,9 +1018,19 @@
         "count": 1
       }
     },
+    "hooks/use-history.ts": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
     "hooks/use-integrations.ts": {
       "complexity_moderate": {
         "count": 1
+      }
+    },
+    "hooks/use-json-validation.ts": {
+      "crap_high": {
+        "count": 4
       }
     },
     "hooks/use-keyboard-shortcuts.ts": {
@@ -785,6 +1039,12 @@
       }
     },
     "hooks/use-new-link-form.ts": {
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 2
+      },
       "crap_moderate": {
         "count": 4
       }
@@ -795,46 +1055,123 @@
       }
     },
     "lib/auth/config.ts": {
-      "crap_high": {
+      "crap_critical": {
         "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "lib/auth/password-service.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/auth/validate-session.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/api.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/case/branch-utils.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
       }
     },
     "lib/case/case-updates.ts": {
-      "crap_moderate": {
+      "crap_critical": {
         "count": 2
+      },
+      "crap_moderate": {
+        "count": 3
       }
     },
-    "lib/case/convert-case.ts": {
-      "crap_moderate": {
+    "lib/case/document-export.ts": {
+      "crap_critical": {
         "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
       }
     },
     "lib/case/evidence.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 5
+      }
+    },
+    "lib/case/identifier-utils.ts": {
       "crap_moderate": {
         "count": 1
       }
     },
+    "lib/case/image-export.ts": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
     "lib/case/node-operations.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
       "crap_moderate": {
         "count": 1
       }
     },
     "lib/case/node-utils.ts": {
-      "crap_moderate": {
+      "crap_critical": {
         "count": 1
+      },
+      "crap_high": {
+        "count": 4
+      },
+      "crap_moderate": {
+        "count": 3
       }
     },
     "lib/case/property-claims.ts": {
-      "crap_moderate": {
+      "crap_critical": {
         "count": 2
+      },
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "lib/case/tree-diff.ts": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 5
       }
     },
     "lib/case/tree-utils.ts": {
+      "crap_critical": {
+        "count": 2
+      },
       "crap_high": {
-        "count": 1
+        "count": 2
       },
       "crap_moderate": {
-        "count": 2
+        "count": 3
       }
     },
     "lib/docs/case-data-transformer.ts": {
@@ -850,29 +1187,77 @@
         "count": 1
       }
     },
-    "lib/export/exporters/markdown-exporter.ts": {
-      "crap_moderate": {
-        "count": 2
-      }
-    },
     "lib/export/exporters/pdf-components.tsx": {
-      "crap_moderate": {
+      "crap_high": {
         "count": 1
       }
     },
     "lib/export/exporters/word-exporter.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "lib/export/templates/base-template.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "lib/export/templates/presets/full-report.ts": {
+      "crap_high": {
+        "count": 1
+      },
       "crap_moderate": {
         "count": 1
       }
     },
-    "lib/export/templates/presets/summary.ts": {
+    "lib/permissions.ts": {
       "crap_moderate": {
         "count": 1
       }
     },
-    "lib/export/templates/renderers/tree-renderer.ts": {
+    "lib/schemas/element-validation.ts": {
       "crap_moderate": {
         "count": 1
+      }
+    },
+    "lib/schemas/version-detection.ts": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "lib/services/blob-storage-service.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "lib/services/case-batch-update-service.ts": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 6
+      }
+    },
+    "lib/services/case-export-service.ts": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "lib/services/case-fetch-service.ts": {
+      "crap_high": {
+        "count": 4
+      },
+      "crap_moderate": {
+        "count": 4
       }
     },
     "lib/services/case-image-service.ts": {
@@ -880,25 +1265,235 @@
         "count": 1
       }
     },
+    "lib/services/case-import-service.ts": {
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "lib/services/case-information-service.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/case-invite-service.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-permission-service.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 5
+      }
+    },
+    "lib/services/case-trash-service.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
     "lib/services/change-detection-service.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
       "crap_moderate": {
         "count": 1
       }
     },
     "lib/services/comment-service.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/connected-accounts-service.ts": {
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/darter-integration-service.ts": {
       "crap_moderate": {
         "count": 1
       }
     },
     "lib/services/discover-service.ts": {
-      "crap_moderate": {
+      "crap_critical": {
         "count": 1
       }
     },
     "lib/services/element-service.ts": {
-      "complexity_moderate": {
+      "complexity_critical": {
         "count": 1
       },
+      "crap_critical": {
+        "count": 6
+      },
+      "crap_high": {
+        "count": 4
+      },
+      "crap_moderate": {
+        "count": 5
+      }
+    },
+    "lib/services/email-service.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/file-storage-service.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "lib/services/github-api-service.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "lib/services/google-drive-service.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "lib/services/health-evidence-service.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/health-scoring-service.ts": {
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/health-staleness-sweep-service.ts": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/identifier-service.ts": {
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "lib/services/integration-registry-service.ts": {
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "lib/services/password-reset-service.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/plugin-data-service.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/plugin-enablement-service.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/publish-service.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "lib/services/rate-limit-service.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "lib/services/sse-connection-manager.ts": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "lib/services/team-member-service.ts": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/team-service.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "lib/services/tour-service.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/user-management-service.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "lib/services/user-service.ts": {
       "crap_high": {
         "count": 1
       },
@@ -906,12 +1501,33 @@
         "count": 2
       }
     },
-    "lib/services/health-scoring-service.ts": {
+    "lib/toast.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/transforms/build-tree.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "lib/transforms/element-response.ts": {
+      "crap_critical": {
+        "count": 1
+      },
       "crap_moderate": {
         "count": 1
       }
     },
-    "middleware.ts": {
+    "lib/transforms/nested-to-flat.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "lib/utils/tree-traversal.ts": {
       "crap_moderate": {
         "count": 1
       }
@@ -939,11 +1555,6 @@
         "count": 2
       }
     },
-    "src/__tests__/integration/publishing-schema-migration.test.ts": {
-      "crap_moderate": {
-        "count": 1
-      }
-    },
     "src/__tests__/mocks/radix-ui-mocks.tsx": {
       "crap_critical": {
         "count": 1
@@ -964,18 +1575,566 @@
       }
     },
     "src/__tests__/utils/accessibility-test-utils.ts": {
+      "complexity_moderate": {
+        "count": 5
+      }
+    },
+    "src/__tests__/utils/env-test-utils.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    }
+  },
+  "identity_finding_counts": {
+    "actions/cases.ts\u0000deleteAssuranceCase": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "actions/cases.ts\u0000fetchCaseComments": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "actions/cases.ts\u0000updateCaseIdentifiers": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/(authenticated)/dashboard/page.tsx\u0000Dashboard": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/(authenticated)/dashboard/settings/_components/appearance-form.tsx\u0000<arrow>": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/(authenticated)/dashboard/settings/_components/connected-accounts-form.tsx\u0000ConnectedAccountsForm": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/(authenticated)/dashboard/settings/_components/connected-accounts-form.tsx\u0000ProviderCard": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "app/(authenticated)/dashboard/settings/_components/connected-accounts-form.tsx\u0000handleDisconnectConfirm": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/(authenticated)/dashboard/settings/_components/delete-form.tsx\u0000handleDeleteUser": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/(authenticated)/dashboard/settings/_components/password-form.tsx\u0000PasswordForm": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/(authenticated)/dashboard/settings/_components/password-form.tsx\u0000onSubmit": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/(authenticated)/dashboard/settings/_components/personal-info-form.tsx\u0000PersonalInfoForm": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "app/(authenticated)/dashboard/settings/_components/personal-info-form.tsx\u0000onSubmit": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/(authenticated)/dashboard/settings/integrations/_components/case-access-section.tsx\u0000CaseAccessSection": {
+      "complexity_moderate": {
+        "count": 1
+      }
+    },
+    "app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx\u0000IntegrationCard": {
+      "complexity_high": {
+        "count": 1
+      }
+    },
+    "app/(authenticated)/dashboard/teams/[id]/page.tsx\u0000TeamDetailPage": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/(authenticated)/dashboard/teams/[id]/settings/_components/team-settings-form.tsx\u0000TeamSettingsForm": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/(authenticated)/dashboard/teams/[id]/settings/_components/team-settings-form.tsx\u0000handleDelete": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/(authenticated)/dashboard/teams/[id]/settings/_components/team-settings-form.tsx\u0000onSubmit": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/(authenticated)/dashboard/teams/[id]/settings/page.tsx\u0000TeamSettingsPage": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/(landing)/discover/[slug]/page.tsx\u0000DiscoverItemPage": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/(landing)/discover/_components/published-items.tsx\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/(landing)/discover/_components/published-items.tsx\u0000filteredItems": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/auth/forgot-password/route.ts\u0000POST": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/auth/reset-password/route.ts\u0000POST": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/batch/route.ts\u0000POST": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/comments/route.ts\u0000POST": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/elements/route.ts\u0000POST": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/elements/route.ts\u0000resolveParentIdFromBody": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/image/route.ts\u0000POST": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/information/image/route.ts\u0000DELETE": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/information/image/route.ts\u0000POST": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/information/route.ts\u0000PUT": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/permissions/[permissionId]/route.ts\u0000DELETE": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/permissions/[permissionId]/route.ts\u0000PATCH": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/permissions/route.ts\u0000POST": {
       "complexity_critical": {
         "count": 1
       },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/publish/route.ts\u0000DELETE": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/publish/route.ts\u0000POST": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/route.ts\u0000PUT": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/cases/[id]/status/route.ts\u0000PATCH": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/cases/backup/gdrive/route.ts\u0000POST": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/cases/import/gdrive/route.ts\u0000POST": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/cases/import/github/route.ts\u0000POST": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/cases/import/github/route.ts\u0000parseRequestBody": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/cases/import/github/route.ts\u0000resolveGitHubLocation": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/cases/import/route.ts\u0000POST": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/comments/[id]/route.ts\u0000PATCH": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/comments/[id]/route.ts\u0000PUT": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/cron/health-staleness-sweep/route.ts\u0000POST": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/cron/purge-trash/route.ts\u0000POST": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/elements/[id]/attach/route.ts\u0000POST": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/elements/[id]/attach/route.ts\u0000resolveParentId": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/elements/[id]/comments/route.ts\u0000POST": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/elements/[id]/detach/route.ts\u0000POST": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/elements/[id]/move/route.ts\u0000POST": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "app/api/elements/[id]/restore/route.ts\u0000POST": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/elements/[id]/route.ts\u0000DELETE": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/elements/[id]/route.ts\u0000PUT": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "app/api/health/route.ts\u0000GET": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/integrations/[id]/case-grants/[caseId]/route.ts\u0000DELETE": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/integrations/[id]/case-grants/route.ts\u0000POST": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/integrations/[id]/route.ts\u0000PATCH": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/integrations/[id]/tokens/[tokenId]/rotate/route.ts\u0000POST": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/integrations/[id]/tokens/[tokenId]/route.ts\u0000DELETE": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/integrations/[id]/tokens/route.ts\u0000POST": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/integrations/route.ts\u0000POST": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/invites/[token]/accept/route.ts\u0000POST": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "app/api/machine/health/elements/[id]/evidence/route.ts\u0000POST": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/teams/[id]/members/[userId]/route.ts\u0000PATCH": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/teams/[id]/members/route.ts\u0000POST": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "app/api/teams/[id]/route.ts\u0000PATCH": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/teams/route.ts\u0000POST": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/templates/route.ts\u0000GET": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/user/plugins/route.ts\u0000PATCH": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "app/api/users/me/route.ts\u0000PATCH": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "app/api/users/register/route.ts\u0000POST": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/auth/forgot-password-form.tsx\u0000onSubmit": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/auth/register-form.tsx\u0000extractValidationErrors": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/auth/reset-password-form.tsx\u0000ResetPasswordForm": {
       "complexity_high": {
         "count": 1
       },
-      "complexity_moderate": {
-        "count": 3
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/auth/reset-password-form.tsx\u0000onSubmit": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/auth/reset-password-form.tsx\u0000validateToken": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/auth/sign-in-form.tsx\u0000SignInForm": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/auth/sign-in-form.tsx\u0000onSubmit": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/cases/action-buttons.tsx\u0000ActionButtons": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/cases/action-buttons.tsx\u0000handleNameReset": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/action-buttons.tsx\u0000onDelete": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/case-card.tsx\u0000CaseCard": {
+      "complexity_critical": {
+        "count": 1
       },
       "crap_critical": {
         "count": 1
+      }
+    },
+    "components/cases/case-container.tsx\u0000CaseContainer": {
+      "complexity_high": {
+        "count": 1
       },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/cases/case-container.tsx\u0000buildToastMessage": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/case-container.tsx\u0000fetchOrphanedElements": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/case-container.tsx\u0000getElementName": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/cases/case-container.tsx\u0000loadCase": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/cases/case-container.tsx\u0000loadOrphanedElementsData": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/cases/case-container.tsx\u0000onEvent": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/case-information-section.tsx\u0000CaseInformationSection": {
+      "complexity_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/case-list.tsx\u0000compareCases": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/cases/case-settings-popover.tsx\u0000<arrow>": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/cases/comments-feed.tsx\u0000CommentActions": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/cases/comments-feed.tsx\u0000CommentItem": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/cases/comments-feed.tsx\u0000CommentMeta": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/cases/comments-feed.tsx\u0000CommentsFeed": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/comments-feed.tsx\u0000handleResolve": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/comments-form.tsx\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/comments-form.tsx\u0000onSubmit": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/comments-sheet.tsx\u0000CommentsSheet": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/cases/evidence-node.tsx\u0000EvidenceNode": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/cases/flow.tsx\u0000<arrow>": {
       "crap_high": {
         "count": 1
       },
@@ -983,14 +2142,2212 @@
         "count": 1
       }
     },
-    "src/__tests__/utils/env-test-utils.ts": {
+    "components/cases/flow.tsx\u0000Flow": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/cases/goal-node.tsx\u0000GoalNode": {
       "crap_moderate": {
         "count": 1
       }
     },
-    "src/__tests__/utils/test-factories.ts": {
+    "components/cases/header.tsx\u0000Header": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/header.tsx\u0000_updateAssuranceCaseName": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/header.tsx\u0000focusNode": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/json-editor-toolbar.tsx\u0000ActionButtons": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/json-editor-toolbar.tsx\u0000JsonEditorToolbar": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/cases/json-editor-toolbar.tsx\u0000formatChangeSummary": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/json-editor-toolbar.tsx\u0000getStatusContent": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/cases/json-view-panel.tsx\u0000JsonViewPanel": {
+      "complexity_high": {
+        "count": 1
+      }
+    },
+    "components/cases/json-view-panel.tsx\u0000fetchJson": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/json-view-panel.tsx\u0000handleApply": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/cases/json-view-panel.tsx\u0000handleBatchResult": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/json-view-panel.tsx\u0000processChangeToCommand": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/cases/json-view-panel.tsx\u0000syncAfterApply": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/node-attributes.tsx\u0000NodeAttributes": {
+      "complexity_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/node-comment.tsx\u0000NodeComment": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/node-comment.tsx\u0000onEvent": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/node-edit-dialog.tsx\u0000NodeEditDialog": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/cases/notes-feed.tsx\u0000<arrow>": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/cases/toggle-button.tsx\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/toggle-button.tsx\u0000_handleToggle": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/trash-list.tsx\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/trash-list.tsx\u0000handlePurge": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/cases/trash-list.tsx\u0000handleRestore": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/demo/landing/hero.tsx\u0000Hero": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/case-studies-index.tsx\u0000getCaseStudyEntries": {
+      "complexity_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/case-viewer-wrapper.tsx\u0000CaseViewerWrapper": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/case-viewer-wrapper.tsx\u0000isCaseExportNested": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/concept-carousel.tsx\u0000<arrow>": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/concept-carousel.tsx\u0000ConceptCarousel": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/concept-carousel.tsx\u0000handleKeyDown": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced-interactive-case-viewer.tsx\u0000ControlButtons": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced-interactive-case-viewer.tsx\u0000EnhancedInteractiveCaseViewerInner": {
+      "complexity_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced-interactive-case-viewer.tsx\u0000calculateNodePosition": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced-interactive-case-viewer.tsx\u0000handlePaneClick": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced-interactive-case-viewer.tsx\u0000onConnectEnd": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/animations/animation-provider.tsx\u0000AnimationProvider": {
+      "complexity_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/animations/animation-provider.tsx\u0000getVariants": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/animations/micro-interactions.tsx\u0000FeedbackToast": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/animations/micro-interactions.tsx\u0000SuccessCheckmark": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/animations/spring-animations.tsx\u0000SpringGesture": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/animations/transition-effects.tsx\u0000AccordionTransition": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/dialogs/create-node-popover.tsx\u0000CreateNodePopover": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/dialogs/edit-node-modal.tsx\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/dialogs/edit-node-modal.tsx\u0000EditNodeModal": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/dialogs/node-action-toolbar.tsx\u0000NodeActionToolbar": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/edges/animated-edge.tsx\u0000AnimatedEdge": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/edges/animated-edge.tsx\u0000GlowAnimatedEdge": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/edges/animated-edge.tsx\u0000PulseAnimatedEdge": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/edges/animated-edge.tsx\u0000ThicknessAnimatedEdge": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/edges/edge-utils.ts\u0000hexToRgb": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/edges/flowing-edge.tsx\u0000FlowingEdge": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/edges/flowing-edge.tsx\u0000PulseFlowEdge": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/edges/flowing-edge.tsx\u0000TrailFlowEdge": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/edges/glowing-edge.tsx\u0000BreathingGlowEdge": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/edges/glowing-edge.tsx\u0000GlowingEdge": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/edges/gradient-edge.tsx\u0000GradientEdge": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/edges/gradient-edge.tsx\u0000RadialGradientEdge": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/edges/gradient-edge.tsx\u0000ShimmerGradientEdge": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/edges/smart-edge.tsx\u0000SmartEdge": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/edges/smart-edge.tsx\u0000calculatePathByType": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/edges/smart-edge.tsx\u0000selectPathType": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/handles/custom-handle.tsx\u0000CustomHandle": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/handles/custom-handle.tsx\u0000HandleTooltip": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/handles/custom-handle.tsx\u0000computeHandleState": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/handles/custom-handle.tsx\u0000getIconForState": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/handles/custom-handle.tsx\u0000getTooltipMessage": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/handles/custom-handle.tsx\u0000getValidationRingClass": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/handles/custom-handle.tsx\u0000getVariantName": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/handles/custom-handle.tsx\u0000handleMouseUp": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/handles/handle-utils.ts\u0000<arrow>": {
       "crap_moderate": {
         "count": 2
+      }
+    },
+    "components/docs/curriculum/enhanced/handles/handle-utils.ts\u0000adjustHandlePosition": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/handles/handle-utils.ts\u0000calculateHandlePosition": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/handles/handle-utils.ts\u0000getConnectionHint": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/handles/handle-utils.ts\u0000getHandleColors": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/handles/handle-utils.ts\u0000validateConnection": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/attribute-badges.tsx\u0000AttributeContentSection": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/attribute-badges.tsx\u0000AttributesSection": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/attribute-badges.tsx\u0000MetadataSection": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/attribute-badges.tsx\u0000getAttributeText": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/base-node.tsx\u0000BaseNode": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/base-node.tsx\u0000NodeHeader": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/collapsible-node.tsx\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/collapsible-node.tsx\u0000CollapsibleNode": {
+      "complexity_moderate": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/collapsible-node.tsx\u0000ControlledCollapsibleNode": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/collapsible-node.tsx\u0000MemoizedCollapsibleNode": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/collapsible-node.tsx\u0000handleDoubleClick": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/collapsible-node.tsx\u0000handleExpandChange": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/evidence-node.tsx\u0000EvidenceNode": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/goal-node.tsx\u0000GoalNode": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/property-claim-node.tsx\u0000MetadataDisplay": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/property-claim-node.tsx\u0000PropertyClaimNode": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/strategy-node.tsx\u0000StrategyNode": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/use-node-state.ts\u0000expandNodeTree": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/use-node-state.ts\u0000expandPathToNode": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/use-node-state.ts\u0000loadFromStorage": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/nodes/use-node-state.ts\u0000useNodeState": {
+      "complexity_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/utils/animations.ts\u0000withReducedMotion": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/utils/identifier-utils.ts\u0000extractAttributes": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/utils/identifier-utils.ts\u0000extractMetadata": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/utils/identifier-utils.ts\u0000getDisplayName": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/enhanced/utils/theme-config.ts\u0000getThemeColors": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/learning-objectives.tsx\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/learning-objectives.tsx\u0000LearningObjectives": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/module-card.tsx\u0000ModuleCard": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/module-progress-tracker.tsx\u0000<arrow>": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/module-progress-tracker.tsx\u0000ModuleProgressTracker": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/module-progress-tracker.tsx\u0000handleTaskClick": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/progress-storage.ts\u0000getAllProgress": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/progress-storage.ts\u0000loadProgress": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/progress-storage.ts\u0000saveProgress": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/quiz-components.tsx\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/quiz-components.tsx\u0000ConfidenceRating": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/quiz-components.tsx\u0000Quiz": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/quiz-components.tsx\u0000SequentialQuiz": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/quiz-components.tsx\u0000TrueFalseRenderer": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/quiz-components.tsx\u0000getCorrectAnswerText": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/quiz-components.tsx\u0000getUserAnswerText": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/reflection-prompts.tsx\u0000ReflectionPrompts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/reflection-prompts.tsx\u0000handleSubmitAll": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/reflection-prompts.tsx\u0000saveCurrentResponse": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/reflection-prompts.tsx\u0000validateResponse": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/stage-selector.tsx\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/docs/curriculum/stage-selector.tsx\u0000StageSelector": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/docs/description-card.tsx\u0000DescriptionCard": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/layout/check-migration-notice.tsx\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/modals/_import-modal/github-import-tab.tsx\u0000GitHubImportTab": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/modals/_import-modal/google-drive-import-tab.tsx\u0000GoogleDriveImportTab": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/modals/_import-modal/use-case-import.ts\u0000extractErrorMessage": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/modals/_import-modal/use-case-import.ts\u0000importCase": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/modals/_import-modal/use-case-import.ts\u0000importFromGitHub": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/modals/_import-modal/use-case-import.ts\u0000importFromGoogleDrive": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/modals/_share-modal/document-export-section.tsx\u0000DocumentExportSection": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/modals/_share-modal/document-export-section.tsx\u0000handleDocumentExport": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/modals/_share-modal/google-backup-section.tsx\u0000GoogleBackupSection": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/modals/_share-modal/google-backup-section.tsx\u0000handleBackupToDrive": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/modals/_share-modal/image-export-section.tsx\u0000handleImageExport": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/modals/_share-modal/json-export-section.tsx\u0000handleExport": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/modals/case-create-modal.tsx\u0000CreateCase": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/modals/delete-element-modal.tsx\u0000DeleteElementModal": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/modals/migration-modal.tsx\u0000MigrationModal": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/modals/permissions-modal.tsx\u0000<arrow>": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/modals/permissions-modal.tsx\u0000handleRemovePermissions": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/navigation/desktop-nav.tsx\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/navigation/logged-in-user.tsx\u0000LoggedInUser": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/navigation/logged-in-user.tsx\u0000loadUser": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/navigation/mobile-nav.tsx\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/publishing/status-modal.tsx\u0000PublishedContent": {
+      "complexity_moderate": {
+        "count": 1
+      }
+    },
+    "components/shared/nodes/animations.ts\u0000withReducedMotion": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/shared/nodes/attach-element-dialog.tsx\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/shared/nodes/attach-element-dialog.tsx\u0000handleAttach": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/shared/nodes/attribute-section.tsx\u0000AttributeItem": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/shared/nodes/attribute-section.tsx\u0000AttributeSection": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/shared/nodes/base-node.tsx\u0000BaseNode": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/shared/nodes/move-element-dialog.tsx\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/shared/nodes/move-element-dialog.tsx\u0000candidates": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/shared/nodes/move-element-dialog.tsx\u0000handleMove": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/shared/nodes/node-action-group.tsx\u0000NodeActionGroup": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "components/sharing/_case-sharing/use-case-permissions.ts\u0000fetchPermissions": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/sharing/_case-sharing/use-case-permissions.ts\u0000onShareByEmail": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/sharing/case-sharing-dialog.tsx\u0000CaseSharingDialog": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/teams/create-team-dialog.tsx\u0000onSubmit": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/teams/invite-member-dialog.tsx\u0000onSubmit": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/teams/team-card.tsx\u0000TeamCard": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/teams/team-member-list.tsx\u0000<arrow>": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "components/teams/team-member-list.tsx\u0000handleRemoveMember": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/tour/tour-card.tsx\u0000TourCard": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/tour/tour-card.tsx\u0000handleKeyDown": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "components/ui/image-upload.tsx\u0000ImageUpload": {
+      "complexity_moderate": {
+        "count": 1
+      }
+    },
+    "hooks/use-history.ts\u0000redo": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "hooks/use-history.ts\u0000refetchCase": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "hooks/use-history.ts\u0000undo": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "hooks/use-integrations.ts\u0000useIntegrations": {
+      "complexity_moderate": {
+        "count": 1
+      }
+    },
+    "hooks/use-json-validation.ts\u0000errorToDiagnostic": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "hooks/use-json-validation.ts\u0000findPositionForPath": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "hooks/use-json-validation.ts\u0000parseJsonWithPosition": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "hooks/use-json-validation.ts\u0000validate": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "hooks/use-keyboard-shortcuts.ts\u0000handler": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "hooks/use-keyboard-shortcuts.ts\u0000isRedoShortcut": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "hooks/use-new-link-form.ts\u0000createPropertyClaimItem": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "hooks/use-new-link-form.ts\u0000createStrategyPayload": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "hooks/use-new-link-form.ts\u0000handleClaimAdd": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "hooks/use-new-link-form.ts\u0000handleContextAdd": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "hooks/use-new-link-form.ts\u0000handleGoalClaimUpdate": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "hooks/use-new-link-form.ts\u0000handlePropertyClaim": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "hooks/use-new-link-form.ts\u0000handleStrategyAdd": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "hooks/use-new-link-form.ts\u0000handleStrategyClaimUpdate": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "hooks/use-new-link-form.ts\u0000updateGoalWithStrategy": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "hooks/use-sidebar-logo.ts\u0000updateLogo": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/auth/config.ts\u0000authenticateGitHubWithPrisma": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/auth/config.ts\u0000authenticateGoogleWithPrisma": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/auth/config.ts\u0000authenticateWithPrisma": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/auth/config.ts\u0000authorize": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/auth/config.ts\u0000redirect": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/auth/config.ts\u0000signIn": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/auth/password-service.ts\u0000verifyPassword": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/auth/validate-session.ts\u0000validateSession": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/api.ts\u0000attachCaseElement": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/case/branch-utils.ts\u0000collectSubtree": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/branch-utils.ts\u0000extractBranches": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/case/case-updates.ts\u0000updateEvidence": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/case/case-updates.ts\u0000updatePropertyClaim": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/case/case-updates.ts\u0000updateStrategy": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/case-updates.ts\u0000updatedStrategies": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "lib/case/document-export.ts\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/document-export.ts\u0000exportDocument": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/case/document-export.ts\u0000layoutForExport": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/document-export.ts\u0000shouldIncludeInDiagram": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/evidence.ts\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/evidence.ts\u0000addEvidenceToClaim": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/evidence.ts\u0000processClaimForEvidenceUpdate": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/case/evidence.ts\u0000result": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/evidence.ts\u0000searchInStrategiesForEvidence": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/evidence.ts\u0000searchSinglePropertyClaimForEvidence": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/identifier-utils.ts\u0000compareIdentifiers": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/image-export.ts\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/image-export.ts\u0000captureAndDownload": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/image-export.ts\u0000shouldInclude": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/node-operations.ts\u0000collectOrphanElements": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/case/node-operations.ts\u0000collectStrategyOrphans": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/case/node-operations.ts\u0000deleteNode": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/node-operations.ts\u0000detachNode": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/case/node-utils.ts\u0000<arrow>": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/case/node-utils.ts\u0000calculateIdentifierFromLastItem": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/case/node-utils.ts\u0000getNodeArray": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/case/node-utils.ts\u0000searchInAllNestedStructures": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/node-utils.ts\u0000searchInPropertyClaims": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/node-utils.ts\u0000searchInStrategyItems": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/node-utils.ts\u0000setNodeIdentifier": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/case/node-utils.ts\u0000traverseNestedStructures": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/case/property-claims.ts\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/property-claims.ts\u0000addPropertyClaimToList": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/case/property-claims.ts\u0000addPropertyClaimToNested": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/case/property-claims.ts\u0000listPropertyClaims": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/case/property-claims.ts\u0000processClaimUpdate": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/case/property-claims.ts\u0000result": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/property-claims.ts\u0000searchInStrategies": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/case/property-claims.ts\u0000searchPropertyClaimItem": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/tree-diff.ts\u0000arraysEqual": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/case/tree-diff.ts\u0000computeElementChanges": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/case/tree-diff.ts\u0000computeEvidenceLinkChanges": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/tree-diff.ts\u0000detectCircularReference": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/tree-diff.ts\u0000flattenTreeWithLinks": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/tree-diff.ts\u0000processElementChange": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/tree-diff.ts\u0000validateParentReferences": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/tree-utils.ts\u0000addHiddenProp": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/case/tree-utils.ts\u0000findParentNode": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/tree-utils.ts\u0000getAdjacent": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/case/tree-utils.ts\u0000handleChildVisibility": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/tree-utils.ts\u0000processChildrenForHiddenStatus": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/case/tree-utils.ts\u0000searchWithDeepFirst": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/case/tree-utils.ts\u0000toggleChildren": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/docs/case-data-transformer.ts\u0000buildNode": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/docs/case-data-transformer.ts\u0000isCaseExportNested": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/docs/elk-layout.ts\u0000getLayoutedElements": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/export/exporters/pdf-components.tsx\u0000formatImageSrc": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/export/exporters/word-exporter.ts\u0000createDiagramPage": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/export/exporters/word-exporter.ts\u0000createElementBlock": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/export/exporters/word-exporter.ts\u0000detectImageType": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/export/exporters/word-exporter.ts\u0000export": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/export/exporters/word-exporter.ts\u0000renderContentBlock": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/export/templates/base-template.ts\u0000collectAllComments": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/export/templates/base-template.ts\u0000collectElementsByType": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/export/templates/base-template.ts\u0000shouldIncludeElement": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/export/templates/presets/full-report.ts\u0000renderElementWithContext": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/export/templates/presets/full-report.ts\u0000renderEvidenceItem": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/permissions.ts\u0000getCasePermissionFromPrisma": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/schemas/element-validation.ts\u0000cleanElementDataForType": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/schemas/version-detection.ts\u0000detectAndValidate": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/schemas/version-detection.ts\u0000detectVersion": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/schemas/version-detection.ts\u0000isNestedFormat": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/blob-storage-service.ts\u0000deleteBlob": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/blob-storage-service.ts\u0000uploadToBlob": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-batch-update-service.ts\u0000applyBatchUpdate": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/case-batch-update-service.ts\u0000applyUpdates": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-batch-update-service.ts\u0000buildCreateData": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-batch-update-service.ts\u0000calculateLevel": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-batch-update-service.ts\u0000createOne": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/case-batch-update-service.ts\u0000validateAssertionStatusChanges": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-batch-update-service.ts\u0000validateCreateParents": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-batch-update-service.ts\u0000validateUpdateParents": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-export-service.ts\u0000exportCase": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/case-export-service.ts\u0000fetchCommentsForElements": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/case-fetch-service.ts\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-fetch-service.ts\u0000buildCaseUpdateData": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-fetch-service.ts\u0000buildGoalStructure": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/case-fetch-service.ts\u0000buildPropertyClaimStructure": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/case-fetch-service.ts\u0000buildStrategyStructure": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/case-fetch-service.ts\u0000fetchCaseFromPrisma": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/case-fetch-service.ts\u0000mapPermissionToFrontend": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-fetch-service.ts\u0000updateCaseWithPrisma": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-image-service.ts\u0000uploadCaseImage": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/case-import-service.ts\u0000buildElementRow": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/case-import-service.ts\u0000createComments": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/case-import-service.ts\u0000initSortGraph": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-import-service.ts\u0000processSortQueue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/case-import-service.ts\u0000resolveExternalCitedElementIds": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-information-service.ts\u0000upsertCaseInformation": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/case-invite-service.ts\u0000acceptInvite": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/case-invite-service.ts\u0000result": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-permission-service.ts\u0000revokeTeamPermission": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-permission-service.ts\u0000revokeUserPermission": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-permission-service.ts\u0000shareByEmail": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/case-permission-service.ts\u0000shareWithTeam": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-permission-service.ts\u0000updateTeamPermission": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-permission-service.ts\u0000updateUserPermission": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-trash-service.ts\u0000purgeExpiredCases": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/case-trash-service.ts\u0000softDeleteCase": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/change-detection-service.ts\u0000compareTreeStructures": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/change-detection-service.ts\u0000detectChanges": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/change-detection-service.ts\u0000elementsAreEqual": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/change-detection-service.ts\u0000extractCompareData": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/comment-service.ts\u0000buildCommentTree": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/comment-service.ts\u0000createElementComment": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/comment-service.ts\u0000getCommentWithPermission": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/comment-service.ts\u0000resolveComment": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/connected-accounts-service.ts\u0000getConnectedAccounts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/connected-accounts-service.ts\u0000getNewAuthProvider": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/connected-accounts-service.ts\u0000unlinkProvider": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/connected-accounts-service.ts\u0000validateUnlinkRequest": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/darter-integration-service.ts\u0000ensureDarterIntegration": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/discover-service.ts\u0000toSummary": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/element-service.ts\u0000<arrow>": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/element-service.ts\u0000applyUrlUpdates": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/element-service.ts\u0000attachElement": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/element-service.ts\u0000buildUpdateData": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/element-service.ts\u0000calculatePropertyClaimLevel": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/element-service.ts\u0000createElement": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/element-service.ts\u0000deleteElement": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/element-service.ts\u0000detachElement": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/element-service.ts\u0000generateElementName": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/element-service.ts\u0000moveElement": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/element-service.ts\u0000resolveUrls": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/element-service.ts\u0000restoreElement": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/element-service.ts\u0000updateElement": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/element-service.ts\u0000validateCitedElementId": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/email-service.ts\u0000sendEmail": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/file-storage-service.ts\u0000deleteFile": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/file-storage-service.ts\u0000saveFile": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/github-api-service.ts\u0000buildParsedUrl": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/github-api-service.ts\u0000fetchFileFromGitHub": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/github-api-service.ts\u0000getUserGitHubToken": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/github-api-service.ts\u0000handleOctokitError": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/github-api-service.ts\u0000parseGitHubUrl": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/google-drive-service.ts\u0000downloadFileFromDrive": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/google-drive-service.ts\u0000getOrCreateBackupFolder": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/google-drive-service.ts\u0000getUserGoogleTokens": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/google-drive-service.ts\u0000listBackupFiles": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/google-drive-service.ts\u0000uploadBackupToDrive": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/health-evidence-service.ts\u0000record": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/health-scoring-service.ts\u0000readHealthState": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/health-scoring-service.ts\u0000recomputeHealthScore": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/health-scoring-service.ts\u0000resolveScoringSettings": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/health-staleness-sweep-service.ts\u0000groupHealthRowsByCase": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/health-staleness-sweep-service.ts\u0000sweepCaseClaims": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/health-staleness-sweep-service.ts\u0000sweepHealthStaleness": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/identifier-service.ts\u0000buildElementTree": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/identifier-service.ts\u0000collectEffectivePropertyClaimChildren": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/identifier-service.ts\u0000findParentNode": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/identifier-service.ts\u0000generatePropertyClaimName": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/identifier-service.ts\u0000processNode": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/identifier-service.ts\u0000resetIdentifiers": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/integration-registry-service.ts\u0000grantIntegrationCaseAccess": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/integration-registry-service.ts\u0000reactivateIntegration": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/integration-registry-service.ts\u0000registerIntegration": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/integration-registry-service.ts\u0000revokeToken": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/integration-registry-service.ts\u0000rotateToken": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/integration-registry-service.ts\u0000updateIntegration": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/integration-registry-service.ts\u0000validateApiToken": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/integration-registry-service.ts\u0000writeAuditLog": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/password-reset-service.ts\u0000requestPasswordReset": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/password-reset-service.ts\u0000resetPassword": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/plugin-data-service.ts\u0000resolveDataAccess": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/plugin-enablement-service.ts\u0000getUserPluginSettings": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/plugin-enablement-service.ts\u0000resolveEffectivePluginState": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/publish-service.ts\u0000getFullPublishStatus": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/publish-service.ts\u0000getPublishStatus": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/publish-service.ts\u0000publishAssuranceCase": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/publish-service.ts\u0000unpublishAssuranceCase": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/publish-service.ts\u0000updatePublishedCase": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/rate-limit-service.ts\u0000checkRateLimit": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/rate-limit-service.ts\u0000recordAttempt": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/sse-connection-manager.ts\u0000addConnection": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/sse-connection-manager.ts\u0000broadcast": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/sse-connection-manager.ts\u0000sendHeartbeat": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/team-member-service.ts\u0000addTeamMember": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/team-member-service.ts\u0000removeMember": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/team-member-service.ts\u0000updateMemberRole": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/team-service.ts\u0000createTeam": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/team-service.ts\u0000transformToResponse": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/team-service.ts\u0000updateTeam": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/tour-service.ts\u0000markTourCompleted": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/user-management-service.ts\u0000buildProfileUpdateData": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/user-management-service.ts\u0000changePassword": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/services/user-management-service.ts\u0000deleteAccount": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/services/user-management-service.ts\u0000updateUserProfile": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/user-management-service.ts\u0000validateProfileInput": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/user-service.ts\u0000dismissMigrationNotice": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/user-service.ts\u0000getCurrentUser": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/services/user-service.ts\u0000registerUser": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/toast.ts\u0000toast": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "lib/transforms/build-tree.ts\u0000addMetadataFields": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/transforms/build-tree.ts\u0000addTypeSpecificFields": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/transforms/build-tree.ts\u0000buildTreeFromElements": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/transforms/element-response.ts\u0000addParentReference": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/transforms/element-response.ts\u0000transformToResponse": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "lib/transforms/nested-to-flat.ts\u0000flattenNode": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/transforms/nested-to-flat.ts\u0000nodeToElement": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "lib/utils/tree-traversal.ts\u0000getDescendantIds": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "prisma/seed/dev-seed.ts\u0000loadCredentials": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "prisma/seed/dev-seed.ts\u0000main": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "providers/theme-preset-provider.tsx\u0000applyPreset": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "providers/tour-provider.tsx\u0000<arrow>": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "scripts/seed-darter-integration.ts\u0000main": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "scripts/seed-darter-integration.ts\u0000parseArgs": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "src/__tests__/mocks/radix-ui-mocks.tsx\u0000<arrow>": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "src/__tests__/mocks/radix-ui-mocks.tsx\u0000MockDropdownMenuItem": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "src/__tests__/mocks/radix-ui-mocks.tsx\u0000MockDropdownMenuTrigger": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "src/__tests__/mocks/radix-ui-mocks.tsx\u0000MockTooltipTrigger": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "src/__tests__/mocks/radix-ui-mocks.tsx\u0000handleKeyDown": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "src/__tests__/setup/dom-polyfills.ts\u0000<anonymous>": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "src/__tests__/setup/dom-polyfills.ts\u0000constructor": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "src/__tests__/utils/accessibility-test-utils.ts\u0000getAccessibleName": {
+      "complexity_moderate": {
+        "count": 1
+      }
+    },
+    "src/__tests__/utils/accessibility-test-utils.ts\u0000runAccessibilityTests": {
+      "complexity_moderate": {
+        "count": 1
+      }
+    },
+    "src/__tests__/utils/accessibility-test-utils.ts\u0000runCustomAccessibilityChecks": {
+      "complexity_moderate": {
+        "count": 1
+      }
+    },
+    "src/__tests__/utils/accessibility-test-utils.ts\u0000testFormAccessibility": {
+      "complexity_moderate": {
+        "count": 1
+      }
+    },
+    "src/__tests__/utils/accessibility-test-utils.ts\u0000testScreenReaderCompatibility": {
+      "complexity_moderate": {
+        "count": 1
+      }
+    },
+    "src/__tests__/utils/env-test-utils.ts\u0000withEnvVars": {
+      "crap_moderate": {
+        "count": 1
       }
     }
   },
@@ -1035,8 +4392,8 @@
     "components/docs/curriculum/enhanced/nodes/attribute-badges.tsx:dead code",
     "components/docs/curriculum/enhanced/utils/theme-config.ts:dead code",
     "components/docs/curriculum/enhanced/handles/custom-handle.tsx:dead code",
-    "lib/routes.ts:dead code",
     "components/shared/nodes/animations.ts:dead code",
+    "lib/routes.ts:dead code",
     "components/docs/curriculum/enhanced/utils/animations.ts:dead code",
     "components/docs/curriculum/enhanced/handles/handle-utils.ts:dead code",
     "src/__tests__/utils/file-test-utils.ts:dead code",

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -46,6 +46,14 @@
     "conventional-changelog-conventionalcommits"
   ],
   "ignoreDependencyOverrides": [{ "package": "@isaacs/brace-expansion" }],
+  "ignoreUnresolvedImports": [
+    "@/src/generated/prisma",
+    "@/src/generated/prisma/**",
+    "../src/generated/prisma",
+    "../src/generated/prisma/**",
+    "../../src/generated/prisma",
+    "../../src/generated/prisma/**"
+  ],
   "audit": {
     "deadCodeBaseline": ".fallow-baseline.dead-code.json",
     "healthBaseline": ".fallow-baseline.health.json",

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -17,6 +17,26 @@ name: Fallow Audit
 # and overstates risk on well-tested code). Neither needs a database; the
 # DATABASE_URL values below are placeholders `prisma generate` and the
 # Prisma client's module-scope config resolve but never connect to.
+#
+# --baseline-mode identity (health only): fallow's own base-commit
+# re-analysis (the mechanism above, not this flag) does NOT get --coverage —
+# it re-checks out the base ref into a worktree fallow manages itself, so a
+# pre-existing, UNTOUCHED high-CRAP function scores low there (module-graph
+# estimate) and high on head (real 0% coverage). The two scores don't match,
+# so the base-side finding and the head-side finding fail to pair up and the
+# untouched function is misattributed introduced:true (confirmed: PATCH in
+# app/api/cases/[id]/status/route.ts, byte-identical function scored with
+# real coverage on both sides, flagged only because fallow's internal base
+# pass omits --coverage). fallow has no flag to feed coverage into that
+# internal base pass, so the fix instead routes health attribution through
+# .fallow-baseline.health.json (audit.healthBaseline in .fallowrc.json,
+# already wired) in --baseline-mode identity: a baseline saved from the base
+# ref WITH real coverage, matched per (file, function name, category) rather
+# than fallow's own coverage-blind base-commit diff. This flag requires
+# .fallow-baseline.health.json to have been saved with BOTH --coverage and
+# --baseline-mode identity — reading it in identity mode otherwise hard-errors
+# (exit 2, a tool-config failure, not a findings failure). Refresh command:
+# see "TEA — Fallow CI gate false positives" issue notes.
 
 on:
   pull_request:
@@ -90,6 +110,8 @@ jobs:
           npx -y fallow audit \
             --changed-since "origin/${{ github.base_ref }}" \
             --coverage coverage/coverage-final.json \
+            --health-baseline .fallow-baseline.health.json \
+            --baseline-mode identity \
             --format pr-comment-github \
             --output-file fallow-comment.md \
             --quiet

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -4,7 +4,19 @@ name: Fallow Audit
 # changed files, scoped to NEW findings only. Posts/updates a PR comment and
 # fails the job when the changeset introduces a finding; inherited debt
 # (tracked via .fallow-baseline.*.json, wired through .fallowrc.json's
-# `audit` block) does not block. Config: .fallowrc.json.
+# `audit` block, plus fallow's own base-commit re-analysis for `--gate
+# new-only`) does not block. Config: .fallowrc.json.
+#
+# The gate needs a real, if minimal, project environment to evaluate
+# honestly rather than on tool-environment artefacts: deps installed so the
+# generated Prisma client resolves (`src/generated/prisma`, gitignored,
+# imported by discover-service.ts/dev-seed.ts — without it fallow reports a
+# hard unresolved-import error unrelated to any PR), and a plain-unit-suite
+# coverage run so fallow's per-function CRAP score is measured, not
+# estimated from the module graph (the estimate can't see test assertions
+# and overstates risk on well-tested code). Neither needs a database; the
+# DATABASE_URL values below are placeholders `prisma generate` and the
+# Prisma client's module-scope config resolve but never connect to.
 
 on:
   pull_request:
@@ -31,10 +43,45 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        # Needed so fallow can resolve real imports (notably the generated
+        # Prisma client below) and so the coverage step has a tree to run in.
+        # --frozen-lockfile: never mutate the lockfile in CI.
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        # discover-service.ts / dev-seed.ts import the generated client
+        # (`src/generated/prisma`, gitignored). Without this, fallow's
+        # import-resolution can't find it and reports a dead-code error —
+        # not a real finding, just an unbuilt environment. `generate` only
+        # needs DATABASE_URL to resolve (prisma.config.ts loads it), it
+        # never connects; the value is a placeholder.
+        run: npx prisma generate --schema prisma/schema.prisma
+        env:
+          DATABASE_URL: "postgresql://fallow:fallow@localhost:5432/fallow"
+
+      - name: Run unit tests with coverage
+        # Istanbul coverage feeds fallow's per-function CRAP score. Without
+        # it, fallow estimates coverage from the module graph, which
+        # overstates risk for functions that ARE tested (module-graph
+        # estimation can't see test assertions, only import structure) and
+        # produces false-positive high-CRAP findings on well-tested code.
+        # This is the plain unit suite (vitest.config.ts), not the
+        # Postgres-backed integration/e2e suites build.yaml runs — no DB
+        # needed, ~10-15s.
+        run: pnpm exec vitest run --coverage
+        env:
+          COVERAGE: "true"
+          DATABASE_URL: "postgresql://fallow:fallow@localhost:5432/fallow"
 
       - name: Run fallow audit on changed files
         id: fallow-audit
@@ -42,6 +89,7 @@ jobs:
           set +e
           npx -y fallow audit \
             --changed-since "origin/${{ github.base_ref }}" \
+            --coverage coverage/coverage-final.json \
             --format pr-comment-github \
             --output-file fallow-comment.md \
             --quiet


### PR DESCRIPTION
## Problem

The Structural Quality gate (landed this morning) failed PRs #896/#897 on tool-environment artefacts rather than real findings:

1. **Unresolved-import errors** — the job never generated the Prisma client, so imports of generated code reported as dead-code majors (a hard-error class that bypasses new-only attribution entirely).
2. **Coverage-blind CRAP scores** — no coverage report was fed to the audit, so genuinely-tested new functions scored as complex-and-untested.
3. Once real coverage was added, a third latent issue surfaced: fallow's base-commit re-analysis for new-vs-inherited attribution never receives the coverage file, so base and head score the same function differently and **untouched pre-existing functions in an edited file get misattributed as introduced** (proven byte-identical either side; only attribution differed).

## Fix (3 commits)

- **Environment**: install deps (cached), generate the Prisma client, run the unit suite with coverage (~11s) and feed `coverage-final.json` to the audit; `ignoreUnresolvedImports` entries scoped to the three literal generated-client specifiers (verified: a genuinely broken import still fails the gate).
- **Attribution**: `--baseline-mode identity` on the health baseline — matches findings per (file, function, category), immune to the coverage asymmetry; proven more precise than count mode in a no-line-shift control.
- **Baseline refresh** (own commit, per convention): health baseline regenerated in identity mode with real coverage.

An upstream bug report for the attribution asymmetry is drafted for fallow's maintainers.

## Verification

- All three open PR branches replayed through the exact CI steps: #898 clean (exit 0, inherited findings correctly excluded); #896/#897 reduced to only their genuinely-new integration-covered-only functions (documented, accepted — feeding integration coverage to the gate is tracked internally as a follow-up).
- Negative controls held: a deliberately broken import and a deliberately new uncovered complex function both still fail the gate, the latter on real measured coverage.
- Fail-closed preserved on every traced failure path (install/generate/coverage/audit failures all fail the job; a missing coverage file hard-errors exit 2 — smoke-tested). Unit-test failures fail a distinct step with vitest's own output, distinguishable from a findings failure.
- actionlint clean; job time ~45–90s, well inside the 10-minute timeout.