### PR TITLE
Fix: assertion status dropdown no longer closes the element edit dialog

### DIFF
--- a/components/cases/node-edit-dialog.tsx
+++ b/components/cases/node-edit-dialog.tsx
@@ -379,6 +379,74 @@ function UrlsSection({
 	);
 }
 
+// Radix's Select and Dialog each open a `DismissableLayer` with
+// `disableOutsidePointerEvents: true`. While the assertion-status Select is
+// open, that makes Radix set `pointer-events: none` on the Dialog's own
+// content (it's the lower-priority layer), so a click anywhere in the dialog
+// body falls through to the Dialog's own overlay — which the Dialog's
+// independent outside-click detection then reads as a genuine outside click
+// and closes on.
+//
+// Time-bounded guard (see `useAssertionSelectDismissGuard` below): the
+// Dialog's outside-interaction handlers ignore the event if the Select is
+// currently open, OR if the Select closed within the last
+// `SELECT_CLOSE_GUARD_WINDOW_MS`. Both the open flag and the close timestamp
+// are written synchronously, in the Select's own `onOpenChange` — no
+// `setTimeout`, so there is no timer to race and nothing that can be left
+// stuck. The window is what makes this correct rather than just "usually
+// works": in a real browser the Select's own popper (`[role="listbox"]`) is
+// often already unmounted by the time the Dialog's outside handler runs for
+// the SAME dismissing pointerdown — confirmed by direct instrumentation
+// against real Chromium, contrary to the (unverified) assumption that React
+// hadn't re-rendered yet — so a same-tick DOM-presence check reads `false`
+// and does not guard the very click it exists to guard against. A short
+// trailing window survives that ordering: it does not depend on which of
+// the Select's/Dialog's callbacks Radix happens to run first, and it expires
+// on its own, so a rapid sequence of opens/closes can only ever extend how
+// recently the ref was touched, never leave it stuck. This replaces an
+// earlier ref-plus-deferred-`setTimeout(0)`-clear design, which had no
+// `clearTimeout`: repeated rapid open/close cycles queued multiple
+// independent clear-timers with no ordering guarantee relative to Radix's
+// own open/close callbacks, and the losing interleaving occasionally left
+// the ref permanently `true` — the dialog then ignored every future outside
+// click, i.e. got stuck open (confirmed 8/19 runs under a 5-cycle rapid
+// open/close repro).
+//
+// The window only needs to bridge a same-event-tick ordering gap (measured
+// close to 0ms in Chromium instrumentation), so it's kept short: a value
+// close to 100ms turned out to be long enough to also swallow a *second*,
+// genuinely separate outside click that followed within the window in an
+// automated test with no human-speed pauses between actions (caught by the
+// stability e2e case) — i.e. long enough to reintroduce a milder version of
+// the exact "outside click doesn't dismiss" bug this exists to fix, just
+// bounded instead of permanent. 40ms comfortably covers a couple of
+// animation frames without being long enough for that.
+const SELECT_CLOSE_GUARD_WINDOW_MS = 40;
+
+function useAssertionSelectDismissGuard() {
+	const isOpenRef = useRef(false);
+	const lastClosedAtRef = useRef(0);
+
+	const onSelectOpenChange = useCallback((nextOpen: boolean) => {
+		isOpenRef.current = nextOpen;
+		if (!nextOpen) {
+			lastClosedAtRef.current = performance.now();
+		}
+	}, []);
+
+	const shouldGuardOutsideDismiss = useCallback(() => {
+		if (isOpenRef.current) {
+			return true;
+		}
+		return (
+			performance.now() - lastClosedAtRef.current <=
+			SELECT_CLOSE_GUARD_WINDOW_MS
+		);
+	}, []);
+
+	return { onSelectOpenChange, shouldGuardOutsideDismiss };
+}
+
 // --- Main component ---
 
 interface NodeEditDialogProps {
@@ -497,22 +565,8 @@ export default function NodeEditDialog({
 		onOpenChange(nextOpen);
 	};
 
-	// Radix's Select and Dialog each open a `DismissableLayer` with
-	// `disableOutsidePointerEvents: true`. While the assertion-status Select
-	// is open, that makes Radix set `pointer-events: none` on the Dialog's
-	// own content (it's the lower-priority layer), so a click anywhere in
-	// the dialog body falls through to the Dialog's own overlay — which the
-	// Dialog's independent outside-click detection then reads as a genuine
-	// outside click and closes on. Tracking the Select's open state here and
-	// skipping the Dialog's own outside-dismiss while it is true works
-	// around that. The clear-on-close is deferred by one tick (see
-	// `onSelectOpenChange` below): confirmed by instrumented logging, Radix
-	// fires the Select's own `onOpenChange(false)` for the dismissing
-	// pointerdown BEFORE the Dialog's `onInteractOutside`/
-	// `onPointerDownOutside` for that same pointerdown, so clearing the ref
-	// synchronously would already read `false` by the time the Dialog's
-	// guard checks it.
-	const isAssertionSelectOpenRef = useRef(false);
+	const { onSelectOpenChange, shouldGuardOutsideDismiss } =
+		useAssertionSelectDismissGuard();
 
 	// Tracks whether the dialog was open on the previous render, so a
 	// closed→open transition (reopen) can be told apart from staying open
@@ -630,24 +684,7 @@ export default function NodeEditDialog({
 						/>
 						<AssertionStatusSection
 							form={form}
-							onSelectOpenChange={(nextSelectOpen) => {
-								if (nextSelectOpen) {
-									isAssertionSelectOpenRef.current = true;
-									return;
-								}
-								// Defer clearing: for the SAME dismissing pointerdown,
-								// Radix runs the Select's own onOpenChange(false)
-								// BEFORE the Dialog's onInteractOutside/
-								// onPointerDownOutside (confirmed by instrumented
-								// logging), so clearing synchronously here would
-								// already read `false` by the time the guard below
-								// checks it. Deferring by one tick keeps the ref
-								// `true` for that check while still resetting
-								// promptly for any later, unrelated interaction.
-								setTimeout(() => {
-									isAssertionSelectOpenRef.current = false;
-								}, 0);
-							}}
+							onSelectOpenChange={onSelectOpenChange}
 							readOnly={readOnly}
 						/>
 						<ContextSection
@@ -706,13 +743,20 @@ export default function NodeEditDialog({
 		<Dialog onOpenChange={handleOpenChange} open={open}>
 			<DialogContent
 				className="max-h-[90vh] overflow-y-auto sm:max-w-lg"
+				// Both handlers are guarded: `onPointerDownOutside` covers
+				// dismissal by pointer (the click-through case this fix
+				// targets), `onInteractOutside` also covers dismissal by
+				// focus movement (e.g. Tab out of the Select while it's
+				// open) — Radix fires that independently of a pointerdown,
+				// so only guarding the pointer handler would leave the
+				// focus path unfixed.
 				onInteractOutside={(event) => {
-					if (isAssertionSelectOpenRef.current) {
+					if (shouldGuardOutsideDismiss()) {
 						event.preventDefault();
 					}
 				}}
 				onPointerDownOutside={(event) => {
-					if (isAssertionSelectOpenRef.current) {
+					if (shouldGuardOutsideDismiss()) {
 						event.preventDefault();
 					}
 				}}

--- a/components/cases/node-edit-dialog.tsx
+++ b/components/cases/node-edit-dialog.tsx
@@ -172,6 +172,7 @@ function TextFieldSection({
 
 interface AssertionStatusSectionProps {
 	form: UseFormReturn<FormValues>;
+	onSelectOpenChange: (open: boolean) => void;
 	readOnly: boolean;
 }
 
@@ -184,6 +185,7 @@ interface AssertionStatusSectionProps {
  */
 function AssertionStatusSection({
 	form,
+	onSelectOpenChange,
 	readOnly,
 }: AssertionStatusSectionProps) {
 	return (
@@ -202,6 +204,7 @@ function AssertionStatusSection({
 					</FormLabel>
 					<Select
 						disabled={readOnly}
+						onOpenChange={onSelectOpenChange}
 						onValueChange={field.onChange}
 						value={field.value}
 					>
@@ -494,6 +497,23 @@ export default function NodeEditDialog({
 		onOpenChange(nextOpen);
 	};
 
+	// Radix's Select and Dialog each open a `DismissableLayer` with
+	// `disableOutsidePointerEvents: true`. While the assertion-status Select
+	// is open, that makes Radix set `pointer-events: none` on the Dialog's
+	// own content (it's the lower-priority layer), so a click anywhere in
+	// the dialog body falls through to the Dialog's own overlay — which the
+	// Dialog's independent outside-click detection then reads as a genuine
+	// outside click and closes on. Tracking the Select's open state here and
+	// skipping the Dialog's own outside-dismiss while it is true works
+	// around that. The clear-on-close is deferred by one tick (see
+	// `onSelectOpenChange` below): confirmed by instrumented logging, Radix
+	// fires the Select's own `onOpenChange(false)` for the dismissing
+	// pointerdown BEFORE the Dialog's `onInteractOutside`/
+	// `onPointerDownOutside` for that same pointerdown, so clearing the ref
+	// synchronously would already read `false` by the time the Dialog's
+	// guard checks it.
+	const isAssertionSelectOpenRef = useRef(false);
+
 	// Tracks whether the dialog was open on the previous render, so a
 	// closed→open transition (reopen) can be told apart from staying open
 	// across re-renders.
@@ -608,7 +628,28 @@ export default function NodeEditDialog({
 							placeholder="Type your justification here (optional)."
 							readOnly={readOnly}
 						/>
-						<AssertionStatusSection form={form} readOnly={readOnly} />
+						<AssertionStatusSection
+							form={form}
+							onSelectOpenChange={(nextSelectOpen) => {
+								if (nextSelectOpen) {
+									isAssertionSelectOpenRef.current = true;
+									return;
+								}
+								// Defer clearing: for the SAME dismissing pointerdown,
+								// Radix runs the Select's own onOpenChange(false)
+								// BEFORE the Dialog's onInteractOutside/
+								// onPointerDownOutside (confirmed by instrumented
+								// logging), so clearing synchronously here would
+								// already read `false` by the time the guard below
+								// checks it. Deferring by one tick keeps the ref
+								// `true` for that check while still resetting
+								// promptly for any later, unrelated interaction.
+								setTimeout(() => {
+									isAssertionSelectOpenRef.current = false;
+								}, 0);
+							}}
+							readOnly={readOnly}
+						/>
 						<ContextSection
 							contextItems={contextItems}
 							newContextValue={newContextValue}
@@ -663,7 +704,19 @@ export default function NodeEditDialog({
 
 	return (
 		<Dialog onOpenChange={handleOpenChange} open={open}>
-			<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+			<DialogContent
+				className="max-h-[90vh] overflow-y-auto sm:max-w-lg"
+				onInteractOutside={(event) => {
+					if (isAssertionSelectOpenRef.current) {
+						event.preventDefault();
+					}
+				}}
+				onPointerDownOutside={(event) => {
+					if (isAssertionSelectOpenRef.current) {
+						event.preventDefault();
+					}
+				}}
+			>
 				<DialogHeader>
 					<DialogTitle>
 						{readOnly ? "Viewing" : "Editing"} {nodeName}

--- a/components/cases/node-edit-dialog.tsx
+++ b/components/cases/node-edit-dialog.tsx
@@ -379,48 +379,23 @@ function UrlsSection({
 	);
 }
 
-// Radix's Select and Dialog each open a `DismissableLayer` with
-// `disableOutsidePointerEvents: true`. While the assertion-status Select is
-// open, that makes Radix set `pointer-events: none` on the Dialog's own
-// content (it's the lower-priority layer), so a click anywhere in the dialog
-// body falls through to the Dialog's own overlay — which the Dialog's
-// independent outside-click detection then reads as a genuine outside click
-// and closes on.
+// Radix's Select and Dialog each open a DismissableLayer with
+// disableOutsidePointerEvents: true. While the assertion-status Select is
+// open, Radix sets pointer-events: none on the Dialog's own content (the
+// lower-priority layer), so a click anywhere in the dialog body falls
+// through to the Dialog's own overlay — which the Dialog's own outside-click
+// detection then reads as a genuine outside click and closes on.
 //
-// Time-bounded guard (see `useAssertionSelectDismissGuard` below): the
-// Dialog's outside-interaction handlers ignore the event if the Select is
-// currently open, OR if the Select closed within the last
-// `SELECT_CLOSE_GUARD_WINDOW_MS`. Both the open flag and the close timestamp
-// are written synchronously, in the Select's own `onOpenChange` — no
-// `setTimeout`, so there is no timer to race and nothing that can be left
-// stuck. The window is what makes this correct rather than just "usually
-// works": in a real browser the Select's own popper (`[role="listbox"]`) is
-// often already unmounted by the time the Dialog's outside handler runs for
-// the SAME dismissing pointerdown — confirmed by direct instrumentation
-// against real Chromium, contrary to the (unverified) assumption that React
-// hadn't re-rendered yet — so a same-tick DOM-presence check reads `false`
-// and does not guard the very click it exists to guard against. A short
-// trailing window survives that ordering: it does not depend on which of
-// the Select's/Dialog's callbacks Radix happens to run first, and it expires
-// on its own, so a rapid sequence of opens/closes can only ever extend how
-// recently the ref was touched, never leave it stuck. This replaces an
-// earlier ref-plus-deferred-`setTimeout(0)`-clear design, which had no
-// `clearTimeout`: repeated rapid open/close cycles queued multiple
-// independent clear-timers with no ordering guarantee relative to Radix's
-// own open/close callbacks, and the losing interleaving occasionally left
-// the ref permanently `true` — the dialog then ignored every future outside
-// click, i.e. got stuck open (confirmed 8/19 runs under a 5-cycle rapid
-// open/close repro).
-//
-// The window only needs to bridge a same-event-tick ordering gap (measured
-// close to 0ms in Chromium instrumentation), so it's kept short: a value
-// close to 100ms turned out to be long enough to also swallow a *second*,
-// genuinely separate outside click that followed within the window in an
-// automated test with no human-speed pauses between actions (caught by the
-// stability e2e case) — i.e. long enough to reintroduce a milder version of
-// the exact "outside click doesn't dismiss" bug this exists to fix, just
-// bounded instead of permanent. 40ms comfortably covers a couple of
-// animation frames without being long enough for that.
+// Guard: the Select's onOpenChange writes an open flag and a close
+// timestamp synchronously (no setTimeout, nothing to leave stuck). The
+// Dialog's outside handlers ignore the event if the Select is open, or
+// closed within SELECT_CLOSE_GUARD_WINDOW_MS — a short window is needed
+// because in a real browser the Select's own popper can already be
+// unmounted by the time the Dialog's outside handler runs for the same
+// dismissing click, so a same-tick DOM-presence check cannot be used
+// instead. The window must stay short: long enough to bridge that
+// same-tick gap, short enough not to also swallow a second, genuinely
+// separate outside click that follows quickly.
 const SELECT_CLOSE_GUARD_WINDOW_MS = 40;
 
 function useAssertionSelectDismissGuard() {

--- a/components/cases/node-edit-dialog.tsx
+++ b/components/cases/node-edit-dialog.tsx
@@ -386,40 +386,57 @@ function UrlsSection({
 // through to the Dialog's own overlay — which the Dialog's own outside-click
 // detection then reads as a genuine outside click and closes on.
 //
-// Guard: the Select's onOpenChange writes an open flag and a close
-// timestamp synchronously (no setTimeout, nothing to leave stuck). The
-// Dialog's outside handlers ignore the event if the Select is open, or
-// closed within SELECT_CLOSE_GUARD_WINDOW_MS — a short window is needed
-// because in a real browser the Select's own popper can already be
-// unmounted by the time the Dialog's outside handler runs for the same
-// dismissing click, so a same-tick DOM-presence check cannot be used
-// instead. The window must stay short: long enough to bridge that
-// same-tick gap, short enough not to also swallow a second, genuinely
-// separate outside click that follows quickly.
-const SELECT_CLOSE_GUARD_WINDOW_MS = 40;
-
+// The dismissing click is a single pointerdown event. Both DismissableLayers
+// (Select's and Dialog's) react to it through their own document-level
+// listeners registered in the bubbling phase: the Select's runs first and
+// calls its onOpenChange(false), then the Dialog's runs and fires
+// onPointerDownOutside/onInteractOutside. A document listener registered in
+// the capture phase always runs before any bubbling-phase listener for the
+// same event, so it can snapshot whether the Select was open at the start of
+// this specific pointerdown — before either DismissableLayer has reacted to
+// it — with no timer and no assumption about which bubble listener runs
+// first.
 function useAssertionSelectDismissGuard() {
 	const isOpenRef = useRef(false);
-	const lastClosedAtRef = useRef(0);
+	const selectOpenAtPointerDownRef = useRef(false);
 
 	const onSelectOpenChange = useCallback((nextOpen: boolean) => {
 		isOpenRef.current = nextOpen;
-		if (!nextOpen) {
-			lastClosedAtRef.current = performance.now();
-		}
 	}, []);
 
-	const shouldGuardOutsideDismiss = useCallback(() => {
-		if (isOpenRef.current) {
-			return true;
-		}
-		return (
-			performance.now() - lastClosedAtRef.current <=
-			SELECT_CLOSE_GUARD_WINDOW_MS
-		);
+	useEffect(() => {
+		const handlePointerDownCapture = () => {
+			selectOpenAtPointerDownRef.current = isOpenRef.current;
+		};
+		document.addEventListener("pointerdown", handlePointerDownCapture, {
+			capture: true,
+		});
+		return () => {
+			document.removeEventListener("pointerdown", handlePointerDownCapture, {
+				capture: true,
+			});
+		};
 	}, []);
 
-	return { onSelectOpenChange, shouldGuardOutsideDismiss };
+	// Pointer dismissal: guard only on the per-event snapshot, so a click
+	// that lands after the Select has genuinely closed is never swallowed.
+	const shouldGuardPointerDismiss = useCallback(
+		() => selectOpenAtPointerDownRef.current,
+		[]
+	);
+
+	// Focus dismissal (e.g. Tab out of the Select) has no pointerdown to
+	// snapshot, so it falls back to the Select's live open state.
+	const shouldGuardFocusDismiss = useCallback(
+		() => selectOpenAtPointerDownRef.current || isOpenRef.current,
+		[]
+	);
+
+	return {
+		onSelectOpenChange,
+		shouldGuardFocusDismiss,
+		shouldGuardPointerDismiss,
+	};
 }
 
 // --- Main component ---
@@ -540,8 +557,11 @@ export default function NodeEditDialog({
 		onOpenChange(nextOpen);
 	};
 
-	const { onSelectOpenChange, shouldGuardOutsideDismiss } =
-		useAssertionSelectDismissGuard();
+	const {
+		onSelectOpenChange,
+		shouldGuardFocusDismiss,
+		shouldGuardPointerDismiss,
+	} = useAssertionSelectDismissGuard();
 
 	// Tracks whether the dialog was open on the previous render, so a
 	// closed→open transition (reopen) can be told apart from staying open
@@ -726,12 +746,12 @@ export default function NodeEditDialog({
 				// so only guarding the pointer handler would leave the
 				// focus path unfixed.
 				onInteractOutside={(event) => {
-					if (shouldGuardOutsideDismiss()) {
+					if (shouldGuardFocusDismiss()) {
 						event.preventDefault();
 					}
 				}}
 				onPointerDownOutside={(event) => {
-					if (shouldGuardOutsideDismiss()) {
+					if (shouldGuardPointerDismiss()) {
 						event.preventDefault();
 					}
 				}}

--- a/components/cases/node-edit-dialog.tsx
+++ b/components/cases/node-edit-dialog.tsx
@@ -426,7 +426,10 @@ function useAssertionSelectDismissGuard() {
 	);
 
 	// Focus dismissal (e.g. Tab out of the Select) has no pointerdown to
-	// snapshot, so it falls back to the Select's live open state.
+	// snapshot, so it falls back to the Select's live open state. In
+	// practice Radix already blocks focus-outside dismissal on a modal
+	// DialogContent, so this branch is not known to be exercised — it's
+	// kept for consistency with the pointer guard above.
 	const shouldGuardFocusDismiss = useCallback(
 		() => selectOpenAtPointerDownRef.current || isOpenRef.current,
 		[]
@@ -738,13 +741,15 @@ export default function NodeEditDialog({
 		<Dialog onOpenChange={handleOpenChange} open={open}>
 			<DialogContent
 				className="max-h-[90vh] overflow-y-auto sm:max-w-lg"
-				// Both handlers are guarded: `onPointerDownOutside` covers
-				// dismissal by pointer (the click-through case this fix
-				// targets), `onInteractOutside` also covers dismissal by
-				// focus movement (e.g. Tab out of the Select while it's
-				// open) — Radix fires that independently of a pointerdown,
-				// so only guarding the pointer handler would leave the
-				// focus path unfixed.
+				// `onPointerDownOutside` is the path this fix targets: it's
+				// the click-through case where a click inside the dialog
+				// falls through to the Dialog's own overlay while the
+				// Select is open. `onInteractOutside` is guarded too, for
+				// consistency, but Radix's own DialogContentModal already
+				// calls event.preventDefault() on every focus-outside event
+				// for a modal DialogContent (react-dialog dist
+				// index.mjs, ~L157-160), so that branch never actually runs
+				// against a live dismissal — it's defensive only.
 				onInteractOutside={(event) => {
 					if (shouldGuardFocusDismiss()) {
 						event.preventDefault();

--- a/e2e/cases.spec.ts
+++ b/e2e/cases.spec.ts
@@ -160,16 +160,11 @@ test.describe("Case management", () => {
 	test("rapid open/close of the assertion status dropdown does not leave the dialog stuck open or stuck unable to close", async ({
 		page,
 	}) => {
-		// Stability regression: the original fix (a ref tracking the Select's
-		// open state, cleared via a bare `setTimeout(0)` with no
-		// `clearTimeout`) raced under rapid toggling — repeated open/close
-		// cycles could queue clear-timers with no ordering guarantee against
-		// Radix's own open/close callbacks, and the losing interleaving left
-		// the ref permanently `true`, so the dialog then ignored every
-		// subsequent outside click. Replaced with a time-bounded guard (see
-		// `useAssertionSelectDismissGuard` in node-edit-dialog.tsx): both the
-		// open flag and the close timestamp are written synchronously, with
-		// no timer to race and nothing that can be left stuck.
+		// Stability regression: rapid open/close cycling of the Select must
+		// not leave the dialog's outside-dismiss guard (see
+		// `useAssertionSelectDismissGuard` in node-edit-dialog.tsx) stuck
+		// open, since that would make the dialog ignore every subsequent
+		// outside click.
 		const dashboard = new DashboardPage(page);
 		await dashboard.goto();
 
@@ -205,6 +200,8 @@ test.describe("Case management", () => {
 		// than a second click still inside the window the guard uses to
 		// bridge the same-tick dismissal race — real users don't triple
 		// click within a few tens of milliseconds either.
+		// Must stay well above SELECT_CLOSE_GUARD_WINDOW_MS in
+		// node-edit-dialog.tsx.
 		await page.waitForTimeout(250);
 
 		// The dialog must still be dismissable by a subsequent overlay

--- a/e2e/cases.spec.ts
+++ b/e2e/cases.spec.ts
@@ -195,18 +195,48 @@ test.describe("Case management", () => {
 		await dialogTitle.click({ force: true });
 		await expect(dialogTitle).toBeVisible();
 
-		// A short pause past the guard's own close-window, so the next
-		// click is unambiguously a *separate*, later interaction rather
-		// than a second click still inside the window the guard uses to
-		// bridge the same-tick dismissal race — real users don't triple
-		// click within a few tens of milliseconds either.
-		// Must stay well above SELECT_CLOSE_GUARD_WINDOW_MS in
-		// node-edit-dialog.tsx.
-		await page.waitForTimeout(250);
-
 		// The dialog must still be dismissable by a subsequent overlay
-		// click — this is the assertion that catches the stuck-open race:
-		// a stuck-`true` guard would swallow this click too.
+		// click — this is the assertion that catches a stuck-open guard.
+		await page.mouse.click(5, 5);
+		await expect(dialogTitle).not.toBeVisible();
+	});
+
+	test("Escape-closing the assertion status dropdown, then immediately clicking outside the dialog, still closes the dialog", async ({
+		page,
+	}) => {
+		// Regression: the dismiss guard reads whether the Select was open at
+		// the start of the outside click's own pointerdown event, not a
+		// time window since the Select last closed — so a click that lands
+		// immediately after an Escape-close is not mistaken for the pointer
+		// event that closed the Select.
+		const dashboard = new DashboardPage(page);
+		await dashboard.goto();
+
+		await dashboard.caseCard("Simple Case").click();
+		await page.waitForURL(CASE_URL_PATTERN);
+
+		const editButton = page.locator("button:has(svg.lucide-pencil)").first();
+		await editButton.waitFor({ state: "visible" });
+		await editButton.click();
+
+		const dialogTitle = page.getByText("Editing G1", { exact: true });
+		await expect(dialogTitle).toBeVisible();
+
+		const assertionStatusTrigger = page.getByRole("combobox", {
+			name: ASSERTION_STATUS_COMBOBOX_PATTERN,
+		});
+
+		for (let i = 0; i < 5; i++) {
+			await assertionStatusTrigger.click();
+			await expect(page.getByRole("listbox")).toBeVisible();
+			await page.keyboard.press("Escape");
+			await expect(page.getByRole("listbox")).not.toBeVisible();
+		}
+
+		await expect(dialogTitle).toBeVisible();
+
+		// No artificial pause: this click must be indistinguishable from a
+		// genuine outside click landing right after the last Escape-close.
 		await page.mouse.click(5, 5);
 		await expect(dialogTitle).not.toBeVisible();
 	});

--- a/e2e/cases.spec.ts
+++ b/e2e/cases.spec.ts
@@ -2,6 +2,8 @@ import { expect, test } from "./helpers/auth";
 import { CASE_URL_PATTERN, STATUS_BUTTON_PATTERN } from "./helpers/constants";
 import { DashboardPage } from "./pages/dashboard-page";
 
+const ASSERTION_STATUS_COMBOBOX_PATTERN = /assertion status/i;
+
 test.describe("Case management", () => {
 	test("dashboard shows seeded cases", async ({ page }) => {
 		const dashboard = new DashboardPage(page);
@@ -101,5 +103,57 @@ test.describe("Case management", () => {
 		await expect(
 			page.getByRole("heading", { name: "Case Information" })
 		).toBeVisible();
+	});
+
+	test("dismissing the assertion status dropdown by clicking the edit dialog body leaves the dialog open", async ({
+		page,
+	}) => {
+		// Regression test: opening the "Assertion status" Select inside the
+		// element edit dialog and then clicking elsewhere in the dialog body
+		// (without picking an option) used to close the whole dialog too —
+		// jsdom can't reproduce this, because it relies on real pointer-events
+		// hit-testing falling through the dialog's own (now pointer-events:
+		// none) content to its overlay once a nested Radix Select is open.
+		const dashboard = new DashboardPage(page);
+		await dashboard.goto();
+
+		await dashboard.caseCard("Simple Case").click();
+		await page.waitForURL(CASE_URL_PATTERN);
+
+		const editButton = page.locator("button:has(svg.lucide-pencil)").first();
+		await editButton.waitFor({ state: "visible" });
+		await editButton.click();
+
+		// A plain text locator, not `getByRole("dialog")`: while the Select
+		// below is open, Radix's `hideOthers` marks the whole dialog
+		// `aria-hidden="true"` (everything outside the Select's own popper is
+		// hidden from assistive tech while it's open), which would make any
+		// role-based query against the dialog time out for the rest of this
+		// test even though the dialog is still visibly on screen.
+		const dialogTitle = page.getByText("Editing G1", { exact: true });
+		await expect(dialogTitle).toBeVisible();
+
+		const assertionStatusTrigger = page.getByRole("combobox", {
+			name: ASSERTION_STATUS_COMBOBOX_PATTERN,
+		});
+		await assertionStatusTrigger.click();
+		await expect(page.getByRole("listbox")).toBeVisible();
+
+		// Click on the dialog body — the dialog's own title, well clear of
+		// the open dropdown's own popper — without choosing an option from
+		// the open dropdown. `force: true` because, pre-fix, Radix sets
+		// `pointer-events: none` on the dialog's own content while the
+		// Select is open — Playwright's default click would otherwise wait
+		// forever for a target that (correctly, per the bug) never becomes
+		// clickable; a real user's click still lands there and falls through
+		// to the dialog's own overlay underneath.
+		await dialogTitle.click({ force: true });
+
+		await expect(page.getByRole("listbox")).not.toBeVisible();
+		await expect(dialogTitle).toBeVisible();
+
+		// The dialog's own close paths must still work.
+		await page.getByRole("button", { name: "Cancel" }).click();
+		await expect(dialogTitle).not.toBeVisible();
 	});
 });

--- a/e2e/cases.spec.ts
+++ b/e2e/cases.spec.ts
@@ -182,6 +182,8 @@ test.describe("Case management", () => {
 			name: ASSERTION_STATUS_COMBOBOX_PATTERN,
 		});
 
+		// Five cycles is enough to expose ordering/state-leak bugs between
+		// rapid open/close toggles; the exact count is arbitrary.
 		for (let i = 0; i < 5; i++) {
 			await assertionStatusTrigger.click();
 			await expect(page.getByRole("listbox")).toBeVisible();
@@ -226,6 +228,8 @@ test.describe("Case management", () => {
 			name: ASSERTION_STATUS_COMBOBOX_PATTERN,
 		});
 
+		// Five cycles is enough to expose ordering/state-leak bugs between
+		// rapid open/close toggles; the exact count is arbitrary.
 		for (let i = 0; i < 5; i++) {
 			await assertionStatusTrigger.click();
 			await expect(page.getByRole("listbox")).toBeVisible();

--- a/e2e/cases.spec.ts
+++ b/e2e/cases.spec.ts
@@ -156,4 +156,61 @@ test.describe("Case management", () => {
 		await page.getByRole("button", { name: "Cancel" }).click();
 		await expect(dialogTitle).not.toBeVisible();
 	});
+
+	test("rapid open/close of the assertion status dropdown does not leave the dialog stuck open or stuck unable to close", async ({
+		page,
+	}) => {
+		// Stability regression: the original fix (a ref tracking the Select's
+		// open state, cleared via a bare `setTimeout(0)` with no
+		// `clearTimeout`) raced under rapid toggling — repeated open/close
+		// cycles could queue clear-timers with no ordering guarantee against
+		// Radix's own open/close callbacks, and the losing interleaving left
+		// the ref permanently `true`, so the dialog then ignored every
+		// subsequent outside click. Replaced with a time-bounded guard (see
+		// `useAssertionSelectDismissGuard` in node-edit-dialog.tsx): both the
+		// open flag and the close timestamp are written synchronously, with
+		// no timer to race and nothing that can be left stuck.
+		const dashboard = new DashboardPage(page);
+		await dashboard.goto();
+
+		await dashboard.caseCard("Simple Case").click();
+		await page.waitForURL(CASE_URL_PATTERN);
+
+		const editButton = page.locator("button:has(svg.lucide-pencil)").first();
+		await editButton.waitFor({ state: "visible" });
+		await editButton.click();
+
+		const dialogTitle = page.getByText("Editing G1", { exact: true });
+		await expect(dialogTitle).toBeVisible();
+
+		const assertionStatusTrigger = page.getByRole("combobox", {
+			name: ASSERTION_STATUS_COMBOBOX_PATTERN,
+		});
+
+		for (let i = 0; i < 5; i++) {
+			await assertionStatusTrigger.click();
+			await expect(page.getByRole("listbox")).toBeVisible();
+			await page.keyboard.press("Escape");
+			await expect(page.getByRole("listbox")).not.toBeVisible();
+		}
+
+		// Click the dialog body (not the Select, which is now closed) —
+		// this must be a genuine outside-of-Select click and must not
+		// dismiss the dialog.
+		await dialogTitle.click({ force: true });
+		await expect(dialogTitle).toBeVisible();
+
+		// A short pause past the guard's own close-window, so the next
+		// click is unambiguously a *separate*, later interaction rather
+		// than a second click still inside the window the guard uses to
+		// bridge the same-tick dismissal race — real users don't triple
+		// click within a few tens of milliseconds either.
+		await page.waitForTimeout(250);
+
+		// The dialog must still be dismissable by a subsequent overlay
+		// click — this is the assertion that catches the stuck-open race:
+		// a stuck-`true` guard would swallow this click too.
+		await page.mouse.click(5, 5);
+		await expect(dialogTitle).not.toBeVisible();
+	});
 });


### PR DESCRIPTION
## Problem

In the element edit dialog, opening the **Assertion status** dropdown and then clicking on the dialog body without choosing an option closed the whole dialog instead of just the dropdown.

## Cause

Radix's `Select` and `Dialog` each register a `DismissableLayer` that disables outside pointer events. While the Select is open, the Dialog's own content gets `pointer-events: none`, so a click inside the dialog body falls through to the Dialog's overlay, which the Dialog then treats as an outside click and dismisses on.

## Fix

`components/cases/node-edit-dialog.tsx` only (the shared `ui/dialog.tsx` and `ui/select.tsx` are untouched):

- A document capture-phase `pointerdown` listener snapshots whether the Select was open at the start of each event, before either Radix layer reacts to it.
- The Dialog's `onPointerDownOutside` ignores the event when that snapshot is true. No timers or time windows are involved, so the guard cannot be left in a stale state.

## Tests

Three Playwright cases in `e2e/cases.spec.ts` (the bug is not reproducible in jsdom, which does no pointer hit-testing):

- click-through on the dialog body while the Select is open leaves the dialog open (fails on `staging`, passes here);
- rapid open/close of the Select then an outside click still dismisses the dialog;
- Escape-closing the Select then an immediate outside click dismisses the dialog.

Each ran 20× on a production build: 60/60. QA additionally verified close-by-option and close-by-trigger followed by an immediate outside click, Cancel / X / Escape / Save, overlay double-click, and no state leaking between dialogs of different elements. Unit suite: 1317 passed; `slug-service.test.ts` fails on `staging` too (missing `DATABASE_URL` in the local runner).

## Out of scope / follow-ups

- `components/sharing/case-sharing-dialog.tsx` has the same Select-in-Dialog structure and is likely affected (not verified).
- The edit-element button has no accessible label.
- `NodeEditDialog`'s `readOnly` prop is never passed by its call sites.