### PR TITLE
ci: run the lint gate on every PR; gate expensive jobs per-job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,18 +49,29 @@ env:
 jobs:
   changes:
     name: Detect code-relevant changes
-    # Only needed to decide whether the expensive PR jobs (test, docker-build)
-    # can be skipped. Validate Code Quality never depends on this — it always
-    # runs, unconditionally, on every PR.
-    if: github.event_name == 'pull_request'
+    # Runs on EVERY event, unfiltered — not just pull_request. Two reasons:
+    # 1. `test` (below) declares `needs: [changes]`. Per GitHub's docs and
+    #    actions/runner#2205, a dependent job is skipped when a needed job is
+    #    skipped UNLESS the dependent's `if:` contains a status-check function
+    #    (always()/!cancelled()/etc). Community reports on the exact trigger
+    #    conditions for that behaviour are contradictory, so rather than rely
+    #    on the subtlety at all, this job simply never skips itself — there is
+    #    no skipped `needs` for push/workflow_dispatch to propagate from.
+    # 2. The dorny/paths-filter step below is the only part that actually
+    #    needs the pull_request event (it reads the PR's changed-files API);
+    #    it is gated on its own `if:`, not the job's.
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      # For any non-PR event (push, workflow_dispatch) there is no PR diff to
+      # filter, so treat everything as code-relevant: 'true'. For pull_request
+      # events, defer to the filter step's actual answer.
+      code: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.code }}
     steps:
       - name: Filter changed paths
         id: filter
+        if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         with:
           filters: |
@@ -138,15 +149,27 @@ jobs:
   test:
     name: Run Tests
     needs: [changes]
-    # `changes` only runs for pull_request events (see its own `if`), so for
-    # push/workflow_dispatch it is skipped, not failed. This is a custom `if`
-    # expression, which means GitHub does NOT apply its usual implicit
-    # `success()` check against `needs` — so a skipped `changes` job does not
-    # skip this one. The first clause covers push/workflow_dispatch (always
-    # run, unchanged from today); the second gates pull_request on whether
-    # code-relevant paths changed. Config-only PRs end up SKIPPED, not
-    # absent, which still satisfies a required status check.
-    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
+    # `changes` now runs unconditionally (see its own comment), so it is never
+    # itself skipped — the skip-propagation subtlety documented there
+    # (GitHub docs + actions/runner#2205; community reports are contradictory
+    # on the precise trigger conditions) cannot bite this job either way, but
+    # we still write this `if:` defensively with an explicit status function
+    # rather than depend on that reasoning holding.
+    #
+    # Fail CLOSED: `!cancelled()` means this only skips evaluation if the
+    # workflow run itself is being cancelled. `needs.changes.result !=
+    # 'success'` covers `changes` failing or erroring (e.g. paths-filter
+    # throwing on a malformed PR diff) — in that case `needs.changes.outputs.
+    # code` would be empty/undefined, and we must NOT silently skip tests
+    # behind a green required check, so this clause runs tests instead.
+    # `needs.changes.outputs.code == 'true'` is the normal path: push/
+    # workflow_dispatch always get code=true from `changes`; PRs get the
+    # paths-filter's real answer. Net effect: push/dispatch → run; PR
+    # touching code paths → run; config-only PR → changes succeeds with
+    # code=false → SKIPPED (skipped still satisfies a required status
+    # check); changes fails or the run is cancelled mid-PR → run (fail
+    # closed), except a genuine cancellation short-circuits via !cancelled().
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.code == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,31 +2,13 @@ name: Build
 
 on:
   workflow_dispatch:
+  # No paths filter here: an unfiltered trigger means Validate Code Quality
+  # (lint + typecheck) runs on every PR, so it always produces a status check
+  # to satisfy branch protection. The `changes` job below still gates the
+  # expensive jobs (test/docker-build) on the same path list, per-job rather
+  # than at the workflow trigger. See PR #861, which merged with zero lint
+  # coverage because it only touched paths outside this filter.
   pull_request:
-    paths:
-      - "app/**"
-      - "components/**"
-      - "lib/**"
-      - "actions/**"
-      - "hooks/**"
-      - "prisma/**"
-      - "scripts/**"
-      - "content/**"
-      - "e2e/**"
-      - "src/__tests__/**"
-      - "theme.config.tsx"
-      - "mdx-components.tsx"
-      - "playwright.config.ts"
-      - "vitest.config.ts"
-      - "vitest.workspace.ts"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "Dockerfile"
-      - "types/**"
-      - "next.config.*"
-      - "tsconfig.json"
-      - "biome.json"
-      - ".github/workflows/**"
   push:
     branches:
       - main
