### PR TITLE
fix(elements): persist and scope defeatsElementId, scope parentId on create, sweep descendant citations on detach

### DIFF
--- a/app/api/cases/[id]/elements/route.ts
+++ b/app/api/cases/[id]/elements/route.ts
@@ -73,6 +73,11 @@ function buildCreateInput(
 		// createElementSchema; applicability/requiredness/existence checks
 		// live in element-service.ts (createElement), not here.
 		moduleReferenceId: body.moduleReferenceId as string | null | undefined,
+		// Dialogical reasoning (defeaters) — validated by createElementSchema;
+		// same-case/existence/self-reference checks live in element-service.ts
+		// (createElement), not here.
+		isDefeater: body.isDefeater as boolean | undefined,
+		defeatsElementId: body.defeatsElementId as string | null | undefined,
 	};
 }
 

--- a/app/api/elements/[id]/route.ts
+++ b/app/api/elements/[id]/route.ts
@@ -69,6 +69,11 @@ function buildUpdateInput(body: Record<string, unknown>): UpdateElementInput {
 		// updateElementSchema; applicability/existence checks live in
 		// element-service.ts (updateElement), not here.
 		moduleReferenceId: body.moduleReferenceId as string | null | undefined,
+		// Dialogical reasoning (defeaters) — validated by updateElementSchema;
+		// same-case/existence/self-reference checks live in element-service.ts
+		// (updateElement), not here.
+		isDefeater: body.isDefeater as boolean | undefined,
+		defeatsElementId: body.defeatsElementId as string | null | undefined,
 	};
 }
 

