### PR TITLE
perf(test-db): dedicated throwaway test Postgres with fsync=off — integration suite 600s to ~20s

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -222,6 +222,14 @@ jobs:
 
     env:
       DATABASE_URL: postgresql://tea_user:tea_password@localhost:5432/tea_test
+      # These two override the LOCAL dev defaults baked into
+      # test-db-config.ts / vitest.workspace.ts, which point at the
+      # dedicated `postgres-test` container from docker-compose.local.yml
+      # (port 5433). CI's services.postgres above is already test-only —
+      # there's nothing to isolate it from — so it keeps using its single
+      # container on 5432, unchanged from before this override existed.
+      DATABASE_URL_INTEGRATION_BASE: postgresql://tea_user:tea_password@localhost:5432/tea_test
+      INTEGRATION_TEST_ADMIN_DATABASE_URL: postgresql://tea_user:tea_password@localhost:5432/tea_dev
       NEXTAUTH_SECRET: test-secret-for-ci-only
       NEXTAUTH_URL: http://localhost:3000
       SEED_USER_PASSWORD: ${{ secrets.SEED_USER_PASSWORD }}
@@ -231,25 +239,40 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Tune Postgres service container (shared_buffers/max_wal_size)
+      - name: Tune Postgres service container (fsync/shared_buffers/max_wal_size)
         # The integration suite's dominant cost is the per-test TRUNCATE
-        # CASCADE in src/__tests__/setup.integration.tsx, slow on the image
-        # default shared_buffers=128MB (cache-starved: pg_stat_bgwriter
-        # buffers_backend:buffers_checkpoint ~13:1). docker-compose.local.yml
-        # fixes this locally via `command:`, which service containers don't
-        # support, so this does it with ALTER SYSTEM (writes
-        # postgresql.auto.conf inside the container) followed by a restart.
-        # A restart, not just a config reload, is required: shared_buffers is
-        # a PGC_POSTMASTER setting in Postgres and only takes effect when the
-        # postmaster restarts (max_wal_size would reload with a SIGHUP alone,
-        # but there's no reason to split the two). `docker restart` targets
-        # the container Docker already created for this job's `postgres`
-        # service (found by image — this job runs exactly one postgres:16
-        # container) — it is not a `docker compose` invocation, so there's no
-        # compose project-name collision.
+        # CASCADE in src/__tests__/setup.integration.tsx: each of the 30
+        # truncated tables pays a DataFileImmediateSync fsync, every test.
+        # Measured proof: fsync=off took a 600.22s run to 22.01s, same
+        # 989/989 pass count. shared_buffers/max_wal_size help a little on
+        # their own but are secondary to fsync=off.
+        #
+        # DO NOT copy fsync=off to anything except a throwaway test/CI
+        # database — an unclean shutdown can leave the data directory
+        # CORRUPTED, not just behind on durability. This service container
+        # only ever holds per-run worker databases the suite creates and
+        # drops itself (see setup-test-db.ts), so that's an acceptable
+        # trade here; it would not be for any service with data worth
+        # keeping (see docker-compose.local.yml's `postgres` — dev's
+        # database — which does NOT get this treatment).
+        #
+        # GitHub Actions service containers have no `command:` key, so none
+        # of these three can be set at container-create time the way
+        # docker-compose.local.yml's `postgres-test` does it. This does it
+        # with ALTER SYSTEM (writes postgresql.auto.conf inside the
+        # container) followed by a restart. A restart, not just a config
+        # reload, is required: shared_buffers is a PGC_POSTMASTER setting in
+        # Postgres and only takes effect when the postmaster restarts
+        # (fsync and max_wal_size would reload with a SIGHUP alone, but
+        # there's no reason to split them from shared_buffers into a second
+        # mechanism). `docker restart` targets the container Docker already
+        # created for this job's `postgres` service (found by image — this
+        # job runs exactly one postgres:16 container) — it is not a `docker
+        # compose` invocation, so there's no compose project-name collision.
         run: |
           set -euo pipefail
           PGPASSWORD=tea_password psql -h localhost -U tea_user -d tea_test \
+            -c "ALTER SYSTEM SET fsync = off;" \
             -c "ALTER SYSTEM SET shared_buffers = '1GB';" \
             -c "ALTER SYSTEM SET max_wal_size = '4GB';"
           cid=$(docker ps --filter "ancestor=postgres:16" --format "{{.ID}}")
