### PR TITLE
Fix: element edit dialog opens read-only for view and comment collaborators

### DIFF
--- a/components/cases/__tests__/node-edit-dialog.test.tsx
+++ b/components/cases/__tests__/node-edit-dialog.test.tsx
@@ -10,7 +10,24 @@ import { recordUpdate } from "@/lib/services/history-service";
 import { toast } from "@/lib/toast";
 import { server } from "@/src/__tests__/mocks/server";
 import { render, screen } from "@/src/__tests__/utils/test-utils";
+import useStore from "@/store/store";
 import NodeEditDialog from "../node-edit-dialog";
+
+// NodeEditDialog derives its read-only state from the case permission held
+// in the store, so every test in this file needs a permission that renders
+// it editable unless the test is specifically exercising read-only mode.
+function resetStoreToEditable(): void {
+	useStore.setState({
+		assuranceCase: {
+			id: "case-1",
+			name: "Test Case",
+			type: "assurance-case",
+			permissions: "manage",
+			createdDate: new Date().toISOString(),
+			comments: [],
+		},
+	});
+}
 
 vi.mock("@/lib/services/history-service", async (importOriginal) => {
 	const actual =
@@ -57,6 +74,10 @@ function mockPluginsResponse(enabled: boolean) {
 		)
 	);
 }