--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -146,6 +146,11 @@ const ERROR_MAPPINGS: Array<{
 	// `moduleReferenceId` (wrong element type, missing on a required type,
 	// nonexistent target case) is a validation failure (400), not a 500.
 	{ pattern: /^moduleReferenceId /, factory: () => validationError("") },
+	// `element-service.ts`'s `validateDefeatsElementId`: a bad
+	// `defeatsElementId` (cross-case, nonexistent, soft-deleted, or
+	// self-reference target) is a validation failure (400), not a 500 —
+	// same shape as citedElementId/moduleReferenceId above.
+	{ pattern: /^defeatsElementId /, factory: () => validationError("") },
 	// Lifecycle/state-guard errors from the integration registry service —
 	// the integration or token exists and is owned by the caller, but its
 	// current status makes the requested action a no-op or a terminal-state

--- a/lib/schemas/element.ts
+++ b/lib/schemas/element.ts
@@ -54,6 +54,12 @@ export const createElementSchema = z.object({
 	// applicability, requiredness, and existence are enforced in
 	// element-service.ts, matching the citedElementId pattern above.
 	moduleReferenceId: z.string().uuid().nullable().optional(),
+	// Dialogical reasoning (defeaters) — applies to every element type.
+	// Same-case, exists, not-deleted, not-self checks are enforced in
+	// element-service.ts, mirroring the batch path
+	// (case-batch-update-service.ts's validateElementOwnership).
+	isDefeater: z.boolean().optional(),
+	defeatsElementId: z.string().uuid().nullable().optional(),
 });
 
 export type CreateElementSchemaInput = z.input<typeof createElementSchema>;
@@ -92,6 +98,12 @@ export const updateElementSchema = z.object({
 	// which allows changing/clearing it without a required-field guard);
 	// applicability and existence are still enforced in element-service.ts.
 	moduleReferenceId: z.string().uuid().nullable().optional(),
+	// Dialogical reasoning (defeaters) — applies to every element type.
+	// Same-case, exists, not-deleted, not-self checks are enforced in
+	// element-service.ts, mirroring the batch path
+	// (case-batch-update-service.ts's validateElementOwnership).
+	isDefeater: z.boolean().optional(),
+	defeatsElementId: z.string().uuid().nullable().optional(),
 
 	// Sandbox flag
 	inSandbox: z.boolean().optional(),

--- a/lib/services/element-service.ts
+++ b/lib/services/element-service.ts
@@ -774,33 +774,20 @@ async function createElementInDatabase(
 }
 
 /**
- * Creates a new element in a case
+ * Runs every create-path reference/uniqueness guard createElement needs, in
+ * the exact order it previously ran them inline: parentId case-membership,
+ * single-goal uniqueness, moduleReferenceId, citedElementId, then
+ * defeatsElementId. Extracted (rather than left as five sequential
+ * `if`-blocks in createElement) to keep createElement under the
+ * cognitive-complexity budget; order is preserved byte-for-byte because nothing
+ * here changes which check fires first when more than one would fail.
  */
-export async function createElement(
-	userId: string,
+async function validateElementReferences(
+	caseId: string,
+	elementType: PrismaElementType,
+	parentId: string | null | undefined,
 	input: CreateElementInput
-): ServiceResult<ElementResponse> {
-	const caseId = input.caseId;
-	if (!caseId) {
-		return { error: "Case ID is required" };
-	}
-
-	const hasAccess = await validateCaseAccess(userId, caseId, "EDIT");
-	if (!hasAccess) {
-		return { error: "Permission denied" };
-	}
-
-	const assertionStatusError = await enforceAssertionStatusRules(
-		input.assertionStatus,
-		userId
-	);
-	if (assertionStatusError) {
-		return { error: assertionStatusError };
-	}
-
-	const elementType = toPrismaType(input.elementType);
-	const parentId = resolveParentId(input);
-
+): Promise<{ error: string } | undefined> {
 	if (parentId) {
 		const parentError = await validateParentIdInCase(caseId, parentId);
 		if (parentError) {
@@ -835,6 +822,47 @@ export async function createElement(
 	);
 	if (defeatsElementIdError) {
 		return { error: defeatsElementIdError };
+	}
+
+	return;
+}
+
+/**
+ * Creates a new element in a case
+ */
+export async function createElement(
+	userId: string,
+	input: CreateElementInput
+): ServiceResult<ElementResponse> {
+	const caseId = input.caseId;
+	if (!caseId) {
+		return { error: "Case ID is required" };
+	}
+
+	const hasAccess = await validateCaseAccess(userId, caseId, "EDIT");
+	if (!hasAccess) {
+		return { error: "Permission denied" };
+	}
+
+	const assertionStatusError = await enforceAssertionStatusRules(
+		input.assertionStatus,
+		userId
+	);
+	if (assertionStatusError) {
+		return { error: assertionStatusError };
+	}
+
+	const elementType = toPrismaType(input.elementType);
+	const parentId = resolveParentId(input);
+
+	const referenceError = await validateElementReferences(
+		caseId,
+		elementType,
+		parentId,
+		input
+	);
+	if (referenceError) {
+		return referenceError;
 	}
 
 	const { level, parentInfo } =

--- a/lib/services/element-service.ts
+++ b/lib/services/element-service.ts
@@ -50,10 +50,14 @@ export interface ElementResponse {
 	comments?: unknown[];
 	context?: string[];
 	createdDate: string;
+	// Dialogical reasoning (defeaters) — applies to every element type.
+	defeatsElementId?: string | null;
 	description: string;
 	goalId?: string | null;
 	id: string;
 	inSandbox: boolean;
+	// Dialogical reasoning (defeaters) — applies to every element type.
+	isDefeater?: boolean;
 	justification?: string;
 	level?: number;
 	// Module reference (MODULE/AWAY_GOAL only) — names the referenced case
@@ -208,6 +212,87 @@ async function enforceCitedElementIdRules(
 		return applicabilityError;
 	}
 	return await validateCitedElementId(citedElementId, ownElementId);
+}
+
+/**
+ * Dialogical reasoning (defeaters): `defeatsElementId` applies to every
+ * element type (unlike `citedElementId`, which is AWAY_GOAL-only and
+ * deliberately cross-case per ADR 0004 D5) and, unlike citations, must stay
+ * inside the case it is written from — this is a same-case FK, not a
+ * cross-case reference. Parity with the batch endpoint's ownership check
+ * (`validateElementOwnership` in case-batch-update-service.ts): target must
+ * exist, be non-deleted, and belong to `caseId`; on update it additionally
+ * cannot be the element itself. The existence and case-membership checks are
+ * combined into a single query (`caseId` in the `where`) so a foreign-case
+ * id and a nonexistent id are indistinguishable in the response — matching
+ * `validateCitedElementId`'s anti-enumeration shape, just scoped to the case
+ * instead of scoped to nothing.
+ */
+async function validateDefeatsElementId(
+	caseId: string,
+	defeatsElementId: string | null | undefined,
+	ownElementId?: string
+): Promise<string | undefined> {
+	if (!defeatsElementId) {
+		return;
+	}
+	if (ownElementId && defeatsElementId === ownElementId) {
+		return "defeatsElementId cannot reference the element itself";
+	}
+	const target = await prisma.assuranceElement.findFirst({
+		where: { id: defeatsElementId, deletedAt: null, caseId },
+		select: { id: true },
+	});
+	if (!target) {
+		return "defeatsElementId must reference an existing element in this case";
+	}
+	return;
+}
+
+/**
+ * Runs the defeatsElementId guard in the order createElement and
+ * updateElement both need. Only one check today (no applicability
+ * restriction — `fieldAppliesTo("defeatsElementId", ...)` is true for every
+ * element type — so this is a thin wrapper today, kept for symmetry with
+ * `enforceCitedElementIdRules`/`enforceModuleReferenceIdRules` and as the
+ * single extension point if a future applicability rule is added.
+ */
+async function enforceDefeatsElementIdRules(
+	caseId: string,
+	defeatsElementId: string | null | undefined,
+	ownElementId?: string
+): Promise<string | undefined> {
+	if (defeatsElementId === undefined) {
+		return;
+	}
+	return await validateDefeatsElementId(caseId, defeatsElementId, ownElementId);
+}
+
+/**
+ * `parentId` must reference an existing, non-deleted element in the SAME
+ * case (`caseId`). This is the create-path counterpart to `updateElement`'s
+ * existing new-parent check (~line 960 below) — that check already scopes a
+ * parent CHANGE to the same case; this closes the equivalent gap on
+ * CREATE, where `parentId` was previously written straight into the
+ * `AssuranceElement.create` call (and, for EVIDENCE, into `EvidenceLink`)
+ * with no case-membership check at all. Found during the element-service.ts
+ * unscoped-reference audit (TEA — Element-service reference integrity).
+ * Same anti-enumeration shape as `validateDefeatsElementId`: existence and
+ * case-membership are one query, so a foreign-case id and a nonexistent id
+ * both come back "not found".
+ */
+async function validateParentIdInCase(
+	caseId: string,
+	parentId: string
+): Promise<string | undefined> {
+	const parent = await prisma.assuranceElement.findFirst({
+		where: { id: parentId, deletedAt: null, caseId },
+		select: { id: true },
+	});
+	if (!parent) {
+		return "Parent element not found";
+	}
+	return;
 }
 
 /**
@@ -660,6 +745,11 @@ async function createElementInDatabase(
 			// and existence are validated in createElement before this function
 			// is called.
 			moduleReferenceId: input.moduleReferenceId,
+			// Dialogical reasoning (defeaters) — same-case existence and
+			// self-reference are validated in createElement before this
+			// function is called.
+			isDefeater: input.isDefeater ?? false,
+			defeatsElementId: input.defeatsElementId,
 			createdById: userId,
 		},
 		include: {
@@ -711,6 +801,13 @@ export async function createElement(
 	const elementType = toPrismaType(input.elementType);
 	const parentId = resolveParentId(input);
 
+	if (parentId) {
+		const parentError = await validateParentIdInCase(caseId, parentId);
+		if (parentError) {
+			return { error: parentError };
+		}
+	}
+
 	if (elementType === "GOAL" && (await caseHasGoal(caseId))) {
 		return { error: "A case can only have one goal claim" };
 	}
@@ -730,6 +827,14 @@ export async function createElement(
 	);
 	if (citedElementIdError) {
 		return { error: citedElementIdError };
+	}
+
+	const defeatsElementIdError = await enforceDefeatsElementIdRules(
+		caseId,
+		input.defeatsElementId
+	);
+	if (defeatsElementIdError) {
+		return { error: defeatsElementIdError };
 	}
 
 	const { level, parentInfo } =
@@ -846,6 +951,12 @@ function buildUpdateData(input: UpdateElementInput): Record<string, unknown> {
 	if (input.moduleReferenceId !== undefined) {
 		updateData.moduleReferenceId = input.moduleReferenceId;
 	}
+	if (input.isDefeater !== undefined) {
+		updateData.isDefeater = input.isDefeater;
+	}
+	if (input.defeatsElementId !== undefined) {
+		updateData.defeatsElementId = input.defeatsElementId;
+	}
 
 	return updateData;
 }
@@ -948,6 +1059,18 @@ export async function updateElement(
 		);
 		if (citedElementIdError) {
 			return { error: citedElementIdError };
+		}
+
+		// Dialogical reasoning (defeaters): defeatsElementId must stay inside
+		// the element's own case (existing.caseId), unlike citedElementId
+		// above — see enforceDefeatsElementIdRules's docstring.
+		const defeatsElementIdError = await enforceDefeatsElementIdRules(
+			existing.caseId,
+			input.defeatsElementId,
+			elementId
+		);
+		if (defeatsElementIdError) {
+			return { error: defeatsElementIdError };
 		}
 
 		// Build update data from input fields
@@ -1112,7 +1235,10 @@ export async function detachElement(
 		// Move to sandbox, clear parent, and nullify+flag any dangling
 		// citations (ADR 0004 D5) atomically — a detached element is no
 		// longer part of the case's argument tree, so a citation pointing at
-		// it is just as broken as one pointing at a deleted element.
+		// it is just as broken as one pointing at a deleted element. A detach
+		// moves the WHOLE subtree out of the tree (children stay parented to
+		// the detached element — see attachElement's cascade below), so the
+		// sweep covers descendants too, the same way deleteElement's does.
 		await prisma.$transaction(async (tx) => {
 			await tx.assuranceElement.update({
 				where: { id: elementId },
@@ -1121,7 +1247,8 @@ export async function detachElement(
 					inSandbox: true,
 				},
 			});
-			await nullifyDanglingCitations(tx, [elementId]);
+			const descendantIds = await getDescendantIds(elementId, tx);
+			await nullifyDanglingCitations(tx, [elementId, ...descendantIds]);
 		});
 
 		return { data: true };
@@ -1134,6 +1261,15 @@ export async function detachElement(
 /**
  * Attaches an element (moves from sandbox to parent)
  * Also cascades to all descendants, removing them from sandbox
+ *
+ * ADR 0004 D5 scope call: attaching (or restoring, in restoreElement below)
+ * does NOT re-heal citations that were nullified and flagged
+ * (`citationDangling`) when this element or a descendant was previously
+ * detached/deleted. Re-attachment is not the same fact as "the citation is
+ * valid again" — the citing AWAY_GOAL's citedElementId was already cleared,
+ * and silently re-populating it here would restore a reference the author
+ * never re-declared. Pinned by the "restore does not re-heal citedElementId"
+ * test in element-citation-integrity.test.ts.
  */
 export async function attachElement(
 	userId: string,

--- a/lib/transforms/element-response.ts
+++ b/lib/transforms/element-response.ts
@@ -33,6 +33,71 @@ function addParentReference(
 }
 
 /**
+ * Applies the optional single-value response fields (URLs, prose fields,
+ * assertion status, and the citation/module-reference/dialogical-reasoning
+ * metadata) that are only present on the response when the underlying
+ * element data is present. Extracted out of transformToResponse — verbatim,
+ * same conditions, same assignments — to keep that function under the
+ * cognitive-complexity budget.
+ */
+function applyOptionalFields(
+	response: ElementResponse,
+	element: {
+		assumption: string | null;
+		justification: string | null;
+		context: string[];
+		url: string | null;
+		urls: string[];
+		level: number | null;
+		assertionStatus?: AssertionStatus | null;
+		citedElementId?: string | null;
+		citationDangling?: boolean;
+		moduleReferenceId?: string | null;
+		isDefeater?: boolean;
+		defeatsElementId?: string | null;
+	}
+): void {
+	// Handle URLs: prefer urls array, fall back to legacy url field
+	if (element.urls && element.urls.length > 0) {
+		response.urls = element.urls;
+		response.URL = element.urls[0]; // Backward compatibility: first URL
+	} else if (element.url) {
+		response.URL = element.url;
+		response.urls = [element.url]; // Backward compatibility
+	}
+	if (element.assumption) {
+		response.assumption = element.assumption;
+	}
+	if (element.justification) {
+		response.justification = element.justification;
+	}
+	if (element.context && element.context.length > 0) {
+		response.context = element.context;
+	}
+	if (element.level !== null) {
+		response.level = element.level;
+	}
+	if (element.assertionStatus) {
+		response.assertionStatus = element.assertionStatus;
+	}
+	if (element.citedElementId) {
+		response.citedElementId = element.citedElementId;
+	}
+	if (element.citationDangling) {
+		response.citationDangling = true;
+	}
+	if (element.moduleReferenceId) {
+		response.moduleReferenceId = element.moduleReferenceId;
+	}
+	if (element.isDefeater) {
+		response.isDefeater = true;
+	}
+	if (element.defeatsElementId) {
+		response.defeatsElementId = element.defeatsElementId;
+	}
+}
+
+/**
  * Transforms a Prisma element to API response format
  */
 export function transformToResponse(element: {
@@ -85,44 +150,7 @@ export function transformToResponse(element: {
 		addParentReference(response, element.parent, element.elementType);
 	}
 
-	// Handle URLs: prefer urls array, fall back to legacy url field
-	if (element.urls && element.urls.length > 0) {
-		response.urls = element.urls;
-		response.URL = element.urls[0]; // Backward compatibility: first URL
-	} else if (element.url) {
-		response.URL = element.url;
-		response.urls = [element.url]; // Backward compatibility
-	}
-	if (element.assumption) {
-		response.assumption = element.assumption;
-	}
-	if (element.justification) {
-		response.justification = element.justification;
-	}
-	if (element.context && element.context.length > 0) {
-		response.context = element.context;
-	}
-	if (element.level !== null) {
-		response.level = element.level;
-	}
-	if (element.assertionStatus) {
-		response.assertionStatus = element.assertionStatus;
-	}
-	if (element.citedElementId) {
-		response.citedElementId = element.citedElementId;
-	}
-	if (element.citationDangling) {
-		response.citationDangling = true;
-	}
-	if (element.moduleReferenceId) {
-		response.moduleReferenceId = element.moduleReferenceId;
-	}
-	if (element.isDefeater) {
-		response.isDefeater = true;
-	}
-	if (element.defeatsElementId) {
-		response.defeatsElementId = element.defeatsElementId;
-	}
+	applyOptionalFields(response, element);
 
 	return response;
 }

--- a/lib/transforms/element-response.ts
+++ b/lib/transforms/element-response.ts
@@ -58,6 +58,9 @@ export function transformToResponse(element: {
 	citationDangling?: boolean;
 	// Module reference (MODULE/AWAY_GOAL only) — names the referenced case
 	moduleReferenceId?: string | null;
+	// Dialogical reasoning (defeaters) — applies to every element type.
+	isDefeater?: boolean;
+	defeatsElementId?: string | null;
 	caseId: string;
 	parentId: string | null;
 	createdAt: Date;
@@ -113,6 +116,12 @@ export function transformToResponse(element: {
 	}
 	if (element.moduleReferenceId) {
 		response.moduleReferenceId = element.moduleReferenceId;
+	}
+	if (element.isDefeater) {
+		response.isDefeater = true;
+	}
+	if (element.defeatsElementId) {
+		response.defeatsElementId = element.defeatsElementId;
 	}
 
 	return response;

--- a/src/__tests__/integration/api-elements-defeats-element-id.test.ts
+++ b/src/__tests__/integration/api-elements-defeats-element-id.test.ts
@@ -1,0 +1,193 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	createTestCase,
+	createTestElement,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+/**
+ * defeatsElementId (dialogical reasoning / defeaters) — route-level coverage,
+ * following the same lesson as api-elements-cited-element-id.test.ts:
+ * buildCreateInput/buildUpdateInput are hand-maintained allowlists that can
+ * silently drop a field never wired through, so this exercises the ACTUAL
+ * route handlers (app/api/cases/[id]/elements/route.ts,
+ * app/api/elements/[id]/route.ts), not just the service layer. Service-layer
+ * coverage of the scoping rule itself (cross-case, nonexistent, soft-deleted,
+ * self-reference, null-clears) lives in element-defeats-scoping.test.ts.
+ */
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/services/sse-connection-manager", () => ({
+	emitSSEEvent: vi.fn(),
+	sseConnectionManager: { broadcast: vi.fn() },
+}));
+
+const CROSS_CASE_PATTERN =
+	/defeatsElementId must reference an existing element in this case/;
+
+beforeEach(async () => {
+	await mockNoAuth();
+});
+
+describe("POST /api/cases/[id]/elements — defeatsElementId", () => {
+	it("creates an element with defeatsElementId end to end, persisted per a separate refetch", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const target = await createTestElement(testCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+			name: "Original claim",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import("@/app/api/cases/[id]/elements/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/elements`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					type: "property_claim",
+					name: "Rebuttal",
+					description: "Defeats the original claim",
+					isDefeater: true,
+					defeatsElementId: target.id,
+				}),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await POST(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(201);
+		const body = await response.json();
+		expect(body.defeatsElementId).toBe(target.id);
+		expect(body.isDefeater).toBe(true);
+
+		// Separate refetch — proves DB persistence, not just an echoed response.
+		const inDb = await prisma.assuranceElement.findFirst({
+			where: { caseId: testCase.id, name: "Rebuttal" },
+		});
+		expect(inDb?.defeatsElementId).toBe(target.id);
+		expect(inDb?.isDefeater).toBe(true);
+	});
+
+	it("rejects a cross-case defeatsElementId through the route handler", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const otherCase = await createTestCase(owner.id);
+		const foreignTarget = await createTestElement(otherCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import("@/app/api/cases/[id]/elements/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/elements`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					type: "property_claim",
+					name: "Rebuttal",
+					description: "Points at a foreign case",
+					defeatsElementId: foreignTarget.id,
+				}),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await POST(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toMatch(CROSS_CASE_PATTERN);
+
+		const elements = await prisma.assuranceElement.findMany({
+			where: { caseId: testCase.id },
+		});
+		expect(elements).toHaveLength(0);
+	});
+});
+
+describe("PUT /api/elements/[id] — defeatsElementId", () => {
+	it("round-trips defeatsElementId through the route handler, persisted per a separate refetch", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const target = await createTestElement(testCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+		});
+		const element = await createTestElement(testCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await import("@/app/api/elements/[id]/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/elements/${element.id}`,
+			{
+				method: "PUT",
+				body: JSON.stringify({
+					isDefeater: true,
+					defeatsElementId: target.id,
+				}),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: element.id }),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.defeatsElementId).toBe(target.id);
+		expect(body.isDefeater).toBe(true);
+
+		// Separate refetch — proves DB persistence, not just an echoed response.
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: element.id },
+		});
+		expect(inDb?.defeatsElementId).toBe(target.id);
+		expect(inDb?.isDefeater).toBe(true);
+	});
+
+	it("rejects a cross-case defeatsElementId through the route handler", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const otherCase = await createTestCase(owner.id);
+		const foreignTarget = await createTestElement(otherCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+		});
+		const element = await createTestElement(testCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await import("@/app/api/elements/[id]/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/elements/${element.id}`,
+			{
+				method: "PUT",
+				body: JSON.stringify({ defeatsElementId: foreignTarget.id }),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: element.id }),
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toMatch(CROSS_CASE_PATTERN);
+
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: element.id },
+		});
+		expect(inDb?.defeatsElementId).toBeNull();
+	});
+});

--- a/src/__tests__/integration/element-citation-integrity.test.ts
+++ b/src/__tests__/integration/element-citation-integrity.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import prisma from "@/lib/prisma";
-import { deleteElement, detachElement } from "@/lib/services/element-service";
+import {
+	attachElement,
+	deleteElement,
+	detachElement,
+} from "@/lib/services/element-service";
 import { expectSuccess } from "../utils/assertion-helpers";
 import {
 	createTestCase,
@@ -161,6 +165,95 @@ describe("element citation integrity (ADR 0004 D5)", () => {
 			});
 			expect(inDb?.citedElementId).toBe(citedClaim.id);
 			expect(inDb?.citationDangling).toBe(false);
+		});
+
+		it("nullifies citations pointing at a descendant swept up by a parent detach", async () => {
+			const owner = await createTestUser();
+			const homeCase = await createTestCase(owner.id);
+			const awayCase = await createTestCase(owner.id);
+			const parentGoal = await createTestElement(awayCase.id, owner.id, {
+				elementType: "GOAL",
+			});
+			const citedChild = await createTestElement(awayCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+				parentId: parentGoal.id,
+			});
+			const awayGoal = await createTestElement(homeCase.id, owner.id, {
+				elementType: "AWAY_GOAL",
+				moduleReferenceId: awayCase.id,
+				citedElementId: citedChild.id,
+			});
+			// An unrelated citation, elsewhere in the SAME case but under a
+			// different root — not a descendant of parentGoal — that must stay
+			// untouched by the detach.
+			const otherRoot = await createTestElement(awayCase.id, owner.id, {
+				elementType: "STRATEGY",
+			});
+			const unrelatedTarget = await createTestElement(awayCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+				parentId: otherRoot.id,
+			});
+			const unrelatedAwayGoal = await createTestElement(homeCase.id, owner.id, {
+				elementType: "AWAY_GOAL",
+				moduleReferenceId: awayCase.id,
+				citedElementId: unrelatedTarget.id,
+			});
+
+			// Detaching the PARENT moves the whole subtree — citedChild included
+			// — out of the case tree, so a citation to citedChild is just as
+			// dangling as one to parentGoal itself.
+			expectSuccess(await detachElement(owner.id, parentGoal.id));
+
+			const inDb = await prisma.assuranceElement.findUnique({
+				where: { id: awayGoal.id },
+			});
+			expect(inDb?.citedElementId).toBeNull();
+			expect(inDb?.citationDangling).toBe(true);
+
+			const unrelatedInDb = await prisma.assuranceElement.findUnique({
+				where: { id: unrelatedAwayGoal.id },
+			});
+			expect(unrelatedInDb?.citedElementId).toBe(unrelatedTarget.id);
+			expect(unrelatedInDb?.citationDangling).toBe(false);
+		});
+	});
+
+	describe("attaching/restoring does not re-heal a dangling citation", () => {
+		it("attachElement leaves a previously-nullified citation dangling (ADR 0004 D5 scope call)", async () => {
+			const owner = await createTestUser();
+			const homeCase = await createTestCase(owner.id);
+			const awayCase = await createTestCase(owner.id);
+			const parentGoal = await createTestElement(awayCase.id, owner.id, {
+				elementType: "GOAL",
+			});
+			const citedClaim = await createTestElement(awayCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+				parentId: parentGoal.id,
+			});
+			const awayGoal = await createTestElement(homeCase.id, owner.id, {
+				elementType: "AWAY_GOAL",
+				moduleReferenceId: awayCase.id,
+				citedElementId: citedClaim.id,
+			});
+
+			expectSuccess(await detachElement(owner.id, citedClaim.id));
+
+			const afterDetach = await prisma.assuranceElement.findUnique({
+				where: { id: awayGoal.id },
+			});
+			expect(afterDetach?.citedElementId).toBeNull();
+			expect(afterDetach?.citationDangling).toBe(true);
+
+			// Re-attach citedClaim to the same parent it was detached from.
+			expectSuccess(
+				await attachElement(owner.id, citedClaim.id, parentGoal.id)
+			);
+
+			const afterAttach = await prisma.assuranceElement.findUnique({
+				where: { id: awayGoal.id },
+			});
+			expect(afterAttach?.citedElementId).toBeNull();
+			expect(afterAttach?.citationDangling).toBe(true);
 		});
 	});
 });

