### PR TITLE
test(e2e): assert the uploaded feature image renders on Discover; share the fallback helper

### DIFF
--- a/app/(landing)/discover/[slug]/page.tsx
+++ b/app/(landing)/discover/[slug]/page.tsx
@@ -109,7 +109,7 @@ const DiscoverItemPage = async ({ params }: DiscoverItemPageProps) => {
 									alt={item.title}
 									className="aspect-12/7 w-full rounded-lg object-cover shadow-lg lg:aspect-auto"
 									height={1376}
-									src={item.featureImageUrl ?? FALLBACK_IMAGE}
+									src={item.featureImageUrl || FALLBACK_IMAGE}
 									width={1184}
 								/>
 								<figcaption className="mt-3 flex text-muted-foreground text-sm">

--- a/app/(landing)/discover/[slug]/page.tsx
+++ b/app/(landing)/discover/[slug]/page.tsx
@@ -5,11 +5,9 @@ import Link from "next/link";
 import { fetchPublishedItemBySlug } from "@/actions/discover";
 import { SanitisedHtml } from "@/components/cases/sanitised-html";
 import { formatShortDate } from "@/lib/date";
+import { resolveFeatureImageSrc } from "@/lib/discover-image";
 import DownloadPublishedItemButton from "../_components/download-published-item-button";
 import PublishableItemTypeBadge from "../_components/publishable-item-type-badge";
-
-const FALLBACK_IMAGE =
-	"https://images.unsplash.com/photo-1634017839464-5c339ebe3cb4?q=80&w=3000&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D";
 
 interface DiscoverItemPageProps {
 	params: Promise<{ slug: string }>;
@@ -109,7 +107,7 @@ const DiscoverItemPage = async ({ params }: DiscoverItemPageProps) => {
 									alt={item.title}
 									className="aspect-12/7 w-full rounded-lg object-cover shadow-lg lg:aspect-auto"
 									height={1376}
-									src={item.featureImageUrl || FALLBACK_IMAGE}
+									src={resolveFeatureImageSrc(item.featureImageUrl)}
 									width={1184}
 								/>
 								<figcaption className="mt-3 flex text-muted-foreground text-sm">

--- a/app/(landing)/discover/_components/published-items.tsx
+++ b/app/(landing)/discover/_components/published-items.tsx
@@ -13,12 +13,10 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { formatShortDate } from "@/lib/date";
+import { resolveFeatureImageSrc } from "@/lib/discover-image";
 import { extractTextFromHtml } from "@/lib/sanitize-html";
 import type { PublishableItemSummaryResponse } from "@/lib/services/discover-transforms";
 import PublishableItemTypeBadge from "./publishable-item-type-badge";
-
-const FALLBACK_IMAGE =
-	"https://images.unsplash.com/photo-1634017839464-5c339ebe3cb4?q=80&w=3000&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D";
 
 interface PublishedItemsProps {
 	items: PublishableItemSummaryResponse[];
@@ -99,7 +97,7 @@ function PublishedItems({ items }: PublishedItemsProps) {
 											alt={`${item.title} featured image`}
 											className="aspect-video w-full rounded-2xl bg-muted object-cover sm:aspect-2/1 lg:aspect-3/2"
 											height={400}
-											src={item.featureImageUrl || FALLBACK_IMAGE}
+											src={resolveFeatureImageSrc(item.featureImageUrl)}
 											width={600}
 										/>
 										<div className="absolute inset-0 rounded-2xl ring-1 ring-border ring-inset" />

--- a/e2e/publish-journey.spec.ts
+++ b/e2e/publish-journey.spec.ts
@@ -52,9 +52,11 @@ const DIVERGENCE_TEXT =
 	"Changes have been made since this case was last published.";
 const CASE_ID_FROM_URL_PATTERN = /\/case\/([a-f0-9-]+)/;
 
-// A 1x1 transparent PNG, base64-encoded — the smallest file the upload
-// control's mime-type check (`file-storage-service.ts`'s `validateFile`)
-// will accept, generated in-test rather than adding a binary fixture.
+// A 1x1 transparent PNG, base64-encoded — the smallest file that clears both
+// the client-side dropzone gate (`components/ui/image-upload.tsx`'s
+// react-dropzone `accept`/`maxSize`) and the server's mime-type check
+// (`file-storage-service.ts`'s `validateFile`), generated in-test rather
+// than adding a binary fixture.
 const TINY_PNG_BASE64 =
 	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
 
@@ -155,7 +157,12 @@ test.describe("ADR 0003 — publish journey", () => {
 		// The dropzone swaps its "Upload an image" prompt for a preview and a
 		// "Remove Image" control once `ImageUpload`'s `imageToShow` is truthy
 		// (image-upload.tsx) — the client-visible confirmation that the
-		// upload round-trip completed and the form now reflects it.
+		// upload round-trip completed and the form now reflects it. This wait
+		// is not just a UI nicety: it also gives `CaseInformationSection`'s
+		// post-upload `featureImageUrl` sync effect time to flush into the
+		// form before "Save case information" fires below — remove it and the
+		// PUT can race ahead of that effect, submitting a stale `""` that
+		// blanks the image the upload just set.
 		await expect(
 			infoForm.getByRole("button", { name: "Remove Image" })
 		).toBeVisible();
@@ -205,14 +212,11 @@ test.describe("ADR 0003 — publish journey", () => {
 		// test exists to catch (the image showed on the /discover index card
 		// but not on /discover/<slug>). The uploaded image's alt text is the
 		// case title (app/(landing)/discover/[slug]/page.tsx); assert it's
-		// visible and its src is the uploaded upload, not the Unsplash
+		// visible and its src is the uploaded image, not the Unsplash
 		// fallback used when a case has no image.
 		const detailImage = page.getByRole("img", { name: CASE_NAME });
 		await expect(detailImage).toBeVisible();
 		await expect(detailImage).toHaveAttribute("src", UPLOADED_IMAGE_PATTERN);
-		expect(await detailImage.getAttribute("src")).not.toContain(
-			"images.unsplash.com"
-		);
 
 		// ---- Same check on the /discover index card for this case.
 		await page.goto("/discover");

--- a/e2e/publish-journey.spec.ts
+++ b/e2e/publish-journey.spec.ts
@@ -52,6 +52,18 @@ const DIVERGENCE_TEXT =
 	"Changes have been made since this case was last published.";
 const CASE_ID_FROM_URL_PATTERN = /\/case\/([a-f0-9-]+)/;
 
+// A 1x1 transparent PNG, base64-encoded — the smallest file the upload
+// control's mime-type check (`file-storage-service.ts`'s `validateFile`)
+// will accept, generated in-test rather than adding a binary fixture.
+const TINY_PNG_BASE64 =
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+
+// next/image rewrites `src` through `/_next/image?url=<url-encoded>` in a
+// production build (`images.unoptimized` is only true in dev — see
+// `next.config.mjs`), so the uploaded image's path has to be matched
+// tolerant of that encoding rather than as an exact `/uploads/...` string.
+const UPLOADED_IMAGE_PATTERN = /(?:\/|%2F)uploads(?:\/|%2F)/;
+
 test.describe("ADR 0003 — publish journey", () => {
 	let caseId: string | undefined;
 
@@ -117,6 +129,37 @@ test.describe("ADR 0003 — publish journey", () => {
 		await infoForm.getByLabel("Sector").click();
 		await page.getByRole("option", { name: CASE_INFO.sector }).click();
 
+		// ---- Feature image: the control at the heart of this test (Discover
+		// detail page not rendering the feature image, the original bug). The
+		// dropzone's file input is hidden (react-dropzone's `getInputProps()`
+		// in `components/ui/image-upload.tsx`), so it's driven directly with
+		// `setInputFiles` rather than a real drag-and-drop. The upload posts
+		// to its own route (`/api/cases/[id]/information/image`) and persists
+		// `featureImageUrl` independently of "Save case information" below —
+		// asserted here, at the step it happens, so a silent upload failure
+		// is caught immediately rather than only surfacing as a missing image
+		// several steps later on Discover.
+		await Promise.all([
+			page.waitForResponse(
+				(resp) =>
+					resp.url().includes(`/api/cases/${caseId}/information/image`) &&
+					resp.request().method() === "POST" &&
+					resp.ok()
+			),
+			infoForm.locator('input[type="file"]').setInputFiles({
+				name: "feature-image.png",
+				mimeType: "image/png",
+				buffer: Buffer.from(TINY_PNG_BASE64, "base64"),
+			}),
+		]);
+		// The dropzone swaps its "Upload an image" prompt for a preview and a
+		// "Remove Image" control once `ImageUpload`'s `imageToShow` is truthy
+		// (image-upload.tsx) — the client-visible confirmation that the
+		// upload round-trip completed and the form now reflects it.
+		await expect(
+			infoForm.getByRole("button", { name: "Remove Image" })
+		).toBeVisible();
+
 		await Promise.all([
 			page.waitForResponse(
 				(resp) =>
@@ -157,6 +200,25 @@ test.describe("ADR 0003 — publish journey", () => {
 
 		await page.goto(`/discover/${slug}`);
 		await expect(page.getByRole("heading", { name: CASE_NAME })).toBeVisible();
+
+		// ---- Feature image renders on the detail page — the regression this
+		// test exists to catch (the image showed on the /discover index card
+		// but not on /discover/<slug>). The uploaded image's alt text is the
+		// case title (app/(landing)/discover/[slug]/page.tsx); assert it's
+		// visible and its src is the uploaded upload, not the Unsplash
+		// fallback used when a case has no image.
+		const detailImage = page.getByRole("img", { name: CASE_NAME });
+		await expect(detailImage).toBeVisible();
+		await expect(detailImage).toHaveAttribute("src", UPLOADED_IMAGE_PATTERN);
+		expect(await detailImage.getAttribute("src")).not.toContain(
+			"images.unsplash.com"
+		);
+
+		// ---- Same check on the /discover index card for this case.
+		await page.goto("/discover");
+		await expect(
+			page.getByRole("img", { name: `${CASE_NAME} featured image` })
+		).toHaveAttribute("src", UPLOADED_IMAGE_PATTERN);
 
 		// `page.request` shares the signed-in browser context's cookies, but
 		// `/api/public/*` is exempted from session auth entirely (middleware.ts)

--- a/lib/__tests__/discover-image.test.ts
+++ b/lib/__tests__/discover-image.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { FALLBACK_IMAGE, resolveFeatureImageSrc } from "../discover-image";
+
+/**
+ * `""` is the case this exists to pin, not an edge case — see the function's
+ * own doc comment: `CaseInformationSection`'s form defaults `featureImageUrl`
+ * to `""`, and the case-information schema keeps `""` distinct from `null`,
+ * so any published case whose author never touched the image field stores
+ * `""` rather than `null`.
+ */
+describe("resolveFeatureImageSrc", () => {
+	it("falls back to the placeholder for an empty string", () => {
+		expect(resolveFeatureImageSrc("")).toBe(FALLBACK_IMAGE);
+	});
+
+	it("falls back to the placeholder for null", () => {
+		expect(resolveFeatureImageSrc(null)).toBe(FALLBACK_IMAGE);
+	});
+
+	it("passes a real URL through unchanged", () => {
+		expect(
+			resolveFeatureImageSrc("/uploads/cases/1/case-information/a.png")
+		).toBe("/uploads/cases/1/case-information/a.png");
+	});
+});

--- a/lib/discover-image.ts
+++ b/lib/discover-image.ts
@@ -1,0 +1,18 @@
+export const FALLBACK_IMAGE =
+	"https://images.unsplash.com/photo-1634017839464-5c339ebe3cb4?q=80&w=3000&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D";
+
+/**
+ * Resolves a published item's feature image `src` for both Discover render
+ * sites (the detail page and the index card). `""` is the common case here,
+ * not an edge case: `CaseInformationSection`'s form defaults
+ * `featureImageUrl` to `""`, and `caseInformationSchema`
+ * (`lib/schemas/case-information.ts`) keeps `""` distinct from `null` so a
+ * caller can tell "leave untouched" (`undefined`) apart from "clear it"
+ * (`null`) — that means any published case whose author never touched the
+ * image field stores `""`, and `""` has to fall back to the placeholder
+ * exactly like `null`/`undefined` do, or the detail/index pages render a
+ * broken image instead of the Unsplash placeholder.
+ */
+export function resolveFeatureImageSrc(url: string | null | undefined): string {
+	return url ? url : FALLBACK_IMAGE;
+}


### PR DESCRIPTION
## Summary

Closes the last open item from the 12 Aug staging walkthrough (finding 4: a published case's feature image showed on the `/discover` index card but not on `/discover/<slug>`). The rendering bug itself was removed by the Discover rebuild (#888) and verified on staging today with a real uploaded image; this PR makes that proof permanent and closes a related gap it surfaced.

- **e2e:** `publish-journey.spec.ts` now uploads a feature image through the real case-information control at the case-information step, and asserts on both the Discover detail page and the index card that the rendered `<img>` is the uploaded file (`/uploads/…`, tolerant of `next/image`'s encoded form in production builds), not the placeholder. Sabotage-checked: forcing the detail page to the placeholder fails the new assertion.
- **fix:** the detail page used `??` for the placeholder fallback while the index card used `||`. An empty-string `featureImageUrl` is the common stored value (the case-information form defaults the field to `""`, and the schema deliberately keeps `""` distinct from `null`), so the detail page would render a broken image for any case whose author never touched the image field. The fallback choice now lives in one shared helper, `lib/discover-image.ts` (`resolveFeatureImageSrc`), used by both render sites, with a three-case unit test.

## Verification

- `pnpm typecheck` clean; `pnpm lint` clean (765 files).
- `pnpm test:unit`: 99 files / 1336 tests pass (+1 file, +3 tests).
- `publish-journey` e2e passes against a production build; the new assertion fails when the detail page is forced to the placeholder and passes on revert.
- Review chain: code review approved (fallow audit: 0 introduced dead code / complexity / duplication); independent QA adequacy review found the empty-string gap (fixed here); delta review of the fix approved.

## Follow-ups (filed separately, not in this PR)

- `e2e/global-setup.ts` resets the local dev database unconditionally, which blocks agent-driven local e2e runs behind Prisma's consent guard.
- `publish-journey.spec.ts` computes its unique case name once per module, so a CI retry after a late failure can collide with an orphaned case.
- `pnpm lint -- <file under app/(landing)/discover/[slug]/>` throws a Biome I/O error on the bracket directory (whole-repo lint is unaffected).
