### PR TITLE
test(gdrive): integration coverage for the Google Drive service, backup/import routes, and connected accounts

### DIFF
--- a/src/__tests__/integration/api-cases-backup-gdrive.test.ts
+++ b/src/__tests__/integration/api-cases-backup-gdrive.test.ts
@@ -1,0 +1,299 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	addTeamMember,
+	createTestCaseWithGoal,
+	createTestPermission,
+	createTestTeam,
+	createTestTeamPermission,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+/**
+ * Mock boundary: `googleapis` only, exactly as
+ * `google-drive-service.test.ts` sets it up — the route delegates every
+ * Drive interaction to `lib/services/google-drive-service.ts`, so this file
+ * exercises that same seam rather than mocking the service module directly.
+ */
+const {
+	mockSetCredentials,
+	mockRefreshAccessToken,
+	mockFilesList,
+	mockFilesCreate,
+	mockDrive,
+} = vi.hoisted(() => ({
+	mockSetCredentials: vi.fn(),
+	mockRefreshAccessToken: vi.fn(),
+	mockFilesList: vi.fn(),
+	mockFilesCreate: vi.fn(),
+	mockDrive: vi.fn(),
+}));
+
+vi.mock("googleapis", () => {
+	class OAuth2 {
+		setCredentials = mockSetCredentials;
+		refreshAccessToken = mockRefreshAccessToken;
+	}
+	return {
+		google: {
+			auth: { OAuth2 },
+			drive: mockDrive,
+		},
+	};
+});
+
+beforeEach(async () => {
+	await mockNoAuth();
+	vi.clearAllMocks();
+	mockDrive.mockReturnValue({
+		files: { list: mockFilesList, create: mockFilesCreate, get: vi.fn() },
+	});
+});
+
+/** Sets the Google OAuth columns on a test user's row so hasGoogleToken()/uploadBackupToDrive() succeed. */
+function setGoogleTokens(userId: string) {
+	return prisma.user.update({
+		where: { id: userId },
+		data: {
+			googleAccessToken: "test-access-token",
+			googleRefreshToken: "test-refresh-token",
+			googleTokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+			googleId: "google-test-id",
+			googleEmail: "googleuser@example.com",
+		},
+	});
+}
+
+/** Configures a successful "existing folder, file created" upload round trip. */
+function mockSuccessfulUpload() {
+	mockFilesList.mockResolvedValueOnce({
+		data: { files: [{ id: "folder-id", name: "TEA Platform Backups" }] },
+	});
+	mockFilesCreate.mockResolvedValueOnce({
+		data: {
+			id: "uploaded-file-id",
+			webViewLink: "https://drive/uploaded-file-id",
+		},
+	});
+}
+
+function buildRequest(body: unknown) {
+	return new NextRequest("http://localhost:3000/api/cases/backup/gdrive", {
+		method: "POST",
+		body: JSON.stringify(body),
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("POST /api/cases/backup/gdrive", () => {
+	it("returns 401 when the request is not authenticated", async () => {
+		const { POST } = await import("@/app/api/cases/backup/gdrive/route");
+		const response = await POST(buildRequest({ caseId: crypto.randomUUID() }));
+
+		expect(response.status).toBe(401);
+	});
+
+	it("returns 403 with a 'not connected' message when the user has no Google token", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCaseWithGoal(user.id);
+		await mockAuth(user.id, user.username, user.email);
+
+		const { POST } = await import("@/app/api/cases/backup/gdrive/route");
+		const response = await POST(buildRequest({ caseId: testCase.id }));
+
+		expect(response.status).toBe(403);
+		const body = await response.json();
+		expect(body.error).toContain("Google not connected");
+	});
+
+	it("returns 400 when caseId is missing", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		await mockAuth(user.id, user.username, user.email);
+
+		const { POST } = await import("@/app/api/cases/backup/gdrive/route");
+		const response = await POST(buildRequest({}));
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns 400 when caseId is not a UUID", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		await mockAuth(user.id, user.username, user.email);
+
+		const { POST } = await import("@/app/api/cases/backup/gdrive/route");
+		const response = await POST(buildRequest({ caseId: "not-a-uuid" }));
+
+		expect(response.status).toBe(400);
+	});
+
+	describe("permission matrix", () => {
+		it("returns 200 for the case owner", async () => {
+			const owner = await createTestUser();
+			await setGoogleTokens(owner.id);
+			const testCase = await createTestCaseWithGoal(owner.id);
+			await mockAuth(owner.id, owner.username, owner.email);
+			mockSuccessfulUpload();
+
+			const { POST } = await import("@/app/api/cases/backup/gdrive/route");
+			const response = await POST(buildRequest({ caseId: testCase.id }));
+
+			expect(response.status).toBe(200);
+		});
+
+		it("returns 200 for a user with VIEW permission via a direct share", async () => {
+			const owner = await createTestUser();
+			const viewer = await createTestUser();
+			await setGoogleTokens(viewer.id);
+			const testCase = await createTestCaseWithGoal(owner.id);
+			await createTestPermission(testCase.id, viewer.id, owner.id, "VIEW");
+			await mockAuth(viewer.id, viewer.username, viewer.email);
+			mockSuccessfulUpload();
+
+			const { POST } = await import("@/app/api/cases/backup/gdrive/route");
+			const response = await POST(buildRequest({ caseId: testCase.id }));
+
+			expect(response.status).toBe(200);
+		});
+
+		it("returns 200 for a user with EDIT permission via a direct share", async () => {
+			const owner = await createTestUser();
+			const editor = await createTestUser();
+			await setGoogleTokens(editor.id);
+			const testCase = await createTestCaseWithGoal(owner.id);
+			await createTestPermission(testCase.id, editor.id, owner.id, "EDIT");
+			await mockAuth(editor.id, editor.username, editor.email);
+			mockSuccessfulUpload();
+
+			const { POST } = await import("@/app/api/cases/backup/gdrive/route");
+			const response = await POST(buildRequest({ caseId: testCase.id }));
+
+			expect(response.status).toBe(200);
+		});
+
+		it("returns 200 for a user with VIEW permission via a team grant", async () => {
+			const owner = await createTestUser();
+			const teamMember = await createTestUser();
+			await setGoogleTokens(teamMember.id);
+			const testCase = await createTestCaseWithGoal(owner.id);
+			const team = await createTestTeam(owner.id);
+			await addTeamMember(team.id, teamMember.id, "MEMBER");
+			await createTestTeamPermission(testCase.id, team.id, owner.id, "VIEW");
+			await mockAuth(teamMember.id, teamMember.username, teamMember.email);
+			mockSuccessfulUpload();
+
+			const { POST } = await import("@/app/api/cases/backup/gdrive/route");
+			const response = await POST(buildRequest({ caseId: testCase.id }));
+
+			expect(response.status).toBe(200);
+		});
+
+		it("returns 403 for a user with no permission on the case", async () => {
+			const owner = await createTestUser();
+			const stranger = await createTestUser();
+			await setGoogleTokens(stranger.id);
+			const testCase = await createTestCaseWithGoal(owner.id);
+			await mockAuth(stranger.id, stranger.username, stranger.email);
+
+			const { POST } = await import("@/app/api/cases/backup/gdrive/route");
+			const response = await POST(buildRequest({ caseId: testCase.id }));
+
+			expect(response.status).toBe(403);
+		});
+
+		// exportCase returns the same "Permission denied" error for a
+		// non-existent case as it does for no access (case-export.test.ts,
+		// api-cases.test.ts) — the route's anti-enumeration behaviour, not a
+		// 404. This deliberately deviates from the brief's "nonexistent case
+		// → 404": see the QA report's deviations section.
+		it("returns 403 (not 404) for a non-existent caseId, matching the anti-enumeration behaviour of every other case route", async () => {
+			const user = await createTestUser();
+			await setGoogleTokens(user.id);
+			await mockAuth(user.id, user.username, user.email);
+
+			const { POST } = await import("@/app/api/cases/backup/gdrive/route");
+			const response = await POST(
+				buildRequest({ caseId: "00000000-0000-0000-0000-000000000000" })
+			);
+
+			expect(response.status).toBe(403);
+		});
+	});
+
+	it("maps a Drive API_ERROR upload failure to 500", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		const testCase = await createTestCaseWithGoal(user.id);
+		await mockAuth(user.id, user.username, user.email);
+		mockFilesList.mockResolvedValueOnce({
+			data: { files: [{ id: "folder-id", name: "TEA Platform Backups" }] },
+		});
+		mockFilesCreate.mockRejectedValueOnce(new Error("Drive quota exceeded"));
+
+		const { POST } = await import("@/app/api/cases/backup/gdrive/route");
+		const response = await POST(buildRequest({ caseId: testCase.id }));
+
+		expect(response.status).toBe(500);
+	});
+
+	it("returns success body {success, fileId, fileName, webViewLink}", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		const testCase = await createTestCaseWithGoal(user.id, "Backup Body Case");
+		await mockAuth(user.id, user.username, user.email);
+		mockSuccessfulUpload();
+
+		const { POST } = await import("@/app/api/cases/backup/gdrive/route");
+		const response = await POST(buildRequest({ caseId: testCase.id }));
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toEqual({
+			success: true,
+			fileId: "uploaded-file-id",
+			fileName: expect.any(String),
+			webViewLink: "https://drive/uploaded-file-id",
+		});
+	});
+});
+
+describe("GET /api/cases/backup/gdrive", () => {
+	it("returns 401 when the request is not authenticated", async () => {
+		const { GET } = await import("@/app/api/cases/backup/gdrive/route");
+		const response = await GET();
+
+		expect(response.status).toBe(401);
+	});
+
+	it("returns {connected: true} when the user has a Google token", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		await mockAuth(user.id, user.username, user.email);
+
+		const { GET } = await import("@/app/api/cases/backup/gdrive/route");
+		const response = await GET();
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toEqual({ connected: true });
+	});
+
+	it("returns {connected: false} when the user has no Google token", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { GET } = await import("@/app/api/cases/backup/gdrive/route");
+		const response = await GET();
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toEqual({ connected: false });
+	});
+});