--- a/src/__tests__/integration/element-defeats-scoping.test.ts
+++ b/src/__tests__/integration/element-defeats-scoping.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+import prisma from "@/lib/prisma";
+import { createElement, updateElement } from "@/lib/services/element-service";
+import { expectError, expectSuccess } from "../utils/assertion-helpers";
+import {
+	createTestCase,
+	createTestElement,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+/**
+ * defeatsElementId (dialogical reasoning / defeaters) — must stay inside the
+ * case it is written from, unlike citedElementId which is deliberately
+ * cross-case (ADR 0004 D5). Parity with the batch endpoint's ownership check
+ * (case-batch-update-service.ts's validateElementOwnership), per Chris's
+ * ruling 2026-08-27 on TEA — Element-service reference integrity: persist
+ * the field with a same-case/exists/not-deleted/not-self check, rather than
+ * merely reject it.
+ */
+
+const NOT_FOUND_PATTERN =
+	/defeatsElementId must reference an existing element in this case/;
+const SELF_REFERENCE_PATTERN =
+	/defeatsElementId cannot reference the element itself/;
+const PARENT_NOT_FOUND_PATTERN = /Parent element not found/;
+
+describe("defeatsElementId scoping (element-service)", () => {
+	describe("createElement", () => {
+		it("persists a valid same-case defeatsElementId and returns it in the response", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			const target = await createTestElement(testCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+			});
+
+			const data = expectSuccess(
+				await createElement(owner.id, {
+					caseId: testCase.id,
+					elementType: "property_claim",
+					isDefeater: true,
+					defeatsElementId: target.id,
+				})
+			);
+			expect(data.defeatsElementId).toBe(target.id);
+			expect(data.isDefeater).toBe(true);
+
+			const inDb = await prisma.assuranceElement.findUnique({
+				where: { id: data.id },
+			});
+			expect(inDb?.defeatsElementId).toBe(target.id);
+			expect(inDb?.isDefeater).toBe(true);
+		});
+
+		it("rejects a defeatsElementId belonging to a different case", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			const otherCase = await createTestCase(owner.id);
+			const foreignTarget = await createTestElement(otherCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+			});
+
+			const result = await createElement(owner.id, {
+				caseId: testCase.id,
+				elementType: "property_claim",
+				defeatsElementId: foreignTarget.id,
+			});
+			expectError(result, NOT_FOUND_PATTERN);
+
+			const elements = await prisma.assuranceElement.findMany({
+				where: { caseId: testCase.id },
+			});
+			expect(elements).toHaveLength(0);
+		});
+
+		it("rejects a nonexistent defeatsElementId", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+
+			const result = await createElement(owner.id, {
+				caseId: testCase.id,
+				elementType: "property_claim",
+				defeatsElementId: "00000000-0000-0000-0000-000000000000",
+			});
+			expectError(result, NOT_FOUND_PATTERN);
+		});
+
+		it("rejects a soft-deleted defeatsElementId target in the same case", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			const target = await createTestElement(testCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+			});
+			await prisma.assuranceElement.update({
+				where: { id: target.id },
+				data: { deletedAt: new Date(), deletedById: owner.id },
+			});
+
+			const result = await createElement(owner.id, {
+				caseId: testCase.id,
+				elementType: "property_claim",
+				defeatsElementId: target.id,
+			});
+			expectError(result, NOT_FOUND_PATTERN);
+		});
+	});
+
+	describe("updateElement", () => {
+		it("persists a valid same-case defeatsElementId and returns it in the response", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			const target = await createTestElement(testCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+			});
+			const element = await createTestElement(testCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+			});
+
+			const data = expectSuccess(
+				await updateElement(owner.id, element.id, {
+					isDefeater: true,
+					defeatsElementId: target.id,
+				})
+			);
+			expect(data.defeatsElementId).toBe(target.id);
+			expect(data.isDefeater).toBe(true);
+
+			const inDb = await prisma.assuranceElement.findUnique({
+				where: { id: element.id },
+			});
+			expect(inDb?.defeatsElementId).toBe(target.id);
+			expect(inDb?.isDefeater).toBe(true);
+		});
+
+		it("rejects a defeatsElementId belonging to a different case", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			const otherCase = await createTestCase(owner.id);
+			const foreignTarget = await createTestElement(otherCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+			});
+			const element = await createTestElement(testCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+			});
+
+			const result = await updateElement(owner.id, element.id, {
+				defeatsElementId: foreignTarget.id,
+			});
+			expectError(result, NOT_FOUND_PATTERN);
+
+			const inDb = await prisma.assuranceElement.findUnique({
+				where: { id: element.id },
+			});
+			expect(inDb?.defeatsElementId).toBeNull();
+		});
+
+		it("rejects a nonexistent defeatsElementId", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			const element = await createTestElement(testCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+			});
+
+			const result = await updateElement(owner.id, element.id, {
+				defeatsElementId: "00000000-0000-0000-0000-000000000000",
+			});
+			expectError(result, NOT_FOUND_PATTERN);
+		});
+
+		it("rejects self-reference", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			const element = await createTestElement(testCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+			});
+
+			const result = await updateElement(owner.id, element.id, {
+				defeatsElementId: element.id,
+			});
+			expectError(result, SELF_REFERENCE_PATTERN);
+
+			const inDb = await prisma.assuranceElement.findUnique({
+				where: { id: element.id },
+			});
+			expect(inDb?.defeatsElementId).toBeNull();
+		});
+
+		it("clears defeatsElementId when explicitly set to null", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			const target = await createTestElement(testCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+			});
+			const element = await createTestElement(testCase.id, owner.id, {
+				elementType: "PROPERTY_CLAIM",
+				defeatsElementId: target.id,
+			});
+
+			const data = expectSuccess(
+				await updateElement(owner.id, element.id, {
+					defeatsElementId: null,
+				})
+			);
+			expect(data.defeatsElementId).toBeUndefined();
+
+			const inDb = await prisma.assuranceElement.findUnique({
+				where: { id: element.id },
+			});
+			expect(inDb?.defeatsElementId).toBeNull();
+		});
+	});
+
+	describe("createElement — parentId same-case scoping (audit finding)", () => {
+		it("rejects a parentId belonging to a different case", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			const otherCase = await createTestCase(owner.id);
+			const foreignParent = await createTestElement(otherCase.id, owner.id, {
+				elementType: "GOAL",
+			});
+
+			const result = await createElement(owner.id, {
+				caseId: testCase.id,
+				elementType: "strategy",
+				parentId: foreignParent.id,
+			});
+			expectError(result, PARENT_NOT_FOUND_PATTERN);
+
+			const elements = await prisma.assuranceElement.findMany({
+				where: { caseId: testCase.id },
+			});
+			expect(elements).toHaveLength(0);
+		});
+
+		it("rejects a nonexistent parentId", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+
+			const result = await createElement(owner.id, {
+				caseId: testCase.id,
+				elementType: "strategy",
+				parentId: "00000000-0000-0000-0000-000000000000",
+			});
+			expectError(result, PARENT_NOT_FOUND_PATTERN);
+		});
+
+		it("accepts a same-case parentId", async () => {
+			const owner = await createTestUser();
+			const testCase = await createTestCase(owner.id);
+			const goal = await createTestElement(testCase.id, owner.id, {
+				elementType: "GOAL",
+			});
+
+			const data = expectSuccess(
+				await createElement(owner.id, {
+					caseId: testCase.id,
+					elementType: "strategy",
+					parentId: goal.id,
+				})
+			);
+
+			const inDb = await prisma.assuranceElement.findUnique({
+				where: { id: data.id },
+			});
+			expect(inDb?.parentId).toBe(goal.id);
+		});
+	});
+});