+
+beforeEach(() => {
+	resetStoreToEditable();
+});
 
 afterEach(() => {
 	elementPanelSlot.resetForTests();
@@ -528,5 +549,114 @@ describe("NodeEditDialog — evidence URL removal", () => {
 		expect(
 			screen.getByPlaceholderText("https://example.com/evidence")
 		).toHaveValue("");
+	});
+});
+
+describe("NodeEditDialog — read-only mode by case permission", () => {
+	function setPermissions(permissions: string): void {
+		useStore.setState({
+			assuranceCase: {
+				id: "case-1",
+				name: "Test Case",
+				type: "assurance-case",
+				permissions,
+				createdDate: new Date().toISOString(),
+				comments: [],
+			},
+		});
+	}
+
+	function setNoAssuranceCase(): void {
+		useStore.setState({ assuranceCase: null });
+	}
+
+	it.each([
+		"edit",
+		"manage",
+	])('permissions "%s" renders editable: Save button present, fields enabled, title starts "Editing"', async (permissions) => {
+		setPermissions(permissions);
+		mockPluginsResponse(true);
+
+		render(
+			<NodeEditDialog
+				node={NODE}
+				nodeType="goal"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={true}
+			/>,
+			{ withProviders: false }
+		);
+
+		const description = await screen.findByLabelText("Description");
+		expect(description).not.toHaveAttribute("readonly");
+		expect(
+			screen.getByRole("button", { name: "Update Goal" })
+		).toBeInTheDocument();
+		expect(screen.getByText("Editing G1")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+	});
+
+	it.each([
+		"view",
+		"comment",
+	])('permissions "%s" renders read-only: no Save button, fields disabled, title starts "Viewing", footer button reads "Close"', async (permissions) => {
+		setPermissions(permissions);
+		mockPluginsResponse(true);
+
+		render(
+			<NodeEditDialog
+				node={NODE}
+				nodeType="goal"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={true}
+			/>,
+			{ withProviders: false }
+		);
+
+		const description = await screen.findByLabelText("Description");
+		expect(description).toHaveAttribute("readonly");
+		expect(
+			screen.queryByRole("button", { name: "Update Goal" })
+		).not.toBeInTheDocument();
+		expect(screen.getByText("Viewing G1")).toBeInTheDocument();
+		// Two "Close"-named buttons: Radix's own dialog-corner close control
+		// (always present, sr-only-labelled "Close") plus the footer button,
+		// which reads "Close" instead of "Cancel" only in read-only mode.
+		expect(screen.getAllByRole("button", { name: "Close" })).toHaveLength(2);
+		expect(
+			screen.queryByRole("button", { name: "Cancel" })
+		).not.toBeInTheDocument();
+	});
+
+	it('no assurance case loaded (permissions undefined) renders read-only: no Save button, fields disabled, title starts "Viewing", footer button reads "Close"', async () => {
+		setNoAssuranceCase();
+		mockPluginsResponse(true);
+
+		render(
+			<NodeEditDialog
+				node={NODE}
+				nodeType="goal"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={true}
+			/>,
+			{ withProviders: false }
+		);
+
+		const description = await screen.findByLabelText("Description");
+		expect(description).toHaveAttribute("readonly");
+		expect(
+			screen.queryByRole("button", { name: "Update Goal" })
+		).not.toBeInTheDocument();
+		expect(screen.getByText("Viewing G1")).toBeInTheDocument();
+		// Two "Close"-named buttons: Radix's own dialog-corner close control
+		// (always present, sr-only-labelled "Close") plus the footer button,
+		// which reads "Close" instead of "Cancel" only in read-only mode.
+		expect(screen.getAllByRole("button", { name: "Close" })).toHaveLength(2);
 	});
 });

--- a/components/cases/__tests__/node-edit-dialog.test.tsx
+++ b/components/cases/__tests__/node-edit-dialog.test.tsx
@@ -553,6 +553,18 @@ describe("NodeEditDialog — evidence URL removal", () => {
 });
 
 describe("NodeEditDialog — read-only mode by case permission", () => {
+	const EVIDENCE_NODE: Node = {
+		id: "3",
+		type: "evidence",
+		position: { x: 0, y: 0 },
+		data: {
+			id: 3,
+			name: "E1",
+			description: "Test results for the acceptance suite",
+			urls: ["https://example.com/evidence"],
+		},
+	};
+
 	function setPermissions(permissions: string): void {
 		useStore.setState({
 			assuranceCase: {
@@ -658,5 +670,70 @@ describe("NodeEditDialog — read-only mode by case permission", () => {
 		// (always present, sr-only-labelled "Close") plus the footer button,
 		// which reads "Close" instead of "Cancel" only in read-only mode.
 		expect(screen.getAllByRole("button", { name: "Close" })).toHaveLength(2);
+	});
+
+	it('permissions "view" on an evidence node renders read-only: URL input readonly, no Add/Remove URL controls, no Update button', async () => {
+		setPermissions("view");
+		mockPluginsResponse(true);
+
+		render(
+			<NodeEditDialog
+				node={EVIDENCE_NODE}
+				nodeType="evidence"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={true}
+			/>,
+			{ withProviders: false }
+		);
+
+		const url = await screen.findByDisplayValue("https://example.com/evidence");
+		expect(url).toHaveAttribute("readonly");
+		expect(
+			screen.queryByRole("button", { name: "Add URL" })
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Remove URL" })
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Update Evidence" })
+		).not.toBeInTheDocument();
+	});
+
+	it("does not submit when Enter is pressed in a read-only evidence URL input (a single-field form still submits implicitly on Enter; `readonly`, unlike `disabled`, does not block that)", async () => {
+		const user = userEvent.setup();
+		setPermissions("view");
+		mockPluginsResponse(true);
+
+		let updateRequestCount = 0;
+		server.use(
+			http.put("/api/elements/3", () => {
+				updateRequestCount++;
+				return HttpResponse.json({}, { status: 200 });
+			})
+		);
+
+		render(
+			<NodeEditDialog
+				node={EVIDENCE_NODE}
+				nodeType="evidence"
+				onOpenChange={() => {
+					// no-op for this assertion
+				}}
+				open={true}
+			/>,
+			{ withProviders: false }
+		);
+
+		const url = await screen.findByDisplayValue("https://example.com/evidence");
+		url.focus();
+		await user.keyboard("{Enter}");
+
+		// Give any (incorrect) implicit-submit request a chance to land
+		// before asserting its absence.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(updateRequestCount).toBe(0);
+		expect(toast).not.toHaveBeenCalled();
 	});
 });

--- a/components/cases/node-edit-dialog.tsx
+++ b/components/cases/node-edit-dialog.tsx
@@ -614,6 +614,12 @@ export default function NodeEditDialog({
 	// alternative — silently discarding the user's in-flight edit, which is
 	// the bug this fix addresses — is worse.
 	const handleSubmit = async (values: FormValues) => {
+		// A single-line `readOnly` input still submits its form implicitly on
+		// Enter per the HTML spec (unlike `disabled`, which suppresses that).
+		// Guard here so that keystroke can never reach the update request.
+		if (readOnly) {
+			return;
+		}
 		// Auto-add any unsaved draft context text
 		if (newContextValue.trim()) {
 			values.context = [...(values.context || []), newContextValue.trim()];

--- a/components/cases/node-edit-dialog.tsx
+++ b/components/cases/node-edit-dialog.tsx
@@ -449,7 +449,6 @@ interface NodeEditDialogProps {
 	nodeType: DiagramNodeType;
 	onOpenChange: (open: boolean) => void;
 	open: boolean;
-	readOnly?: boolean;
 }
 
 export default function NodeEditDialog({
@@ -457,7 +456,6 @@ export default function NodeEditDialog({
 	nodeType,
 	open,
 	onOpenChange,
-	readOnly = false,
 }: NodeEditDialogProps) {
 	const [loading, setLoading] = useState(false);
 	const [newContextValue, setNewContextValue] = useState("");
@@ -465,6 +463,13 @@ export default function NodeEditDialog({
 	const [idCounter, setIdCounter] = useState(0);
 	const { assuranceCase } = useStore();
 	const panelSlot = useElementPanelSlot();
+	// Fail-closed, positive rule: editable only when the case permission is
+	// explicitly "edit" or "manage". Any other value — "view", "comment",
+	// or unset/unknown while the case is still loading — renders read-only.
+	const readOnly = !(
+		assuranceCase?.permissions === "edit" ||
+		assuranceCase?.permissions === "manage"
+	);
 
 	const form = useForm<FormValues>({
 		resolver: zodResolver(nodeEditFormSchema),

--- a/e2e/sharing.spec.ts
+++ b/e2e/sharing.spec.ts
@@ -4,6 +4,10 @@ import { CASE_URL_PATTERN } from "./helpers/constants";
 // Sharing tests use different user sessions — no pre-saved state
 test.use({ storageState: { cookies: [], origins: [] } });
 
+// Matches NodeEditDialog's Save button ("Update Goal", "Update Evidence",
+// etc.) — must be absent in read-only mode regardless of element type.
+const UPDATE_BUTTON_PATTERN = /^Update /i;
+
 test.describe("Sharing and permissions", () => {
 	test("alice sees Medium Case on shared page", async ({
 		page,
@@ -89,5 +93,19 @@ test.describe("Sharing and permissions", () => {
 		await expect(page.getByTestId("action-buttons")).toBeVisible();
 		// Viewer should NOT see the share button (requires manage permission)
 		await expect(page.getByTestId("toolbar-share")).not.toBeVisible();
+
+		// Opening an element's dialog (the pencil icon relabels itself "View
+		// details" for a viewer, but always opens the same dialog) must land
+		// in read-only mode, not the editable form.
+		const viewDetailsButton = page
+			.locator("button:has(svg.lucide-pencil)")
+			.first();
+		await viewDetailsButton.waitFor({ state: "visible" });
+		await viewDetailsButton.click();
+
+		await expect(page.getByText("Viewing G1", { exact: true })).toBeVisible();
+		await expect(
+			page.getByRole("button", { name: UPDATE_BUTTON_PATTERN })
+		).not.toBeVisible();
 	});
 });


### PR DESCRIPTION
## Summary

`NodeEditDialog` accepts a `readOnly` prop that no call site passed, so collaborators with VIEW or COMMENT permission on a shared case opened a fully editable element dialog. The server already rejects the save (`updateElement` requires EDIT), so the effect was a confusing form and a failed-update error rather than a data problem.

The dialog now derives read-only state itself from the case permission held in the store: editable only when the permission is `edit` or `manage`; `view`, `comment`, or no loaded case render the existing viewing mode (disabled fields, no save button, "Close"). The unused prop is removed so the mode cannot be forgotten again at a call site.

A second commit closes one remaining path: an evidence element's URL field is a single-line input, and a form with one text field submits implicitly on Enter even when the input is `readonly`. `handleSubmit` now returns early in read-only mode.

## Changes

- `components/cases/node-edit-dialog.tsx` — derive `readOnly` from `assuranceCase.permissions` (fail-closed); remove the prop; early return in `handleSubmit` when read-only.
- `components/cases/__tests__/node-edit-dialog.test.tsx` — permission matrix (edit, manage, view, comment, no case); evidence-node read-only rendering; Enter in a read-only URL input issues no update request. Existing tests seed a `manage` permission.
- `e2e/sharing.spec.ts` — the viewer test now opens an element and asserts viewing mode with no update button.

## Verification

- Unit: 1324 pass on `83fb5d87` (one pre-existing environment-only failure in `slug-service.test.ts`, unrelated).
- Typecheck and lint clean.
- E2E `sharing.spec.ts`: 7/7, and 19/19 with `--repeat-each=3`, on a production build.
- Fallow audit: no new dead code, complexity, or duplication.

## Out of scope (tracked separately)

- The same permission rule is spelled out inline in eleven components; consolidating it into one helper is a follow-up.
- The shared Radix Select test mock drops `disabled`, so unit tests cannot observe the assertion-status dropdown's disabled state; verified by source read, follow-up filed.