### PR TITLE
fix: trustworthy client-IP extraction (x-client-ip / rightmost XFF hop)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,12 @@ Hard rules:
 - **API routes:** `requireAuth()` → `userId` (throws `unauthorised()`).
   **Server actions:** `validateSession()` → `{userId, username, email}`.
 - **Never trust a client-supplied user ID** — always derive identity from the session.
+- **Client IP for rate limiting / audit logging:** use `extractClientIp` from
+  `lib/auth/extract-client-ip.ts` — the one sanctioned way to read a client
+  IP. Never read `x-forwarded-for`'s first hop or `x-real-ip` directly; both
+  are attacker-controllable in our deployment. If a CDN or Front Door is
+  ever added in front of App Service, the helper's trusted-hop policy must
+  be revisited.
 - Permission checks live in the **service layer** via `canAccessCase` / helpers
   in `lib/permissions.ts`, not in routes.
 - Return the **same error for not-found and no-permission** — prevents

--- a/app/(authenticated)/dashboard/settings/_components/__tests__/plugin-settings-slot-registry.test.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/__tests__/plugin-settings-slot-registry.test.tsx
@@ -14,7 +14,7 @@ afterEach(() => {
 	settingsSectionSlot.resetForTests();
 });
 
-describe("PluginSettingsSlot — registry wiring ([[TEA — UI extension slots]])", () => {
+describe("PluginSettingsSlot — registry wiring", () => {
 	it("still renders nothing for a pluginId with no registration (registry empty by default in 1.0)", () => {
 		const { container } = renderWithoutProviders(
 			<PluginSettingsSlot pluginId="tea.health" />

--- a/app/(authenticated)/dashboard/settings/_components/plugin-settings-slot.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/plugin-settings-slot.tsx
@@ -4,7 +4,7 @@ import { settingsSectionSlot } from "@/lib/plugins/slots";
  * The `settings-section` extension point (ADR 0002 v2 §2.3) — the region
  * within a plugin's row where an enabled plugin contributes its own settings
  * UI (e.g. the health plugin's scoring thresholds), wired through the
- * build-time slot registry (`[[TEA — UI extension slots]]`).
+ * build-time slot registry (tracked internally as "TEA — UI extension slots").
  *
  * No official plugin registers into this slot yet, so this renders nothing
  * in every 1.0 deployment — matching §2.3's rule that "slots render nothing

--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -5,6 +5,7 @@ import {
 	apiRateLimited,
 	apiSuccess,
 } from "@/lib/api-response";
+import { extractClientIp } from "@/lib/auth/extract-client-ip";
 import { AppError, validationError } from "@/lib/errors";
 import { requestPasswordReset } from "@/lib/services/password-reset-service";
 
@@ -27,10 +28,7 @@ export async function POST(request: Request) {
 
 		// Get client IP and user agent for rate limiting
 		const headersList = await headers();
-		const forwarded = headersList.get("x-forwarded-for");
-		const ipAddress = forwarded
-			? (forwarded.split(",")[0]?.trim() ?? "unknown")
-			: (headersList.get("x-real-ip") ?? "unknown");
+		const ipAddress = extractClientIp(headersList);
 		const userAgent = headersList.get("user-agent") ?? undefined;
 
 		const result = await requestPasswordReset(body.email, ipAddress, userAgent);

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -5,6 +5,7 @@ import {
 	apiSuccess,
 	serviceErrorToAppError,
 } from "@/lib/api-response";
+import { extractClientIp } from "@/lib/auth/extract-client-ip";
 import { validationError } from "@/lib/errors";
 import { resetPasswordSchema } from "@/lib/schemas/auth";
 import {
@@ -58,10 +59,7 @@ export async function POST(request: Request) {
 
 		// Get client IP and user agent for audit logging
 		const headersList = await headers();
-		const forwarded = headersList.get("x-forwarded-for");
-		const ipAddress = forwarded
-			? (forwarded.split(",")[0]?.trim() ?? "unknown")
-			: (headersList.get("x-real-ip") ?? "unknown");
+		const ipAddress = extractClientIp(headersList);
 		const userAgent = headersList.get("user-agent") ?? undefined;
 
 		const result = await resetPassword(

--- a/app/api/invites/[token]/accept/route.ts
+++ b/app/api/invites/[token]/accept/route.ts
@@ -7,6 +7,7 @@ import {
 	requireAuth,
 	serviceErrorToAppError,
 } from "@/lib/api-response";
+import { extractClientIp } from "@/lib/auth/extract-client-ip";
 import { acceptInvite } from "@/lib/services/case-invite-service";
 import {
 	checkAndRecordRateLimit,
@@ -28,10 +29,7 @@ export async function POST(
 
 		// Extract security context for audit logging
 		const headersList = await headers();
-		const forwarded = headersList.get("x-forwarded-for");
-		const ipAddress = forwarded
-			? (forwarded.split(",")[0]?.trim() ?? "unknown")
-			: (headersList.get("x-real-ip") ?? "unknown");
+		const ipAddress = extractClientIp(headersList);
 		const userAgent = headersList.get("user-agent") ?? null;
 
 		// Check rate limit before processing

--- a/app/api/users/register/route.ts
+++ b/app/api/users/register/route.ts
@@ -6,6 +6,7 @@ import {
 	apiSuccess,
 	serviceErrorToAppError,
 } from "@/lib/api-response";
+import { extractClientIp } from "@/lib/auth/extract-client-ip";
 import { validationError } from "@/lib/errors";
 import { registerUserSchema } from "@/lib/schemas/user";
 import {
@@ -33,10 +34,7 @@ export async function POST(request: Request) {
 
 		// Extract IP address and user agent for rate limiting
 		const headersList = await headers();
-		const forwarded = headersList.get("x-forwarded-for");
-		const ipAddress = forwarded
-			? (forwarded.split(",")[0]?.trim() ?? "unknown")
-			: (headersList.get("x-real-ip") ?? "unknown");
+		const ipAddress = extractClientIp(headersList);
 		const userAgent = headersList.get("user-agent") ?? undefined;
 
 		// Check rate limit before processing

--- a/hooks/use-plugin-settings.ts
+++ b/hooks/use-plugin-settings.ts
@@ -17,7 +17,7 @@ import { toast } from "@/lib/toast";
 // (not re-exporting the local import above) so biome's `noExportedImports`
 // doesn't fire. The fetch itself is delegated to `use-plugin-enablement.ts`
 // — the shared fetch mechanism both this pane and the build-time UI slots
-// read through (`[[TEA — UI extension slots]]`); this hook keeps its own
+// read through (tracked internally as "TEA — UI extension slots"); this hook keeps its own
 // public API unchanged.
 export type {
 	PluginPinnedAt,

--- a/lib/auth/__tests__/extract-client-ip.test.ts
+++ b/lib/auth/__tests__/extract-client-ip.test.ts
@@ -79,4 +79,35 @@ describe("extractClientIp", () => {
 
 		expect(extractClientIp(headers)).toBe("203.0.113.10");
 	});
+
+	it("returns 'unknown' for a trailing comma (empty rightmost entry) — fails closed by design, no fallback to an earlier hop", () => {
+		const headers = headersOf({
+			"x-forwarded-for": "198.51.100.1, 203.0.113.7,",
+		});
+
+		expect(extractClientIp(headers)).toBe("unknown");
+	});
+
+	it("returns 'unknown' for a whitespace-only x-forwarded-for", () => {
+		const headers = headersOf({ "x-forwarded-for": "   " });
+
+		expect(extractClientIp(headers)).toBe("unknown");
+	});
+
+	it("falls through to x-forwarded-for when x-client-ip is present but empty", () => {
+		const headers = headersOf({
+			"x-client-ip": "",
+			"x-forwarded-for": "198.51.100.1, 203.0.113.11",
+		});
+
+		expect(extractClientIp(headers)).toBe("203.0.113.11");
+	});
+
+	it("strips the brackets from a [IPv6] rightmost entry with no port", () => {
+		const headers = headersOf({
+			"x-forwarded-for": "198.51.100.1, [2001:db8::1]",
+		});
+
+		expect(extractClientIp(headers)).toBe("2001:db8::1");
+	});
 });

--- a/lib/auth/__tests__/extract-client-ip.test.ts
+++ b/lib/auth/__tests__/extract-client-ip.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { extractClientIp } from "../extract-client-ip";
+
+function headersOf(entries: Record<string, string>): Headers {
+	return new Headers(entries);
+}
+
+describe("extractClientIp", () => {
+	it("prefers x-client-ip over x-forwarded-for, even when both are present (spoof attempt)", () => {
+		const headers = headersOf({
+			"x-client-ip": "203.0.113.5",
+			"x-forwarded-for": "198.51.100.1, 203.0.113.5",
+		});
+
+		expect(extractClientIp(headers)).toBe("203.0.113.5");
+	});
+
+	it("uses x-client-ip alone when x-forwarded-for is absent", () => {
+		const headers = headersOf({ "x-client-ip": "203.0.113.6" });
+
+		expect(extractClientIp(headers)).toBe("203.0.113.6");
+	});
+
+	it("takes the rightmost entry of a comma-separated x-forwarded-for chain", () => {
+		const headers = headersOf({
+			"x-forwarded-for": "198.51.100.1, 70.41.3.18, 203.0.113.7",
+		});
+
+		expect(extractClientIp(headers)).toBe("203.0.113.7");
+	});
+
+	it("strips the port from an IPv4:port rightmost entry", () => {
+		const headers = headersOf({
+			"x-forwarded-for": "198.51.100.1:4000, 203.0.113.8:5000",
+		});
+
+		expect(extractClientIp(headers)).toBe("203.0.113.8");
+	});
+
+	it("strips the port and brackets from a [IPv6]:port rightmost entry", () => {
+		const headers = headersOf({
+			"x-forwarded-for": "198.51.100.1:4000, [2001:db8::1]:5000",
+		});
+
+		expect(extractClientIp(headers)).toBe("2001:db8::1");
+	});
+
+	it("returns a bare IPv6 rightmost entry untouched (no brackets, ambiguous port)", () => {
+		const headers = headersOf({
+			"x-forwarded-for": "198.51.100.1:4000, 2001:db8::1",
+		});
+
+		expect(extractClientIp(headers)).toBe("2001:db8::1");
+	});
+
+	it("returns 'unknown' when neither header is present", () => {
+		const headers = headersOf({});
+
+		expect(extractClientIp(headers)).toBe("unknown");
+	});
+
+	it("returns 'unknown' when x-forwarded-for is present but empty", () => {
+		const headers = new Headers();
+		headers.set("x-forwarded-for", "");
+
+		expect(extractClientIp(headers)).toBe("unknown");
+	});
+
+	it("trims whitespace around the rightmost x-forwarded-for entry", () => {
+		const headers = headersOf({
+			"x-forwarded-for": "198.51.100.1 ,  203.0.113.9  ",
+		});
+
+		expect(extractClientIp(headers)).toBe("203.0.113.9");
+	});
+
+	it("handles a single-entry x-forwarded-for with a port", () => {
+		const headers = headersOf({ "x-forwarded-for": "203.0.113.10:9000" });
+
+		expect(extractClientIp(headers)).toBe("203.0.113.10");
+	});
+});

--- a/lib/auth/extract-client-ip.ts
+++ b/lib/auth/extract-client-ip.ts
@@ -1,0 +1,66 @@
+/**
+ * Trustworthy client-IP extraction — the ONE sanctioned way to read a
+ * client IP anywhere in this codebase. Do not read `x-forwarded-for`'s
+ * first hop or `x-real-ip` directly; both are attacker-controllable in
+ * our deployment.
+ *
+ * Trust chain (Azure App Service, no CDN/Front Door in front of it):
+ * 1. `x-client-ip` — set by Azure App Service's front end with the true
+ *    client IP, and OVERWRITTEN if a client tries to supply it. Not
+ *    spoofable in this deployment.
+ * 2. `x-forwarded-for` — Azure appends the true client IP as the LAST
+ *    (rightmost) entry; every entry to its left can be attacker-supplied.
+ *    Entries are formatted `IP:port` (or `[IPv6]:port`); the port is
+ *    stripped.
+ * 3. `"unknown"` if neither header is present.
+ *
+ * If a CDN or Front Door is ever placed in front of App Service, this
+ * trust chain must be revisited — a CDN can change which hop is safe to
+ * trust, or introduce its own trusted-IP header.
+ */
+export function extractClientIp(headers: Headers): string {
+	const clientIp = headers.get("x-client-ip");
+	if (clientIp) {
+		return clientIp;
+	}
+
+	const forwardedFor = headers.get("x-forwarded-for");
+	if (forwardedFor) {
+		const entries = forwardedFor.split(",");
+		const rightmost = entries.at(-1)?.trim() ?? "";
+		if (rightmost) {
+			return stripPort(rightmost);
+		}
+	}
+
+	return "unknown";
+}
+
+/**
+ * Strips a `:port` suffix from an `IPv4:port` or `[IPv6]:port` entry.
+ * A bare IPv6 address (multiple colons, no brackets) is ambiguous between
+ * "address" and "address:port" and is returned unchanged.
+ */
+function stripPort(entry: string): string {
+	// Bracketed IPv6, optionally with a port: [::1] or [::1]:8080
+	if (entry.startsWith("[")) {
+		const closeBracket = entry.indexOf("]");
+		if (closeBracket !== -1) {
+			return entry.slice(1, closeBracket);
+		}
+		return entry;
+	}
+
+	// Bare IPv6 has more than one colon — leave it untouched, port or not.
+	const colonCount = (entry.match(/:/g) ?? []).length;
+	if (colonCount > 1) {
+		return entry;
+	}
+
+	// IPv4:port or a plain host with no port.
+	if (colonCount === 1) {
+		return entry.slice(0, entry.indexOf(":"));
+	}
+
+	return entry;
+}

--- a/lib/auth/extract-client-ip.ts
+++ b/lib/auth/extract-client-ip.ts
@@ -11,15 +11,20 @@
  * 2. `x-forwarded-for` — Azure appends the true client IP as the LAST
  *    (rightmost) entry; every entry to its left can be attacker-supplied.
  *    Entries are formatted `IP:port` (or `[IPv6]:port`); the port is
- *    stripped.
- * 3. `"unknown"` if neither header is present.
+ *    stripped. If the rightmost entry is empty (e.g. a trailing comma,
+ *    `"1.2.3.4, 5.6.7.8,"`) this FAILS CLOSED to `"unknown"` by design —
+ *    it does not fall back to an earlier entry. Earlier entries are
+ *    attacker-controllable, so falling back to one would let a caller
+ *    reopen rate-limit-bucket rotation in any topology where this
+ *    deployment's Azure assumptions don't hold.
+ * 3. `"unknown"` if neither header is present (or both are empty/blank).
  *
  * If a CDN or Front Door is ever placed in front of App Service, this
  * trust chain must be revisited — a CDN can change which hop is safe to
  * trust, or introduce its own trusted-IP header.
  */
 export function extractClientIp(headers: Headers): string {
-	const clientIp = headers.get("x-client-ip");
+	const clientIp = headers.get("x-client-ip")?.trim();
 	if (clientIp) {
 		return clientIp;
 	}

--- a/lib/auth/require-api-token.ts
+++ b/lib/auth/require-api-token.ts
@@ -1,4 +1,5 @@
 import type { NextRequest } from "next/server";
+import { extractClientIp } from "@/lib/auth/extract-client-ip";
 import type { Scope } from "@/lib/auth/scopes";
 import { AppError, unauthorised } from "@/lib/errors";
 import {
@@ -28,15 +29,6 @@ function extractBearerToken(request: NextRequest): string | null {
 	return token.length > 0 ? token : null;
 }
 
-/** Best-effort client IP for throttling — matches the pattern used elsewhere (e.g. forgot-password). */
-function extractIpAddress(request: NextRequest): string {
-	const forwarded = request.headers.get("x-forwarded-for");
-	if (forwarded) {
-		return forwarded.split(",")[0]?.trim() ?? "unknown";
-	}
-	return request.headers.get("x-real-ip") ?? "unknown";
-}
-
 /**
  * Validates the bearer token on `request` and returns the acting
  * integration's identity. Pass `scope` to additionally require that scope
@@ -58,7 +50,7 @@ export async function requireApiToken(
 	scope?: Scope
 ): Promise<ApiTokenPrincipal> {
 	const token = extractBearerToken(request);
-	const ipAddress = extractIpAddress(request);
+	const ipAddress = extractClientIp(request.headers);
 
 	const result = await validateApiToken({ token, scope, ipAddress });
 	if ("error" in result) {

--- a/src/__tests__/integration/machine-auth.test.ts
+++ b/src/__tests__/integration/machine-auth.test.ts
@@ -974,8 +974,8 @@ describe("requireApiToken — header shapes", () => {
 	});
 });
 
-describe("requireApiToken — extractIpAddress, via whoami's failed-attempt audit trail", () => {
-	/** A failed whoami call always audit-logs the IP `extractIpAddress` resolved — the cheapest observable proxy for a private helper. */
+describe("requireApiToken — extractClientIp, via whoami's failed-attempt audit trail", () => {
+	/** A failed whoami call always audit-logs the IP `extractClientIp` resolved — the cheapest observable proxy for a private helper. */
 	async function failedWhoamiIpAddress(
 		headers: Record<string, string>
 	): Promise<void> {
@@ -989,6 +989,18 @@ describe("requireApiToken — extractIpAddress, via whoami's failed-attempt audi
 		expect(response.status).toBe(401);
 	}
 
+	it("prefers x-client-ip over x-forwarded-for", async () => {
+		await failedWhoamiIpAddress({
+			"x-client-ip": "203.0.113.59",
+			"x-forwarded-for": "198.51.100.1:1000, 203.0.113.58:2000",
+		});
+
+		const event = await prisma.securityAuditLog.findFirst({
+			where: { eventType: "machine_auth_failed", ipAddress: "203.0.113.59" },
+		});
+		expect(event).not.toBeNull();
+	});
+
 	it("uses a single x-forwarded-for value as the client IP", async () => {
 		await failedWhoamiIpAddress({ "x-forwarded-for": "203.0.113.60" });
 
@@ -998,9 +1010,9 @@ describe("requireApiToken — extractIpAddress, via whoami's failed-attempt audi
 		expect(event).not.toBeNull();
 	});
 
-	it("takes the first entry of a comma-separated x-forwarded-for chain", async () => {
+	it("takes the RIGHTMOST entry of a comma-separated x-forwarded-for chain (Azure appends the true client IP last)", async () => {
 		await failedWhoamiIpAddress({
-			"x-forwarded-for": "203.0.113.61, 70.41.3.18, 150.172.238.178",
+			"x-forwarded-for": "150.172.238.178, 70.41.3.18, 203.0.113.61",
 		});
 
 		const event = await prisma.securityAuditLog.findFirst({
@@ -1009,11 +1021,11 @@ describe("requireApiToken — extractIpAddress, via whoami's failed-attempt audi
 		expect(event).not.toBeNull();
 	});
 
-	it("falls back to x-real-ip when x-forwarded-for is absent", async () => {
+	it("does NOT fall back to x-real-ip when x-forwarded-for is absent (that header is client-suppliable and untrusted)", async () => {
 		await failedWhoamiIpAddress({ "x-real-ip": "203.0.113.62" });
 
 		const event = await prisma.securityAuditLog.findFirst({
-			where: { eventType: "machine_auth_failed", ipAddress: "203.0.113.62" },
+			where: { eventType: "machine_auth_failed", ipAddress: "unknown" },
 		});
 		expect(event).not.toBeNull();
 	});
@@ -1048,6 +1060,72 @@ describe("HTTP 429 through whoami/requireApiToken", () => {
 		const body = await blocked.json();
 		expect(body.code).toBe("RATE_LIMITED");
 		expect(typeof body.error).toBe("string");
+	});
+
+	/**
+	 * Security regression for the x-forwarded-for trust fix: before it, the
+	 * throttle keyed on XFF's FIRST hop, which a caller controls. Rotating a
+	 * fake first hop on every request while keeping the real (rightmost)
+	 * hop fixed used to mint a fresh throttle bucket per request and evade
+	 * the limit entirely. Now the real IP is the one that decides the
+	 * bucket, so rotating the spoofable hop changes nothing.
+	 */
+	it("a spoofed leading x-forwarded-for hop no longer evades the machineAuth throttle — the true (rightmost) IP still gets blocked", async () => {
+		const realIp = "203.0.113.80";
+		const maxAttempts = RATE_LIMIT_CONFIGS.machineAuth.limits[0].maxAttempts;
+
+		for (let i = 0; i < maxAttempts; i++) {
+			const spoofedFirstHop = `10.0.${i}.${i}`;
+			const response = await whoamiGET(
+				whoamiRequest({
+					"x-forwarded-for": `${spoofedFirstHop}, ${realIp}`,
+				})
+			);
+			expect(response.status).toBe(401);
+		}
+
+		const blocked = await whoamiGET(
+			whoamiRequest({
+				"x-forwarded-for": `10.0.99.99, ${realIp}`,
+			})
+		);
+
+		expect(blocked.status).toBe(429);
+		const body = await blocked.json();
+		expect(body.code).toBe("RATE_LIMITED");
+
+		// All attempts landed in ONE bucket keyed on the real (rightmost) IP,
+		// not one bucket per spoofed first hop.
+		const attempts = await prisma.rateLimitAttempt.count({
+			where: { endpoint: "machine_auth", identifier: realIp },
+		});
+		expect(attempts).toBeGreaterThanOrEqual(maxAttempts);
+	});
+
+	/**
+	 * Same evasion attempt, but via `x-client-ip` — the header Azure sets
+	 * and overwrites on every request. A caller trying to defeat the
+	 * throttle by sending a different (attacker-supplied) x-client-ip per
+	 * request would, in a REAL deployment, have that value overwritten by
+	 * Azure's front end before it reaches this app. This test only proves
+	 * the code-level behaviour: a fixed x-client-ip still buckets together.
+	 */
+	it("shared x-client-ip requests count into one throttle bucket", async () => {
+		const clientIp = "203.0.113.81";
+		const maxAttempts = RATE_LIMIT_CONFIGS.machineAuth.limits[0].maxAttempts;
+
+		for (let i = 0; i < maxAttempts; i++) {
+			const response = await whoamiGET(
+				whoamiRequest({ "x-client-ip": clientIp })
+			);
+			expect(response.status).toBe(401);
+		}
+
+		const blocked = await whoamiGET(whoamiRequest({ "x-client-ip": clientIp }));
+
+		expect(blocked.status).toBe(429);
+		const body = await blocked.json();
+		expect(body.code).toBe("RATE_LIMITED");
 	});
 });
 


### PR DESCRIPTION
## Summary

Client-IP extraction previously read the FIRST hop of `x-forwarded-for` (attacker-controllable) with an `x-real-ip` fallback, in five places. A client could rotate spoofed IPs to evade IP-keyed rate limits and poison SecurityAuditLog attribution.

This PR replaces all five call sites with one shared helper, `extractClientIp` (`lib/auth/extract-client-ip.ts`):

1. `x-client-ip` — set and overwritten by Azure App Service's front end; not spoofable in this deployment (direct App Service, no CDN/Front Door).
2. Else the RIGHTMOST `x-forwarded-for` entry, port-stripped (IPv6-safe). An empty rightmost entry (trailing comma) fails closed to `unknown` by design — earlier hops are attacker-controllable.
3. Else `unknown`.

Call sites migrated: forgot-password, reset-password, invite accept, register, `requireApiToken`.

## Tests

- 14 unit tests for the helper (precedence, rightmost selection, IPv4/bracketed-IPv6 port stripping, bare-IPv6 untouched, fail-closed edge cases).
- Integration regression tests in `machine-auth.test.ts`: a rotating spoofed leading XFF hop no longer evades the machineAuth throttle; shared `x-client-ip` requests count into one throttle bucket. Assertions are against real `rateLimitAttempt` rows through the live handler chain.
- Full unit suite 1323/1323 green; machine-auth integration suite 81/81 green.

## Review

Implemented by the backend track; QA review (coverage + non-vacuity of the security tests) and code review (trust-policy audit, IPv6 edge cases, fallow hygiene audit — no new dead code/complexity/duplication) both passed, with all findings addressed in-branch.

Also includes a small comment-tidying commit.

## Note

If a CDN or Front Door is ever placed in front of App Service, the helper's trust chain must be revisited (documented in the helper and CLAUDE.md).