--- a/src/__tests__/integration/element-reference-integrity-adversarial.test.ts
+++ b/src/__tests__/integration/element-reference-integrity-adversarial.test.ts
@@ -1,0 +1,447 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import {
+	attachElement,
+	createElement,
+	detachElement,
+	updateElement,
+} from "@/lib/services/element-service";
+import {
+	expectError,
+	expectSameError,
+	expectSuccess,
+} from "../utils/assertion-helpers";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	createTestCase,
+	createTestElement,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+/**
+ * QA G3 adversarial suite for "TEA — Element-service reference integrity"
+ * (branch fix/element-service-reference-integrity, commit 9894783c).
+ *
+ * Written independently of barret's tests (element-defeats-scoping.test.ts,
+ * api-elements-defeats-element-id.test.ts, element-citation-integrity.test.ts)
+ * — read only afterwards to avoid duplicating coverage. Does not modify
+ * those files.
+ */
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/services/sse-connection-manager", () => ({
+	emitSSEEvent: vi.fn(),
+	sseConnectionManager: { broadcast: vi.fn() },
+}));
+
+beforeEach(async () => {
+	await mockNoAuth();
+});
+
+const NOT_FOUND_PATTERN =
+	/defeatsElementId must reference an existing element in this case/;
+const PARENT_NOT_FOUND_PATTERN = /Parent element not found/;
+
+describe("defeatsElementId — anti-enumeration (cross-case vs nonexistent give the SAME message)", () => {
+	it("HTTP create: cross-case and nonexistent ids produce byte-identical error bodies", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const otherCase = await createTestCase(owner.id);
+		const foreignTarget = await createTestElement(otherCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import("@/app/api/cases/[id]/elements/route");
+
+		const crossCaseReq = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/elements`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					type: "property_claim",
+					name: "Cross-case attempt",
+					defeatsElementId: foreignTarget.id,
+				}),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const crossCaseRes = await POST(crossCaseReq, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+		const crossCaseBody = await crossCaseRes.json();
+
+		const nonexistentReq = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/elements`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					type: "property_claim",
+					name: "Nonexistent attempt",
+					defeatsElementId: "00000000-0000-0000-0000-000000000000",
+				}),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const nonexistentRes = await POST(nonexistentReq, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+		const nonexistentBody = await nonexistentRes.json();
+
+		expect(crossCaseRes.status).toBe(400);
+		expect(nonexistentRes.status).toBe(400);
+		expect(crossCaseBody.error).toBe(nonexistentBody.error);
+	});
+
+	it("service layer: cross-case and nonexistent defeatsElementId are the SAME error on create", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const otherCase = await createTestCase(owner.id);
+		const foreignTarget = await createTestElement(otherCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+		});
+
+		const crossCaseResult = await createElement(owner.id, {
+			caseId: testCase.id,
+			elementType: "property_claim",
+			defeatsElementId: foreignTarget.id,
+		});
+		const nonexistentResult = await createElement(owner.id, {
+			caseId: testCase.id,
+			elementType: "property_claim",
+			defeatsElementId: "00000000-0000-0000-0000-000000000000",
+		});
+
+		expectSameError(crossCaseResult, nonexistentResult);
+	});
+});
+
+describe("defeatsElementId — cases barret's suite didn't cover", () => {
+	it("rejects a soft-deleted same-case target on UPDATE (barret only pinned this on create)", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const target = await createTestElement(testCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+		});
+		await prisma.assuranceElement.update({
+			where: { id: target.id },
+			data: { deletedAt: new Date(), deletedById: owner.id },
+		});
+		const element = await createTestElement(testCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+		});
+
+		const result = await updateElement(owner.id, element.id, {
+			defeatsElementId: target.id,
+		});
+		expectError(result, NOT_FOUND_PATTERN);
+
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: element.id },
+		});
+		expect(inDb?.defeatsElementId).toBeNull();
+	});
+
+	it("omitting defeatsElementId on update leaves the existing value unchanged", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const target = await createTestElement(testCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+		});
+		const element = await createTestElement(testCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+			defeatsElementId: target.id,
+			isDefeater: true,
+		});
+
+		// Update an unrelated field only — defeatsElementId is not in the input.
+		const data = expectSuccess(
+			await updateElement(owner.id, element.id, {
+				name: "Renamed, defeatsElementId untouched",
+			})
+		);
+		expect(data.defeatsElementId).toBe(target.id);
+
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: element.id },
+		});
+		expect(inDb?.defeatsElementId).toBe(target.id);
+		expect(inDb?.isDefeater).toBe(true);
+	});
+});
+
+describe("parentId same-case scoping — EVIDENCE path specifically", () => {
+	it("rejects a cross-case parentId when creating an EVIDENCE element (EvidenceLink path, not just direct parentId)", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const otherCase = await createTestCase(owner.id);
+		const foreignClaim = await createTestElement(otherCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+		});
+
+		const result = await createElement(owner.id, {
+			caseId: testCase.id,
+			elementType: "evidence",
+			parentId: foreignClaim.id,
+		});
+		expectError(result, PARENT_NOT_FOUND_PATTERN);
+
+		// No element created in the target case...
+		const elements = await prisma.assuranceElement.findMany({
+			where: { caseId: testCase.id },
+		});
+		expect(elements).toHaveLength(0);
+
+		// ...and, critically, no EvidenceLink was created against the foreign
+		// claim either (the vulnerable path pre-fix would have written the
+		// AssuranceElement row and then created the EvidenceLink regardless
+		// of case membership).
+		const links = await prisma.evidenceLink.findMany({
+			where: { claimId: foreignClaim.id },
+		});
+		expect(links).toHaveLength(0);
+	});
+
+	it("accepts a same-case parentId when creating an EVIDENCE element and creates the EvidenceLink", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const claim = await createTestElement(testCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+		});
+
+		const data = expectSuccess(
+			await createElement(owner.id, {
+				caseId: testCase.id,
+				elementType: "evidence",
+				parentId: claim.id,
+			})
+		);
+
+		const link = await prisma.evidenceLink.findFirst({
+			where: { claimId: claim.id, evidenceId: data.id },
+		});
+		expect(link).not.toBeNull();
+	});
+
+	it("rejects a cross-case parentId for EVIDENCE through the HTTP route", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const otherCase = await createTestCase(owner.id);
+		const foreignClaim = await createTestElement(otherCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import("@/app/api/cases/[id]/elements/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/elements`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					type: "evidence",
+					name: "Cross-case evidence",
+					propertyClaimId: foreignClaim.id,
+				}),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await POST(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		// Unlike defeatsElementId/citedElementId/moduleReferenceId (structured
+		// "<field> ..." messages explicitly mapped to 400 in
+		// lib/api-response.ts), "Parent element not found" matches the
+		// generic "not found" -> 404 mapping — consistent with
+		// updateElement's pre-existing new-parent check ("Element not
+		// found", also 404). Not a bug: same shape as the sibling check,
+		// just a different status code family. See QA note in the G3 return.
+		expect(response.status).toBe(404);
+		const body = await response.json();
+		expect(body.error).toMatch(PARENT_NOT_FOUND_PATTERN);
+
+		const links = await prisma.evidenceLink.findMany({
+			where: { claimId: foreignClaim.id },
+		});
+		expect(links).toHaveLength(0);
+	});
+});
+
+describe("detachElement — descendant citation sweep, two levels deep", () => {
+	it("nullifies a citation to a GRANDCHILD (depth 2), not just an immediate child", async () => {
+		const owner = await createTestUser();
+		const homeCase = await createTestCase(owner.id);
+		const awayCase = await createTestCase(owner.id);
+		const root = await createTestElement(awayCase.id, owner.id, {
+			elementType: "GOAL",
+		});
+		const child = await createTestElement(awayCase.id, owner.id, {
+			elementType: "STRATEGY",
+			parentId: root.id,
+		});
+		const grandchild = await createTestElement(awayCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+			parentId: child.id,
+		});
+		const citer = await createTestElement(homeCase.id, owner.id, {
+			elementType: "AWAY_GOAL",
+			moduleReferenceId: awayCase.id,
+			citedElementId: grandchild.id,
+		});
+
+		// A citation to a sibling subtree — must survive the detach untouched.
+		const otherRoot = await createTestElement(awayCase.id, owner.id, {
+			elementType: "STRATEGY",
+		});
+		const otherLeaf = await createTestElement(awayCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+			parentId: otherRoot.id,
+		});
+		const siblingCiter = await createTestElement(homeCase.id, owner.id, {
+			elementType: "AWAY_GOAL",
+			moduleReferenceId: awayCase.id,
+			citedElementId: otherLeaf.id,
+		});
+
+		expectSuccess(await detachElement(owner.id, root.id));
+
+		const citerAfter = await prisma.assuranceElement.findUnique({
+			where: { id: citer.id },
+		});
+		expect(citerAfter?.citedElementId).toBeNull();
+		expect(citerAfter?.citationDangling).toBe(true);
+
+		const siblingCiterAfter = await prisma.assuranceElement.findUnique({
+			where: { id: siblingCiter.id },
+		});
+		expect(siblingCiterAfter?.citedElementId).toBe(otherLeaf.id);
+		expect(siblingCiterAfter?.citationDangling).toBe(false);
+	});
+});
+
+describe("detach + re-attach does not silently re-heal (regression guard, mirrors ADR 0004 D5)", () => {
+	it("re-attaching a detached element with descendants leaves ALL swept citations dangling", async () => {
+		const owner = await createTestUser();
+		const homeCase = await createTestCase(owner.id);
+		const awayCase = await createTestCase(owner.id);
+		const root = await createTestElement(awayCase.id, owner.id, {
+			elementType: "GOAL",
+		});
+		const child = await createTestElement(awayCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+			parentId: root.id,
+		});
+		const citerOfRoot = await createTestElement(homeCase.id, owner.id, {
+			elementType: "AWAY_GOAL",
+			moduleReferenceId: awayCase.id,
+			citedElementId: root.id,
+		});
+		const citerOfChild = await createTestElement(homeCase.id, owner.id, {
+			elementType: "AWAY_GOAL",
+			moduleReferenceId: awayCase.id,
+			citedElementId: child.id,
+		});
+		// Detach needs a parent to detach FROM in the sense of moving to
+		// sandbox; root has no parent, which is fine — detachElement clears
+		// parentId and sets inSandbox regardless.
+		const grandparent = await createTestElement(awayCase.id, owner.id, {
+			elementType: "GOAL",
+		});
+		await prisma.assuranceElement.update({
+			where: { id: root.id },
+			data: { parentId: grandparent.id },
+		});
+
+		expectSuccess(await detachElement(owner.id, root.id));
+
+		expectSuccess(await attachElement(owner.id, root.id, grandparent.id));
+
+		const rootCiterAfter = await prisma.assuranceElement.findUnique({
+			where: { id: citerOfRoot.id },
+		});
+		const childCiterAfter = await prisma.assuranceElement.findUnique({
+			where: { id: citerOfChild.id },
+		});
+		expect(rootCiterAfter?.citedElementId).toBeNull();
+		expect(rootCiterAfter?.citationDangling).toBe(true);
+		expect(childCiterAfter?.citedElementId).toBeNull();
+		expect(childCiterAfter?.citationDangling).toBe(true);
+	});
+});
+
+describe("id-reuse-class bypass check (style of batch-ownership-adversarial.test.ts)", () => {
+	/**
+	 * The batch endpoint's bug (TEA — Batch endpoint does not verify element
+	 * ownership against the case) worked because a client-controlled
+	 * `elementId` appearing in the SAME batch's `create` changes was
+	 * excluded from the ownership lookup, letting a `delete` for that same
+	 * id slip past the check on a real foreign row.
+	 *
+	 * That exploit needs two ingredients neither of which exist on the
+	 * single-element create/update paths touched by this change:
+	 *   1. A client-supplied `id` for a new row (createElementInDatabase's
+	 *      `prisma.assuranceElement.create` never accepts one — Prisma/the
+	 *      schema generates it), so there is no id for an attacker to
+	 *      collide with a victim's row.
+	 *   2. Multiple operations sharing one id-collection pass. The batch bug
+	 *      lived in `validateElementOwnership`'s `createdIds` exclusion set,
+	 *      built once across a whole batch; createElement/updateElement each
+	 *      validate a single defeatsElementId/parentId against `caseId`
+	 *      directly, with no equivalent "ids I'm about to create" allowlist
+	 *      to smuggle a foreign id through.
+	 *
+	 * This test is the closest reachable analogue: prove that validating
+	 * defeatsElementId against a target created moments earlier IN THE SAME
+	 * TEST (i.e. no batching, no id reuse) still enforces case scoping
+	 * correctly when the target and the referencing element are created in
+	 * rapid succession — a sequential-request approximation of the
+	 * interleaving the batch bug exploited.
+	 */
+	it("validates defeatsElementId against the target's actual case even when both elements are created back-to-back", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const otherCase = await createTestCase(owner.id);
+
+		const foreignTarget = await createTestElement(otherCase.id, owner.id, {
+			elementType: "PROPERTY_CLAIM",
+		});
+		// Immediately attempt to reference it from testCase, no delay.
+		const result = await createElement(owner.id, {
+			caseId: testCase.id,
+			elementType: "property_claim",
+			defeatsElementId: foreignTarget.id,
+		});
+		expectError(result, NOT_FOUND_PATTERN);
+	});
+
+	it("confirms createElementInDatabase never accepts a client-supplied id (the precondition the batch exploit needed)", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const victim = await createTestElement(testCase.id, owner.id, {
+			elementType: "GOAL",
+			name: "Victim",
+		});
+
+		// Attempt to smuggle an `id` field through createElement's input —
+		// even if a caller tried to collide with an existing row's id, the
+		// service does not forward `id` into the create call.
+		const result = await createElement(owner.id, {
+			caseId: testCase.id,
+			elementType: "strategy",
+			// @ts-expect-error — id is not part of CreateElementInput; this is
+			// exactly the adversarial payload shape to probe for.
+			id: victim.id,
+			name: "Attempted collision",
+		});
+
+		expectSuccess(result);
+		const stillVictim = await prisma.assuranceElement.findUnique({
+			where: { id: victim.id },
+		});
+		expect(stillVictim?.name).toBe("Victim");
+	});
+});