--- a/src/__tests__/integration/api-cases-import-gdrive.test.ts
+++ b/src/__tests__/integration/api-cases-import-gdrive.test.ts
@@ -1,0 +1,240 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	createNestedCaseJSON,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+/**
+ * Mock boundary: `googleapis` only, matching `google-drive-service.test.ts`
+ * and `api-cases-backup-gdrive.test.ts` — this route delegates every Drive
+ * interaction to `lib/services/google-drive-service.ts`.
+ */
+const {
+	mockSetCredentials,
+	mockRefreshAccessToken,
+	mockFilesList,
+	mockFilesGet,
+	mockDrive,
+} = vi.hoisted(() => ({
+	mockSetCredentials: vi.fn(),
+	mockRefreshAccessToken: vi.fn(),
+	mockFilesList: vi.fn(),
+	mockFilesGet: vi.fn(),
+	mockDrive: vi.fn(),
+}));
+
+vi.mock("googleapis", () => {
+	class OAuth2 {
+		setCredentials = mockSetCredentials;
+		refreshAccessToken = mockRefreshAccessToken;
+	}
+	return {
+		google: {
+			auth: { OAuth2 },
+			drive: mockDrive,
+		},
+	};
+});
+
+beforeEach(async () => {
+	await mockNoAuth();
+	vi.clearAllMocks();
+	mockDrive.mockReturnValue({
+		files: { list: mockFilesList, create: vi.fn(), get: mockFilesGet },
+	});
+});
+
+/** Sets the Google OAuth columns on a test user's row so hasGoogleToken()/downloadFileFromDrive() succeed. */
+function setGoogleTokens(userId: string) {
+	return prisma.user.update({
+		where: { id: userId },
+		data: {
+			googleAccessToken: "test-access-token",
+			googleRefreshToken: "test-refresh-token",
+			googleTokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+			googleId: "google-test-id",
+			googleEmail: "googleuser@example.com",
+		},
+	});
+}
+
+/** Metadata fetch then content fetch, as downloadFileFromDrive issues them in sequence. */
+function mockDownload(mimeType: string, content: string, name = "backup.json") {
+	mockFilesGet
+		.mockImplementationOnce(() => Promise.resolve({ data: { name, mimeType } }))
+		.mockImplementationOnce(() => Promise.resolve({ data: content }));
+}
+
+function buildRequest(body: unknown) {
+	return new NextRequest("http://localhost:3000/api/cases/import/gdrive", {
+		method: "POST",
+		body: JSON.stringify(body),
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("POST /api/cases/import/gdrive", () => {
+	it("returns 401 when the request is not authenticated", async () => {
+		const { POST } = await import("@/app/api/cases/import/gdrive/route");
+		const response = await POST(buildRequest({ fileId: "some-file-id" }));
+
+		expect(response.status).toBe(401);
+	});
+
+	it("returns 403 with a 'not connected' message when the user has no Google token", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { POST } = await import("@/app/api/cases/import/gdrive/route");
+		const response = await POST(buildRequest({ fileId: "some-file-id" }));
+
+		expect(response.status).toBe(403);
+		const body = await response.json();
+		expect(body.error).toContain("Google not connected");
+	});
+
+	it("returns 400 when fileId is missing", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		await mockAuth(user.id, user.username, user.email);
+
+		const { POST } = await import("@/app/api/cases/import/gdrive/route");
+		const response = await POST(buildRequest({}));
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns 400 when fileId is an empty string", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		await mockAuth(user.id, user.username, user.email);
+
+		const { POST } = await import("@/app/api/cases/import/gdrive/route");
+		const response = await POST(buildRequest({ fileId: "" }));
+
+		expect(response.status).toBe(400);
+	});
+
+	it("maps a Drive API_ERROR download failure to 500", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		await mockAuth(user.id, user.username, user.email);
+		mockFilesGet.mockRejectedValueOnce(new Error("file not found on Drive"));
+
+		const { POST } = await import("@/app/api/cases/import/gdrive/route");
+		const response = await POST(buildRequest({ fileId: "missing-file-id" }));
+
+		expect(response.status).toBe(500);
+	});
+
+	it("returns 400 naming the file when its content is not valid JSON", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		await mockAuth(user.id, user.username, user.email);
+		mockDownload(
+			"application/json",
+			"this is not { valid json",
+			"corrupt.json"
+		);
+
+		const { POST } = await import("@/app/api/cases/import/gdrive/route");
+		const response = await POST(buildRequest({ fileId: "corrupt-file-id" }));
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toContain("corrupt.json");
+	});
+
+	it("imports a valid backup, returning 200 with a gdrive source and creating a real case row", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		await mockAuth(user.id, user.username, user.email);
+		const backupJson = createNestedCaseJSON({
+			case: { name: "Imported From Drive", description: "A backup restore" },
+		});
+		mockDownload(
+			"application/json",
+			JSON.stringify(backupJson),
+			"tea-backup.json"
+		);
+
+		const { POST } = await import("@/app/api/cases/import/gdrive/route");
+		const response = await POST(buildRequest({ fileId: "good-file-id" }));
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.name).toBe("Imported From Drive");
+		expect(body.source).toEqual({
+			type: "gdrive",
+			fileId: "good-file-id",
+			fileName: "tea-backup.json",
+		});
+
+		const createdCase = await prisma.assuranceCase.findUnique({
+			where: { id: body.id },
+		});
+		expect(createdCase).not.toBeNull();
+		expect(createdCase?.createdById).toBe(user.id);
+	});
+});
+
+describe("GET /api/cases/import/gdrive", () => {
+	it("returns 401 when the request is not authenticated", async () => {
+		const { GET } = await import("@/app/api/cases/import/gdrive/route");
+		const response = await GET();
+
+		expect(response.status).toBe(401);
+	});
+
+	it("returns {connected: false, files: []} when the user has no Google token", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { GET } = await import("@/app/api/cases/import/gdrive/route");
+		const response = await GET();
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toEqual({ connected: false, files: [] });
+	});
+
+	it("returns {connected: true, files: [...]} when the user has a token", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		await mockAuth(user.id, user.username, user.email);
+		mockFilesList
+			.mockResolvedValueOnce({
+				data: { files: [{ id: "folder-id", name: "TEA Platform Backups" }] },
+			})
+			.mockResolvedValueOnce({
+				data: {
+					files: [
+						{
+							id: "file-1",
+							name: "backup-1.json",
+							mimeType: "application/json",
+							createdTime: "2026-01-01T00:00:00.000Z",
+							modifiedTime: "2026-01-02T00:00:00.000Z",
+							size: "100",
+						},
+					],
+				},
+			});
+
+		const { GET } = await import("@/app/api/cases/import/gdrive/route");
+		const response = await GET();
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.connected).toBe(true);
+		expect(body.files).toHaveLength(1);
+		expect(body.files[0].id).toBe("file-1");
+	});
+});

