### PR TITLE
ci: run Structural Quality on pull_request events only

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -464,6 +464,16 @@ jobs:
     # merged from BOTH suites.
     name: Structural Quality (blocking)
     needs: [test]
+    # PR events only. This workflow also triggers on push (the staging deploy
+    # path), where github.base_ref is EMPTY — the audit's
+    # `--changed-since "origin/${{ github.base_ref }}"` becomes `origin/`
+    # (invalid ref) and fallow exits 2, failing every staging merge closed
+    # (runs 32847546410 / 32861374911, 2026-08-25). The gate's enforcement
+    # point is the PR: nothing reaches staging without passing it there, so a
+    # push re-audit is redundant. Job-level custom `if:` drops the implicit
+    # success() (PR #904 lesson) — safe HERE because the steps below already
+    # branch explicitly on needs.test.result and fail closed on failure.
+    if: github.event_name == 'pull_request'
     # Branches explicitly on needs.test.result rather than relying on either
     # documented "needs skip propagation" reading (actions/runner#2205 class,
     # see the `changes`/`test` comments above) or on the implicit success() a

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -473,7 +473,6 @@ jobs:
     # push re-audit is redundant. Job-level custom `if:` drops the implicit
     # success() (PR #904 lesson) — safe HERE because the steps below already
     # branch explicitly on needs.test.result and fail closed on failure.
-    if: github.event_name == 'pull_request'
     # Branches explicitly on needs.test.result rather than relying on either
     # documented "needs skip propagation" reading (actions/runner#2205 class,
     # see the `changes`/`test` comments above) or on the implicit success() a
@@ -504,7 +503,7 @@ jobs:
     # separate always-runs job that sets the commit status via the API)
     # is out of scope here and should be its own issue if this bites in
     # practice.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## What

Conditions the `structural-quality` job (required check "Structural Quality (blocking)") to pull-request events only.

## Why

The workflow also triggers on push — the staging deploy path — and on push `github.base_ref` is empty. The fallow audit's `--changed-since "origin/${{ github.base_ref }}"` then resolves to `origin/` (not a valid ref), the tool exits 2, and the job fails closed. Every staging merge since the gate landed shows a red ✗ (runs 32847546410 and 32861374911, both 2026-08-25) despite the code having passed the same gate on its PR. Deploys were never affected — the job is not upstream of `docker-build`.

The gate's enforcement point is the PR: nothing reaches staging without passing it there, so a push-time re-audit is redundant, and wiring it into the deploy chain would only add a way for a tooling error to stall shipping.

## Safety

The repo's documented PR #904 lesson (a custom `if:` drops the implicit `success()`) does not bite here: the job's steps already branch explicitly on `needs.test.result` and fail closed when tests did not succeed. This PR's own CI run demonstrates the job still executes on pull requests; the next staging merge should show it skipped rather than red.