### PR TITLE
ci: pin release.yaml checkout to ref main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          # workflow_run always checks out the DEFAULT branch unless pinned —
+          # correct today only because main is the default. This checkout
+          # carries a write-scoped RELEASE_TOKEN feeding semantic-release, so
+          # pin explicitly. Same bug class as seed-staging.yml (fixed 2026-07-05).
+          ref: main
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
 


### PR DESCRIPTION
## What

Adds `ref: main` to the checkout step in `.github/workflows/release.yaml`.

## Why

`release.yaml` triggers on `workflow_run` after Build completes on `main`. An unpinned checkout under a `workflow_run` trigger takes the repository's **default branch**, not the branch that triggered the run — correct today only because `main` happens to be the default. This checkout carries the write-scoped `RELEASE_TOKEN` that feeds `semantic-release`, so a default-branch change would have silently released from the wrong tree. Same bug class as the seed workflow fix (2026-07-05); `seed-staging.yml` already pins `ref: staging`.

A repo-wide sweep confirmed these are the only two `workflow_run` workflows; both are now pinned.

## Review

Implemented by the backend track; QA and code review both approved (security review verified the pin closes the wrong-tree-with-write-token vector; fallow audit clean). Verification of the live behaviour happens on the next real promotion: watch the Release run's Checkout step log print the checked-out ref.