### PR TITLE
fix(ci): don't let a curl timeout abort deploy health checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -780,7 +780,7 @@ jobs:
             echo "Health check attempt $i of 10..."
             HEALTH_STATUS=$(curl -sL -o /dev/null -w "%{http_code}" \
               --max-time 10 \
-              "${{ env.PROD_APP_URL }}/api/health")
+              "${{ env.PROD_APP_URL }}/api/health" || true)
 
             if [ "$HEALTH_STATUS" = "200" ]; then
               echo "Application is healthy!"
@@ -843,7 +843,7 @@ jobs:
             echo "Health check attempt $i of 10..."
             HEALTH_STATUS=$(curl -sL -o /dev/null -w "%{http_code}" \
               --max-time 10 \
-              "${{ env.STAGING_APP_URL }}/api/health")
+              "${{ env.STAGING_APP_URL }}/api/health" || true)
 
             if [ "$HEALTH_STATUS" = "200" ]; then
               echo "Application is healthy!"


### PR DESCRIPTION
Both post-deploy health-check loops run `HEALTH_STATUS=$(curl ...)` under the run step's fail-fast shell (`bash -e {0}`). When curl itself fails — e.g. a 10s timeout while the app cold-starts — the command substitution's failure propagates to the assignment and kills the job on attempt 1 of 10, even though a later attempt would have passed. Evidence: run 29319754936 (2026-07-14 staging deploy) aborted on attempt 1 while the deploy had actually succeeded.

Fix: append `|| true` inside both curl substitutions (production and staging blocks) so a curl-level failure no longer aborts the step. curl's `-w "%{http_code}"` already emits `000` on timeout/DNS/connection failures, so the loop logs `HTTP 000` and retries as designed. Loop count, backoff, and success condition unchanged.

Verification:
- Sandbox reproduction under the runner's exact shell (`bash -eo pipefail`): old form aborts attempt 1 with exit 28; new form runs all 10 attempts and fails through the intended `::error::` path (exit 1); healthy endpoint succeeds immediately on attempt 1.
- Empirical check of curl failure modes (timeout, DNS failure, connection refused): all emit `000` before their nonzero exit, so `HEALTH_STATUS` is always well-formed.
- YAML parses; whole-file duplicate-key check clean; diff is exactly 1 file / 2 lines; fallow audit vs staging: pass, zero introduced findings.