--- a/src/__tests__/integration/connected-accounts-service.test.ts
+++ b/src/__tests__/integration/connected-accounts-service.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import prisma from "@/lib/prisma";
+import {
+	getConnectedAccounts,
+	unlinkProvider,
+} from "@/lib/services/connected-accounts-service";
+import { createTestUser } from "../utils/prisma-factories";
+
+/**
+ * Pure-DB service — no SDK, so no `googleapis` mock is needed here (per the
+ * issue's Design section). Real Postgres throughout, per repo convention.
+ */
+
+/** Connects Google on a test user's row via direct Prisma update. */
+function connectGoogle(
+	userId: string,
+	overrides: Partial<{ googleRefreshToken: string | null }> = {}
+) {
+	return prisma.user.update({
+		where: { id: userId },
+		data: {
+			googleId: "google-account-id",
+			googleEmail: "connected@example.com",
+			googleAccessToken: "access-token",
+			googleRefreshToken:
+				overrides.googleRefreshToken === undefined
+					? "refresh-token"
+					: overrides.googleRefreshToken,
+			googleTokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+		},
+	});
+}
+
+describe("getConnectedAccounts", () => {
+	it("reports hasDriveAccess true when Google is connected with a refresh token", async () => {
+		const user = await createTestUser();
+		await connectGoogle(user.id);
+
+		const result = await getConnectedAccounts(user.id);
+		expect("data" in result).toBe(true);
+		if (!("data" in result)) {
+			throw new Error("expected success");
+		}
+		expect(result.data.google.connected).toBe(true);
+		expect(result.data.google.hasDriveAccess).toBe(true);
+	});
+
+	it("reports hasDriveAccess false when Google is connected without a refresh token", async () => {
+		const user = await createTestUser();
+		await connectGoogle(user.id, { googleRefreshToken: null });
+
+		const result = await getConnectedAccounts(user.id);
+		expect("data" in result).toBe(true);
+		if (!("data" in result)) {
+			throw new Error("expected success");
+		}
+		expect(result.data.google.connected).toBe(true);
+		expect(result.data.google.hasDriveAccess).toBe(false);
+	});
+});
+
+describe("unlinkProvider('google')", () => {
+	it("clears all five Google columns and, when Google was the sign-in provider, switches authProvider to LOCAL (password present)", async () => {
+		const user = await createTestUser({ authProvider: "GOOGLE" });
+		await connectGoogle(user.id);
+
+		const result = await unlinkProvider(user.id, "google");
+		expect("data" in result).toBe(true);
+
+		const updated = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(updated?.googleId).toBeNull();
+		expect(updated?.googleEmail).toBeNull();
+		expect(updated?.googleAccessToken).toBeNull();
+		expect(updated?.googleRefreshToken).toBeNull();
+		expect(updated?.googleTokenExpiresAt).toBeNull();
+		expect(updated?.authProvider).toBe("LOCAL");
+	});
+
+	it("refuses to unlink Google when it is the account's only sign-in method", async () => {
+		const user = await createTestUser({ authProvider: "GOOGLE" });
+		await prisma.user.update({
+			where: { id: user.id },
+			data: { passwordHash: null },
+		});
+		await connectGoogle(user.id);
+
+		const result = await unlinkProvider(user.id, "google");
+		expect("error" in result).toBe(true);
+		if (!("error" in result)) {
+			throw new Error("expected failure");
+		}
+		expect(result.error).toBe(
+			"Cannot disconnect Google. It is your only way to sign in. Connect another provider first."
+		);
+
+		// The guard fired before any write — columns are untouched.
+		const unchanged = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(unchanged?.googleId).toBe("google-account-id");
+	});
+
+	it("returns an error when Google is not connected", async () => {
+		const user = await createTestUser();
+
+		const result = await unlinkProvider(user.id, "google");
+		expect("error" in result).toBe(true);
+		if (!("error" in result)) {
+			throw new Error("expected failure");
+		}
+		expect(result.error).toBe("Google is not connected to your account.");
+	});
+});

