### PR TITLE
ci: block docker-build and deploy on failed upstream jobs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -303,7 +303,14 @@ jobs:
   docker-build:
     name: Build and Push Docker Image
     needs: [validate, test]
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    # explicit needs-success checks: a custom if drops GitHub's implicit
+    # success() — fail-closed under either documented reading (actions/runner#2205,
+    # discussions 45058/26945)
+    if: >-
+      !cancelled() &&
+      needs.validate.result == 'success' &&
+      needs.test.result == 'success' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -413,7 +420,13 @@ jobs:
     name: Deploy to Azure
     runs-on: ubuntu-latest
     needs: [docker-build]
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging'
+    # explicit needs-success check: a custom if drops GitHub's implicit
+    # success() — fail-closed under either documented reading (actions/runner#2205,
+    # discussions 45058/26945)
+    if: >-
+      !cancelled() &&
+      needs.docker-build.result == 'success' &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
 
     steps:
       - name: Deploy to Azure (Production)


### PR DESCRIPTION
## What

build.yaml's docker-build and deploy jobs had custom `if:` conditions with no status-check function, which drops GitHub's implicit success-of-needs gate — so on the push path a failed validate/test did not reliably block the Docker image build, and a failed docker-build did not reliably block deploy. Pre-existing gap flagged in PR #904's review; PR checks were unaffected.

## Fix

Explicit fail-closed conditions on both jobs (`!cancelled() && needs.<x>.result == 'success' && <original event/ref condition>`), safe under either documented reading of the custom-if semantics (actions/runner#2205, discussions 45058/26945). Original event/ref logic preserved verbatim; the `changes` job's idle-runner cost on pushes accepted deliberately to keep #904's condition simple.

## Verification

- QA and code review: no blocking findings; fallow audit clean.
- Observed run 32728659319 (throwaway branch, deliberately red unit test): Run Tests failure → Build and Push Docker Image **Skipped**, Deploy to Azure **Skipped**. Probe branch deleted after capture.
- Happy-path control: this PR's own CI plus the post-merge staging push.