@@ -65,6 +47,48 @@ env:
   STAGING_APP_URL: https://staging-assuranceplatform.azurewebsites.net
 
 jobs:
+  changes:
+    name: Detect code-relevant changes
+    # Only needed to decide whether the expensive PR jobs (test, docker-build)
+    # can be skipped. Validate Code Quality never depends on this — it always
+    # runs, unconditionally, on every PR.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          filters: |
+            code:
+              - "app/**"
+              - "components/**"
+              - "lib/**"
+              - "actions/**"
+              - "hooks/**"
+              - "prisma/**"
+              - "scripts/**"
+              - "content/**"
+              - "e2e/**"
+              - "src/__tests__/**"
+              - "theme.config.tsx"
+              - "mdx-components.tsx"
+              - "playwright.config.ts"
+              - "vitest.config.ts"
+              - "vitest.workspace.ts"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - "Dockerfile"
+              - "types/**"
+              - "next.config.*"
+              - "tsconfig.json"
+              - "biome.json"
+              - ".github/workflows/**"
+
   validate:
     name: Validate Code Quality
     runs-on: ubuntu-latest
@@ -113,6 +137,16 @@ jobs:
 
   test:
     name: Run Tests
+    needs: [changes]
+    # `changes` only runs for pull_request events (see its own `if`), so for
+    # push/workflow_dispatch it is skipped, not failed. This is a custom `if`
+    # expression, which means GitHub does NOT apply its usual implicit
+    # `success()` check against `needs` — so a skipped `changes` job does not
+    # skip this one. The first clause covers push/workflow_dispatch (always
+    # run, unchanged from today); the second gates pull_request on whether
+    # code-relevant paths changed. Config-only PRs end up SKIPPED, not
+    # absent, which still satisfies a required status check.
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,11 @@ export default defineConfig({
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 2 : 0,
 	workers: process.env.CI ? 2 : undefined,
-	reporter: process.env.CI ? "github" : "html",
+	// The "github" reporter only annotates the PR — it never writes a
+	// playwright-report/ folder, so CI's "Upload Playwright report" step had
+	// nothing to upload, pass or fail (0 artifacts on a failed run, 2026-07-17).
+	// Keep github annotations and also emit the html report CI uploads.
+	reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "html",
 	use: {
 		baseURL: "http://localhost:3000",
 		trace: "on-first-retry",


### PR DESCRIPTION
## What

- Removes the `paths:` filter from `build.yaml`'s `pull_request` trigger, so the workflow — and with it **Validate Code Quality** (lint + typecheck, ~90s) — runs on every PR. The `push` trigger keeps its filter.
- Adds a `changes` job (dorny/paths-filter, pinned to the GPG-verified v4.0.3 commit SHA, job-scoped `pull-requests: read`, no checkout) that answers whether code-relevant paths changed. **Run Tests** now skips itself on config-only PRs instead of never appearing — a skipped job still satisfies a required status check, whereas a never-triggered workflow leaves the check hanging.
- `changes` runs on **every** event (outputting `code=true` for non-PR events) so no job in the `needs` chain is ever skipped on push — GitHub skips the dependent of a skipped job unless its `if:` carries a status function (actions/runner#2205), and the `test` condition is written defensively with `!cancelled()` regardless.
- `test`'s condition **fails closed**: if the `changes` detector errors on a PR, tests run rather than silently skipping behind green checks.
- Fixes the CI Playwright artifact gap: the `github` reporter never writes `playwright-report/`, so the upload step had nothing to upload on any run (the 0-artifacts-on-failure incident). CI now also emits the `html` report.

## Why

PR #861 touched only root-level config files, matched nothing in the path filter, and merged with zero lint coverage; the broken formatting it introduced then failed every subsequent PR's lint. This closes the structural gap (the interim Biome exclusion closed only the instance). Follow-up (repo admin, not this PR): mark Validate Code Quality and Run Tests as required checks on `staging`, then a config-only probe PR verifies the behaviour by observation.

## Review

Implemented by the backend track; two QA rounds + code review. Round 1 caught the skipped-`needs` propagation trap and the fail-open detector edge; the rework resolving both was re-reviewed and approved at this tip. Fallow audit clean; lint/typecheck show no new findings on the changed files.