### PR TITLE
fix: make case import atomic by threading tx through the import chain

### DIFF
--- a/lib/services/case-import-service.ts
+++ b/lib/services/case-import-service.ts
@@ -466,6 +466,11 @@ async function createElements(
 
 	try {
 		await tx.assuranceElement.createMany({ data });
+		// Success path: deliberately not RELEASE-ing the savepoint here.
+		// Postgres releases it automatically when the enclosing
+		// transaction commits; an explicit RELEASE could race with a
+		// later ROLLBACK TO SAVEPOINT issued by another helper further
+		// down the import chain. Do not "fix" this by adding one.
 	} catch (error) {
 		if (!isCitedElementIdForeignKeyError(error)) {
 			throw error;
@@ -608,6 +613,11 @@ export async function importCase(
 		// leaving a partial case (each helper previously called the global
 		// `prisma` singleton, which auto-commits per statement regardless of
 		// this wrapper).
+		// No explicit timeout/maxWait: the default 5s interactive-transaction
+		// timeout is fine here because the in-transaction round-trips are
+		// O(1) — a fixed ~4-6 calls (createCaseWithPermission, createElements,
+		// createEvidenceLinks, createComments, plus one retry on the
+		// savepoint path) — regardless of import payload size, not O(elements).
 		const result = await prisma.$transaction(async (tx) => {
 			// Create case
 			const caseId = await createCaseWithPermission(tx, v2Data.case, userId);

--- a/lib/services/case-import-service.ts
+++ b/lib/services/case-import-service.ts
@@ -3,6 +3,27 @@ import type { CaseExportV2, ElementV2 } from "@/lib/schemas/case-export";
 import { detectAndValidate } from "@/lib/schemas/version-detection";
 import { Prisma } from "@/src/generated/prisma";
 
+// Derived from `prisma.$transaction`'s own callback parameter — same pattern
+// as `publish-service.ts` / `slug-service.ts` (kept local rather than
+// imported: `Prisma.TransactionClient` does not structurally match this
+// project's `.$extends()`-wrapped client from `lib/prisma.ts`).
+type TransactionCallback = Parameters<typeof prisma.$transaction>[0];
+type TransactionClient = TransactionCallback extends (
+	tx: infer T
+) => Promise<unknown>
+	? T
+	: never;
+
+/**
+ * Prisma-compatible client that can run queries: either the global `prisma`
+ * singleton (for calls made before/outside the import's transaction) or the
+ * transaction-scoped `tx` client (for calls made from inside it). Used by
+ * `resolveExternalCitedElementIds`, which is called both ways — once before
+ * `prisma.$transaction` opens (keeps the transaction short) and once more,
+ * against `tx`, from inside `createElements`' resolve-window race backstop.
+ */
+type PrismaLikeClient = typeof prisma | TransactionClient;
+
 export type ImportResult =
 	| {
 			data: {
@@ -152,10 +173,11 @@ function buildIdMap(elements: ElementV2[]): Map<string, string> {
  * Creates the case and grants ADMIN permission to the user.
  */
 async function createCaseWithPermission(
+	tx: TransactionClient,
 	caseData: CaseExportV2["case"],
 	userId: string
 ): Promise<string> {
-	const newCase = await prisma.assuranceCase.create({
+	const newCase = await tx.assuranceCase.create({
 		data: {
 			name: caseData.name,
 			description: caseData.description,
@@ -187,8 +209,13 @@ async function createCaseWithPermission(
  * window race backstop: if an id resolved here is deleted before the insert
  * actually runs, re-calling this same function after that P2003 correctly
  * comes back without it — see createElements' docstring.
+ *
+ * Takes a `client` (global `prisma` for the pre-transaction call in
+ * `importCase`, or the transaction-scoped `tx` for the in-transaction retry
+ * inside `createElements`) rather than being duplicated per call site.
  */
 async function resolveExternalCitedElementIds(
+	client: PrismaLikeClient,
 	elements: ElementV2[],
 	idMap: Map<string, string>
 ): Promise<Set<string>> {
@@ -203,7 +230,7 @@ async function resolveExternalCitedElementIds(
 		return externalIds;
 	}
 
-	const found = await prisma.assuranceElement.findMany({
+	const found = await client.assuranceElement.findMany({
 		where: { id: { in: [...externalIds] } },
 		select: { id: true },
 	});
@@ -388,8 +415,32 @@ function buildElementRows(
  * P2003 on any OTHER foreign key (caseId, parentId, defeatsElementId,
  * moduleReferenceId) — or a second failure on retry — is not this module's
  * to recover from and propagates, failing the import as before.
+ *
+ * SAVEPOINT/ROLLBACK TO SAVEPOINT around the first attempt (verified against
+ * a real Postgres, see case-import-service.test.ts and the issue writeup):
+ * now that this whole import runs inside one real `prisma.$transaction`,
+ * Postgres aborts the transaction on ANY error — including the P2003 this
+ * catch recovers from — and every statement after an aborted-but-uncaught-
+ * at-the-database-level error fails with `25P02 current transaction is
+ * aborted` until the transaction ends. Catching the P2003 in JS is not
+ * enough to make the connection usable again. A `SAVEPOINT` taken
+ * immediately before the first `createMany` gives the retry somewhere to
+ * roll back to — `ROLLBACK TO SAVEPOINT` undoes exactly (and only) the
+ * failed insert, clears the aborted state, and lets the retry's `createMany`
+ * run on the same transaction. This also removes the createMany-chunking
+ * caveat noted at the fix's original review (2026-07-20): the retry
+ * re-inserts the entire element row set, which was previously safe only
+ * because `createMany` happened to be a single non-transactional INSERT — if
+ * a future change chunked it into several statements, a partial success
+ * before the failing chunk would have already committed under the old
+ * auto-commit-per-statement code. Under this savepoint, nothing commits
+ * until the OUTER transaction commits, so `ROLLBACK TO SAVEPOINT` undoes
+ * every chunk executed since the savepoint was taken, not just the one that
+ * failed — chunking `createMany` in future would remain safe to retry
+ * whole-batch without re-introducing this caveat.
  */
 async function createElements(
+	tx: TransactionClient,
 	caseId: string,
 	elements: ElementV2[],
 	idMap: Map<string, string>,
@@ -407,15 +458,25 @@ async function createElements(
 		userId
 	);
 
+	// Savepoint name is generated internally (crypto.randomUUID, never
+	// user input) so interpolating it into raw SQL carries no injection
+	// risk; Prisma has no parameterised SAVEPOINT API.
+	const savepoint = `import_elements_${crypto.randomUUID().replaceAll("-", "_")}`;
+	await tx.$executeRawUnsafe(`SAVEPOINT "${savepoint}"`);
+
 	try {
-		await prisma.assuranceElement.createMany({ data });
+		await tx.assuranceElement.createMany({ data });
 	} catch (error) {
 		if (!isCitedElementIdForeignKeyError(error)) {
 			throw error;
 		}
 
+		// Undo the failed insert and clear the transaction's aborted state
+		// before issuing any further statement on this connection.
+		await tx.$executeRawUnsafe(`ROLLBACK TO SAVEPOINT "${savepoint}"`);
+
 		const reResolvedExternalCitedElementIds =
-			await resolveExternalCitedElementIds(elements, idMap);
+			await resolveExternalCitedElementIds(tx, elements, idMap);
 		const retryData = buildElementRows(
 			sortedElements,
 			idMap,
@@ -423,7 +484,7 @@ async function createElements(
 			caseId,
 			userId
 		);
-		await prisma.assuranceElement.createMany({ data: retryData });
+		await tx.assuranceElement.createMany({ data: retryData });
 	}
 
 	return data.length;
@@ -434,6 +495,7 @@ async function createElements(
  * Note: EvidenceLink only has evidenceId and claimId - no caseId.
  */
 async function createEvidenceLinks(
+	tx: TransactionClient,
 	links: CaseExportV2["evidenceLinks"],
 	idMap: Map<string, string>
 ): Promise<number> {
@@ -448,7 +510,7 @@ async function createEvidenceLinks(
 		})
 		.filter((d) => d !== null);
 
-	await prisma.evidenceLink.createMany({ data });
+	await tx.evidenceLink.createMany({ data });
 
 	return data.length;
 }
@@ -457,6 +519,7 @@ async function createEvidenceLinks(
  * Creates comments for all elements that have them.
  */
 async function createComments(
+	tx: TransactionClient,
 	elements: ElementV2[],
 	idMap: Map<string, string>,
 	userId: string
@@ -500,7 +563,7 @@ async function createComments(
 	}
 
 	if (data.length > 0) {
-		await prisma.comment.createMany({ data });
+		await tx.comment.createMany({ data });
 	}
 
 	return data.length;
@@ -536,15 +599,22 @@ export async function importCase(
 		// target DB BEFORE opening the transaction — keeps the transaction
 		// short and means the createMany insert never has to guess.
 		const resolvedExternalCitedElementIds =
-			await resolveExternalCitedElementIds(v2Data.elements, idMap);
+			await resolveExternalCitedElementIds(prisma, v2Data.elements, idMap);
 
-		// Use a transaction to ensure atomicity
-		const result = await prisma.$transaction(async () => {
+		// Use a transaction to ensure atomicity. The callback takes the
+		// transaction-scoped `tx` client and threads it through every helper
+		// below — the whole import is one atomic Postgres transaction, so a
+		// mid-import failure rolls back everything written so far instead of
+		// leaving a partial case (each helper previously called the global
+		// `prisma` singleton, which auto-commits per statement regardless of
+		// this wrapper).
+		const result = await prisma.$transaction(async (tx) => {
 			// Create case
-			const caseId = await createCaseWithPermission(v2Data.case, userId);
+			const caseId = await createCaseWithPermission(tx, v2Data.case, userId);
 
 			// Create elements
 			const elementCount = await createElements(
+				tx,
 				caseId,
 				v2Data.elements,
 				idMap,
@@ -554,12 +624,18 @@ export async function importCase(
 
 			// Create evidence links
 			const evidenceLinkCount = await createEvidenceLinks(
+				tx,
 				v2Data.evidenceLinks,
 				idMap
 			);
 
 			// Create comments for elements that have them
-			const commentCount = await createComments(v2Data.elements, idMap, userId);
+			const commentCount = await createComments(
+				tx,
+				v2Data.elements,
+				idMap,
+				userId
+			);
 
 			return {
 				caseId,

--- a/src/__tests__/integration/case-import.test.ts
+++ b/src/__tests__/integration/case-import.test.ts
@@ -140,6 +140,94 @@ describe("importCase", () => {
 
 		expectSameError(nullResult, badResult);
 	});
+
+	/**
+	 * Atomicity — the issue this fix addresses. `importCase`'s
+	 * `prisma.$transaction` callback previously called the global `prisma`
+	 * singleton throughout (not the transaction-scoped `tx` client), so every
+	 * statement auto-committed independently: a failure partway through left
+	 * the case and any elements already written stuck in the database. This
+	 * is an HONEST failure injection against a real constraint — not a mock
+	 * of the transaction, and not a spy on any Prisma method (spying on the
+	 * global `prisma` client's methods does not intercept calls made through
+	 * the transaction-scoped `tx` client the fix now uses throughout, so a
+	 * spy-based injection would silently no-op and prove nothing). The flat
+	 * V2 import payload below is hand-built (bypassing the nested→flat
+	 * transform) with a genuinely duplicated `evidenceLinks` entry — the same
+	 * `(evidenceId, claimId)` pair twice — which hits the real
+	 * `evidence_links_evidence_id_claim_id_key` unique constraint on
+	 * `createEvidenceLinks`' `createMany`, genuinely AFTER the case and both
+	 * elements have been written inside the same transaction. If the
+	 * transaction is truly atomic, that real Postgres error rolls back
+	 * everything; if it is not, the case and elements survive despite
+	 * `importCase` reporting an error.
+	 */
+	it("rolls back the entire case (and every element already written) when a real DB constraint failure hits partway through the import", async () => {
+		const user = await createTestUser();
+		const { importCase } = await import("@/lib/services/case-import-service");
+
+		const claimId = "70000000-0000-4000-8000-000000000001";
+		const evidenceId = "70000000-0000-4000-8000-000000000002";
+		const json = {
+			version: "2.0",
+			exportedAt: new Date().toISOString(),
+			case: {
+				name: "Atomicity Rollback Case",
+				description:
+					"Case whose evidence links genuinely violate a DB constraint",
+			},
+			elements: [
+				{
+					id: claimId,
+					elementType: "PROPERTY_CLAIM",
+					role: "TOP_LEVEL",
+					parentId: null,
+					name: "Root Claim",
+					description: "A property claim",
+					inSandbox: false,
+				},
+				{
+					id: evidenceId,
+					elementType: "EVIDENCE",
+					role: null,
+					parentId: null,
+					name: "Supporting Evidence",
+					description: "Evidence for the claim",
+					inSandbox: false,
+					url: "https://example.com/evidence",
+				},
+			],
+			// Duplicated pair — a real unique-constraint violation
+			// (evidence_links_evidence_id_claim_id_key) on the createMany
+			// insert, not a mocked/injected error.
+			evidenceLinks: [
+				{ evidenceId, claimId },
+				{ evidenceId, claimId },
+			],
+		};
+
+		const result = await importCase(user.id, json);
+		expectError(result);
+
+		// Nothing from the failed import landed: not the case, not either of
+		// its elements. A partial write here (case/elements present despite
+		// the reported error) is exactly the non-atomic bug this test guards
+		// against.
+		const cases = await prisma.assuranceCase.findMany({
+			where: { name: "Atomicity Rollback Case", createdById: user.id },
+		});
+		expect(cases).toHaveLength(0);
+
+		const elements = await prisma.assuranceElement.findMany({
+			where: { id: { in: [claimId, evidenceId] } },
+		});
+		expect(elements).toHaveLength(0);
+
+		const links = await prisma.evidenceLink.findMany({
+			where: { evidenceId, claimId },
+		});
+		expect(links).toHaveLength(0);
+	});
 });
 
 // ============================================

--- a/src/__tests__/integration/case-import.test.ts
+++ b/src/__tests__/integration/case-import.test.ts
@@ -91,6 +91,56 @@ describe("importCase", () => {
 		expect(links.length).toBeGreaterThanOrEqual(1);
 	});
 
+	it("creates comment rows for an element carrying a comments array", async () => {
+		const user = await createTestUser();
+		const { importCase } = await import("@/lib/services/case-import-service");
+
+		const json = createNestedCaseJSON({
+			tree: {
+				id: "20000000-0000-4000-8000-000000000001",
+				type: "GOAL",
+				name: "Commented Goal",
+				description: "The root goal",
+				inSandbox: false,
+				role: "TOP_LEVEL",
+				comments: [
+					{
+						author: "reviewer",
+						content: "Looks good, one nit below.",
+						createdAt: new Date().toISOString(),
+					},
+					{
+						author: "reviewer",
+						content: "Please add a citation here.",
+						createdAt: new Date().toISOString(),
+					},
+				],
+				children: [],
+			},
+		});
+
+		const data = expectSuccess(await importCase(user.id, json));
+		expect(data.commentCount).toBe(2);
+
+		const goal = await prisma.assuranceElement.findFirst({
+			where: { caseId: data.caseId, name: "Commented Goal" },
+		});
+		expect(goal).not.toBeNull();
+
+		const comments = await prisma.comment.findMany({
+			where: { elementId: goal?.id },
+			orderBy: { content: "asc" },
+		});
+		expect(comments).toHaveLength(2);
+		expect(comments.map((c) => c.content).sort()).toEqual(
+			["Looks good, one nit below.", "Please add a citation here."].sort()
+		);
+		for (const comment of comments) {
+			expect(comment.authorId).toBe(user.id);
+			expect(comment.elementId).toBe(goal?.id);
+		}
+	});
+
 	it("returns an error for null/empty JSON input", async () => {
 		const user = await createTestUser();
 		const { importCase } = await import("@/lib/services/case-import-service");
@@ -632,6 +682,14 @@ describe("validateImportData", () => {
 			where: { name: "Root Goal" },
 		});
 		expect(elements).toHaveLength(0);
+
+		// The case row itself must also be gone — createCaseWithPermission
+		// runs inside the same transaction as createElements, so the whole
+		// import (case included) rolls back on the unrelated FK failure.
+		const cases = await prisma.assuranceCase.findMany({
+			where: { name: "Bad Module Reference Case" },
+		});
+		expect(cases).toHaveLength(0);
 	});
 
 	/**


### PR DESCRIPTION
## What

Case import's `prisma.$transaction(async () => {...})` callback called the global `prisma` client throughout (`createCaseWithPermission`, `createElements`, `createEvidenceLinks`, `createComments`), so each statement auto-committed and the import was not atomic — a mid-import failure left a partially-written case behind. This threads the transaction-scoped `tx` client through the whole chain so the import commits or rolls back as one unit.

## Key changes

- `lib/services/case-import-service.ts`: `tx` (typed via the repo's `Parameters<typeof prisma.$transaction>[0]` pattern, as in `publish-service.ts`/`slug-service.ts`) threaded through all import helpers; `resolveExternalCitedElementIds` now takes the client as a parameter (called once pre-transaction with `prisma` to keep the transaction short, once inside on the retry path with `tx`).
- The `citedElementId` P2003 retry-once (from the resolve-window race fix) is reshaped around a Postgres `SAVEPOINT` / `ROLLBACK TO SAVEPOINT` (via `$executeRawUnsafe` with fixed statements and a `randomUUID()`-derived name — no user input). This is required: inside a real interactive transaction, any statement error aborts the transaction (`25P02`), so the previous JS-level catch/retry cannot work. Verified against a live Postgres. Unrelated-FK P2003s and second failures still fail the import loudly.
- Side effect: the earlier `createMany`-chunking caveat on whole-batch retry no longer applies — nothing commits until the outer transaction commits, so a savepoint rollback undoes all chunks.

## Tests

- New integration test forces a real unique-constraint violation (`evidence_links_evidence_id_claim_id_key`) mid-import — genuinely after the case and elements were written — and asserts zero case/element/link rows survive. Proven failing against the pre-fix code (leaked case row) and passing post-fix. Deliberately payload-driven rather than spy-based: spies on the global client do not intercept `tx`-scoped calls.
- The pre-existing resolve-window race test exercises the new savepoint path for real (its mid-import delete is a committed delete, producing a genuine P2003 inside the transaction).
- Review round added: a comments happy-path import test (previously uncovered) and a zero-case-rows assertion on the unrelated-FK test.

## Verification

- Full integration suite at the final commit: 55 files, 910/910 green.
- `tsc --noEmit` clean; ultracite clean; fallow audit (per-analysis baselines, `--changed-since origin/staging`) 0 issues.
- QA and code review both passed; the post-review delta (comments + test additions only, +68 lines) was re-reviewed and approved.