@@ -258,7 +281,7 @@ jobs:
             PGPASSWORD=tea_password pg_isready -h localhost -U tea_user -d tea_test && break
             sleep 1
           done
-          PGPASSWORD=tea_password psql -h localhost -U tea_user -d tea_test -c "SHOW shared_buffers; SHOW max_wal_size;"
+          PGPASSWORD=tea_password psql -h localhost -U tea_user -d tea_test -c "SHOW fsync; SHOW shared_buffers; SHOW max_wal_size;"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -281,7 +281,22 @@ jobs:
             PGPASSWORD=tea_password pg_isready -h localhost -U tea_user -d tea_test && break
             sleep 1
           done
-          PGPASSWORD=tea_password psql -h localhost -U tea_user -d tea_test -c "SHOW fsync; SHOW shared_buffers; SHOW max_wal_size;"
+          # Hard assertions, not just a log line: a silent regression here
+          # (e.g. the restart racing the ALTER SYSTEM writes, or a future
+          # image bump resetting defaults) would otherwise let the job pass
+          # green while quietly falling back to the slow 600s+ path.
+          check() {
+            local setting="$1" expected="$2" actual
+            actual=$(PGPASSWORD=tea_password psql -h localhost -U tea_user -d tea_test -tAc "SHOW ${setting};")
+            echo "${setting} = ${actual}"
+            if [ "$actual" != "$expected" ]; then
+              echo "::error::Postgres ${setting} is '${actual}', expected '${expected}' — tuning did not take effect"
+              exit 1
+            fi
+          }
+          check fsync off
+          check shared_buffers 1GB
+          check max_wal_size 4GB
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -208,7 +208,13 @@ jobs:
           POSTGRES_DB: tea_test
         ports:
           - 5432:5432
+        # GitHub Actions service containers have no `command:` key, so
+        # shared_buffers/max_wal_size can't be set at container-create time
+        # the way docker-compose.local.yml does it (see the "Tune Postgres"
+        # step below). --shm-size can be set here, though: it's a `docker
+        # create` option, which `options:` does pass through.
         options: >-
+          --shm-size=1gb
           --health-cmd "pg_isready -U tea_user"
           --health-interval 10s
           --health-timeout 5s
@@ -224,6 +230,35 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+
+      - name: Tune Postgres service container (shared_buffers/max_wal_size)
+        # The integration suite's dominant cost is the per-test TRUNCATE
+        # CASCADE in src/__tests__/setup.integration.tsx, slow on the image
+        # default shared_buffers=128MB (cache-starved: pg_stat_bgwriter
+        # buffers_backend:buffers_checkpoint ~13:1). docker-compose.local.yml
+        # fixes this locally via `command:`, which service containers don't
+        # support, so this does it with ALTER SYSTEM (writes
+        # postgresql.auto.conf inside the container) followed by a restart.
+        # A restart, not just a config reload, is required: shared_buffers is
+        # a PGC_POSTMASTER setting in Postgres and only takes effect when the
+        # postmaster restarts (max_wal_size would reload with a SIGHUP alone,
+        # but there's no reason to split the two). `docker restart` targets
+        # the container Docker already created for this job's `postgres`
+        # service (found by image — this job runs exactly one postgres:16
+        # container) — it is not a `docker compose` invocation, so there's no
+        # compose project-name collision.
+        run: |
+          set -euo pipefail
+          PGPASSWORD=tea_password psql -h localhost -U tea_user -d tea_test \
+            -c "ALTER SYSTEM SET shared_buffers = '1GB';" \
+            -c "ALTER SYSTEM SET max_wal_size = '4GB';"
+          cid=$(docker ps --filter "ancestor=postgres:16" --format "{{.ID}}")
+          docker restart "$cid"
+          for _ in $(seq 1 30); do
+            PGPASSWORD=tea_password pg_isready -h localhost -U tea_user -d tea_test && break
+            sleep 1
+          done
+          PGPASSWORD=tea_password psql -h localhost -U tea_user -d tea_test -c "SHOW shared_buffers; SHOW max_wal_size;"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,11 +59,14 @@ repos:
         exclude: '\.next/'
         pass_filenames: false
 
-  # Integration tests (requires Docker PostgreSQL on port 5432)
+  # Integration tests (requires the dedicated postgres-test container from
+  # docker-compose.local.yml, port 5433 by default; see
+  # scripts/run-integration-tests.sh for the INTEGRATION_TEST_ADMIN_DATABASE_URL
+  # override)
   - repo: local
     hooks:
       - id: integration-tests