--- a/src/__tests__/integration/google-drive-service.test.ts
+++ b/src/__tests__/integration/google-drive-service.test.ts
@@ -43,6 +43,8 @@ const FOLDER_MIME = "application/vnd.google-apps.folder";
 const JSON_MIME = "application/json";
 const BACKUP_FILE_NAME_PATTERN =
 	/^My_Case___v2_-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.json$/;
+const ALL_UNDERSCORES_FILE_NAME_PATTERN =
+	/^_______-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.json$/;
 
 beforeEach(() => {
 	vi.clearAllMocks();
@@ -173,10 +175,12 @@ describe("hasGoogleToken / getUserGoogleTokens (via hasGoogleToken)", () => {
 		expect(mockRefreshAccessToken).not.toHaveBeenCalled();
 	});
 
-	it("returns false when refreshAccessToken throws", async () => {
+	it("returns false when refreshAccessToken throws, and leaves the stored token/expiry unchanged", async () => {
 		const user = await createTestUser();
+		const originalExpiry = new Date(Date.now() - 60 * 1000);
 		await setGoogleTokens(user.id, {
-			googleTokenExpiresAt: new Date(Date.now() - 60 * 1000),
+			googleAccessToken: "stale-token",
+			googleTokenExpiresAt: originalExpiry,
 		});
 		mockRefreshAccessToken.mockRejectedValueOnce(new Error("refresh failed"));
 
@@ -184,6 +188,95 @@ describe("hasGoogleToken / getUserGoogleTokens (via hasGoogleToken)", () => {
 			"@/lib/services/google-drive-service"
 		);
 		expect(await hasGoogleToken(user.id)).toBe(false);
+
+		const unchanged = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(unchanged?.googleAccessToken).toBe("stale-token");
+		expect(unchanged?.googleTokenExpiresAt?.getTime()).toBe(
+			originalExpiry.getTime()
+		);
+	});
+
+	it("returns false and leaves the user row unchanged when the refresh response carries no access_token", async () => {
+		const user = await createTestUser();
+		const originalExpiry = new Date(Date.now() - 60 * 1000);
+		await setGoogleTokens(user.id, {
+			googleAccessToken: "stale-token",
+			googleTokenExpiresAt: originalExpiry,
+		});
+		// Refresh "succeeds" (resolves, doesn't throw) but the credentials
+		// object carries no access_token — the service's own defensive guard
+		// (google-drive-service.ts:117-119) must treat this the same as a
+		// thrown refresh failure.
+		mockRefreshAccessToken.mockResolvedValueOnce({ credentials: {} });
+
+		const { hasGoogleToken } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		expect(await hasGoogleToken(user.id)).toBe(false);
+
+		const unchanged = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(unchanged?.googleAccessToken).toBe("stale-token");
+		expect(unchanged?.googleTokenExpiresAt?.getTime()).toBe(
+			originalExpiry.getTime()
+		);
+	});
+
+	// The expiry check is `expiresAt.getTime() - bufferMs < now.getTime()` —
+	// strictly less-than, so an expiry exactly 5 minutes out is NOT expired.
+	// Fake timers freeze `now` for the whole call so the boundary can't be
+	// crossed by real elapsed time between building the fixture and the
+	// service reading `new Date()` internally (both dates are derived from
+	// one `Date.now()` snapshot, per the review request).
+	it("does not refresh when the expiry sits exactly on the 5-minute buffer boundary", async () => {
+		const user = await createTestUser();
+		const snapshot = new Date("2026-01-01T00:00:00.000Z");
+		vi.useFakeTimers();
+		vi.setSystemTime(snapshot);
+		try {
+			const exactlyFiveMinutesOut = new Date(
+				snapshot.getTime() + 5 * 60 * 1000
+			);
+			await setGoogleTokens(user.id, {
+				googleTokenExpiresAt: exactlyFiveMinutesOut,
+			});
+
+			const { hasGoogleToken } = await import(
+				"@/lib/services/google-drive-service"
+			);
+			expect(await hasGoogleToken(user.id)).toBe(true);
+			expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("refreshes when the expiry sits 1ms inside the 5-minute buffer boundary", async () => {
+		const user = await createTestUser();
+		const snapshot = new Date("2026-01-01T00:00:00.000Z");
+		vi.useFakeTimers();
+		vi.setSystemTime(snapshot);
+		try {
+			const oneMsInsideBuffer = new Date(
+				snapshot.getTime() + 5 * 60 * 1000 - 1
+			);
+			await setGoogleTokens(user.id, {
+				googleTokenExpiresAt: oneMsInsideBuffer,
+			});
+			mockRefreshAccessToken.mockResolvedValueOnce({
+				credentials: {
+					access_token: "boundary-refreshed-token",
+					expiry_date: snapshot.getTime() + 60 * 60 * 1000,
+				},
+			});
+
+			const { hasGoogleToken } = await import(
+				"@/lib/services/google-drive-service"
+			);
+			expect(await hasGoogleToken(user.id)).toBe(true);
+			expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });
 
@@ -297,6 +390,53 @@ describe("uploadBackupToDrive", () => {
 				media: expect.objectContaining({ mimeType: JSON_MIME }),
 			})
 		);
+	});
+
+	it("passes the exact JSON content through the upload's media body stream", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		mockExistingFolder("folder-id");
+		const jsonContent = '{"hello":"world","nested":{"a":1}}';
+		let capturedBody = "";
+		mockFilesCreate.mockImplementationOnce(
+			async (args: { media: { body: AsyncIterable<string> } }) => {
+				for await (const chunk of args.media.body) {
+					capturedBody += chunk;
+				}
+				return { data: { id: "file-id", webViewLink: undefined } };
+			}
+		);
+
+		const { uploadBackupToDrive } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		const result = await uploadBackupToDrive(user.id, "Case", jsonContent);
+
+		expect("data" in result).toBe(true);
+		expect(capturedBody).toBe(jsonContent);
+	});
+
+	it("sanitises a case name made entirely of stripped characters to all underscores", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		mockExistingFolder("folder-id");
+		mockFilesCreate.mockResolvedValueOnce({
+			data: { id: "file-id", webViewLink: undefined },
+		});
+
+		const { uploadBackupToDrive } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		const result = await uploadBackupToDrive(user.id, "!!! ???", "{}");
+
+		expect("data" in result).toBe(true);
+		if (!("data" in result)) {
+			throw new Error("expected success");
+		}
+		// "!!! ???" is 7 characters, every one of them stripped by
+		// `[^a-zA-Z0-9-_]` — the sanitised name is 7 underscores, not an
+		// empty string.
+		expect(result.data.fileName).toMatch(ALL_UNDERSCORES_FILE_NAME_PATTERN);
 	});
 
 	it("returns an API_ERROR result carrying the SDK's message when the upload throws", async () => {

--- a/src/__tests__/integration/google-drive-service.test.ts
+++ b/src/__tests__/integration/google-drive-service.test.ts
@@ -1,0 +1,496 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import { createTestUser } from "../utils/prisma-factories";
+
+/**
+ * Mock boundary: `googleapis` only (decided in the issue's Design section).
+ * `google.auth.OAuth2` is a class exposing the two methods the service
+ * calls (`setCredentials`, `refreshAccessToken`); `google.drive()` returns
+ * an object with the three `files` methods the service calls, each a
+ * `vi.fn()` this file controls per test. Postgres stays real throughout —
+ * never mock Prisma.
+ */
+const {
+	mockSetCredentials,
+	mockRefreshAccessToken,
+	mockFilesList,
+	mockFilesCreate,
+	mockFilesGet,
+	mockDrive,
+} = vi.hoisted(() => ({
+	mockSetCredentials: vi.fn(),
+	mockRefreshAccessToken: vi.fn(),
+	mockFilesList: vi.fn(),
+	mockFilesCreate: vi.fn(),
+	mockFilesGet: vi.fn(),
+	mockDrive: vi.fn(),
+}));
+
+vi.mock("googleapis", () => {
+	class OAuth2 {
+		setCredentials = mockSetCredentials;
+		refreshAccessToken = mockRefreshAccessToken;
+	}
+	return {
+		google: {
+			auth: { OAuth2 },
+			drive: mockDrive,
+		},
+	};
+});
+
+const FOLDER_MIME = "application/vnd.google-apps.folder";
+const JSON_MIME = "application/json";
+const BACKUP_FILE_NAME_PATTERN =
+	/^My_Case___v2_-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.json$/;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockDrive.mockReturnValue({
+		files: {
+			list: mockFilesList,
+			create: mockFilesCreate,
+			get: mockFilesGet,
+		},
+	});
+});
+
+/** Sets the Google OAuth columns on a test user's row directly via Prisma. */
+function setGoogleTokens(
+	userId: string,
+	overrides: Partial<{
+		googleAccessToken: string | null;
+		googleRefreshToken: string | null;
+		googleTokenExpiresAt: Date | null;
+	}> = {}
+) {
+	return prisma.user.update({
+		where: { id: userId },
+		data: {
+			googleAccessToken:
+				overrides.googleAccessToken === undefined
+					? "test-access-token"
+					: overrides.googleAccessToken,
+			googleRefreshToken:
+				overrides.googleRefreshToken === undefined
+					? "test-refresh-token"
+					: overrides.googleRefreshToken,
+			googleTokenExpiresAt:
+				overrides.googleTokenExpiresAt === undefined
+					? new Date(Date.now() + 60 * 60 * 1000)
+					: overrides.googleTokenExpiresAt,
+			googleId: "google-test-id",
+			googleEmail: "googleuser@example.com",
+		},
+	});
+}
+
+/** Folder search resolves to an existing "TEA Platform Backups" folder. */
+function mockExistingFolder(folderId = "existing-folder-id") {
+	mockFilesList.mockResolvedValueOnce({
+		data: { files: [{ id: folderId, name: "TEA Platform Backups" }] },
+	});
+}
+
+/** Folder search resolves to no match, and files.create makes one. */
+function mockFolderCreation(newFolderId = "new-folder-id") {
+	mockFilesList.mockResolvedValueOnce({ data: { files: [] } });
+	mockFilesCreate.mockResolvedValueOnce({ data: { id: newFolderId } });
+}
+
+describe("hasGoogleToken / getUserGoogleTokens (via hasGoogleToken)", () => {
+	it("returns true for a valid, unexpired token", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+
+		const { hasGoogleToken } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		expect(await hasGoogleToken(user.id)).toBe(true);
+	});
+
+	it("returns false when the user has no access token", async () => {
+		const user = await createTestUser();
+		// No setGoogleTokens call — googleAccessToken stays null.
+
+		const { hasGoogleToken } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		expect(await hasGoogleToken(user.id)).toBe(false);
+	});
+
+	it("refreshes an expired token, calling refreshAccessToken and writing the new token + expiry back to the user row", async () => {
+		const user = await createTestUser();
+		const pastExpiry = new Date(Date.now() - 60 * 1000);
+		await setGoogleTokens(user.id, { googleTokenExpiresAt: pastExpiry });
+
+		const newExpiry = Date.now() + 60 * 60 * 1000;
+		mockRefreshAccessToken.mockResolvedValueOnce({
+			credentials: { access_token: "refreshed-token", expiry_date: newExpiry },
+		});
+
+		const { hasGoogleToken } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		expect(await hasGoogleToken(user.id)).toBe(true);
+		expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+
+		const updated = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(updated?.googleAccessToken).toBe("refreshed-token");
+		expect(updated?.googleTokenExpiresAt?.getTime()).toBe(newExpiry);
+	});
+
+	it("treats a token inside the 5-minute expiry buffer as expired and refreshes it", async () => {
+		const user = await createTestUser();
+		const withinBuffer = new Date(Date.now() + 60 * 1000); // 1 min out
+		await setGoogleTokens(user.id, { googleTokenExpiresAt: withinBuffer });
+
+		mockRefreshAccessToken.mockResolvedValueOnce({
+			credentials: {
+				access_token: "buffer-refreshed-token",
+				expiry_date: Date.now() + 60 * 60 * 1000,
+			},
+		});
+
+		const { hasGoogleToken } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		expect(await hasGoogleToken(user.id)).toBe(true);
+		expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns false for an expired token with no refresh token available", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id, {
+			googleTokenExpiresAt: new Date(Date.now() - 60 * 1000),
+			googleRefreshToken: null,
+		});
+
+		const { hasGoogleToken } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		expect(await hasGoogleToken(user.id)).toBe(false);
+		expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+	});
+
+	it("returns false when refreshAccessToken throws", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id, {
+			googleTokenExpiresAt: new Date(Date.now() - 60 * 1000),
+		});
+		mockRefreshAccessToken.mockRejectedValueOnce(new Error("refresh failed"));
+
+		const { hasGoogleToken } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		expect(await hasGoogleToken(user.id)).toBe(false);
+	});
+});
+
+describe("createDriveClient (via uploadBackupToDrive)", () => {
+	it("builds the Drive client with the user's stored access token", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id, { googleAccessToken: "specific-token" });
+		mockExistingFolder();
+		mockFilesCreate.mockResolvedValueOnce({
+			data: { id: "file-id", webViewLink: "https://drive/file-id" },
+		});
+
+		const { uploadBackupToDrive } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		const result = await uploadBackupToDrive(user.id, "Case", "{}");
+
+		expect("data" in result).toBe(true);
+		expect(mockSetCredentials).toHaveBeenCalledWith(
+			expect.objectContaining({
+				access_token: "specific-token",
+				refresh_token: "test-refresh-token",
+			})
+		);
+	});
+});
+
+describe("getOrCreateBackupFolder (via uploadBackupToDrive)", () => {
+	it("reuses an existing 'TEA Platform Backups' folder without creating one", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		mockExistingFolder("reused-folder-id");
+		mockFilesCreate.mockResolvedValueOnce({
+			data: { id: "file-id", webViewLink: undefined },
+		});
+
+		const { uploadBackupToDrive } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		await uploadBackupToDrive(user.id, "Case", "{}");
+
+		// files.create is called exactly once — for the file, not the folder.
+		expect(mockFilesCreate).toHaveBeenCalledTimes(1);
+		expect(mockFilesCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				requestBody: expect.objectContaining({ parents: ["reused-folder-id"] }),
+			})
+		);
+	});
+
+	it("creates the folder with the folder MIME type when none exists", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		mockFolderCreation("brand-new-folder-id");
+		mockFilesCreate.mockResolvedValueOnce({
+			data: { id: "file-id", webViewLink: undefined },
+		});
+
+		const { uploadBackupToDrive } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		await uploadBackupToDrive(user.id, "Case", "{}");
+
+		expect(mockFilesCreate).toHaveBeenCalledTimes(2);
+		expect(mockFilesCreate).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				requestBody: expect.objectContaining({ mimeType: FOLDER_MIME }),
+			})
+		);
+		expect(mockFilesCreate).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				requestBody: expect.objectContaining({
+					parents: ["brand-new-folder-id"],
+				}),
+			})
+		);
+	});
+});
+
+describe("uploadBackupToDrive", () => {
+	it("names the file '<sanitised case name>-<timestamp>.json', uploads inside the folder, and returns fileId/fileName/webViewLink", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		mockExistingFolder("folder-id");
+		mockFilesCreate.mockResolvedValueOnce({
+			data: { id: "new-file-id", webViewLink: "https://drive/new-file-id" },
+		});
+
+		const { uploadBackupToDrive } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		const result = await uploadBackupToDrive(
+			user.id,
+			"My Case! (v2)",
+			'{"hello":"world"}'
+		);
+
+		expect("data" in result).toBe(true);
+		if (!("data" in result)) {
+			throw new Error("expected success");
+		}
+		expect(result.data.fileId).toBe("new-file-id");
+		expect(result.data.webViewLink).toBe("https://drive/new-file-id");
+		expect(result.data.fileName).toMatch(BACKUP_FILE_NAME_PATTERN);
+
+		expect(mockFilesCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				requestBody: expect.objectContaining({ parents: ["folder-id"] }),
+				media: expect.objectContaining({ mimeType: JSON_MIME }),
+			})
+		);
+	});
+
+	it("returns an API_ERROR result carrying the SDK's message when the upload throws", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		mockExistingFolder();
+		mockFilesCreate.mockRejectedValueOnce(new Error("quota exceeded"));
+
+		const { uploadBackupToDrive } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		const result = await uploadBackupToDrive(user.id, "Case", "{}");
+
+		expect("error" in result).toBe(true);
+		if (!("error" in result)) {
+			throw new Error("expected failure");
+		}
+		expect(result.driveError.code).toBe("API_ERROR");
+		expect(result.error).toBe("quota exceeded");
+	});
+
+	it("returns a NO_TOKEN error when the user has no Google token", async () => {
+		const user = await createTestUser();
+
+		const { uploadBackupToDrive } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		const result = await uploadBackupToDrive(user.id, "Case", "{}");
+
+		expect("error" in result).toBe(true);
+		if (!("error" in result)) {
+			throw new Error("expected failure");
+		}
+		expect(result.driveError.code).toBe("NO_TOKEN");
+	});
+});
+
+describe("downloadFileFromDrive", () => {
+	function mockMetadataThenContent(mimeType: string, content = "file body") {
+		mockFilesGet
+			.mockImplementationOnce(async () => ({
+				data: { name: "backup.json", mimeType },
+			}))
+			.mockImplementationOnce(async () => ({ data: content }));
+	}
+
+	it("returns content and name for a JSON file", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		mockMetadataThenContent(JSON_MIME, '{"case":{}}');
+
+		const { downloadFileFromDrive } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		const result = await downloadFileFromDrive(user.id, "file-id");
+
+		expect("data" in result).toBe(true);
+		if (!("data" in result)) {
+			throw new Error("expected success");
+		}
+		expect(result.data.content).toBe('{"case":{}}');
+		expect(result.data.name).toBe("backup.json");
+		expect(mockFilesGet).toHaveBeenCalledTimes(2);
+	});
+
+	it("rejects a non-JSON file before fetching its content", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		mockFilesGet.mockImplementationOnce(async () => ({
+			data: { name: "notes.txt", mimeType: "text/plain" },
+		}));
+
+		const { downloadFileFromDrive } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		const result = await downloadFileFromDrive(user.id, "file-id");
+
+		expect("error" in result).toBe(true);
+		if (!("error" in result)) {
+			throw new Error("expected failure");
+		}
+		expect(result.driveError.code).toBe("API_ERROR");
+		// Only the metadata fetch happened — content fetch was never attempted.
+		expect(mockFilesGet).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns an API_ERROR result carrying the SDK's message when the SDK throws", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		mockFilesGet.mockRejectedValueOnce(new Error("file not found"));
+
+		const { downloadFileFromDrive } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		const result = await downloadFileFromDrive(user.id, "file-id");
+
+		expect("error" in result).toBe(true);
+		if (!("error" in result)) {
+			throw new Error("expected failure");
+		}
+		expect(result.driveError.code).toBe("API_ERROR");
+		expect(result.error).toBe("file not found");
+	});
+});
+
+describe("listBackupFiles", () => {
+	it("maps Drive file fields onto DriveFileMetadata", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		mockExistingFolder("folder-id");
+		mockFilesList.mockResolvedValueOnce({
+			data: {
+				files: [
+					{
+						id: "file-1",
+						name: "backup-1.json",
+						mimeType: JSON_MIME,
+						createdTime: "2026-01-01T00:00:00.000Z",
+						modifiedTime: "2026-01-02T00:00:00.000Z",
+						size: "1234",
+					},
+				],
+			},
+		});
+
+		const { listBackupFiles } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		const files = await listBackupFiles(user.id);
+
+		expect(files).toEqual([
+			{
+				id: "file-1",
+				name: "backup-1.json",
+				mimeType: JSON_MIME,
+				createdTime: "2026-01-01T00:00:00.000Z",
+				modifiedTime: "2026-01-02T00:00:00.000Z",
+				size: "1234",
+			},
+		]);
+	});
+
+	it("returns an empty array when the user has no token", async () => {
+		const user = await createTestUser();
+
+		const { listBackupFiles } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		expect(await listBackupFiles(user.id)).toEqual([]);
+	});
+
+	it("returns an empty array when finding/creating the folder fails", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		mockFilesList.mockRejectedValueOnce(new Error("folder search failed"));
+
+		const { listBackupFiles } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		expect(await listBackupFiles(user.id)).toEqual([]);
+	});
+
+	it("returns an empty array when listing files in the folder fails", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		mockExistingFolder("folder-id");
+		mockFilesList.mockRejectedValueOnce(new Error("list failed"));
+
+		const { listBackupFiles } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		expect(await listBackupFiles(user.id)).toEqual([]);
+	});
+});
+
+describe("DRIVE_ERROR_MAP", () => {
+	// TOKEN_EXPIRED, REFRESH_FAILED, FORBIDDEN and NOT_FOUND are declared on
+	// GoogleDriveErrorCode and mapped here, but nothing in this service ever
+	// constructs a GoogleDriveError with those codes (only NO_TOKEN and
+	// API_ERROR are ever produced — confirmed by reading every
+	// `createDriveError` call site). This test pins the map's own data
+	// rather than a route response, since the unreachable codes can't be
+	// exercised through a live request. See the QA report's follow-ups.
+	it("maps every GoogleDriveErrorCode to the documented ErrorCode", async () => {
+		const { DRIVE_ERROR_MAP } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		expect(DRIVE_ERROR_MAP).toEqual({
+			NO_TOKEN: "FORBIDDEN",
+			TOKEN_EXPIRED: "UNAUTHORISED",
+			REFRESH_FAILED: "UNAUTHORISED",
+			NOT_FOUND: "NOT_FOUND",
+			FORBIDDEN: "FORBIDDEN",
+			API_ERROR: "INTERNAL",
+		});
+	});
+});