--- a/src/__tests__/utils/prisma-factories.ts
+++ b/src/__tests__/utils/prisma-factories.ts
@@ -172,6 +172,9 @@ type ElementOverrides = Partial<{
 	// ADR 0004 D5 — AWAY_GOAL only
 	citedElementId: string | null;
 	citationDangling: boolean;
+	// Dialogical reasoning (defeaters) — applies to every element type
+	isDefeater: boolean;
+	defeatsElementId: string | null;
 }>;
 
 export function createTestElement(
@@ -195,6 +198,8 @@ export function createTestElement(
 			moduleReferenceId: overrides.moduleReferenceId,
 			citedElementId: overrides.citedElementId,
 			citationDangling: overrides.citationDangling ?? false,
+			isDefeater: overrides.isDefeater ?? false,
+			defeatsElementId: overrides.defeatsElementId,
 		},
 	});
 }


### PR DESCRIPTION
## Summary

Two reference-integrity fixes in `lib/services/element-service.ts`, plus one found during the in-file audit.

1. **`defeatsElementId` on the single-element create/update paths.** The field was accepted by the request schema but never persisted. It is now forwarded from both routes, validated (target exists, not soft-deleted, same case, not self on update), persisted, and returned in the response — matching the batch endpoint (#913). `isDefeater` had the same gap and is handled alongside. A new `ERROR_MAPPINGS` entry surfaces the rejection as 400.
2. **`parentId` on element create** had no case-membership check (update/move/attach already had one). Added `validateParentIdInCase`; for EVIDENCE this also prevents a cross-case `EvidenceLink`.
3. **`detachElement`** now nullifies and flags citations to the detached element's whole descendant subtree, matching `deleteElement`. Restore/attach deliberately does not re-heal citations (ADR 0004 D5); pinned by a test.

## Review chain

- Implementation: `9894783c`. Deviations from brief accepted: response-mapping fix; `isDefeater`/`defeatsElementId` surfaced in the single-element response; audit finding fixed in-file.
- Code review: APPROVE, no must-fixes. fallow vs baseline: dead-code 0 new, duplication 0 new, complexity 2 new (cognitive-15 advisory on `createElement` and `transformToResponse`; cyclomatic max 19, under cap). Lint clean, typecheck clean.
- QA: PASS. Authoritative run on `9894783c`: unit 1324/1324, integration 978/978. 11 adversarial tests added (`element-reference-integrity-adversarial.test.ts`, `61efa6a6`); each guard verified by reversion (7/3/3 tests fail when removed). No callers rely on cross-case parenting (routes, e2e, seed, demo, import all checked).
- Final tree `61efa6a6` = `9894783c` + test-only commit. On `61efa6a6`: typecheck clean, lint clean (759 files), unit 1324/1324, integration 989/989.

Known pre-existing: `lib/services/__tests__/slug-service.test.ts` fails to load in the unit project (missing `DATABASE_URL`), reproduced on `origin/staging`.

## Follow-ups filed (not in this PR)

- `defeatsElementId` is not nullified/flagged when its target is soft-deleted or detached (needs a migration).
- `updateElement` writes `parentId` directly for EVIDENCE instead of updating the evidence link (pre-existing).