-        name: integration tests (requires Docker PostgreSQL)
+        name: integration tests (requires Docker PostgreSQL test container)
         entry: ./scripts/run-integration-tests.sh
         language: script
         files: '\.(ts|tsx)$'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,11 @@ Risk-tiered, integration-heavy ("testing trophy", not pyramid):
   test-db-config.ts` and `vitest.workspace.ts` default to port 5433 locally;
   CI overrides both via env vars (`build.yaml`) to keep using its own
   single, already test-only service container on 5432 instead.
+- **`postgres-test` is not started by anything else** — run
+  `docker compose -f docker-compose.local.yml up -d postgres-test` before
+  `pnpm test:integration` (or the pre-commit hook that runs it). It's a
+  separate container from dev's `postgres`, so unlike before, having dev's
+  stack up already is not enough.
 
 ## Quality gates & conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,18 @@ Risk-tiered, integration-heavy ("testing trophy", not pyramid):
 - **Presentational components:** tests optional. No snapshot tests anywhere —
   test behaviour, not implementation.
 - Commands: `pnpm test:unit` / `pnpm test:integration` / `pnpm test:e2e`.
+- **`pnpm test:integration` needs its own Postgres, separate from dev's.**
+  `docker-compose.local.yml` runs two Postgres containers: `postgres` (dev's
+  database, port 5432, crash-safe, untouched) and `postgres-test` (port 5433,
+  `fsync=off` — safe only because this container's data is fully disposable,
+  recreated by the suite on every run; see that file's comment before
+  copying `fsync=off` anywhere else). `fsync=off` is what actually fixes the
+  suite's runtime: the per-test `TRUNCATE ... CASCADE`
+  (`src/__tests__/setup.integration.tsx`) was paying an fsync per truncated
+  table, every test — 600s down to ~20s. `src/__tests__/scripts/
+  test-db-config.ts` and `vitest.workspace.ts` default to port 5433 locally;
+  CI overrides both via env vars (`build.yaml`) to keep using its own
+  single, already test-only service container on 5432 instead.
 
 ## Quality gates & conventions
 
@@ -138,7 +150,10 @@ Risk-tiered, integration-heavy ("testing trophy", not pyramid):
   **Never `docker-compose down -v`** — it wipes the local database volume. The
   image bakes source and dependencies in at build time (no source bind
   mount), so `--build` alone picks up new npm packages and source changes;
-  there is no separate volume to clear.
+  there is no separate volume to clear. (This warning is about the `postgres`
+  service's `postgres_data` volume — `postgres-test`, used by
+  `pnpm test:integration`, is tmpfs-backed and disposable by design; there is
+  nothing to lose there.)
 - Docs run in production mode inside Docker (Nextra 4 dev-mode crash); for hot
   reload run `pnpm dev` on the host against Docker's Postgres.
 - Seed test users: `chris`, `alice`, `bob`, `charlie` (password from the

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -2,6 +2,13 @@ services:
   postgres:
     image: postgres:15-alpine
     container_name: tea_postgres_dev
+    # The integration suite TRUNCATEs 30 tables after every test; on the image
+    # defaults (shared_buffers=128MB) that's cache-starved and dominates the
+    # run's wall-clock (see the perf/test-db-memory issue). shm_size must rise
+    # in step with shared_buffers, or Postgres fails to start (default shm is
+    # 64MB).
+    command: postgres -c shared_buffers=1GB -c max_wal_size=4GB
+    shm_size: 1gb
     environment:
       POSTGRES_DB: tea_dev
       POSTGRES_USER: tea_user

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -2,13 +2,6 @@ services:
   postgres:
     image: postgres:15-alpine
     container_name: tea_postgres_dev
-    # The integration suite TRUNCATEs 30 tables after every test; on the image
-    # defaults (shared_buffers=128MB) that's cache-starved and dominates the
-    # run's wall-clock (see the perf/test-db-memory issue). shm_size must rise
-    # in step with shared_buffers, or Postgres fails to start (default shm is
-    # 64MB).
-    command: postgres -c shared_buffers=1GB -c max_wal_size=4GB
-    shm_size: 1gb
     environment:
       POSTGRES_DB: tea_dev
       POSTGRES_USER: tea_user
@@ -21,6 +14,55 @@ services:
       - tea_dev_network
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U tea_user -d tea_dev']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Dedicated, throwaway Postgres for the integration test suite. Kept
+  # SEPARATE from the `postgres` service above (dev's database, which stays
+  # crash-safe/untouched — Chris's call, 2026-09-02). This container's data
+  # only ever holds per-test worker databases the suite creates and drops on
+  # every run (see src/__tests__/scripts/setup-test-db.ts), so it's tuned for
+  # throughput with zero regard for durability:
+  #
+  #   fsync=off tells Postgres to skip flushing WAL/data pages to disk at
+  #   all. This is what actually fixed the integration suite's runtime
+  #   (600.22s -> 22.01s measured) — the TRUNCATE CASCADE after every test
+  #   was paying for a DataFileImmediateSync on each of the 30 truncated
+  #   tables, every test. shared_buffers/max_wal_size are kept from the
+  #   stage-A tuning; they helped a little on their own but fsync=off is the
+  #   dominant effect.
+  #
+  #   DO NOT copy fsync=off to any service holding data you'd mind losing —
+  #   an unclean shutdown (crash, OOM-kill, `docker kill`) can leave the data
+  #   directory CORRUPTED, not just behind on durability, because Postgres
+  #   assumes fsync'd writes actually landed when deciding what's safe to
+  #   trust on crash recovery. That's an acceptable trade here because the
+  #   data is fully disposable and rebuilt every run; it is never acceptable
+  #   for `postgres` above or any other service with data worth keeping.
+  #
+  # tmpfs-backed (not the `postgres_data` named volume): the data is
+  # throwaway anyway, so there's no reason to pay for disk I/O — or leave
+  # stale worker databases on disk between runs — when RAM will do. `size`
+  # covers the migrated template plus INTEGRATION_TEST_WORKER_COUNT (4)
+  # cloned worker databases with headroom.
+  postgres-test:
+    image: postgres:15-alpine
+    container_name: tea_postgres_test
+    command: postgres -c fsync=off -c shared_buffers=1GB -c max_wal_size=4GB
+    shm_size: 1gb
+    tmpfs:
+      - /var/lib/postgresql/data:size=2g
+    environment:
+      POSTGRES_DB: tea_test_admin
+      POSTGRES_USER: tea_user
+      POSTGRES_PASSWORD: tea_password
+    ports:
+      - '5433:5432'
+    networks:
+      - tea_dev_network
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U tea_user -d tea_test_admin']
       interval: 10s
       timeout: 5s
       retries: 5

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -1,10 +1,29 @@
 #!/usr/bin/env bash
-# Pre-commit hook: run integration tests if PostgreSQL is available.
-# Skips gracefully when Docker PostgreSQL is not running.
+# Pre-commit hook: run integration tests if the dedicated test Postgres is
+# available. Skips gracefully when it's not running — this is a local
+# convenience hook, not a CI gate.
+#
+# Host/port here MUST agree with src/__tests__/scripts/test-db-config.ts's
+# INTEGRATION_TEST_ADMIN_DATABASE_URL: same env var, same default (the
+# throwaway `postgres-test` container from docker-compose.local.yml, port
+# 5433 — NOT dev's `postgres` container on 5432). Before the fsync=off
+# change (see the perf/test-db-memory issue) this hook free-rode on dev
+# postgres already being up on 5432; the integration suite no longer talks
+# to that container, so probing 5432 here would silently skip when only
+# postgres-test is up, or wrongly run (and fail) when only dev is up.
+set -euo pipefail
 
-if ! pg_isready -h localhost -p 5432 -q 2>/dev/null; then
-  echo "⚠ Skipping integration tests — PostgreSQL not running on port 5432"
-  echo "  Start it with: docker-compose -f docker-compose.local.yml up -d tea_postgres"
+DEFAULT_URL="postgresql://tea_user:tea_password@localhost:5433/tea_test_admin"
+DB_URL="${INTEGRATION_TEST_ADMIN_DATABASE_URL:-$DEFAULT_URL}"
+
+read -r PG_HOST PG_PORT <<< "$(node -e '
+const u = new URL(process.argv[1]);
+console.log(u.hostname, u.port || "5432");
+' "$DB_URL")"
+
+if ! pg_isready -h "$PG_HOST" -p "$PG_PORT" -q 2>/dev/null; then
+  echo "⚠ Skipping integration tests — PostgreSQL not running on $PG_HOST:$PG_PORT"
+  echo "  Start it with: docker compose -f docker-compose.local.yml up -d postgres-test"
   exit 0
 fi
 

--- a/src/__tests__/scripts/test-db-config.ts
+++ b/src/__tests__/scripts/test-db-config.ts
@@ -14,9 +14,18 @@
  */
 export const INTEGRATION_TEST_WORKER_COUNT = 4;
 
-/** Admin connection — guaranteed to exist, used only to issue DDL (CREATE/DROP DATABASE). */
+/**
+ * Admin connection — guaranteed to exist, used only to issue database
+ * create/drop DDL. Defaults to the dedicated, throwaway `postgres-test`
+ * container in docker-compose.local.yml (port 5433, fsync=off — see that
+ * file's comment for why the integration suite gets its own Postgres rather
+ * than sharing the crash-safe dev one on 5432). CI overrides this via the
+ * `INTEGRATION_TEST_ADMIN_DATABASE_URL` env var (build.yaml) to keep
+ * pointing at its single, already test-only service container instead.
+ */
 export const INTEGRATION_TEST_ADMIN_DATABASE_URL =
-	"postgresql://tea_user:tea_password@localhost:5432/tea_dev";
+	process.env.INTEGRATION_TEST_ADMIN_DATABASE_URL ??
+	"postgresql://tea_user:tea_password@localhost:5433/tea_test_admin";
 
 /** Migrated template that every worker database is cloned from. */
 export const INTEGRATION_TEST_TEMPLATE_DATABASE = "tea_test_template";

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -62,9 +62,15 @@ export default defineConfig({
 					env: {
 						// Fallback/admin connection only — each worker's setup file
 						// (setup.integration.tsx) overrides DATABASE_URL to point at its
-						// own throwaway `tea_test_w*` database before any test runs.
+						// own throwaway `tea_test_w*` database before any test runs. Host/
+						// port here just need to resolve to SOME Postgres server; the
+						// pathname is discarded per-worker. Defaults to the dedicated
+						// `postgres-test` container (docker-compose.local.yml, port 5433,
+						// fsync=off) — CI overrides via DATABASE_URL_INTEGRATION_BASE
+						// (build.yaml) to keep using its own single service container.
 						DATABASE_URL:
-							"postgresql://tea_user:tea_password@localhost:5432/tea_test",
+							process.env.DATABASE_URL_INTEGRATION_BASE ??
+							"postgresql://tea_user:tea_password@localhost:5433/tea_test",
 						SKIP_ELEMENT_VALIDATION: "false",
 					},
 				},


### PR DESCRIPTION
The integration suite's ~10-minute wall clock was almost entirely Postgres durability overhead: the per-test `TRUNCATE ... CASCADE` (30 tables, every one of 989 tests) pays a synchronous per-relation fsync (`DataFileImmediateSync`), ~1.5–2.5s per test. Root cause established by live wait-event polling; lock contention and connection overhead ruled out explicitly.

**Measured result: 600.22s → 13.5–22s** (multiple independent runs, 989/989 green every time; median per-test 2469ms → 29ms).

Changes:
- **`docker-compose.local.yml`** — new `postgres-test` service (port 5433): `fsync=off`, `shared_buffers=1GB`, `max_wal_size=4GB`, tmpfs-backed data dir. Loud comment on why `fsync=off` is safe *only* for throwaway data. Dev's `postgres` service is untouched and stays fully crash-safe.
- **`test-db-config.ts` / `vitest.workspace.ts`** — env-overridable connection URLs, defaulting to the new container. This also closes a latent wart: worker create/drop DDL previously ran against the dev container.
- **`build.yaml`** — CI's (already test-only) service container gets the same tuning via an `ALTER SYSTEM` + restart step with hard assertions (the job fails loudly if a setting didn't take); job-level env pins CI to its own container on 5432.
- **`scripts/run-integration-tests.sh` / `.pre-commit-config.yaml`** — the pre-commit gate now derives host/port from the same env var as the test config (default 5433) instead of hardcoding the old port.
- **`CLAUDE.md`** — documents the two-container model and the new `docker compose -f docker-compose.local.yml up -d postgres-test` prerequisite.

Verification: independent QA reproduction of the full suite (13.54s / 13.73s, 989/989); settings confirmed live via `SHOW` on both containers (test: fsync off; dev: fsync on); dev compose service byte-identical to staging; tmpfs peak usage ~213MB of 2GB; assertion strings verified against a real container including the connection-failure path; dry-run merge against current staging clean with the recent deploy-workflow changes coexisting; fallow audit: pass, zero introduced findings; typecheck + lint clean.

Note for local dev: start the test container once with `docker compose -f docker-compose.local.yml up -d postgres-test` before `pnpm test:integration`.