### PR TITLE
ci(deploy): add job-level concurrency guard for same-branch deploys

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -733,6 +733,21 @@ jobs:
       needs.docker-build.result == 'success' &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
 
+    # Serialise deploys to the same branch: stacked merges to staging or
+    # main otherwise fire this job's Azure webhook concurrently, which is
+    # what failed the deploy on 2026-07-14 (three merges, webhook retries
+    # exhausted). cancel-in-progress stays false — cancelling a RUNNING job
+    # here wouldn't stop the Azure webhook it already fired, it would just
+    # abandon that deployment's health-check monitoring. GitHub's queueing
+    # semantics do the coalescing for us: only one job per group runs at a
+    # time and only one waits behind it, so a burst of pushes to the same
+    # branch collapses to "whatever's currently deploying" plus "the latest
+    # push", never two webhook calls in flight together. main and staging
+    # use different refs, so production and staging deploys stay parallel.
+    concurrency:
+      group: deploy-${{ github.ref }}
+      cancel-in-progress: false
+
     steps:
       - name: Deploy to Azure (Production)
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Three merges landing close together fire the deploy job's Azure webhook concurrently — the mechanism behind the 2026-07-14 staging deploy failure (webhook retries exhausted). This adds a job-level `concurrency:` group to the deploy job only:

```yaml
concurrency:
  group: deploy-${{ github.ref }}
  cancel-in-progress: false
```

- Deploys to the same branch queue instead of racing; a burst of pushes coalesces to "one deploying + the latest push waiting" (GitHub cancels only the older *queued* run, never a running one).
- `cancel-in-progress: false` is deliberate: cancelling a running job wouldn't stop the Azure webhook it already fired — it would only abandon that deployment's health-check monitoring.
- `main` and `staging` are separate groups, so production and staging deploys stay independent; PR runs never enter the group (the job's existing `if:` gates on those two refs).

Verification: YAML parse + whole-file duplicate-key check clean; block confirmed job-level (not workflow-level) by parsing the structure; every semantic claim in the in-file comment checked against GitHub's concurrency documentation; diff is exactly 1 file / 1 hunk / 15 insertions; fallow audit vs staging: pass, zero introduced findings.

Companion to #920 (health-check retry fix); independent branches, both directly off staging.