### PR TITLE
Verify element ownership against the case in batch updates

### DIFF
--- a/lib/schemas/__tests__/batch-update.test.ts
+++ b/lib/schemas/__tests__/batch-update.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { batchUpdateRequestSchema } from "../batch-update";
+
+/**
+ * TEA — Batch endpoint does not verify element ownership against the case:
+ * uncapped `changes` arrays let a huge batch reach the recursive level
+ * resolution in case-batch-update-service.ts, which stack-overflows into a
+ * 500 rather than failing cleanly. The route's `safeParse` already turns any
+ * schema failure into a 400, so the cap only needs to exist here.
+ */
+describe("batchUpdateRequestSchema — changes array cap", () => {
+	const makeDelete = () => ({
+		type: "delete" as const,
+		elementId: crypto.randomUUID(),
+	});
+
+	it("accepts a batch of exactly 1000 changes", () => {
+		const changes = Array.from({ length: 1000 }, makeDelete);
+		const result = batchUpdateRequestSchema.safeParse({ changes });
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects a batch of 1001 changes", () => {
+		const changes = Array.from({ length: 1001 }, makeDelete);
+		const result = batchUpdateRequestSchema.safeParse({ changes });
+		expect(result.success).toBe(false);
+	});
+
+	it("still accepts a small, ordinary batch", () => {
+		const result = batchUpdateRequestSchema.safeParse({
+			changes: [makeDelete()],
+		});
+		expect(result.success).toBe(true);
+	});
+});