### PR DESCRIPTION
## Summary

The Google Drive backup/import feature shipped without tests. This adds integration coverage for the whole surface, following the repo's testing conventions: real Postgres, only the `googleapis` SDK mocked, route auth mocked at `@/lib/auth/validate-session`.

Four new files under `src/__tests__/integration/` (55 tests):

- `google-drive-service.test.ts` — token expiry and refresh (including write-back of the refreshed token, the exact 5-minute buffer boundary, a refresh response with no access token, and a thrown refresh leaving the row unchanged), backup-folder find-or-create, upload file naming and stream content, non-JSON download rejection, `listBackupFiles` failure swallowing, `DRIVE_ERROR_MAP` data.
- `api-cases-backup-gdrive.test.ts` — 401 / 403 not-connected / 400, permission matrix through `exportCase` (owner, VIEW and EDIT via share, VIEW via team, no permission, nonexistent → 403 per the anti-enumeration convention), Drive error mapping, success shape, `GET` connected check.
- `api-cases-import-gdrive.test.ts` — 401 / 403 / 400, download error mapping, non-JSON content, a real case row created on success with `source.type === "gdrive"`, `GET` listing.
- `connected-accounts-service.test.ts` — `hasDriveAccess`, unlink clearing all Google columns, the last-sign-in-method guard.

No product code changes.

## Verification

- `pnpm test:integration`: 63 files / 1044 tests pass, ~14 s
- `pnpm lint`: clean (763 files)
- `pnpm typecheck`: clean
- fallow audit (`--changed-since staging`, per-analysis baselines): 0 introduced

## Follow-ups noted (not in this PR)

- `DRIVE_ERROR_MAP` is defined three times (service and both routes); four of its six error codes are never produced by the service; the import `GET`'s inner try/catch is unreachable. Logged for a separate tidy-up.