--- a/lib/schemas/batch-update.ts
+++ b/lib/schemas/batch-update.ts
@@ -15,74 +15,79 @@ const assertionStatusInputSchema = AssertionStatusSchema.nullable().optional();
  * Extracted from cases/[id]/batch/route.ts for reuse.
  */
 export const batchUpdateRequestSchema = z.object({
-	changes: z.array(
-		z.discriminatedUnion("type", [
-			z.object({
-				type: z.literal("create"),
-				elementId: z.string().uuid(),
-				parentId: z.string().uuid().nullable(),
-				data: z.object({
-					id: z.string().uuid(),
-					type: z.string(),
-					name: z.string().nullable(),
-					description: z.string(),
-					inSandbox: z.boolean(),
-					role: z.string().nullable().optional(),
-					assertionStatus: assertionStatusInputSchema,
-					assumption: z.string().nullable().optional(),
-					justification: z.string().nullable().optional(),
-					context: z.array(z.string()).optional(),
-					url: z.string().nullable().optional(),
-					level: z.number().nullable().optional(),
-					moduleReferenceId: z.string().optional(),
-					moduleEmbedType: z.string().optional(),
-					modulePublicSummary: z.string().nullable().optional(),
-					fromPattern: z.boolean().optional(),
-					modifiedFromPattern: z.boolean().optional(),
-					isDefeater: z.boolean().optional(),
-					defeatsElementId: z.string().optional(),
+	changes: z
+		.array(
+			z.discriminatedUnion("type", [
+				z.object({
+					type: z.literal("create"),
+					elementId: z.string().uuid(),
+					parentId: z.string().uuid().nullable(),
+					data: z.object({
+						id: z.string().uuid(),
+						type: z.string(),
+						name: z.string().nullable(),
+						description: z.string(),
+						inSandbox: z.boolean(),
+						role: z.string().nullable().optional(),
+						assertionStatus: assertionStatusInputSchema,
+						assumption: z.string().nullable().optional(),
+						justification: z.string().nullable().optional(),
+						context: z.array(z.string()).optional(),
+						url: z.string().nullable().optional(),
+						level: z.number().nullable().optional(),
+						moduleReferenceId: z.string().optional(),
+						moduleEmbedType: z.string().optional(),
+						modulePublicSummary: z.string().nullable().optional(),
+						fromPattern: z.boolean().optional(),
+						modifiedFromPattern: z.boolean().optional(),
+						isDefeater: z.boolean().optional(),
+						defeatsElementId: z.string().optional(),
+					}),
 				}),
-			}),
-			z.object({
-				type: z.literal("update"),
-				elementId: z.string().uuid(),
-				data: z.object({
-					name: z.string().nullable().optional(),
-					description: z.string().optional(),
-					inSandbox: z.boolean().optional(),
-					parentId: z.string().uuid().nullable().optional(),
-					role: z.string().nullable().optional(),
-					assertionStatus: assertionStatusInputSchema,
-					assumption: z.string().nullable().optional(),
-					justification: z.string().nullable().optional(),
-					context: z.array(z.string()).optional(),
-					url: z.string().nullable().optional(),
-					level: z.number().nullable().optional(),
-					moduleReferenceId: z.string().optional(),
-					moduleEmbedType: z.string().optional(),
-					modulePublicSummary: z.string().nullable().optional(),
-					fromPattern: z.boolean().optional(),
-					modifiedFromPattern: z.boolean().optional(),
-					isDefeater: z.boolean().optional(),
-					defeatsElementId: z.string().optional(),
+				z.object({
+					type: z.literal("update"),
+					elementId: z.string().uuid(),
+					data: z.object({
+						name: z.string().nullable().optional(),
+						description: z.string().optional(),
+						inSandbox: z.boolean().optional(),
+						parentId: z.string().uuid().nullable().optional(),
+						role: z.string().nullable().optional(),
+						assertionStatus: assertionStatusInputSchema,
+						assumption: z.string().nullable().optional(),
+						justification: z.string().nullable().optional(),
+						context: z.array(z.string()).optional(),
+						url: z.string().nullable().optional(),
+						level: z.number().nullable().optional(),
+						moduleReferenceId: z.string().optional(),
+						moduleEmbedType: z.string().optional(),
+						modulePublicSummary: z.string().nullable().optional(),
+						fromPattern: z.boolean().optional(),
+						modifiedFromPattern: z.boolean().optional(),
+						isDefeater: z.boolean().optional(),
+						defeatsElementId: z.string().optional(),
+					}),
 				}),
-			}),
-			z.object({
-				type: z.literal("delete"),
-				elementId: z.string().uuid(),
-			}),
-			z.object({
-				type: z.literal("link_evidence"),
-				evidenceId: z.string().uuid(),
-				claimId: z.string().uuid(),
-			}),
-			z.object({
-				type: z.literal("unlink_evidence"),
-				evidenceId: z.string().uuid(),
-				claimId: z.string().uuid(),
-			}),
-		])
-	),
+				z.object({
+					type: z.literal("delete"),
+					elementId: z.string().uuid(),
+				}),
+				z.object({
+					type: z.literal("link_evidence"),
+					evidenceId: z.string().uuid(),
+					claimId: z.string().uuid(),
+				}),
+				z.object({
+					type: z.literal("unlink_evidence"),
+					evidenceId: z.string().uuid(),
+					claimId: z.string().uuid(),
+				}),
+			])
+		)
+		.max(
+			1000,
+			"Batch is too large - split into batches of 1000 changes or fewer."
+		),
 	expectedVersion: z.string().datetime().optional(),
 });
 

--- a/lib/services/case-batch-update-service.ts
+++ b/lib/services/case-batch-update-service.ts
@@ -131,13 +131,30 @@ async function validateEditAccess(
  * update, delete, re-parent, or evidence-link/unlink elements that live in
  * case B.
  *
- * Collects every id this batch references that is expected to ALREADY
- * exist — update/delete targets, parentIds set on updates or creates, and
- * both sides of a link/unlink evidence change — excluding ids this same
- * batch is about to create (those don't exist yet, so they can't be
- * cross-case). One batched `findMany` then rejects the WHOLE batch if any
- * referenced id is missing or belongs to a different case, so a batch is
- * atomic in its acceptance as well as its application.
+ * Two different kinds of reference are collected, and only one of them is
+ * ever exempted by an in-batch create:
+ *
+ * - MUST-EXIST-REGARDLESS ids — a delete's own `elementId`, an update's own
+ *   `elementId`. These name a row the batch claims ALREADY exists and is
+ *   being mutated in place; nothing a batch also creates can satisfy that.
+ *   Checked unconditionally, even if the SAME id also appears as a create's
+ *   `elementId` in this batch — otherwise a batch containing both
+ *   `{type:"delete", elementId:X}` and `{type:"create", elementId:X, ...}`
+ *   for a foreign X would pass ownership (X "will exist" by the time the
+ *   create runs), and since `applyDeletes` runs before `applyCreates` and
+ *   deletes by bare PK with no case filter, the victim's row would be
+ *   hard-deleted and silently recreated under the attacker's case.
+ * - MAY-BE-SATISFIED-BY-A-SIBLING-CREATE ids — parent references
+ *   (`parentId` on a create/update) and FK-style references to another
+ *   element (`defeatsElementId` on a create/update, both sides of a
+ *   link/unlink evidence change). These are legitimately allowed to point
+ *   at an id this SAME batch is creating (e.g. a new claim citing another
+ *   new claim as its defeater), so — and only so — they're exempted when the
+ *   referenced id is also this batch's own create `elementId`.
+ *
+ * One batched `findMany` then rejects the WHOLE batch if any checked
+ * reference is missing or belongs to a different case, so a batch is atomic
+ * in its acceptance as well as its application.
  *
  * Soft-deleted elements (`deletedAt` set) are NOT excluded from the lookup:
  * every other query in this file (`fetchLevelInfo`, `validateCreateParents`)
@@ -162,29 +179,42 @@ async function validateElementOwnership(
 	const createdIds = new Set(creates.map((c) => c.elementId));
 
 	const referencedIds = new Set<string>();
-	const addIfExisting = (id: string | null | undefined) => {
+	// A delete's/update's OWN target: must already exist, full stop — never
+	// exempted just because the same id also appears as a create in this
+	// batch (see the delete+recreate id-reuse note above).
+	const addAlways = (id: string | null | undefined) => {
+		if (id) {
+			referencedIds.add(id);
+		}
+	};
+	// A reference that's legitimately satisfiable by a sibling create in
+	// this same batch (parentId, defeatsElementId, evidence link/unlink
+	// ids) — exempted only when the id IS one of this batch's own creates.
+	const addUnlessSiblingCreate = (id: string | null | undefined) => {
 		if (id && !createdIds.has(id)) {
 			referencedIds.add(id);
 		}
 	};
 
 	for (const change of updates) {
-		addIfExisting(change.elementId);
-		addIfExisting(change.data.parentId);
+		addAlways(change.elementId);
+		addUnlessSiblingCreate(change.data.parentId);
+		addUnlessSiblingCreate(change.data.defeatsElementId);
 	}
 	for (const change of deletes) {
-		addIfExisting(change.elementId);
+		addAlways(change.elementId);
 	}
 	for (const change of creates) {
-		addIfExisting(change.parentId);
+		addUnlessSiblingCreate(change.parentId);
+		addUnlessSiblingCreate(change.data.defeatsElementId);
 	}
 	for (const change of links) {
-		addIfExisting(change.evidenceId);
-		addIfExisting(change.claimId);
+		addUnlessSiblingCreate(change.evidenceId);
+		addUnlessSiblingCreate(change.claimId);
 	}
 	for (const change of unlinks) {
-		addIfExisting(change.evidenceId);
-		addIfExisting(change.claimId);
+		addUnlessSiblingCreate(change.evidenceId);
+		addUnlessSiblingCreate(change.claimId);
 	}
 
 	if (referencedIds.size === 0) {
@@ -880,6 +910,16 @@ async function applyUpdates(
 	);
 	// Grandparent {elementType, level} for any new parent that is a STRATEGY —
 	// the transparent-strategy hop (see calculateLevelFromParentChain).
+	//
+	// KNOWN LIMITATION (flagged in review, tracked as a follow-up, not fixed
+	// here): this snapshot is taken once, before any of this batch's own
+	// moves are applied. If the SAME batch both moves a STRATEGY to a new
+	// PROPERTY_CLAIM parent AND reparents some other element to be a child
+	// of that STRATEGY, the child's level is computed from the STRATEGY's
+	// OLD (pre-batch) grandparent, not its post-batch one — a narrower gap
+	// than the delete/create-reuse and defeatsElementId issues fixed
+	// alongside this comment, and still an improvement over the pre-existing
+	// behaviour (which ignored the transparent-strategy hop here entirely).
 	const grandparentInfoById = await fetchGrandparentInfoForStrategies(
 		tx,
 		parentInfoById

--- a/lib/services/case-batch-update-service.ts
+++ b/lib/services/case-batch-update-service.ts
@@ -12,6 +12,7 @@ import type {
 } from "@/lib/case/tree-diff";
 import { prisma } from "@/lib/prisma";
 import {
+	calculateLevelFromParentChain,
 	enforceAssertionStatusRules,
 	isSystemUserPrincipal,
 } from "@/lib/services/element-service";
@@ -120,6 +121,89 @@ async function validateEditAccess(
 ): Promise<boolean> {
 	const { canAccessCase } = await import("@/lib/permissions");
 	return canAccessCase({ userId, caseId }, "EDIT");
+}
+
+/**
+ * Guards against cross-case writes through the batch endpoint (IDOR):
+ * `validateEditAccess` only checks the caller has EDIT permission on the
+ * target case, it never confirms the element ids in `changes` actually
+ * belong to that case. Without this, a user with edit access to case A could
+ * update, delete, re-parent, or evidence-link/unlink elements that live in
+ * case B.
+ *
+ * Collects every id this batch references that is expected to ALREADY
+ * exist — update/delete targets, parentIds set on updates or creates, and
+ * both sides of a link/unlink evidence change — excluding ids this same
+ * batch is about to create (those don't exist yet, so they can't be
+ * cross-case). One batched `findMany` then rejects the WHOLE batch if any
+ * referenced id is missing or belongs to a different case, so a batch is
+ * atomic in its acceptance as well as its application.
+ *
+ * Soft-deleted elements (`deletedAt` set) are NOT excluded from the lookup:
+ * every other query in this file (`fetchLevelInfo`, `validateCreateParents`)
+ * already ignores `deletedAt`, and `applyDeletes` hard-deletes rows, so
+ * treating a soft-deleted row as still "belonging to its case" here matches
+ * how the rest of this file already behaves — it does not open a new hole,
+ * and excluding them would just add an inconsistent extra rule for this one
+ * validator.
+ *
+ * The error message names the offending id(s) but never the case they
+ * actually belong to, so a caller probing for other cases' element ids
+ * learns only "not in this case", not which case it's really in.
+ */
+async function validateElementOwnership(
+	caseId: string,
+	creates: CreateChange[],
+	updates: UpdateChange[],
+	deletes: DeleteChange[],
+	links: LinkEvidenceChange[],
+	unlinks: UnlinkEvidenceChange[]
+): Promise<string | null> {
+	const createdIds = new Set(creates.map((c) => c.elementId));
+
+	const referencedIds = new Set<string>();
+	const addIfExisting = (id: string | null | undefined) => {
+		if (id && !createdIds.has(id)) {
+			referencedIds.add(id);
+		}
+	};
+
+	for (const change of updates) {
+		addIfExisting(change.elementId);
+		addIfExisting(change.data.parentId);
+	}
+	for (const change of deletes) {
+		addIfExisting(change.elementId);
+	}
+	for (const change of creates) {
+		addIfExisting(change.parentId);
+	}
+	for (const change of links) {
+		addIfExisting(change.evidenceId);
+		addIfExisting(change.claimId);
+	}
+	for (const change of unlinks) {
+		addIfExisting(change.evidenceId);
+		addIfExisting(change.claimId);
+	}
+
+	if (referencedIds.size === 0) {
+		return null;
+	}
+
+	const ids = Array.from(referencedIds);
+	const rows = await prisma.assuranceElement.findMany({
+		where: { id: { in: ids } },
+		select: { id: true, caseId: true },
+	});
+	const rowById = new Map(rows.map((r) => [r.id, r]));
+
+	const offendingIds = ids.filter((id) => rowById.get(id)?.caseId !== caseId);
+	if (offendingIds.length > 0) {
+		return `Element${offendingIds.length > 1 ? "s" : ""} ${offendingIds.join(", ")} not found in this case`;
+	}
+
+	return null;
 }
 
 /**
@@ -237,17 +321,23 @@ async function validateUpdateParents(
 	return null;
 }
 
-/** Minimal shape needed to decide a child's level from its parent row. */
+/**
+ * Minimal shape needed to decide a child's level from its parent row —
+ * `parentId` is included so a STRATEGY parent's own parent (the transparent
+ * grandparent hop — see `calculateLevelFromParentChain`) can be looked up
+ * from the same batched-fetch shape.
+ */
 interface LevelInfo {
 	elementType: PrismaElementType;
 	level: number | null;
+	parentId: string | null;
 }
 
 /**
  * Batched replacement for calling `tx.assuranceElement.findUnique` once per
- * id: fetches {level, elementType} for every id in one `findMany`. Used by
- * `applyCreates`/`applyUpdates` so level lookups for a whole batch cost one
- * query instead of one per element.
+ * id: fetches {level, elementType, parentId} for every id in one
+ * `findMany`. Used by `applyCreates`/`applyUpdates`/the cascade so level
+ * lookups for a whole batch cost one query instead of one per element.
  */
 async function fetchLevelInfo(
 	tx: TransactionClient,
@@ -258,24 +348,38 @@ async function fetchLevelInfo(
 	}
 	const rows = await tx.assuranceElement.findMany({
 		where: { id: { in: ids } },
-		select: { id: true, level: true, elementType: true },
+		select: { id: true, level: true, elementType: true, parentId: true },
 	});
 	return new Map(
-		rows.map((r) => [r.id, { level: r.level, elementType: r.elementType }])
+		rows.map((r) => [
+			r.id,
+			{ level: r.level, elementType: r.elementType, parentId: r.parentId },
+		])
 	);
 }
 
 /**
- * Calculates a child's level from its parent's {level, elementType} — same
- * rule as the old per-row `calculateLevel`: a PROPERTY_CLAIM parent yields
- * parent.level+1 (defaulting the parent's own level to 1 if unset), anything
- * else (including an unresolvable/absent parent) yields 1.
+ * For every STRATEGY entry in `parentInfoById`, batch-fetches its OWN parent
+ * (the grandparent, from the child's point of view) — the extra hop
+ * `calculateLevelFromParentChain` needs to apply the transparent-strategy
+ * rule. Keyed by grandparent id, same shape as `fetchLevelInfo` so it can be
+ * looked up alongside `parentInfoById`/`ownTypeById` interchangeably.
  */
-function levelFromParentInfo(parentInfo: LevelInfo | undefined): number {
-	if (parentInfo?.elementType === "PROPERTY_CLAIM") {
-		return (parentInfo.level ?? 1) + 1;
-	}
-	return 1;
+function fetchGrandparentInfoForStrategies(
+	tx: TransactionClient,
+	parentInfoById: Map<string, LevelInfo>
+): Promise<Map<string, LevelInfo>> {
+	const grandparentIds = Array.from(
+		new Set(
+			Array.from(parentInfoById.values())
+				.filter(
+					(info): info is LevelInfo & { parentId: string } =>
+						info.elementType === "STRATEGY" && Boolean(info.parentId)
+				)
+				.map((info) => info.parentId)
+		)
+	);
+	return fetchLevelInfo(tx, grandparentIds);
 }
 
 /**
@@ -351,7 +455,9 @@ async function applyCreates(
 
 	// Parents referenced by property-claim creates that are NOT themselves
 	// part of this batch: their level is fixed pre-transaction state, so
-	// fetch it once for all of them instead of once per create.
+	// fetch it once for all of them instead of once per create. A second pass
+	// fetches the grandparent of any of those parents that is a STRATEGY —
+	// the transparent-strategy hop `calculateLevelFromParentChain` needs.
 	const externalParentIds = Array.from(
 		new Set(
 			creates
@@ -361,15 +467,38 @@ async function applyCreates(
 		)
 	);
 	const externalParentInfo = await fetchLevelInfo(tx, externalParentIds);
+	const externalGrandparentInfo = await fetchGrandparentInfoForStrategies(
+		tx,
+		externalParentInfo
+	);
+	const externalInfo = new Map([
+		...externalParentInfo,
+		...externalGrandparentInfo,
+	]);
+
+	// Resolves {elementType, level, parentId} for any id referenced by this
+	// batch's creates, whether it's being created in this same call (in which
+	// case its level was just computed by an earlier, parent-first `createOne`
+	// call) or already exists (the pre-transaction snapshot above).
+	const resolveInfo = (id: string): LevelInfo | undefined => {
+		const withinBatch = createMap.get(id);
+		if (withinBatch) {
+			return {
+				elementType: mapElementType(withinBatch.data.type),
+				level: levelById.get(id) ?? null,
+				parentId: withinBatch.parentId ?? null,
+			};
+		}
+		return externalInfo.get(id);
+	};
 
 	const resolveParentLevel = (parentId: string): number => {
-		const withinBatchParent = createMap.get(parentId);
-		if (withinBatchParent) {
-			const parentType = mapElementType(withinBatchParent.data.type);
-			const parentLevel = levelById.get(parentId) ?? null;
-			return parentType === "PROPERTY_CLAIM" ? (parentLevel ?? 1) + 1 : 1;
-		}
-		return levelFromParentInfo(externalParentInfo.get(parentId));
+		const parentInfo = resolveInfo(parentId);
+		const grandparentInfo =
+			parentInfo?.elementType === "STRATEGY" && parentInfo.parentId
+				? resolveInfo(parentInfo.parentId)
+				: undefined;
+		return calculateLevelFromParentChain(parentInfo, grandparentInfo);
 	};
 
 	const createOne = async (change: CreateChange): Promise<void> => {
@@ -465,10 +594,32 @@ function buildUpdateData(data: UpdateElementData): Record<string, unknown> {
 function resolveFinalLevelsForBatch(
 	moveMap: Map<string, string>,
 	ownTypeById: Map<string, LevelInfo>,
-	parentInfoById: Map<string, LevelInfo>
+	externalInfoById: Map<string, LevelInfo>
 ): Map<string, number> {
 	const finalLevels = new Map<string, number>();
 	const visiting = new Set<string>();
+
+	// Static (pre-batch) info for any id this batch references, whether it's
+	// one of the moved elements themselves or one of their (non-moved) new
+	// parents/grandparents.
+	const getInfo = (id: string): LevelInfo | undefined =>
+		ownTypeById.get(id) ?? externalInfoById.get(id);
+
+	// Resolves {elementType, level, parentId} for `id` as it will stand AFTER
+	// this batch: if `id` is itself being moved and is a PROPERTY_CLAIM, its
+	// level comes from `resolve` (below); otherwise it's the static snapshot.
+	// Only ever recurses into `resolve` for ids already known to be
+	// PROPERTY_CLAIM, so `finalLevels` never gets a spurious entry for a
+	// STRATEGY (which would wrongly cause its own update to write a level).
+	const resolvedInfo = (id: string): LevelInfo | undefined => {
+		const info = getInfo(id);
+		if (!info) {
+			return undefined;
+		}
+		const isMovedClaim =
+			moveMap.has(id) && info.elementType === "PROPERTY_CLAIM";
+		return isMovedClaim ? { ...info, level: resolve(id) } : info;
+	};
 
 	const resolve = (elementId: string): number => {
 		const memoised = finalLevels.get(elementId);
@@ -485,16 +636,12 @@ function resolveFinalLevelsForBatch(
 		const newParentId = moveMap.get(elementId);
 		let level = 1;
 		if (newParentId) {
-			const parentIsMoved = moveMap.has(newParentId);
-			const parentType = parentIsMoved
-				? ownTypeById.get(newParentId)?.elementType
-				: parentInfoById.get(newParentId)?.elementType;
-			if (parentType === "PROPERTY_CLAIM") {
-				const parentLevel = parentIsMoved
-					? resolve(newParentId)
-					: (parentInfoById.get(newParentId)?.level ?? 1);
-				level = parentLevel + 1;
-			}
+			const parentInfo = resolvedInfo(newParentId);
+			const grandparentInfo =
+				parentInfo?.elementType === "STRATEGY" && parentInfo.parentId
+					? resolvedInfo(parentInfo.parentId)
+					: undefined;
+			level = calculateLevelFromParentChain(parentInfo, grandparentInfo);
 		}
 
 		visiting.delete(elementId);
@@ -530,19 +677,27 @@ interface DescendantRow {
  * it is itself one of the roots this function is called for, so its
  * subtree is recomputed from ITS new position via its own separate call.
  */
-/** One pending descendant row in `cascadeFromRoot`'s frontier walk. */
+/**
+ * One pending descendant row in `cascadeFromRoot`'s frontier walk.
+ * `parentInfo`/`grandparentInfo` are the {elementType, level} of the row's
+ * OWN actual parent and grandparent (not a rolling "nearest property claim"
+ * anchor) — same shape `calculateLevelFromParentChain` takes everywhere
+ * else, so a STRATEGY row in the middle of a subtree is transparent here
+ * too: its level is computed but never used to gate its children (its
+ * elementType, not its level, is what the shared rule looks at).
+ */
 interface CascadeFrontierEntry {
-	parentIsPropertyClaim: boolean;
-	parentLevel: number;
+	grandparentInfo: LevelInfo | undefined;
+	parentInfo: LevelInfo;
 	row: DescendantRow;
 }
 
 /**
  * Processes a single descendant row for `cascadeFromRoot`: computes its
- * level, records a level update when it's a property claim, and returns the
- * next frontier entries for its children — or an empty array if this row is
- * an explicit mover in `moveMap` (stop descending, per `cascadeFromRoot`'s
- * contract).
+ * level via the shared `calculateLevelFromParentChain` rule, records a level
+ * update when it's a property claim, and returns the next frontier entries
+ * for its children — or an empty array if this row is an explicit mover in
+ * `moveMap` (stop descending, per `cascadeFromRoot`'s contract).
  */
 function cascadeFrontierStep(
 	entry: CascadeFrontierEntry,
@@ -550,9 +705,9 @@ function cascadeFrontierStep(
 	moveMap: Map<string, string>,
 	levelUpdates: Map<string, number>
 ): CascadeFrontierEntry[] {
-	const { row, parentLevel, parentIsPropertyClaim } = entry;
+	const { row, parentInfo, grandparentInfo } = entry;
 	const isPropertyClaim = row.elementType === "PROPERTY_CLAIM";
-	const level = parentIsPropertyClaim ? parentLevel + 1 : 1;
+	const level = calculateLevelFromParentChain(parentInfo, grandparentInfo);
 
 	if (moveMap.has(row.id)) {
 		return [];
@@ -560,10 +715,16 @@ function cascadeFrontierStep(
 	if (isPropertyClaim) {
 		levelUpdates.set(row.id, level);
 	}
+
+	const ownInfo: LevelInfo = {
+		elementType: row.elementType,
+		level,
+		parentId: row.parentId,
+	};
 	return (childrenByParent.get(row.id) ?? []).map((child) => ({
 		row: child,
-		parentLevel: level,
-		parentIsPropertyClaim: isPropertyClaim,
+		parentInfo: ownInfo,
+		grandparentInfo: parentInfo,
 	}));
 }
 
@@ -574,12 +735,17 @@ function cascadeFromRoot(
 	moveMap: Map<string, string>,
 	levelUpdates: Map<string, number>
 ): void {
+	const rootInfo: LevelInfo = {
+		elementType: "PROPERTY_CLAIM" as PrismaElementType,
+		level: rootLevel,
+		parentId: null,
+	};
 	let frontier: CascadeFrontierEntry[] = (
 		childrenByParent.get(rootId) ?? []
 	).map((row) => ({
 		row,
-		parentLevel: rootLevel,
-		parentIsPropertyClaim: true,
+		parentInfo: rootInfo,
+		grandparentInfo: undefined,
 	}));
 
 	while (frontier.length > 0) {
@@ -712,6 +878,13 @@ async function applyUpdates(
 		tx,
 		Array.from(new Set(relevantForLevel.map((c) => c.data.parentId as string)))
 	);
+	// Grandparent {elementType, level} for any new parent that is a STRATEGY —
+	// the transparent-strategy hop (see calculateLevelFromParentChain).
+	const grandparentInfoById = await fetchGrandparentInfoForStrategies(
+		tx,
+		parentInfoById
+	);
+	const externalInfoById = new Map([...parentInfoById, ...grandparentInfoById]);
 	const moveMap = new Map(
 		relevantForLevel.map((c) => [c.elementId, c.data.parentId as string])
 	);
@@ -719,7 +892,7 @@ async function applyUpdates(
 	const finalLevels = resolveFinalLevelsForBatch(
 		moveMap,
 		ownTypeById,
-		parentInfoById
+		externalInfoById
 	);
 	const cascadeLevels = await resolveDescendantCascadeLevels(
 		tx,
@@ -831,6 +1004,21 @@ export async function applyBatchUpdate(
 	const links = changes.filter(
 		(c): c is LinkEvidenceChange => c.type === "link_evidence"
 	);
+
+	// IDOR guard: confirms every existing element this batch references
+	// (update/delete targets, parent references, evidence links) actually
+	// belongs to `caseId` — case-level EDIT access alone doesn't prove that.
+	const ownershipError = await validateElementOwnership(
+		caseId,
+		creates,
+		updates,
+		deletes,
+		links,
+		unlinks
+	);
+	if (ownershipError) {
+		return { error: ownershipError };
+	}
 
 	// ADR 0004 D3 write rule: assertionStatus is author-declared only — see
 	// enforceAssertionStatusRules's docstring (element-service.ts) for why

--- a/lib/services/element-service.ts
+++ b/lib/services/element-service.ts
@@ -503,10 +503,49 @@ async function generateElementName(
 }
 
 /**
+ * Minimal {level, elementType} shape needed to decide a PROPERTY_CLAIM
+ * child's level from a parent or grandparent row. Shared between the
+ * single-element create path here and the batch/JSON-editor path
+ * (case-batch-update-service.ts) so both compute levels the same way.
+ */
+export interface LevelRuleParentInfo {
+	elementType: string;
+	level: number | null;
+}
+
+/**
+ * Single source of truth for the property-claim level rule: a PROPERTY_CLAIM
+ * parent yields parent.level+1 (defaulting an unset parent level to 1); a
+ * STRATEGY parent whose OWN parent is a PROPERTY_CLAIM is transparent —
+ * strategies don't carry a level themselves, so the child's level is derived
+ * from that grandparent instead (grandparent.level+1); anything else
+ * (including an unresolvable parent) yields 1. Takes pre-fetched info only —
+ * no DB calls, so both the single-element and batch paths can call it after
+ * their own (very different) fetch strategies.
+ */
+export function calculateLevelFromParentChain(
+	parentInfo: LevelRuleParentInfo | null | undefined,
+	grandparentInfo: LevelRuleParentInfo | null | undefined
+): number {
+	if (parentInfo?.elementType === "PROPERTY_CLAIM") {
+		return (parentInfo.level ?? 1) + 1;
+	}
+	if (
+		parentInfo?.elementType === "STRATEGY" &&
+		grandparentInfo?.elementType === "PROPERTY_CLAIM"
+	) {
+		return (grandparentInfo.level ?? 1) + 1;
+	}
+	return 1;
+}
+
+/**
  * Calculates level for property claims and retrieves parent info.
  *
  * Strategies are transparent: if the parent is a strategy whose parent is a
  * property claim, the level is derived from that ancestor claim (one hop up).
+ * The rule itself lives in `calculateLevelFromParentChain`; this function
+ * only owns the fetching (parent, then grandparent if needed).
  */
 async function calculatePropertyClaimLevel(parentId: string): Promise<{
 	level: number;
@@ -524,23 +563,23 @@ async function calculatePropertyClaimLevel(parentId: string): Promise<{
 		parentId?: string | null;
 	};
 
-	if (parentInfo?.elementType === "PROPERTY_CLAIM") {
-		return { level: (parentInfo.level || 1) + 1, parentInfo };
-	}
-
-	// Transparent strategy: look one hop further to find ancestor property claim
+	let grandparentInfo: LevelRuleParentInfo | undefined;
 	if (parentInfo?.elementType === "STRATEGY" && parentInfo.parentId) {
 		const grandparent = await prisma.assuranceElement.findFirst({
 			where: { id: parentInfo.parentId, deletedAt: null },
 			select: { level: true, elementType: true, name: true },
 		});
-
-		if (grandparent?.elementType === "PROPERTY_CLAIM") {
-			return { level: (grandparent.level || 1) + 1, parentInfo };
-		}
+		grandparentInfo = grandparent ?? undefined;
 	}
 
-	return { level: 1, parentInfo };
+	const level = calculateLevelFromParentChain(
+		parentInfo
+			? { elementType: parentInfo.elementType, level: parentInfo.level ?? null }
+			: undefined,
+		grandparentInfo
+	);
+
+	return { level, parentInfo };
 }
 
 /**

--- a/src/__tests__/integration/batch-ownership-adversarial.test.ts
+++ b/src/__tests__/integration/batch-ownership-adversarial.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ElementChange } from "@/lib/case/tree-diff";
+import prisma from "@/lib/prisma";
+import { expectError, expectSuccess } from "../utils/assertion-helpers";
+import {
+	createTestCase,
+	createTestElement,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+/**
+ * QA G3 adversarial suite for "TEA — Batch endpoint does not verify element
+ * ownership against the case" (branch fix/batch-element-ownership).
+ *
+ * Written independently of barret's tests in
+ * case-batch-update-service.test.ts (same directory) — only reads them
+ * afterwards to avoid duplicating coverage. Does not modify that file.
+ */
+
+vi.mock("@/lib/services/sse-connection-manager", () => ({
+	emitSSEEvent: vi.fn(),
+	sseConnectionManager: { broadcast: vi.fn() },
+}));
+
+describe("batch ownership — adversarial (QA G3)", () => {
+	/**
+	 * CRITICAL FINDING: `validateElementOwnership` builds `createdIds` from
+	 * every `elementId` appearing in the batch's `create` changes, then
+	 * excludes any id in `createdIds` from the ownership lookup — including
+	 * for `delete` changes that happen to reuse the same id
+	 * (case-batch-update-service.ts, `addIfExisting` applied to
+	 * `deletes[].elementId`).
+	 *
+	 * A batch that pairs `{type: "delete", elementId: X}` with
+	 * `{type: "create", elementId: X, ...}` for the SAME id X therefore
+	 * skips the ownership check for the delete entirely, even when X is a
+	 * real row belonging to a different case. `applyDeletes` runs before
+	 * `applyCreates` (see the apply order comment in `applyBatchUpdate`), so
+	 * if this is accepted the foreign row is hard-deleted by primary key
+	 * (Prisma `delete({ where: { id } })` does not filter by caseId) and then
+	 * recreated under the attacker's own case with attacker-controlled data
+	 * — a cross-case delete-and-hijack that the ownership gate was supposed
+	 * to prevent.
+	 */
+	it("rejects a batch that deletes a foreign element and recreates the same id (delete+recreate id-reuse exploit)", async () => {
+		const attacker = await createTestUser();
+		const victim = await createTestUser();
+		const attackerCase = await createTestCase(attacker.id);
+		const victimCase = await createTestCase(victim.id);
+		const victimElement = await createTestElement(victimCase.id, victim.id, {
+			elementType: "GOAL",
+			name: "Victim's Goal",
+		});
+
+		const { applyBatchUpdate } = await import(
+			"@/lib/services/case-batch-update-service"
+		);
+
+		const changes: ElementChange[] = [
+			{ type: "delete", elementId: victimElement.id },
+			{
+				type: "create",
+				elementId: victimElement.id,
+				parentId: null,
+				data: {
+					id: victimElement.id,
+					type: "GOAL",
+					name: "Hijacked by attacker",
+					description: "Recreated under attacker's case",
+					inSandbox: false,
+				},
+			},
+		];
+
+		expectError(await applyBatchUpdate(attacker.id, attackerCase.id, changes));
+
+		const stillVictims = await prisma.assuranceElement.findUnique({
+			where: { id: victimElement.id },
+		});
+		expect(stillVictims).not.toBeNull();
+		expect(stillVictims?.caseId).toBe(victimCase.id);
+		expect(stillVictims?.name).toBe("Victim's Goal");
+	});
+
+	it("rejects a mixed batch where only ONE of several changes references a foreign element (atomicity)", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+		const otherCase = await createTestCase(user.id);
+		const legalElementA = await createTestElement(testCase.id, user.id, {
+			elementType: "GOAL",
+			name: "Legal A",
+		});
+		const legalElementB = await createTestElement(testCase.id, user.id, {
+			elementType: "GOAL",
+			name: "Legal B",
+		});
+		const foreignElement = await createTestElement(otherCase.id, user.id, {
+			elementType: "GOAL",
+		});
+
+		const { applyBatchUpdate } = await import(
+			"@/lib/services/case-batch-update-service"
+		);
+
+		const changes: ElementChange[] = [
+			{
+				type: "update",
+				elementId: legalElementA.id,
+				data: { name: "Legal A Renamed" },
+			},
+			{
+				type: "update",
+				elementId: legalElementB.id,
+				data: { name: "Legal B Renamed" },
+			},
+			{
+				// buried in the middle of an otherwise entirely legal batch
+				type: "update",
+				elementId: foreignElement.id,
+				data: { name: "Hijacked" },
+			},
+		];
+
+		expectError(await applyBatchUpdate(user.id, testCase.id, changes));
+
+		const a = await prisma.assuranceElement.findUnique({
+			where: { id: legalElementA.id },
+		});
+		const b = await prisma.assuranceElement.findUnique({
+			where: { id: legalElementB.id },
+		});
+		expect(a?.name).toBe("Legal A");
+		expect(b?.name).toBe("Legal B");
+	});
+
+	it("rejects link_evidence when claimId is a batch-created id but evidenceId is foreign", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+		const otherCase = await createTestCase(user.id);
+		const foreignEvidence = await createTestElement(otherCase.id, user.id, {
+			elementType: "EVIDENCE",
+		});
+
+		const { applyBatchUpdate } = await import(
+			"@/lib/services/case-batch-update-service"
+		);
+
+		const newClaimId = `element-created-claim-${Date.now()}`;
+		const changes: ElementChange[] = [
+			{
+				type: "create",
+				elementId: newClaimId,
+				parentId: null,
+				data: {
+					id: newClaimId,
+					type: "PROPERTY_CLAIM",
+					name: "Batch-created claim",
+					description: "Created in the same batch as the link",
+					inSandbox: false,
+				},
+			},
+			{
+				type: "link_evidence",
+				evidenceId: foreignEvidence.id,
+				claimId: newClaimId,
+			},
+		];
+
+		expectError(await applyBatchUpdate(user.id, testCase.id, changes));
+
+		const created = await prisma.assuranceElement.findUnique({
+			where: { id: newClaimId },
+		});
+		expect(created).toBeNull();
+
+		const link = await prisma.evidenceLink.findFirst({
+			where: { evidenceId: foreignEvidence.id, claimId: newClaimId },
+		});
+		expect(link).toBeNull();
+	});
+
+	it("rejects a create chain (create-under-create) whose outer parent is foreign", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+		const otherCase = await createTestCase(user.id);
+		const foreignParent = await createTestElement(otherCase.id, user.id, {
+			elementType: "GOAL",
+		});
+
+		const { applyBatchUpdate } = await import(
+			"@/lib/services/case-batch-update-service"
+		);
+
+		const middleId = `element-chain-middle-${Date.now()}`;
+		const leafId = `element-chain-leaf-${Date.now()}`;
+		const changes: ElementChange[] = [
+			{
+				type: "create",
+				elementId: middleId,
+				parentId: foreignParent.id,
+				data: {
+					id: middleId,
+					type: "PROPERTY_CLAIM",
+					name: "Middle (parented to a foreign element)",
+					description: "Should be rejected",
+					inSandbox: false,
+				},
+			},
+			{
+				type: "create",
+				elementId: leafId,
+				parentId: middleId,
+				data: {
+					id: leafId,
+					type: "STRATEGY",
+					name: "Leaf (parented to the middle create)",
+					description: "Should never be reached",
+					inSandbox: false,
+				},
+			},
+		];
+
+		expectError(await applyBatchUpdate(user.id, testCase.id, changes));
+
+		const middle = await prisma.assuranceElement.findUnique({
+			where: { id: middleId },
+		});
+		const leaf = await prisma.assuranceElement.findUnique({
+			where: { id: leafId },
+		});
+		expect(middle).toBeNull();
+		expect(leaf).toBeNull();
+	});
+
+	/**
+	 * `calculateLevelFromParentChain`'s transparent-strategy hop is pinned by
+	 * barret's tests for batch CREATES ("transparent-strategy grandparent
+	 * hop (batch creates)") but not for a batch UPDATE that MOVES an
+	 * existing property claim under a strategy. Both `applyCreates` and
+	 * `applyUpdates` are meant to share the same rule — this pins that the
+	 * move path actually does.
+	 */
+	it("computes the correct level when a batch UPDATE moves a property claim under a STRATEGY whose parent is a PROPERTY_CLAIM", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+		const goal = await createTestElement(testCase.id, user.id, {
+			elementType: "GOAL",
+		});
+		const grandparent = await createTestElement(testCase.id, user.id, {
+			elementType: "PROPERTY_CLAIM",
+			parentId: goal.id,
+		});
+		await prisma.assuranceElement.update({
+			where: { id: grandparent.id },
+			data: { level: 1 },
+		});
+		const strategy = await createTestElement(testCase.id, user.id, {
+			elementType: "STRATEGY",
+			parentId: grandparent.id,
+		});
+		// The claim being moved starts out unrelated (top-level, level 1) so a
+		// wrong "leave it alone" implementation can't accidentally pass.
+		const mover = await createTestElement(testCase.id, user.id, {
+			elementType: "PROPERTY_CLAIM",
+		});
+		await prisma.assuranceElement.update({
+			where: { id: mover.id },
+			data: { level: 1 },
+		});
+
+		const { applyBatchUpdate } = await import(
+			"@/lib/services/case-batch-update-service"
+		);
+
+		const changes: ElementChange[] = [
+			{
+				type: "update",
+				elementId: mover.id,
+				data: { parentId: strategy.id },
+			},
+		];
+
+		expectSuccess(await applyBatchUpdate(user.id, testCase.id, changes));
+
+		const moved = await prisma.assuranceElement.findUnique({
+			where: { id: mover.id },
+		});
+		expect(moved?.parentId).toBe(strategy.id);
+		// grandparent.level (1) + 1 = 2, skipping the transparent strategy —
+		// same rule the single-element route and batch creates use.
+		expect(moved?.level).toBe(2);
+	});
+
+	it("rejects a batch referencing a soft-deleted element that belongs to a different case", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+		const otherCase = await createTestCase(user.id);
+		const foreignSoftDeleted = await createTestElement(otherCase.id, user.id, {
+			elementType: "GOAL",
+		});
+		await prisma.assuranceElement.update({
+			where: { id: foreignSoftDeleted.id },
+			data: { deletedAt: new Date() },
+		});
+
+		const { applyBatchUpdate } = await import(
+			"@/lib/services/case-batch-update-service"
+		);
+
+		const changes: ElementChange[] = [
+			{
+				type: "update",
+				elementId: foreignSoftDeleted.id,
+				data: { name: "Hijacked soft-deleted element" },
+			},
+		];
+
+		expectError(await applyBatchUpdate(user.id, testCase.id, changes));
+	});
+});

--- a/src/__tests__/integration/batch-ownership-adversarial.test.ts
+++ b/src/__tests__/integration/batch-ownership-adversarial.test.ts
@@ -571,7 +571,7 @@ describe("batch ownership — adversarial (QA G3)", () => {
 		];
 
 		const result = await applyBatchUpdate(user.id, testCase.id, changes);
-		expect(result.error).toBeDefined();
+		expect("error" in result && result.error).toBeTruthy();
 
 		const linkStillThere = await prisma.evidenceLink.findFirst({
 			where: { evidenceId: foreignEvidence.id, claimId: claim.id },

--- a/src/__tests__/integration/batch-ownership-adversarial.test.ts
+++ b/src/__tests__/integration/batch-ownership-adversarial.test.ts
@@ -317,4 +317,265 @@ describe("batch ownership — adversarial (QA G3)", () => {
 
 		expectError(await applyBatchUpdate(user.id, testCase.id, changes));
 	});
+
+	/**
+	 * Re-verification round (dba9edf6): confirms the delete/update
+	 * "addAlways" fix holds under a slightly harder id-reuse variant — the
+	 * recreate ALSO smuggles a second, DIFFERENT foreign id in as its
+	 * parentId, so a fix that only special-cased the single-id
+	 * delete+recreate pattern (and forgot parentId is still
+	 * addUnlessSiblingCreate) would wrongly accept this.
+	 */
+	it("rejects delete+recreate id-reuse when the recreate's parentId ALSO reuses a second, different foreign id", async () => {
+		const attacker = await createTestUser();
+		const attackerCase = await createTestCase(attacker.id);
+		const victimCase = await createTestCase(attacker.id);
+		const victimElement = await createTestElement(victimCase.id, attacker.id, {
+			elementType: "GOAL",
+			name: "Victim Element",
+		});
+		const secondForeignParent = await createTestElement(
+			victimCase.id,
+			attacker.id,
+			{ elementType: "GOAL", name: "Second Foreign Element" }
+		);
+
+		const { applyBatchUpdate } = await import(
+			"@/lib/services/case-batch-update-service"
+		);
+
+		const changes: ElementChange[] = [
+			{ type: "delete", elementId: victimElement.id },
+			{
+				type: "create",
+				elementId: victimElement.id,
+				parentId: secondForeignParent.id,
+				data: {
+					id: victimElement.id,
+					type: "GOAL",
+					name: "Hijacked, parented under a second foreign element",
+					description: "Should never be created",
+					inSandbox: false,
+				},
+			},
+		];
+
+		expectError(await applyBatchUpdate(attacker.id, attackerCase.id, changes));
+
+		const stillThere = await prisma.assuranceElement.findUnique({
+			where: { id: victimElement.id },
+		});
+		expect(stillThere).not.toBeNull();
+		expect(stillThere?.caseId).toBe(victimCase.id);
+		expect(stillThere?.name).toBe("Victim Element");
+
+		const secondUntouched = await prisma.assuranceElement.findUnique({
+			where: { id: secondForeignParent.id },
+		});
+		expect(secondUntouched).not.toBeNull();
+	});
+
+	/**
+	 * The `addAlways` split applies to BOTH delete's and update's own
+	 * elementId. This pins the update side specifically: a batch that both
+	 * updates a foreign element AND (elsewhere in the same batch) creates a
+	 * NEW element reusing that same id must still reject — an
+	 * implementation that only fixed the delete path, or that special-cased
+	 * "update+create pairs" differently from "delete+create pairs", would
+	 * miss this.
+	 */
+	it("rejects an update whose elementId is foreign even when that same id is also used by a create elsewhere in the batch", async () => {
+		const attacker = await createTestUser();
+		const attackerCase = await createTestCase(attacker.id);
+		const victimCase = await createTestCase(attacker.id);
+		const victimElement = await createTestElement(victimCase.id, attacker.id, {
+			elementType: "GOAL",
+			name: "Victim Element",
+		});
+		const otherNewId = `element-update-plus-create-${Date.now()}`;
+
+		const { applyBatchUpdate } = await import(
+			"@/lib/services/case-batch-update-service"
+		);
+
+		const changes: ElementChange[] = [
+			{
+				type: "update",
+				elementId: victimElement.id,
+				data: { name: "Hijacked via update" },
+			},
+			{
+				// Same id as the update target, reused by an UNRELATED create
+				// elsewhere in the batch — must not exempt the update above.
+				type: "create",
+				elementId: victimElement.id,
+				parentId: null,
+				data: {
+					id: victimElement.id,
+					type: "GOAL",
+					name: "Should never be created (duplicate id)",
+					description: "id collides with the update target above",
+					inSandbox: false,
+				},
+			},
+			{
+				type: "create",
+				elementId: otherNewId,
+				parentId: null,
+				data: {
+					id: otherNewId,
+					type: "GOAL",
+					name: "Unrelated legitimate create",
+					description: "Should not be created either — whole batch rejected",
+					inSandbox: false,
+				},
+			},
+		];
+
+		expectError(await applyBatchUpdate(attacker.id, attackerCase.id, changes));
+
+		const unchanged = await prisma.assuranceElement.findUnique({
+			where: { id: victimElement.id },
+		});
+		expect(unchanged?.name).toBe("Victim Element");
+		expect(unchanged?.caseId).toBe(victimCase.id);
+
+		const notCreated = await prisma.assuranceElement.findUnique({
+			where: { id: otherNewId },
+		});
+		expect(notCreated).toBeNull();
+	});
+
+	/**
+	 * Combines the delete+recreate id-reuse pattern with defeatsElementId:
+	 * a sibling create's defeatsElementId points at the SAME foreign id the
+	 * batch deletes and recreates. The delete's own `addAlways` check must
+	 * still catch this even though defeatsElementId (addUnlessSiblingCreate)
+	 * would, on its own, exempt a reference to that id once it's also a
+	 * batch create target.
+	 */
+	it("rejects delete+recreate id-reuse even when a sibling create's defeatsElementId also points at the reused id", async () => {
+		const attacker = await createTestUser();
+		const attackerCase = await createTestCase(attacker.id);
+		const victimCase = await createTestCase(attacker.id);
+		const victimElement = await createTestElement(victimCase.id, attacker.id, {
+			elementType: "PROPERTY_CLAIM",
+		});
+
+		const { applyBatchUpdate } = await import(
+			"@/lib/services/case-batch-update-service"
+		);
+
+		const defeaterId = crypto.randomUUID();
+		const changes: ElementChange[] = [
+			{ type: "delete", elementId: victimElement.id },
+			{
+				type: "create",
+				elementId: victimElement.id,
+				parentId: null,
+				data: {
+					id: victimElement.id,
+					type: "PROPERTY_CLAIM",
+					name: "Hijacked",
+					description: "Should never be created",
+					inSandbox: false,
+				},
+			},
+			{
+				type: "create",
+				elementId: defeaterId,
+				parentId: null,
+				data: {
+					id: defeaterId,
+					type: "PROPERTY_CLAIM",
+					name: "Defeater citing the reused id",
+					description: "defeatsElementId points at the delete+recreate target",
+					inSandbox: false,
+					isDefeater: true,
+					defeatsElementId: victimElement.id,
+				},
+			},
+		];
+
+		expectError(await applyBatchUpdate(attacker.id, attackerCase.id, changes));
+
+		const stillThere = await prisma.assuranceElement.findUnique({
+			where: { id: victimElement.id },
+		});
+		expect(stillThere).not.toBeNull();
+		expect(stillThere?.caseId).toBe(victimCase.id);
+
+		const defeaterCreated = await prisma.assuranceElement.findUnique({
+			where: { id: defeaterId },
+		});
+		expect(defeaterCreated).toBeNull();
+	});
+
+	/**
+	 * Residual-gap probe (not an exploit — documents why): `unlink_evidence`
+	 * ids still use `addUnlessSiblingCreate`, so an unlink whose evidenceId
+	 * equals a batch create's elementId is exempted from the ownership
+	 * check even when that id is a REAL foreign row (no delete involved,
+	 * unlike the fixed pattern above). If it were exploitable, an attacker
+	 * could unlink a foreign evidence/claim pair by "recreating" the
+	 * foreign id. It is NOT exploitable in practice: `applyUnlinkEvidence`
+	 * runs first in transaction order, but `tx.assuranceElement.create`
+	 * with an id that already exists always throws a unique-constraint
+	 * error, which rolls back the WHOLE transaction (including the unlink
+	 * that ran earlier in the same `$transaction` callback) — Prisma
+	 * interactive transactions are all-or-nothing. This test pins that the
+	 * net effect is still a full rejection with no persisted change, as a
+	 * regression guard on that safety net rather than on the validator
+	 * itself.
+	 */
+	it("leaves no persisted change when unlink_evidence's evidenceId is exempted via a same-id create that collides with a real foreign row", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+		const claim = await createTestElement(testCase.id, user.id, {
+			elementType: "PROPERTY_CLAIM",
+		});
+		const otherCase = await createTestCase(user.id);
+		const foreignEvidence = await createTestElement(otherCase.id, user.id, {
+			elementType: "EVIDENCE",
+		});
+		await prisma.evidenceLink.create({
+			data: { evidenceId: foreignEvidence.id, claimId: claim.id },
+		});
+
+		const { applyBatchUpdate } = await import(
+			"@/lib/services/case-batch-update-service"
+		);
+
+		const changes: ElementChange[] = [
+			{
+				type: "unlink_evidence",
+				evidenceId: foreignEvidence.id,
+				claimId: claim.id,
+			},
+			{
+				// Reuses the foreign evidence's id as a create target WITHOUT
+				// deleting it first — this "exempts" the unlink's evidenceId
+				// from the ownership check, but the create itself must fail
+				// (id already exists), rolling back the whole transaction.
+				type: "create",
+				elementId: foreignEvidence.id,
+				parentId: null,
+				data: {
+					id: foreignEvidence.id,
+					type: "EVIDENCE",
+					name: "Attempted id collision",
+					description: "Should never persist — unique constraint + rollback",
+					inSandbox: false,
+				},
+			},
+		];
+
+		const result = await applyBatchUpdate(user.id, testCase.id, changes);
+		expect(result.error).toBeDefined();
+
+		const linkStillThere = await prisma.evidenceLink.findFirst({
+			where: { evidenceId: foreignEvidence.id, claimId: claim.id },
+		});
+		expect(linkStillThere).not.toBeNull();
+	});
 });

--- a/src/__tests__/integration/case-batch-update-service.test.ts
+++ b/src/__tests__/integration/case-batch-update-service.test.ts
@@ -2440,4 +2440,242 @@ describe("applyBatchUpdate", () => {
 			expect(created?.level).toBe(2);
 		});
 	});
+
+	/**
+	 * TEA — Batch endpoint does not verify element ownership against the
+	 * case (fix round, nanaki-verified repro): a batch containing BOTH a
+	 * delete AND a create for the SAME elementId let a foreign element's id
+	 * slip through `validateElementOwnership`'s createdIds exemption — the
+	 * exemption was meant only for parent-style references that a sibling
+	 * create can legitimately satisfy, not for a delete's own target.
+	 * `applyDeletes` runs before `applyCreates` and deletes by bare PK with
+	 * no case filter, so this pattern hard-deleted the victim's row and
+	 * recreated it under the attacker's case — a cross-case delete-and-
+	 * hijack. `addAlways` now checks a delete's/update's own elementId
+	 * unconditionally, regardless of what else the same batch creates.
+	 */
+	describe("delete+recreate id-reuse bypass (regression)", () => {
+		it("rejects a batch that deletes and recreates the same id when that id belongs to a different case", async () => {
+			const attacker = await createTestUser();
+			const attackerCase = await createTestCase(attacker.id);
+			const victimCase = await createTestCase(attacker.id);
+			const victimElement = await createTestElement(
+				victimCase.id,
+				attacker.id,
+				{ elementType: "GOAL", name: "Victim Element" }
+			);
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			// Same elementId used for BOTH a delete and a create in one batch —
+			// the id-reuse pattern that bypassed the old createdIds exemption.
+			const changes: ElementChange[] = [
+				{ type: "delete", elementId: victimElement.id },
+				{
+					type: "create",
+					elementId: victimElement.id,
+					parentId: null,
+					data: {
+						id: victimElement.id,
+						type: "GOAL",
+						name: "Hijacked Into Attacker Case",
+						description: "Should never be created",
+						inSandbox: false,
+					},
+				},
+			];
+
+			expectError(
+				await applyBatchUpdate(attacker.id, attackerCase.id, changes)
+			);
+
+			// The victim's element must survive, untouched, in its own case.
+			const stillThere = await prisma.assuranceElement.findUnique({
+				where: { id: victimElement.id },
+			});
+			expect(stillThere).not.toBeNull();
+			expect(stillThere?.caseId).toBe(victimCase.id);
+			expect(stillThere?.name).toBe("Victim Element");
+		});
+
+		it("still allows a same-batch delete+recreate of the same id when the id genuinely belongs to the target case", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const element = await createTestElement(testCase.id, user.id, {
+				elementType: "GOAL",
+				name: "Original",
+			});
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const changes: ElementChange[] = [
+				{ type: "delete", elementId: element.id },
+				{
+					type: "create",
+					elementId: element.id,
+					parentId: null,
+					data: {
+						id: element.id,
+						type: "GOAL",
+						name: "Recreated",
+						description: "Legitimate delete+recreate within the owning case",
+						inSandbox: false,
+					},
+				},
+			];
+
+			const data = expectSuccess(
+				await applyBatchUpdate(user.id, testCase.id, changes)
+			);
+			expect(data.summary.created).toBe(1);
+			expect(data.summary.deleted).toBe(1);
+
+			const recreated = await prisma.assuranceElement.findUnique({
+				where: { id: element.id },
+			});
+			expect(recreated?.name).toBe("Recreated");
+			expect(recreated?.caseId).toBe(testCase.id);
+		});
+	});
+
+	/**
+	 * TEA — Batch endpoint does not verify element ownership against the
+	 * case (fix round, vincent): `defeatsElementId` is a real FK to
+	 * AssuranceElement (`defeatsElement` relation "Defeater",
+	 * prisma/schema.prisma) carried on both the create and update payload
+	 * shapes (lib/schemas/batch-update.ts), but `validateElementOwnership`
+	 * never collected it — the same IDOR class already closed for
+	 * `parentId` and the evidence-link ids. Scoped to the batch path only;
+	 * the single-element route (element-service.ts) has the same gap,
+	 * tracked as a separate issue.
+	 */
+	describe("defeatsElementId cross-case reference (regression)", () => {
+		it("rejects a create whose defeatsElementId belongs to a different case", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const otherCase = await createTestCase(user.id);
+			const foreignTarget = await createTestElement(otherCase.id, user.id, {
+				elementType: "PROPERTY_CLAIM",
+			});
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const newId = `element-defeats-foreign-create-${Date.now()}`;
+			const changes: ElementChange[] = [
+				{
+					type: "create",
+					elementId: newId,
+					parentId: null,
+					data: {
+						id: newId,
+						type: "PROPERTY_CLAIM",
+						name: "Smuggled Defeater",
+						description: "Should never be created",
+						inSandbox: false,
+						isDefeater: true,
+						defeatsElementId: foreignTarget.id,
+					},
+				},
+			];
+
+			expectError(await applyBatchUpdate(user.id, testCase.id, changes));
+
+			const created = await prisma.assuranceElement.findUnique({
+				where: { id: newId },
+			});
+			expect(created).toBeNull();
+		});
+
+		it("rejects an update whose defeatsElementId belongs to a different case", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const claim = await createTestElement(testCase.id, user.id, {
+				elementType: "PROPERTY_CLAIM",
+				name: "Not Yet A Defeater",
+			});
+			const otherCase = await createTestCase(user.id);
+			const foreignTarget = await createTestElement(otherCase.id, user.id, {
+				elementType: "PROPERTY_CLAIM",
+			});
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const changes: ElementChange[] = [
+				{
+					type: "update",
+					elementId: claim.id,
+					data: { isDefeater: true, defeatsElementId: foreignTarget.id },
+				},
+			];
+
+			expectError(await applyBatchUpdate(user.id, testCase.id, changes));
+
+			const unchanged = await prisma.assuranceElement.findUnique({
+				where: { id: claim.id },
+			});
+			expect(unchanged?.defeatsElementId).toBeNull();
+		});
+
+		it("accepts a defeatsElementId that points at a sibling create in the same batch", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			// defeatsElementId is validated as a UUID by the element-data
+			// validation layer (lib/schemas/element-validation.ts), so both
+			// ids here must be real UUIDs, not the plain test-fixture strings
+			// used for elementId elsewhere in this file.
+			const targetId = crypto.randomUUID();
+			const defeaterId = crypto.randomUUID();
+			const changes: ElementChange[] = [
+				{
+					type: "create",
+					elementId: targetId,
+					parentId: null,
+					data: {
+						id: targetId,
+						type: "PROPERTY_CLAIM",
+						name: "Defeated Claim",
+						description: "Created in the same batch as its defeater",
+						inSandbox: false,
+					},
+				},
+				{
+					type: "create",
+					elementId: defeaterId,
+					parentId: null,
+					data: {
+						id: defeaterId,
+						type: "PROPERTY_CLAIM",
+						name: "Defeater Claim",
+						description: "References a sibling create as its defeats target",
+						inSandbox: false,
+						isDefeater: true,
+						defeatsElementId: targetId,
+					},
+				},
+			];
+
+			const data = expectSuccess(
+				await applyBatchUpdate(user.id, testCase.id, changes)
+			);
+			expect(data.summary.created).toBe(2);
+
+			const defeater = await prisma.assuranceElement.findUnique({
+				where: { id: defeaterId },
+			});
+			expect(defeater?.defeatsElementId).toBe(targetId);
+		});
+	});
 });

--- a/src/__tests__/integration/case-batch-update-service.test.ts
+++ b/src/__tests__/integration/case-batch-update-service.test.ts
@@ -2066,4 +2066,378 @@ describe("applyBatchUpdate", () => {
 			expect(grandchild?.level).toBe(3);
 		});
 	});
+
+	/**
+	 * TEA — Batch endpoint does not verify element ownership against the
+	 * case: `validateEditAccess` only confirms the caller has EDIT access to
+	 * the TARGET case, never that the element ids the batch actually touches
+	 * belong to that case. Without `validateElementOwnership`, a user with
+	 * edit access to case A could write to, delete, re-parent, or evidence-
+	 * link/unlink elements that live in case B (IDOR). Every change type
+	 * that references an id expected to already exist is covered here.
+	 */
+	describe("cross-case element ownership (IDOR guard)", () => {
+		it("rejects an update targeting an element that belongs to a different case", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const otherCase = await createTestCase(user.id);
+			const foreignElement = await createTestElement(otherCase.id, user.id, {
+				elementType: "GOAL",
+			});
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const changes: ElementChange[] = [
+				{
+					type: "update",
+					elementId: foreignElement.id,
+					data: { name: "Hijacked" },
+				},
+			];
+
+			expectError(await applyBatchUpdate(user.id, testCase.id, changes));
+
+			const unchanged = await prisma.assuranceElement.findUnique({
+				where: { id: foreignElement.id },
+			});
+			expect(unchanged?.name).not.toBe("Hijacked");
+		});
+
+		it("rejects a delete targeting an element that belongs to a different case", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const otherCase = await createTestCase(user.id);
+			const foreignElement = await createTestElement(otherCase.id, user.id, {
+				elementType: "GOAL",
+			});
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const changes: ElementChange[] = [
+				{ type: "delete", elementId: foreignElement.id },
+			];
+
+			expectError(await applyBatchUpdate(user.id, testCase.id, changes));
+
+			const stillThere = await prisma.assuranceElement.findUnique({
+				where: { id: foreignElement.id },
+			});
+			expect(stillThere).not.toBeNull();
+		});
+
+		it("rejects a create whose parentId belongs to a different case", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const otherCase = await createTestCase(user.id);
+			const foreignParent = await createTestElement(otherCase.id, user.id, {
+				elementType: "GOAL",
+			});
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const newId = `element-foreign-parent-${Date.now()}`;
+			const changes: ElementChange[] = [
+				{
+					type: "create",
+					elementId: newId,
+					parentId: foreignParent.id,
+					data: {
+						id: newId,
+						type: "PROPERTY_CLAIM",
+						name: "Smuggled Under Foreign Parent",
+						description: "Should never be created",
+						inSandbox: false,
+					},
+				},
+			];
+
+			expectError(await applyBatchUpdate(user.id, testCase.id, changes));
+
+			const created = await prisma.assuranceElement.findUnique({
+				where: { id: newId },
+			});
+			expect(created).toBeNull();
+		});
+
+		it("rejects an update that moves an element to a parentId belonging to a different case", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const mover = await createTestElement(testCase.id, user.id, {
+				elementType: "PROPERTY_CLAIM",
+			});
+			const otherCase = await createTestCase(user.id);
+			const foreignParent = await createTestElement(otherCase.id, user.id, {
+				elementType: "GOAL",
+			});
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const changes: ElementChange[] = [
+				{
+					type: "update",
+					elementId: mover.id,
+					data: { parentId: foreignParent.id },
+				},
+			];
+
+			expectError(await applyBatchUpdate(user.id, testCase.id, changes));
+
+			const unmoved = await prisma.assuranceElement.findUnique({
+				where: { id: mover.id },
+			});
+			expect(unmoved?.parentId).toBeNull();
+		});
+
+		it("rejects link_evidence when the evidenceId belongs to a different case", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const claim = await createTestElement(testCase.id, user.id, {
+				elementType: "PROPERTY_CLAIM",
+			});
+			const otherCase = await createTestCase(user.id);
+			const foreignEvidence = await createTestElement(otherCase.id, user.id, {
+				elementType: "EVIDENCE",
+			});
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const changes: ElementChange[] = [
+				{
+					type: "link_evidence",
+					evidenceId: foreignEvidence.id,
+					claimId: claim.id,
+				},
+			];
+
+			expectError(await applyBatchUpdate(user.id, testCase.id, changes));
+
+			const link = await prisma.evidenceLink.findFirst({
+				where: { evidenceId: foreignEvidence.id, claimId: claim.id },
+			});
+			expect(link).toBeNull();
+		});
+
+		it("rejects link_evidence when the claimId belongs to a different case", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const evidence = await createTestElement(testCase.id, user.id, {
+				elementType: "EVIDENCE",
+			});
+			const otherCase = await createTestCase(user.id);
+			const foreignClaim = await createTestElement(otherCase.id, user.id, {
+				elementType: "PROPERTY_CLAIM",
+			});
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const changes: ElementChange[] = [
+				{
+					type: "link_evidence",
+					evidenceId: evidence.id,
+					claimId: foreignClaim.id,
+				},
+			];
+
+			expectError(await applyBatchUpdate(user.id, testCase.id, changes));
+
+			const link = await prisma.evidenceLink.findFirst({
+				where: { evidenceId: evidence.id, claimId: foreignClaim.id },
+			});
+			expect(link).toBeNull();
+		});
+
+		it("rejects unlink_evidence when the evidenceId belongs to a different case", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const claim = await createTestElement(testCase.id, user.id, {
+				elementType: "PROPERTY_CLAIM",
+			});
+			const otherCase = await createTestCase(user.id);
+			const foreignEvidence = await createTestElement(otherCase.id, user.id, {
+				elementType: "EVIDENCE",
+			});
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const changes: ElementChange[] = [
+				{
+					type: "unlink_evidence",
+					evidenceId: foreignEvidence.id,
+					claimId: claim.id,
+				},
+			];
+
+			expectError(await applyBatchUpdate(user.id, testCase.id, changes));
+		});
+
+		it("rejects unlink_evidence when the claimId belongs to a different case", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const evidence = await createTestElement(testCase.id, user.id, {
+				elementType: "EVIDENCE",
+			});
+			const otherCase = await createTestCase(user.id);
+			const foreignClaim = await createTestElement(otherCase.id, user.id, {
+				elementType: "PROPERTY_CLAIM",
+			});
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const changes: ElementChange[] = [
+				{
+					type: "unlink_evidence",
+					evidenceId: evidence.id,
+					claimId: foreignClaim.id,
+				},
+			];
+
+			expectError(await applyBatchUpdate(user.id, testCase.id, changes));
+		});
+
+		it("rejects the whole batch when a referenced elementId does not exist at all", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const changes: ElementChange[] = [
+				{
+					type: "update",
+					elementId: "00000000-0000-0000-0000-000000000099",
+					data: { name: "Ghost" },
+				},
+			];
+
+			expectError(await applyBatchUpdate(user.id, testCase.id, changes));
+		});
+
+		it("accepts a batch-created id used as a parentId elsewhere in the same batch", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const parentId = `element-ownership-parent-${Date.now()}`;
+			const childId = `element-ownership-child-${Date.now()}`;
+			const changes: ElementChange[] = [
+				{
+					type: "create",
+					elementId: parentId,
+					parentId: null,
+					data: {
+						id: parentId,
+						type: "GOAL",
+						name: "Batch Parent",
+						description: "Created earlier in this same batch",
+						inSandbox: false,
+					},
+				},
+				{
+					type: "create",
+					elementId: childId,
+					parentId,
+					data: {
+						id: childId,
+						type: "STRATEGY",
+						name: "Batch Child",
+						description: "Parented to a sibling create in this same batch",
+						inSandbox: false,
+					},
+				},
+			];
+
+			const data = expectSuccess(
+				await applyBatchUpdate(user.id, testCase.id, changes)
+			);
+			expect(data.summary.created).toBe(2);
+
+			const child = await prisma.assuranceElement.findUnique({
+				where: { id: childId },
+			});
+			expect(child?.parentId).toBe(parentId);
+		});
+	});
+
+	/**
+	 * TEA — Batch endpoint does not verify element ownership against the
+	 * case (fold-in): the batch path's level rule (`levelFromParentInfo`,
+	 * now `calculateLevelFromParentChain`) lacked the transparent-strategy
+	 * grandparent hop that `element-service.ts`'s `calculatePropertyClaimLevel`
+	 * already had for the single-element create route — a batch create under
+	 * a STRATEGY silently landed at level 1 instead of following the
+	 * grandparent PROPERTY_CLAIM. This pins that the batch and single-element
+	 * paths now agree.
+	 */
+	describe("transparent-strategy grandparent hop (batch creates)", () => {
+		it("computes a batch-created claim's level from its STRATEGY parent's PROPERTY_CLAIM grandparent", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const goal = await createTestElement(testCase.id, user.id, {
+				elementType: "GOAL",
+			});
+			// grandparent: a top-level property claim.
+			const grandparent = await createTestElement(testCase.id, user.id, {
+				elementType: "PROPERTY_CLAIM",
+				parentId: goal.id,
+			});
+			await prisma.assuranceElement.update({
+				where: { id: grandparent.id },
+				data: { level: 1 },
+			});
+			// parent: a strategy directly under the grandparent claim.
+			const strategy = await createTestElement(testCase.id, user.id, {
+				elementType: "STRATEGY",
+				parentId: grandparent.id,
+			});
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const newId = `element-transparent-strategy-${Date.now()}`;
+			const changes: ElementChange[] = [
+				{
+					type: "create",
+					elementId: newId,
+					parentId: strategy.id,
+					data: {
+						id: newId,
+						type: "PROPERTY_CLAIM",
+						name: "Claim Under Strategy",
+						description: "Should skip the strategy and use the grandparent",
+						inSandbox: false,
+					},
+				},
+			];
+
+			expectSuccess(await applyBatchUpdate(user.id, testCase.id, changes));
+
+			const created = await prisma.assuranceElement.findUnique({
+				where: { id: newId },
+			});
+			// grandparent.level (1) + 1 = 2 — matches the single-element route
+			// (element-service.ts's calculatePropertyClaimLevel).
+			expect(created?.level).toBe(2);
+		});
+	});
 });


### PR DESCRIPTION
## What

Closes an IDOR (insecure direct object reference) in `POST /api/cases/[id]/batch`: the endpoint checked case-level EDIT permission once but never verified that the element ids in the `changes` array belong to that case. A user with edit access to case A could reference — and write to, delete, or re-parent — elements of case B.

## Changes

- **Ownership gate** (`case-batch-update-service.ts`): a single pre-flight check resolves every referenced existing element id against the request's `caseId` and rejects the whole batch if any id is missing or foreign. Delete/update targets are checked unconditionally; parent/defeater/evidence references are exempt only when satisfied by a sibling create in the same batch.
- **Batch-size cap** (`batch-update.ts`): `.max(1000)` on `changes` — oversized batches now fail as a clean 400 instead of a stack-overflow 500.
- **Level-rule reconciliation**: the transparent-strategy grandparent hop is now a single shared function used by the batch path (creates, moves, cascade) and the single-element path, which previously diverged.

## Review chain

- Design accepted; implemented by backend; adjudicated at return.
- Code review + adversarial QA caught two cross-case exploits beyond the original scope: a **delete-and-recreate id-reuse bypass** (critical) and an unscoped **`defeatsElementId`** reference. Both fixed and regression-tested.
- Full suite green on the landing commit: 1326 unit + 960 integration, 0 failures. Lint and typecheck clean. Fallow audit: no new dead code, complexity, or duplication.

## Follow-ups (filed separately)

- The single-element endpoint has the same `defeatsElementId` gap (pre-existing) — tracked separately.
- A narrow co-moved-strategy level edge case is documented in-code as a known limitation.
- Integration suite runtime (~9.5 min) tracked for profiling.

https://claude.ai/code/session_014HVd1SnmtLBSvMod3owvvk
