### PR TITLE
Reject unknown request fields at the API boundary; validate batch-route URLs

### DIFF
--- a/app/api/cases/[id]/batch/route.ts
+++ b/app/api/cases/[id]/batch/route.ts
@@ -48,7 +48,11 @@ export async function POST(
 		// Validate request body
 		const parseResult = batchUpdateRequestSchema.safeParse(body);
 		if (!parseResult.success) {
-			return apiError(validationError("Invalid request body"));
+			return apiError(
+				validationError(
+					parseResult.error.issues[0]?.message ?? "Invalid request body"
+				)
+			);
 		}
 
 		const { changes, expectedVersion } = parseResult.data;

--- a/app/api/cases/[id]/elements/route.ts
+++ b/app/api/cases/[id]/elements/route.ts
@@ -7,79 +7,7 @@ import {
 } from "@/lib/api-response";
 import { validationError } from "@/lib/errors";
 import { createElementSchema } from "@/lib/schemas/element";
-import type { CreateElementInput } from "@/lib/services/element-service";
 import { createElement } from "@/lib/services/element-service";
-import type { AssertionStatus } from "@/src/generated/prisma";
-
-/**
- * Resolves `parentId` from the request body.
- *
- * The UI sends legacy relationship fields (`goalId`, `strategyId`,
- * `propertyClaimId`) instead of a unified `parentId`. This normalises
- * them before the payload reaches the service layer.
- */
-function resolveParentIdFromBody(
-	body: Record<string, unknown>
-): string | undefined {
-	if (body.parentId != null) {
-		return String(body.parentId);
-	}
-	if (body.goalId != null) {
-		return String(body.goalId);
-	}
-	if (body.strategyId != null) {
-		return String(body.strategyId);
-	}
-
-	const claimId = body.propertyClaimId;
-	if (claimId != null) {
-		return String(Array.isArray(claimId) ? claimId[0] : claimId);
-	}
-
-	return;
-}
-
-/**
- * Builds element creation input from validated body.
- */
-function buildCreateInput(
-	caseId: string,
-	body: Record<string, unknown>,
-	rawBody: Record<string, unknown>
-): CreateElementInput {
-	const url = (body.url || body.URL) as string | undefined;
-	return {
-		caseId,
-		elementType: (body.type || body.elementType) as string,
-		name: body.name as string | undefined,
-		description: body.description as string | undefined,
-		shortDescription: body.shortDescription as string | undefined,
-		longDescription: body.longDescription as string | undefined,
-		parentId: resolveParentIdFromBody(rawBody),
-		url,
-		URL: url,
-		urls: body.urls as string[] | undefined,
-		assumption: body.assumption as string | undefined,
-		justification: body.justification as string | undefined,
-		// Per-assertion status (ADR 0004 D3) — validated by createElementSchema;
-		// the guard against machine/integration writers and AS_CITED declaration
-		// lives in element-service.ts (createElement), not here.
-		assertionStatus: body.assertionStatus as AssertionStatus | null | undefined,
-		// Element-level citation (ADR 0004 D5) — validated by
-		// createElementSchema; applicability/existence/self-citation checks
-		// live in element-service.ts (createElement), not here.
-		citedElementId: body.citedElementId as string | null | undefined,
-		// Module reference (MODULE/AWAY_GOAL) — validated by
-		// createElementSchema; applicability/requiredness/existence checks
-		// live in element-service.ts (createElement), not here.
-		moduleReferenceId: body.moduleReferenceId as string | null | undefined,
-		// Dialogical reasoning (defeaters) — validated by createElementSchema;
-		// same-case/existence/self-reference checks live in element-service.ts
-		// (createElement), not here.
-		isDefeater: body.isDefeater as boolean | undefined,
-		defeatsElementId: body.defeatsElementId as string | null | undefined,
-	};
-}
 
 /**
  * Create a new element in a case
@@ -115,12 +43,13 @@ export async function POST(
 			);
 		}
 
-		const input = buildCreateInput(
+		// element-service.ts's createElement resolves url/URL itself
+		// (url || URL) — do not collapse them here.
+		const result = await createElement(session.userId, {
+			...parsed.data,
 			caseId,
-			parsed.data as unknown as Record<string, unknown>,
-			rawBody ?? {}
-		);
-		const result = await createElement(session.userId, input);
+			elementType: parsed.data.type ?? parsed.data.elementType ?? "",
+		});
 
 		if ("error" in result) {
 			return apiError(serviceErrorToAppError(result.error));

--- a/app/api/elements/[id]/attach/route.ts
+++ b/app/api/elements/[id]/attach/route.ts
@@ -10,19 +10,6 @@ import { attachElementSchema } from "@/lib/schemas/element";
 import { attachElement } from "@/lib/services/element-service";
 
 /**
- * Resolves parent ID from request body, handling legacy field names.
- */
-function resolveParentId(body: Record<string, unknown>): string | undefined {
-	const parentId =
-		body.parentId ||
-		body.parent_id ||
-		body.goal_id ||
-		body.strategy_id ||
-		body.property_claim_id;
-	return parentId ? String(parentId) : undefined;
-}
-
-/**
  * POST /api/elements/[id]/attach
  * Attaches an element to a parent (moves from sandbox)
  */
@@ -35,8 +22,7 @@ export async function POST(
 		const { id: elementId } = await params;
 
 		const body = await request.json();
-		const normalised = { parentId: resolveParentId(body) };
-		const parsed = attachElementSchema.safeParse(normalised);
+		const parsed = attachElementSchema.safeParse(body);
 
 		if (!parsed.success) {
 			return apiError(validationError("Invalid parent ID format"));

--- a/app/api/elements/[id]/route.ts
+++ b/app/api/elements/[id]/route.ts
@@ -7,13 +7,11 @@ import {
 } from "@/lib/api-response";
 import { validationError } from "@/lib/errors";
 import { updateElementSchema } from "@/lib/schemas/element";
-import type { UpdateElementInput } from "@/lib/services/element-service";
 import {
 	deleteElement,
 	getElement,
 	updateElement,
 } from "@/lib/services/element-service";
-import type { AssertionStatus } from "@/src/generated/prisma";
 
 /**
  * GET /api/elements/[id]
@@ -40,44 +38,6 @@ export async function GET(
 }
 
 /**
- * Builds update input from validated body.
- */
-function buildUpdateInput(body: Record<string, unknown>): UpdateElementInput {
-	const url = (body.url || body.URL) as string | undefined;
-	return {
-		name: body.name as string | undefined,
-		description: body.description as string | undefined,
-		shortDescription: body.shortDescription as string | undefined,
-		longDescription: body.longDescription as string | undefined,
-		parentId: body.parentId as string | undefined,
-		url,
-		URL: url,
-		urls: body.urls as string[] | undefined,
-		assumption: body.assumption as string | undefined,
-		justification: body.justification as string | undefined,
-		context: body.context as string[] | undefined,
-		inSandbox: body.inSandbox as boolean | undefined,
-		// Per-assertion status (ADR 0004 D3) — validated by updateElementSchema;
-		// the guard against machine/integration writers and AS_CITED declaration
-		// lives in element-service.ts (updateElement), not here.
-		assertionStatus: body.assertionStatus as AssertionStatus | null | undefined,
-		// Element-level citation (ADR 0004 D5) — validated by
-		// updateElementSchema; applicability/existence/self-citation checks
-		// live in element-service.ts (updateElement), not here.
-		citedElementId: body.citedElementId as string | null | undefined,
-		// Module reference (MODULE/AWAY_GOAL) — validated by
-		// updateElementSchema; applicability/existence checks live in
-		// element-service.ts (updateElement), not here.
-		moduleReferenceId: body.moduleReferenceId as string | null | undefined,
-		// Dialogical reasoning (defeaters) — validated by updateElementSchema;
-		// same-case/existence/self-reference checks live in element-service.ts
-		// (updateElement), not here.
-		isDefeater: body.isDefeater as boolean | undefined,
-		defeatsElementId: body.defeatsElementId as string | null | undefined,
-	};
-}
-
-/**
  * PUT /api/elements/[id]
  * Updates an existing element
  */
@@ -98,10 +58,9 @@ export async function PUT(
 			);
 		}
 
-		const input = buildUpdateInput(
-			parsed.data as unknown as Record<string, unknown>
-		);
-		const result = await updateElement(session.userId, elementId, input);
+		// element-service.ts's updateElement resolves url/URL itself
+		// (url || URL) — do not collapse them here.
+		const result = await updateElement(session.userId, elementId, parsed.data);
 
 		if ("error" in result) {
 			return apiError(serviceErrorToAppError(result.error));

--- a/biome.json
+++ b/biome.json
@@ -106,6 +106,10 @@
           }
         }
       }
+    },
+    {
+      "includes": ["lib/schemas/**"],
+      "plugins": ["./lint-rules/no-bare-zod-object.grit"]
     }
   ]
 }

--- a/hooks/__tests__/use-new-link-form.test.ts
+++ b/hooks/__tests__/use-new-link-form.test.ts
@@ -31,12 +31,15 @@ function mockElementsRoute() {
 				);
 			}
 			// apiSuccess() returns the element flat (no envelope) — matches
-			// what createAssuranceCaseNode (lib/case/api.ts) expects.
+			// what createAssuranceCaseNode (lib/case/api.ts) expects. Mirrors
+			// element-service.ts's real response shape: propertyClaimId is
+			// derived from the request's parentId (the evidence link target),
+			// not sent as its own field.
 			return HttpResponse.json(
 				{
 					id: "evidence-1",
 					...parsed.data,
-					propertyClaimId: body.propertyClaimId,
+					propertyClaimId: [body.parentId],
 					name: "E1",
 				},
 				{ status: 201 }

--- a/hooks/__tests__/use-new-link-form.test.ts
+++ b/hooks/__tests__/use-new-link-form.test.ts
@@ -58,21 +58,41 @@ const NODE: Node = {
 	data: { id: "claim-1" },
 };
 
+// A strategy node - for the createStrategyPayload/createPropertyClaimItem
+// branches keyed on node.type === "strategy".
+const STRATEGY_NODE: Node = {
+	id: "2",
+	type: "strategy",
+	position: { x: 0, y: 0 },
+	data: { id: "strategy-1" },
+};
+
+// A goal node - exercises the default/goal branch of createStrategyPayload
+// and createPropertyClaimItem, where parentId comes from
+// assuranceCase.goals[0].id rather than node.data.id.
+const GOAL_NODE: Node = {
+	id: "3",
+	type: "goal",
+	position: { x: 0, y: 0 },
+	data: { id: "goal-1" },
+};
+
 const CASE_WITH_CLAIM = {
 	id: "case-1",
 	goals: [
 		{
+			id: "goal-1",
 			propertyClaims: [{ id: "claim-1", propertyClaims: [], evidence: [] }],
 			strategies: [],
 		},
 	],
 } as unknown as AssuranceCaseResponse;
 
-function setup() {
+function setup(overrides: { node?: Node; linkType?: string } = {}) {
 	return renderHook(() =>
 		useNewLinkForm({
-			node: NODE,
-			linkType: "evidence",
+			node: overrides.node ?? NODE,
+			linkType: overrides.linkType ?? "evidence",
 			actions: {
 				setSelectedLink: vi.fn(),
 				setLinkToCreate: vi.fn(),
@@ -81,6 +101,20 @@ function setup() {
 			setUnresolvedChanges: vi.fn(),
 		})
 	);
+}
+
+/** Submits the description-only form (context/claim/strategy paths - no urls field). */
+async function submitDescription(
+	result: { current: ReturnType<typeof useNewLinkForm> },
+	description: string
+) {
+	act(() => {
+		result.current.form.setValue("description", description);
+	});
+	await act(async () => {
+		await result.current.onSubmit(result.current.form.getValues());
+	});
+	await waitFor(() => expect(result.current.loading).toBe(false));
 }
 
 beforeEach(() => {
@@ -132,5 +166,82 @@ describe("useNewLinkForm — evidence URL submission", () => {
 				description: "Enter a web address, such as example.com/report.pdf",
 			})
 		);
+	});
+});
+
+/**
+ * Each rewritten payload builder (TEA — Mutation-schema hardening, commit
+ * 00a77f7e) sends a narrow named shape — { description, parentId,
+ * assuranceCaseId } — instead of legacy relationship keys (goalId/
+ * strategyId/propertyClaimId). These pin that every branch of every
+ * builder still resolves parentId correctly and produces a body the real
+ * createElementSchema accepts (via mockElementsRoute's real-schema check,
+ * same as the evidence describe block above) — no DB, mocked fetch only.
+ */
+describe("useNewLinkForm — rewritten payload builders (parentId resolution)", () => {
+	it("handleContextAdd sends parentId = the goal's id (context is always attached under the goal)", async () => {
+		const { getReceivedBody } = mockElementsRoute();
+		const { result } = setup({ node: GOAL_NODE, linkType: "context" });
+
+		await submitDescription(result, "A context description");
+
+		const body = getReceivedBody();
+		expect(body).toBeDefined();
+		expect(body?.parentId).toBe("goal-1");
+	});
+
+	it("createStrategyPayload sends parentId = node.data.id when node.type is 'property'", async () => {
+		const { getReceivedBody } = mockElementsRoute();
+		const { result } = setup({ node: NODE, linkType: "strategy" });
+
+		await submitDescription(result, "A strategy description");
+
+		const body = getReceivedBody();
+		expect(body).toBeDefined();
+		expect(body?.parentId).toBe("claim-1");
+	});
+
+	it("createStrategyPayload sends parentId = the goal's id for the goal/default branch", async () => {
+		const { getReceivedBody } = mockElementsRoute();
+		const { result } = setup({ node: GOAL_NODE, linkType: "strategy" });
+
+		await submitDescription(result, "A strategy description");
+
+		const body = getReceivedBody();
+		expect(body).toBeDefined();
+		expect(body?.parentId).toBe("goal-1");
+	});
+
+	it("createPropertyClaimItem sends parentId = node.data.id for the strategy branch", async () => {
+		const { getReceivedBody } = mockElementsRoute();
+		const { result } = setup({ node: STRATEGY_NODE, linkType: "claim" });
+
+		await submitDescription(result, "A property claim description");
+
+		const body = getReceivedBody();
+		expect(body).toBeDefined();
+		expect(body?.parentId).toBe("strategy-1");
+	});
+
+	it("createPropertyClaimItem sends parentId = node.data.id for the property branch", async () => {
+		const { getReceivedBody } = mockElementsRoute();
+		const { result } = setup({ node: NODE, linkType: "claim" });
+
+		await submitDescription(result, "A property claim description");
+
+		const body = getReceivedBody();
+		expect(body).toBeDefined();
+		expect(body?.parentId).toBe("claim-1");
+	});
+
+	it("createPropertyClaimItem sends parentId = the goal's id for the goal/default branch", async () => {
+		const { getReceivedBody } = mockElementsRoute();
+		const { result } = setup({ node: GOAL_NODE, linkType: "claim" });
+
+		await submitDescription(result, "A property claim description");
+
+		const body = getReceivedBody();
+		expect(body).toBeDefined();
+		expect(body?.parentId).toBe("goal-1");
 	});
 });

--- a/hooks/use-new-link-form.ts
+++ b/hooks/use-new-link-form.ts
@@ -76,9 +76,8 @@ export function useNewLinkForm({
 	const handleContextAdd = async (description: string) => {
 		const newContextItem = {
 			description,
-			goalId: assuranceCase?.goals?.[0]?.id || 0,
+			parentId: assuranceCase?.goals?.[0]?.id ?? null,
 			assuranceCaseId: assuranceCase?.id,
-			type: "context",
 		};
 
 		const result = await createAssuranceCaseNode(
@@ -127,16 +126,13 @@ export function useNewLinkForm({
 
 	/** Builds the strategy creation payload based on the parent node type */
 	const createStrategyPayload = (description: string) => {
-		if (node.type === "property") {
-			return {
-				description,
-				propertyClaimId: node.data.id as string,
-				assuranceCaseId: assuranceCase?.id,
-			};
-		}
+		const parentId =
+			node.type === "property"
+				? (node.data.id as string)
+				: (assuranceCase?.goals?.[0]?.id ?? null);
 		return {
 			description,
-			goalId: assuranceCase?.goals?.[0]?.id,
+			parentId,
 			assuranceCaseId: assuranceCase?.id,
 		};
 	};
@@ -213,20 +209,18 @@ export function useNewLinkForm({
 	const createPropertyClaimItem = (description: string) => {
 		const baseItem = {
 			description,
-			claimType: "Property Claim",
-			propertyClaims: [],
-			evidence: [],
-			type: "property_claim",
 			assuranceCaseId: assuranceCase?.id,
 		};
 
 		switch (node.type) {
 			case "strategy":
-				return { ...baseItem, strategyId: node.data.id };
 			case "property":
-				return { ...baseItem, propertyClaimId: node.data.id };
+				return { ...baseItem, parentId: node.data.id as string };
 			default:
-				return { ...baseItem, goalId: assuranceCase?.goals?.[0]?.id || 0 };
+				return {
+					...baseItem,
+					parentId: assuranceCase?.goals?.[0]?.id ?? null,
+				};
 		}
 	};
 
@@ -422,8 +416,7 @@ export function useNewLinkForm({
 		description,
 		urls,
 		URL: urls[0] || "",
-		propertyClaimId: [node.data.id],
-		type: "evidence",
+		parentId: node.data.id as string,
 		assuranceCaseId: assuranceCase?.id,
 	});
 

--- a/lib/case/api.ts
+++ b/lib/case/api.ts
@@ -37,9 +37,9 @@ export const createAssuranceCaseNode = async (
 	newItem: CreateNodePayload,
 	_token: string | null
 ): Promise<{ data?: ApiNodeResponse; error?: string | unknown }> => {
-	// Get case ID from the payload
-	const caseId = (newItem as { assuranceCaseId?: number | string })
-		.assuranceCaseId;
+	// assuranceCaseId routes the request; it is not part of the body the
+	// server schema declares, so it must not be sent.
+	const { assuranceCaseId: caseId, ...namedFields } = newItem;
 	if (!caseId) {
 		return { error: "Case ID is required" };
 	}
@@ -55,8 +55,7 @@ export const createAssuranceCaseNode = async (
 				"Content-Type": "application/json",
 			},
 			body: JSON.stringify({
-				...newItem,
-				elementType: resolvedType,
+				...namedFields,
 				type: resolvedType,
 			}),
 		};
@@ -220,46 +219,17 @@ export const detachCaseElement = async (
  * Note: Authentication is handled via NextAuth session cookies, not the token parameter.
  */
 export const attachCaseElement = async (
-	orphan: ReactFlowNode,
+	_orphan: ReactFlowNode,
 	id: number | string,
 	_token: string | null,
 	parent: ReactFlowNode
 ): Promise<{ attached: boolean } | { error: string | unknown }> => {
-	// Build payload for attach operation
-	const payload: {
-		parentId?: string | number;
-		elementType?: string;
-		goalId?: string | null;
-		strategyId?: string | null;
-		propertyClaimId?: string | null;
-	} = {
-		parentId: parent.data.id,
-		elementType: orphan.type.toLowerCase(),
-	};
-
-	// Include camelCase parent references
-	switch (orphan.type.toLowerCase()) {
-		case "context":
-		case "strategy":
-			payload.goalId = parent.data.id;
-			break;
-		case "propertyclaim":
-			if (parent.type === "property") {
-				payload.propertyClaimId = parent.data.id;
-			}
-			if (parent.type === "strategy") {
-				payload.strategyId = parent.data.id;
-			}
-			if (parent.type === "goal") {
-				payload.goalId = parent.data.id;
-			}
-			break;
-		case "evidence":
-			payload.propertyClaimId = parent.data.id;
-			break;
-		default:
-			break;
-	}
+	// attachElementSchema only declares parentId — the legacy goalId/
+	// strategyId/propertyClaimId/elementType fields this used to send were
+	// dead weight even before strict mode (the route already resolved
+	// parentId from the payload's own parentId first); under strict
+	// z.strictObject() they would 400 outright.
+	const payload = { parentId: parent.data.id };
 
 	try {
 		// Use internal API route which handles Django/Prisma switching

--- a/lib/case/types.ts
+++ b/lib/case/types.ts
@@ -75,12 +75,23 @@ export interface CommentPayload {
 	content: string;
 }
 
-// Type for node creation payloads
-export type CreateNodePayload =
-	| Partial<GoalResponse>
-	| Partial<StrategyResponse>
-	| Partial<PropertyClaimResponse>
-	| Partial<EvidenceResponse>;
+// Type for node creation payloads — sent to POST /api/cases/[id]/elements via
+// createAssuranceCaseNode. `assuranceCaseId` is read by createAssuranceCaseNode
+// to build the request URL and is NOT sent in the request body; `parentId` is
+// resolved client-side from the node the user clicked before calling in. This
+// replaced a union of Partial<XResponse> types (2026-09, mutation-schema
+// hardening) that let payloads carry legacy fields (goalId/strategyId/
+// propertyClaimId, claimType, propertyClaims, evidence, elementType) the
+// server schema never declared — silently dropped under lenient parsing,
+// rejected outright once request schemas went strict.
+export interface CreateNodePayload {
+	assuranceCaseId?: string;
+	description: string;
+	name?: string;
+	parentId: string | null;
+	URL?: string;
+	urls?: string[];
+}
 
 // Type for nested array items that can contain various node types
 export type NestedArrayItem =

--- a/lib/schemas/__tests__/element-url.test.ts
+++ b/lib/schemas/__tests__/element-url.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { lenientUrlSchema, optionalUrlSchema } from "../base";
+import {
+	lenientUrlSchema,
+	nullableUrlSchema,
+	optionalUrlSchema,
+} from "../base";
 import { createElementSchema, updateElementSchema } from "../element";
 
 const SCHEME_MESSAGE = "Enter a web address, such as example.com/report.pdf";
@@ -230,5 +234,63 @@ describe("updateElementSchema — evidence urls field", () => {
 		const result = updateElementSchema.safeParse({ URL: "example.com" });
 		expect(result.success).toBe(true);
 		expect(result.success && result.data.URL).toBe("https://example.com");
+	});
+});
+
+describe("nullableUrlSchema", () => {
+	it("passes undefined through as undefined (field absent - leave unchanged)", () => {
+		expect(nullableUrlSchema.safeParse(undefined)).toMatchObject({
+			success: true,
+			data: undefined,
+		});
+	});
+
+	it("normalises null to null (explicit clear)", () => {
+		expect(nullableUrlSchema.safeParse(null)).toMatchObject({
+			success: true,
+			data: null,
+		});
+	});
+
+	it("normalises an empty string to null", () => {
+		expect(nullableUrlSchema.safeParse("")).toMatchObject({
+			success: true,
+			data: null,
+		});
+	});
+
+	it("normalises a whitespace-only string to null", () => {
+		expect(nullableUrlSchema.safeParse("   ")).toMatchObject({
+			success: true,
+			data: null,
+		});
+	});
+
+	it("normalises a bare domain with a path via lenientUrlSchema", () => {
+		const result = nullableUrlSchema.safeParse("example.com/x");
+		expect(result.success).toBe(true);
+		expect(result.success && result.data).toBe("https://example.com/x");
+	});
+
+	it("normalises a protocol-relative address via lenientUrlSchema", () => {
+		const result = nullableUrlSchema.safeParse("//cdn.example.com/x");
+		expect(result.success).toBe(true);
+		expect(result.success && result.data).toBe("https://cdn.example.com/x");
+	});
+
+	it("rejects a mailto: address with the friendly message", () => {
+		const result = nullableUrlSchema.safeParse("mailto:a@b");
+		expect(result.success).toBe(false);
+		expect(result.success || result.error.issues[0]?.message).toBe(
+			SCHEME_MESSAGE
+		);
+	});
+
+	it("rejects a javascript: address with the friendly message", () => {
+		const result = nullableUrlSchema.safeParse("javascript:alert(1)");
+		expect(result.success).toBe(false);
+		expect(result.success || result.error.issues[0]?.message).toBe(
+			SCHEME_MESSAGE
+		);
 	});
 });

--- a/lib/schemas/__tests__/no-bare-zod-object-lint.test.ts
+++ b/lib/schemas/__tests__/no-bare-zod-object-lint.test.ts
@@ -38,6 +38,7 @@ const GOOD_SOURCE =
 
 function runBiomeCheck(filePath: string): {
 	status: number | null;
+	error: Error | undefined;
 	combinedOutput: string;
 } {
 	const result = spawnSync(BIOME_BIN, ["check", filePath], {
@@ -46,6 +47,7 @@ function runBiomeCheck(filePath: string): {
 	});
 	return {
 		status: result.status,
+		error: result.error,
 		combinedOutput: `${result.stdout ?? ""}${result.stderr ?? ""}`,
 	};
 }
@@ -69,8 +71,14 @@ describe("lint-rules/no-bare-zod-object.grit — fires via the biome.json overri
 		mkdirSync(PROBE_DIR, { recursive: true });
 		writeFileSync(BAD_PROBE_PATH, BAD_SOURCE);
 		try {
-			const { status, combinedOutput } = runBiomeCheck(BAD_PROBE_PATH);
-			expect(status).not.toBe(0);
+			const { status, error, combinedOutput } = runBiomeCheck(BAD_PROBE_PATH);
+			// A missing/unresolvable Biome binary makes spawnSync return
+			// status: null with `error` set, rather than throwing — status
+			// null would otherwise satisfy `not.toBe(0)` and pass this test
+			// without Biome ever having run. Assert error is unset AND status
+			// is a genuine positive exit code, not just "not zero".
+			expect(error).toBeUndefined();
+			expect(status).toBeGreaterThan(0);
 			expect(combinedOutput).toContain("Bare z.object()");
 		} finally {
 			deleteProbe(BAD_PROBE_PATH);
@@ -81,7 +89,8 @@ describe("lint-rules/no-bare-zod-object.grit — fires via the biome.json overri
 		mkdirSync(PROBE_DIR, { recursive: true });
 		writeFileSync(GOOD_PROBE_PATH, GOOD_SOURCE);
 		try {
-			const { status, combinedOutput } = runBiomeCheck(GOOD_PROBE_PATH);
+			const { status, error, combinedOutput } = runBiomeCheck(GOOD_PROBE_PATH);
+			expect(error).toBeUndefined();
 			expect(status).toBe(0);
 			expect(combinedOutput).not.toContain("Bare z.object()");
 		} finally {

--- a/lib/schemas/__tests__/no-bare-zod-object-lint.test.ts
+++ b/lib/schemas/__tests__/no-bare-zod-object-lint.test.ts
@@ -1,0 +1,91 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+/**
+ * Permanent, non-mutating proof that lint-rules/no-bare-zod-object.grit
+ * actually fires, wired through the biome.json override scoped to
+ * lib/schemas/** (TEA — Mutation-schema hardening, QA gap #5). Runs the
+ * repo's own Biome binary against a throwaway probe file written under
+ * lib/schemas/__tests__/ (so the override's includes glob covers it) and
+ * deleted in a finally block — nothing is left behind on disk or in git.
+ *
+ * Deviation from the brief's first choice (spawning Biome with
+ * --stdin-file-path and piping source on stdin): verified by hand that
+ * Biome 2.4.6's stdin mode does not distinguish pass/fail here at all —
+ * `biome check --stdin-file-path=...` (no --write) exits 1 for BOTH a
+ * clean z.strictObject() probe and a bare z.object() probe, exits 0 with
+ * --write for both regardless of unfixable plugin diagnostics, and never
+ * prints the plugin's diagnostic text to stdout/stderr in either case —
+ * only a generic "The contents aren't fixed. Use the --write flag..."
+ * message. So neither the exit code nor the message text is usable via
+ * stdin. Biome DOES report correctly (right exit code, right message)
+ * against a real file path, which is what this test uses instead.
+ */
+
+const REPO_ROOT = process.cwd();
+const BIOME_BIN = path.join(REPO_ROOT, "node_modules", ".bin", "biome");
+const PROBE_DIR = path.join(REPO_ROOT, "lib", "schemas", "__tests__");
+
+const BAD_PROBE_PATH = path.join(PROBE_DIR, "zod-object-lint-probe-bad.ts");
+const GOOD_PROBE_PATH = path.join(PROBE_DIR, "zod-object-lint-probe-good.ts");
+
+const BAD_SOURCE =
+	'import { z } from "zod";\nexport const s = z.object({ a: z.string() });\n';
+const GOOD_SOURCE =
+	'import { z } from "zod";\nexport const s = z.strictObject({ a: z.string() });\n';
+
+function runBiomeCheck(filePath: string): {
+	status: number | null;
+	combinedOutput: string;
+} {
+	const result = spawnSync(BIOME_BIN, ["check", filePath], {
+		cwd: REPO_ROOT,
+		encoding: "utf8",
+	});
+	return {
+		status: result.status,
+		combinedOutput: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+	};
+}
+
+function deleteProbe(filePath: string): void {
+	if (existsSync(filePath)) {
+		rmSync(filePath);
+	}
+}
+
+afterEach(() => {
+	// Belt-and-braces — each it() already cleans up in its own finally, but
+	// a failed assertion between write and finally must not leave a probe
+	// file behind for the next `pnpm lint`/test run to trip over.
+	deleteProbe(BAD_PROBE_PATH);
+	deleteProbe(GOOD_PROBE_PATH);
+});
+
+describe("lint-rules/no-bare-zod-object.grit — fires via the biome.json override", () => {
+	it("flags a bare z.object() under lib/schemas/ with the plugin message and a non-zero exit", () => {
+		mkdirSync(PROBE_DIR, { recursive: true });
+		writeFileSync(BAD_PROBE_PATH, BAD_SOURCE);
+		try {
+			const { status, combinedOutput } = runBiomeCheck(BAD_PROBE_PATH);
+			expect(status).not.toBe(0);
+			expect(combinedOutput).toContain("Bare z.object()");
+		} finally {
+			deleteProbe(BAD_PROBE_PATH);
+		}
+	});
+
+	it("passes a z.strictObject() under lib/schemas/ with a clean, zero exit", () => {
+		mkdirSync(PROBE_DIR, { recursive: true });
+		writeFileSync(GOOD_PROBE_PATH, GOOD_SOURCE);
+		try {
+			const { status, combinedOutput } = runBiomeCheck(GOOD_PROBE_PATH);
+			expect(status).toBe(0);
+			expect(combinedOutput).not.toContain("Bare z.object()");
+		} finally {
+			deleteProbe(GOOD_PROBE_PATH);
+		}
+	});
+});

--- a/lib/schemas/assurance-case.ts
+++ b/lib/schemas/assurance-case.ts
@@ -5,7 +5,7 @@ import { requiredString } from "./base";
  * Schema for creating a new assurance case
  */
 export const createAssuranceCaseSchema = z
-	.object({
+	.strictObject({
 		name: requiredString("Case name", 1, 255),
 		description: requiredString("Description", 1, 5000),
 		colourProfile: z
@@ -27,7 +27,7 @@ export type CreateAssuranceCaseData = z.output<
  * All fields are optional — only provided fields are updated.
  */
 export const updateAssuranceCaseSchema = z
-	.object({
+	.strictObject({
 		name: z.string().min(1).max(255).optional(),
 		description: z.string().min(1).max(5000).optional(),
 		colourProfile: z.string().optional(),

--- a/lib/schemas/auth.ts
+++ b/lib/schemas/auth.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 /**
  * Schema for resetting a password using a valid token.
  */
-export const resetPasswordSchema = z.object({
+export const resetPasswordSchema = z.strictObject({
 	token: z.string().min(1, "Token is required"),
 	password: z.string().min(1, "Password is required"),
 });
@@ -13,7 +13,7 @@ export type ResetPasswordInput = z.infer<typeof resetPasswordSchema>;
 /**
  * Schema for changing the current user's password.
  */
-export const changePasswordSchema = z.object({
+export const changePasswordSchema = z.strictObject({
 	currentPassword: z.string().min(1, "Current password is required"),
 	newPassword: z.string().min(1, "New password is required"),
 });

--- a/lib/schemas/base.ts
+++ b/lib/schemas/base.ts
@@ -110,6 +110,11 @@ const URL_ERROR_MESSAGE = "Enter a web address, such as example.com/report.pdf";
  * there is no silent divergence between what a user typed and what is
  * saved. A scheme that isn't followed by "//" (mailto:, javascript:,
  * data:, …) is rejected outright rather than mangled.
+ *
+ * Import paths (DOIs, URNs, file paths) deliberately do NOT use this
+ * schema — see element-validation.ts's BaseElementSchema `url` comment for
+ * the reverse pointer. This schema, and the two below it, are for entry
+ * points that mean "a web address": UI forms and the batch-update route.
  */
 export const lenientUrlSchema = z
 	.string()
@@ -157,6 +162,52 @@ export const optionalUrlSchema = z
 	// files.
 	.optional()
 	.describe("Optional web address field");
+
+/**
+ * Nullable web address field — for entry points where `null` is a
+ * meaningful instruction to CLEAR an existing value, not "no opinion".
+ *
+ * Do NOT reuse optionalUrlSchema here: it folds null to undefined, and any
+ * caller that treats undefined as "leave unchanged" (e.g. the batch-update
+ * service's field loop) would then be unable to clear a URL at all. This
+ * schema keeps null distinct from undefined all the way through:
+ *   - undefined -> undefined (field genuinely absent — leave unchanged)
+ *   - null, "", or whitespace-only -> null (explicit clear)
+ *   - anything else -> validated/normalised via lenientUrlSchema
+ */
+export const nullableUrlSchema = z
+	.string()
+	.nullable()
+	.optional()
+	// A z.union([z.undefined(), z.null(), lenientUrlSchema]).pipe(...) reads
+	// more like optionalUrlSchema's pattern, but zod's union error-picking
+	// swallows lenientUrlSchema's specific message (falls back to a generic
+	// "Invalid input") whenever the failure comes from lenientUrlSchema's
+	// leading .refine() rather than its trailing .url() check — e.g.
+	// "mailto:…". Calling lenientUrlSchema directly inside the transform and
+	// re-raising its own issues keeps the friendly message in every failure
+	// case.
+	.transform((v, ctx) => {
+		if (v === undefined) {
+			return undefined;
+		}
+		const trimmed = v?.trim();
+		if (!trimmed) {
+			return null;
+		}
+		const result = lenientUrlSchema.safeParse(trimmed);
+		if (!result.success) {
+			for (const issue of result.error.issues) {
+				ctx.addIssue(issue);
+			}
+			return z.NEVER;
+		}
+		return result.data;
+	})
+	// See optionalUrlSchema's NOTE above — kept for the same type-inference
+	// reason (an optional key on the object schema, not required|undefined).
+	.optional()
+	.describe("Nullable web address field — null means 'clear this value'");
 
 // ============================================
 // Number Primitives

--- a/lib/schemas/base.ts
+++ b/lib/schemas/base.ts
@@ -198,7 +198,7 @@ export const nullableUrlSchema = z
 		const result = lenientUrlSchema.safeParse(trimmed);
 		if (!result.success) {
 			for (const issue of result.error.issues) {
-				ctx.addIssue(issue);
+				ctx.addIssue({ code: "custom", message: issue.message });
 			}
 			return z.NEVER;
 		}

--- a/lib/schemas/batch-update.ts
+++ b/lib/schemas/batch-update.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { nullableUrlSchema } from "./base";
 import { AssertionStatusSchema } from "./case-export";
 
 /**
@@ -33,7 +34,7 @@ export const batchUpdateRequestSchema = z.object({
 						assumption: z.string().nullable().optional(),
 						justification: z.string().nullable().optional(),
 						context: z.array(z.string()).optional(),
-						url: z.string().nullable().optional(),
+						url: nullableUrlSchema,
 						level: z.number().nullable().optional(),
 						moduleReferenceId: z.string().optional(),
 						moduleEmbedType: z.string().optional(),
@@ -57,7 +58,7 @@ export const batchUpdateRequestSchema = z.object({
 						assumption: z.string().nullable().optional(),
 						justification: z.string().nullable().optional(),
 						context: z.array(z.string()).optional(),
-						url: z.string().nullable().optional(),
+						url: nullableUrlSchema,
 						level: z.number().nullable().optional(),
 						moduleReferenceId: z.string().optional(),
 						moduleEmbedType: z.string().optional(),

--- a/lib/schemas/batch-update.ts
+++ b/lib/schemas/batch-update.ts
@@ -15,15 +15,15 @@ const assertionStatusInputSchema = AssertionStatusSchema.nullable().optional();
  * Schema for batch update request body.
  * Extracted from cases/[id]/batch/route.ts for reuse.
  */
-export const batchUpdateRequestSchema = z.object({
+export const batchUpdateRequestSchema = z.strictObject({
 	changes: z
 		.array(
 			z.discriminatedUnion("type", [
-				z.object({
+				z.strictObject({
 					type: z.literal("create"),
 					elementId: z.string().uuid(),
 					parentId: z.string().uuid().nullable(),
-					data: z.object({
+					data: z.strictObject({
 						id: z.string().uuid(),
 						type: z.string(),
 						name: z.string().nullable(),
@@ -45,10 +45,10 @@ export const batchUpdateRequestSchema = z.object({
 						defeatsElementId: z.string().optional(),
 					}),
 				}),
-				z.object({
+				z.strictObject({
 					type: z.literal("update"),
 					elementId: z.string().uuid(),
-					data: z.object({
+					data: z.strictObject({
 						name: z.string().nullable().optional(),
 						description: z.string().optional(),
 						inSandbox: z.boolean().optional(),
@@ -69,16 +69,16 @@ export const batchUpdateRequestSchema = z.object({
 						defeatsElementId: z.string().optional(),
 					}),
 				}),
-				z.object({
+				z.strictObject({
 					type: z.literal("delete"),
 					elementId: z.string().uuid(),
 				}),
-				z.object({
+				z.strictObject({
 					type: z.literal("link_evidence"),
 					evidenceId: z.string().uuid(),
 					claimId: z.string().uuid(),
 				}),
-				z.object({
+				z.strictObject({
 					type: z.literal("unlink_evidence"),
 					evidenceId: z.string().uuid(),
 					claimId: z.string().uuid(),

--- a/lib/schemas/case-export.ts
+++ b/lib/schemas/case-export.ts
@@ -75,6 +75,7 @@ export type AssertionStatus = z.infer<typeof AssertionStatusSchema>;
 /**
  * V2 Element schema - flat structure with parentId references
  */
+// biome-ignore lint/plugin: case-export.ts parses the export/import document shape (and the JSON editor's saved document) — older exports and hand-edited documents carry keys this repo no longer models; they must be dropped silently, not rejected.
 export const ElementV2Schema = z
 	.object({
 		id: z.string().uuid().describe("Unique identifier for the element"),
@@ -151,6 +152,7 @@ export const ElementV2Schema = z
 			.describe("Whether the element has been modified from its pattern"),
 		comments: z
 			.array(
+				// biome-ignore lint/plugin: case-export.ts parses the export/import document shape (and the JSON editor's saved document) — older exports and hand-edited documents carry keys this repo no longer models; they must be dropped silently, not rejected.
 				z.object({
 					author: z.string().describe("Username of comment author"),
 					content: z.string().describe("Comment text content"),
@@ -169,6 +171,7 @@ export type ElementV2 = z.infer<typeof ElementV2Schema>;
 /**
  * V2 Evidence Link schema - many-to-many relationship
  */
+// biome-ignore lint/plugin: case-export.ts parses the export/import document shape (and the JSON editor's saved document) — older exports and hand-edited documents carry keys this repo no longer models; they must be dropped silently, not rejected.
 export const EvidenceLinkV2Schema = z
 	.object({
 		evidenceId: z.string().uuid().describe("ID of the evidence element"),
@@ -184,10 +187,12 @@ export type EvidenceLinkV2 = z.infer<typeof EvidenceLinkV2Schema>;
 /**
  * V2 Export format - the canonical export schema
  */
+// biome-ignore lint/plugin: case-export.ts parses the export/import document shape (and the JSON editor's saved document) — older exports and hand-edited documents carry keys this repo no longer models; they must be dropped silently, not rejected.
 export const CaseExportV2Schema = z
 	.object({
 		version: z.literal("2.0").describe("Schema version identifier"),
 		exportedAt: z.string().datetime().describe("ISO 8601 timestamp of export"),
+		// biome-ignore lint/plugin: case-export.ts parses the export/import document shape (and the JSON editor's saved document) — older exports and hand-edited documents carry keys this repo no longer models; they must be dropped silently, not rejected.
 		case: z
 			.object({
 				name: z
@@ -276,6 +281,7 @@ export interface TreeNode {
 }
 
 // Comment schema for export/import
+// biome-ignore lint/plugin: case-export.ts parses the export/import document shape (and the JSON editor's saved document) — older exports and hand-edited documents carry keys this repo no longer models; they must be dropped silently, not rejected.
 export const ExportCommentSchema = z
 	.object({
 		author: z.string().describe("Username of the comment author"),
@@ -286,6 +292,7 @@ export const ExportCommentSchema = z
 
 // biome-ignore lint/suspicious/noExplicitAny: Required for Zod recursive schema typing
 export const TreeNodeSchema: z.ZodType<any> = z.lazy(() =>
+	// biome-ignore lint/plugin: case-export.ts parses the export/import document shape (and the JSON editor's saved document) — older exports and hand-edited documents carry keys this repo no longer models; they must be dropped silently, not rejected.
 	z.object({
 		id: z.string().uuid(),
 		type: ElementTypeSchema,
@@ -328,10 +335,12 @@ export const TreeNodeSchema: z.ZodType<any> = z.lazy(() =>
  * Uses version "1.0" as this is the first officially versioned export format
  * (the legacy Django format had no version field).
  */
+// biome-ignore lint/plugin: case-export.ts parses the export/import document shape (and the JSON editor's saved document) — older exports and hand-edited documents carry keys this repo no longer models; they must be dropped silently, not rejected.
 export const CaseExportNestedSchema = z
 	.object({
 		version: z.literal("1.0").describe("Schema version identifier"),
 		exportedAt: z.string().datetime().describe("ISO 8601 timestamp of export"),
+		// biome-ignore lint/plugin: case-export.ts parses the export/import document shape (and the JSON editor's saved document) — older exports and hand-edited documents carry keys this repo no longer models; they must be dropped silently, not rejected.
 		case: z
 			.object({
 				name: z

--- a/lib/schemas/case-information.ts
+++ b/lib/schemas/case-information.ts
@@ -9,7 +9,7 @@ import { optionalString } from "./base";
  * model (`category`, `contact`, `type`) — those are not part of the ADR's
  * named case-information set and are not carried forward.
  */
-export const caseInformationSchema = z.object({
+export const caseInformationSchema = z.strictObject({
 	description: optionalString(5000),
 	authors: optionalString(255),
 	sector: optionalString(100),

--- a/lib/schemas/comment.ts
+++ b/lib/schemas/comment.ts
@@ -6,7 +6,7 @@ import { requiredString, uuidSchema } from "@/lib/schemas/base";
 // Case-level comment (note)
 // ============================================
 
-export const createCommentSchema = z.object({
+export const createCommentSchema = z.strictObject({
 	content: requiredString("Content", 1, 5000),
 	parentId: uuidSchema.optional().nullable(),
 });
@@ -19,7 +19,7 @@ export type CreateCommentOutput = z.output<typeof createCommentSchema>;
 // ============================================
 
 export const createElementCommentSchema = z
-	.object({
+	.strictObject({
 		content: z.string().optional(),
 		comment: z.string().optional(),
 		parentId: uuidSchema.optional().nullable(),
@@ -29,7 +29,7 @@ export const createElementCommentSchema = z
 		parentId: val.parentId ?? null,
 	}))
 	.pipe(
-		z.object({
+		z.strictObject({
 			content: z.string().min(1, "Comment content is required"),
 			parentId: z.string().uuid().nullable(),
 		})
@@ -46,7 +46,7 @@ export type CreateElementCommentOutput = z.output<
 // Update comment content
 // ============================================
 
-export const updateCommentSchema = z.object({
+export const updateCommentSchema = z.strictObject({
 	content: requiredString("Content", 1, 5000),
 });
 
@@ -57,7 +57,7 @@ export type UpdateCommentOutput = z.output<typeof updateCommentSchema>;
 // Resolve / unresolve a comment thread
 // ============================================
 
-export const resolveCommentSchema = z.object({
+export const resolveCommentSchema = z.strictObject({
 	resolved: z.boolean({ error: "resolved must be a boolean" }),
 });
 
@@ -72,7 +72,7 @@ export type ResolveCommentOutput = z.output<typeof resolveCommentSchema>;
  * Comment form schema — for create and edit forms.
  * Field name is `comment` to match existing component field names.
  */
-export const commentFormSchema = z.object({
+export const commentFormSchema = z.strictObject({
 	comment: z
 		.string()
 		.min(2, "Comment must be at least 2 characters")
@@ -86,7 +86,7 @@ export type CommentFormOutput = z.output<typeof commentFormSchema>;
  * Note form schema — for case-level note create form.
  * Field name is `note` to match existing component field names.
  */
-export const noteFormSchema = z.object({
+export const noteFormSchema = z.strictObject({
 	note: z
 		.string()
 		.min(2, "Note must be at least 2 characters")

--- a/lib/schemas/element-validation.ts
+++ b/lib/schemas/element-validation.ts
@@ -146,6 +146,7 @@ const ModuleEmbedTypeSchema = z
 /**
  * Base fields common to all element types.
  */
+// biome-ignore lint/plugin: import leniency, ADR-level decision — this validates data already persisted or being imported (Prisma middleware / element-service.ts), not a live request body; unknown keys from older records must be dropped silently, not rejected.
 const BaseElementSchema = z
 	.object({
 		name: z

--- a/lib/schemas/element-validation.ts
+++ b/lib/schemas/element-validation.ts
@@ -212,7 +212,13 @@ const EvidenceSchema = BaseElementSchema.extend({
 	elementType: z.literal("EVIDENCE"),
 	url: z.string().nullable().optional(),
 	// URLs/URIs are stored as simple strings - no strict validation
-	// to allow DOIs, URNs, file paths, document references, etc.
+	// to allow DOIs, URNs, file paths, document references, etc. This is a
+	// deliberate split from base.ts's lenientUrlSchema/nullableUrlSchema,
+	// which normalise and validate as a *web address* (prepend https://,
+	// http(s)-only allowlist) — those are used by UI form entry points and
+	// the batch-update route, where "url" always means a web address. This
+	// import path means "identifier or reference of any kind" instead, so
+	// it stays a bare string.
 	urls: z.array(z.string()).default([]),
 });
 

--- a/lib/schemas/element.ts
+++ b/lib/schemas/element.ts
@@ -21,7 +21,7 @@ const elementTypeSchema = z
 /**
  * Create element input schema
  */
-export const createElementSchema = z.object({
+export const createElementSchema = z.strictObject({
 	// Type (required)
 	type: elementTypeSchema.optional(),
 	elementType: elementTypeSchema.optional(),
@@ -68,7 +68,7 @@ export type CreateElementSchemaOutput = z.output<typeof createElementSchema>;
 /**
  * Update element input schema
  */
-export const updateElementSchema = z.object({
+export const updateElementSchema = z.strictObject({
 	// Names/descriptions
 	name: optionalString(500),
 	description: optionalString(5000),
@@ -115,7 +115,7 @@ export type UpdateElementSchemaOutput = z.output<typeof updateElementSchema>;
 /**
  * Move element input schema
  */
-export const moveElementSchema = z.object({
+export const moveElementSchema = z.strictObject({
 	parentId: z.string().uuid("Invalid parent ID format"),
 });
 
@@ -125,7 +125,7 @@ export type MoveElementSchemaOutput = z.output<typeof moveElementSchema>;
 /**
  * Attach element input schema
  */
-export const attachElementSchema = z.object({
+export const attachElementSchema = z.strictObject({
 	parentId: z.string().uuid("Invalid parent ID format"),
 });
 
@@ -139,7 +139,7 @@ export type AttachElementSchemaOutput = z.output<typeof attachElementSchema>;
 /**
  * Description field schema — used across create/edit forms
  */
-export const elementDescriptionFormSchema = z.object({
+export const elementDescriptionFormSchema = z.strictObject({
 	description: z.string().min(2, {
 		message: "Description must be at least 2 characters",
 	}),
@@ -155,7 +155,7 @@ export type ElementDescriptionFormOutput = z.output<
 /**
  * Attributes schema — assumption, justification, context (goal/strategy/property only)
  */
-export const elementAttributesFormSchema = z.object({
+export const elementAttributesFormSchema = z.strictObject({
 	assumption: z.string().optional(),
 	justification: z.string().optional(),
 	context: z.array(z.string()).optional(),
@@ -171,8 +171,8 @@ export type ElementAttributesFormOutput = z.output<
 /**
  * URLs field array schema — used in evidence edit/create forms
  */
-export const elementUrlsFormSchema = z.object({
-	urls: z.array(z.object({ value: z.string() })),
+export const elementUrlsFormSchema = z.strictObject({
+	urls: z.array(z.strictObject({ value: z.string() })),
 });
 
 export type ElementUrlsFormInput = z.input<typeof elementUrlsFormSchema>;
@@ -182,14 +182,14 @@ export type ElementUrlsFormOutput = z.output<typeof elementUrlsFormSchema>;
  * Combined node edit form schema — description + attributes + urls
  * Used by NodeEditDialog and EditForm components
  */
-export const nodeEditFormSchema = z.object({
+export const nodeEditFormSchema = z.strictObject({
 	description: z.string().min(2, {
 		message: "Description must be at least 2 characters",
 	}),
 	assumption: z.string().optional(),
 	justification: z.string().optional(),
 	context: z.array(z.string()).optional(),
-	urls: z.array(z.object({ value: z.string() })),
+	urls: z.array(z.strictObject({ value: z.string() })),
 	// Per-assertion status (ADR 0004 D3). The five author-declarable values
 	// only — `AS_CITED` is derived-only and must never be offered in this
 	// form's Select (components/cases/node-edit-dialog.tsx). "Unset" is

--- a/lib/schemas/feedback.ts
+++ b/lib/schemas/feedback.ts
@@ -4,7 +4,7 @@ import { emailSchema, requiredString } from "./base";
 /**
  * Feedback form schema — used by the public feedback form.
  */
-export const feedbackFormSchema = z.object({
+export const feedbackFormSchema = z.strictObject({
 	name: requiredString("Name", 2, 200),
 	email: emailSchema,
 	feedback: requiredString("Feedback", 2, 5000),

--- a/lib/schemas/github-import.ts
+++ b/lib/schemas/github-import.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
  * Request body schema for GitHub import
  */
 export const GitHubImportSchema = z
-	.object({
+	.strictObject({
 		url: z
 			.string()
 			.min(1, "GitHub URL is required")

--- a/lib/schemas/google-drive.ts
+++ b/lib/schemas/google-drive.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 /**
  * Schema for backing up a case to Google Drive.
  */
-export const backupToDriveSchema = z.object({
+export const backupToDriveSchema = z.strictObject({
 	caseId: z.string().uuid("Invalid case ID"),
 	includeComments: z.boolean().optional().default(true),
 });
@@ -13,7 +13,7 @@ export type BackupToDriveInput = z.input<typeof backupToDriveSchema>;
 /**
  * Schema for importing a case from Google Drive.
  */
-export const importFromDriveSchema = z.object({
+export const importFromDriveSchema = z.strictObject({
 	fileId: z.string().min(1, "File ID is required"),
 });
 

--- a/lib/schemas/health-evidence.ts
+++ b/lib/schemas/health-evidence.ts
@@ -11,7 +11,7 @@ import {
 /**
  * Zod schema for `docs/specs/evidence-format-v0.1.md` — the FROZEN
  * ingestion contract for `POST /api/machine/health/elements/[id]/evidence`.
- * Implemented exactly: unknown top-level fields are rejected (`.strict()`),
+ * Implemented exactly: unknown top-level fields are rejected (`z.strictObject()`),
  * unknown `provenance` keys are preserved verbatim (`.catchall()`, not
  * `.strip()`). Any deviation from the spec is a question back to cid, not a
  * unilateral change — see the health-plugin delegation brief.
@@ -19,7 +19,7 @@ import {
  * Fields the spec says a producer does NOT send (`recordHash`,
  * `previousRecordHash`, `createdAt`, `createdById`) are simply absent from
  * this schema — they are set server-side by `health-evidence-service.ts`
- * and would be rejected anyway by `.strict()` if a caller tried to smuggle
+ * and would be rejected anyway by `z.strictObject()` if a caller tried to smuggle
  * them in.
  */
 
@@ -51,6 +51,7 @@ const PROVENANCE_MAX_BYTES = 8192;
  * additional key validated (and KEPT, never stripped) against the bounded
  * JSON schema shared with `lib/schemas/plugin.ts`.
  */
+// biome-ignore lint/plugin: evidence-format-v0.1 requires unknown provenance keys to be PRESERVED verbatim (.catchall(), see the schema comment above) — the opposite problem to the usual silent-strip leniency, but z.strictObject()'s reject-unknown-keys behaviour is just as wrong here.
 const provenanceSchema = z
 	.object({
 		check: z
@@ -78,51 +79,49 @@ const provenanceSchema = z
  * expressible in the body schema alone, since path and body are parsed
  * separately.
  */
-export const healthEvidenceItemSchema = z
-	.object({
-		formatVersion: z.literal(EVIDENCE_FORMAT_VERSION, {
-			message: `formatVersion must be "${EVIDENCE_FORMAT_VERSION}"`,
-		}),
-		claimId: uuidSchema,
-		metricName: z
-			.string()
-			.min(1, "metricName is required")
-			.max(
-				METRIC_NAME_MAX_LENGTH,
-				`metricName must be at most ${METRIC_NAME_MAX_LENGTH} characters`
-			),
-		value: z.number().finite().optional(),
-		threshold: z.number().finite().optional(),
-		verdict: z.enum(["PASS", "FAIL", "DEGRADED"], {
-			message: "verdict must be PASS, FAIL, or DEGRADED",
-		}),
-		oddDimensions: z
-			.array(
-				z
-					.string()
-					.min(1)
-					.max(
-						ODD_DIMENSION_MAX_LENGTH,
-						`Each oddDimensions entry must be at most ${ODD_DIMENSION_MAX_LENGTH} characters`
-					)
-			)
-			.max(
-				ODD_DIMENSION_MAX_ITEMS,
-				`oddDimensions must have at most ${ODD_DIMENSION_MAX_ITEMS} entries`
-			)
-			.default([]),
-		sourceSystem: z
-			.string()
-			.min(1, "sourceSystem is required")
-			.max(
-				SOURCE_SYSTEM_MAX_LENGTH,
-				`sourceSystem must be at most ${SOURCE_SYSTEM_MAX_LENGTH} characters`
-			),
-		provenance: provenanceSchema,
-		// "ISO 8601 UTC" (spec) — no offset variants accepted, matching the
-		// spec's own example ("...T09:41:07Z").
-		evaluatedAt: z
-			.string()
-			.datetime({ message: "evaluatedAt must be an ISO 8601 UTC timestamp" }),
-	})
-	.strict();
+export const healthEvidenceItemSchema = z.strictObject({
+	formatVersion: z.literal(EVIDENCE_FORMAT_VERSION, {
+		message: `formatVersion must be "${EVIDENCE_FORMAT_VERSION}"`,
+	}),
+	claimId: uuidSchema,
+	metricName: z
+		.string()
+		.min(1, "metricName is required")
+		.max(
+			METRIC_NAME_MAX_LENGTH,
+			`metricName must be at most ${METRIC_NAME_MAX_LENGTH} characters`
+		),
+	value: z.number().finite().optional(),
+	threshold: z.number().finite().optional(),
+	verdict: z.enum(["PASS", "FAIL", "DEGRADED"], {
+		message: "verdict must be PASS, FAIL, or DEGRADED",
+	}),
+	oddDimensions: z
+		.array(
+			z
+				.string()
+				.min(1)
+				.max(
+					ODD_DIMENSION_MAX_LENGTH,
+					`Each oddDimensions entry must be at most ${ODD_DIMENSION_MAX_LENGTH} characters`
+				)
+		)
+		.max(
+			ODD_DIMENSION_MAX_ITEMS,
+			`oddDimensions must have at most ${ODD_DIMENSION_MAX_ITEMS} entries`
+		)
+		.default([]),
+	sourceSystem: z
+		.string()
+		.min(1, "sourceSystem is required")
+		.max(
+			SOURCE_SYSTEM_MAX_LENGTH,
+			`sourceSystem must be at most ${SOURCE_SYSTEM_MAX_LENGTH} characters`
+		),
+	provenance: provenanceSchema,
+	// "ISO 8601 UTC" (spec) — no offset variants accepted, matching the
+	// spec's own example ("...T09:41:07Z").
+	evaluatedAt: z
+		.string()
+		.datetime({ message: "evaluatedAt must be an ISO 8601 UTC timestamp" }),
+});

--- a/lib/schemas/integration.ts
+++ b/lib/schemas/integration.ts
@@ -47,7 +47,7 @@ export const integrationScopesSchema = z
  * name a different owner (vincent's session-derived-identity trust
  * statement, 2026-07-03).
  */
-export const registerIntegrationSchema = z.object({
+export const registerIntegrationSchema = z.strictObject({
 	name: requiredString("Name", 1, 100),
 	description: optionalString(1000),
 	scopes: integrationScopesSchema,
@@ -81,7 +81,7 @@ export type RegisterIntegrationFormInput = z.input<
 // type outside the route's own `.safeParse` call. Add one back when an edit UI
 // lands and a caller needs the parsed shape by name.
 export const updateIntegrationSchema = z
-	.object({
+	.strictObject({
 		description: optionalString(1000),
 		scopes: integrationScopesSchema.optional(),
 	})
@@ -106,7 +106,7 @@ export const updateIntegrationSchema = z
 // No `z.infer` alias here — nothing currently consumes an issueTokenSchema
 // type outside the route's own `.safeParse` call. Add one back when an
 // expiry-picker UI lands and a caller needs the parsed shape by name.
-export const issueTokenSchema = z.object({
+export const issueTokenSchema = z.strictObject({
 	expiresAt: z.coerce
 		.date()
 		.refine((date) => date.getTime() > Date.now(), {
@@ -149,7 +149,7 @@ const grantableCasePermissionSchema = z.enum(["VIEW", "COMMENT", "EDIT"], {
 // type outside the route's own `.safeParse` call (file convention — see
 // `updateIntegrationSchema`/`issueTokenSchema` above). Add one back when a
 // caller needs the parsed shape by name.
-export const grantCaseAccessSchema = z.object({
+export const grantCaseAccessSchema = z.strictObject({
 	caseId: uuidSchema,
 	permission: grantableCasePermissionSchema,
 });

--- a/lib/schemas/permission.ts
+++ b/lib/schemas/permission.ts
@@ -4,7 +4,7 @@ import { emailSchema, permissionLevelSchema, uuidSchema } from "./base";
 /**
  * Share case by email
  */
-export const shareByEmailSchema = z.object({
+export const shareByEmailSchema = z.strictObject({
 	type: z.literal("user").optional(),
 	email: emailSchema,
 	permission: permissionLevelSchema,
@@ -16,7 +16,7 @@ export type ShareByEmailSchemaOutput = z.output<typeof shareByEmailSchema>;
 /**
  * Share case with team
  */
-export const shareWithTeamSchema = z.object({
+export const shareWithTeamSchema = z.strictObject({
 	type: z.literal("team"),
 	teamId: uuidSchema,
 	permission: permissionLevelSchema,
@@ -41,7 +41,7 @@ export type SharePermissionSchemaOutput = z.output<
 /**
  * Update an existing permission
  */
-export const updatePermissionSchema = z.object({
+export const updatePermissionSchema = z.strictObject({
 	permission: permissionLevelSchema,
 	type: z.enum(["user", "team"]).optional(),
 });

--- a/lib/schemas/plugin.ts
+++ b/lib/schemas/plugin.ts
@@ -71,7 +71,7 @@ const pluginSettingsSchema = z
  * The acting user is never part of this schema — the route derives it from
  * the session (`requireAuth()`), never from the request body.
  */
-export const pluginToggleSchema = z.object({
+export const pluginToggleSchema = z.strictObject({
 	pluginId: z
 		.string()
 		.min(1, "pluginId is required")

--- a/lib/schemas/publish.ts
+++ b/lib/schemas/publish.ts
@@ -8,7 +8,7 @@ import { optionalString } from "./base";
  * (`lib/schemas/case-information.ts`), which is the public-facing summary
  * of the case itself.
  */
-export const publishCaseBodySchema = z.object({
+export const publishCaseBodySchema = z.strictObject({
 	description: optionalString(2000),
 });
 

--- a/lib/schemas/publishable-item.ts
+++ b/lib/schemas/publishable-item.ts
@@ -48,13 +48,16 @@ export type PublishableItemSlug = z.infer<typeof publishableItemSlugSchema>;
  * are ever read back out — so a malformed or legacy-shaped snapshot
  * degrades to missing fields rather than throwing.
  */
+// biome-ignore lint/plugin: defensive read of frozen snapshots — older snapshots carry keys we no longer model, and only case/caseInformation are ever read back out, so unknown keys must be dropped silently, not rejected.
 export const publishedSnapshotMetaSchema = z.object({
+	// biome-ignore lint/plugin: defensive read of frozen snapshots — see the schema-level comment above.
 	case: z
 		.object({
 			name: z.string().optional(),
 			description: z.string().optional(),
 		})
 		.optional(),
+	// biome-ignore lint/plugin: defensive read of frozen snapshots — see the schema-level comment above.
 	caseInformation: z
 		.object({
 			description: z.string().nullable().optional(),

--- a/lib/schemas/status.ts
+++ b/lib/schemas/status.ts
@@ -4,7 +4,7 @@ import { optionalString } from "./base";
 /**
  * Update case publish status input
  */
-export const updateCaseStatusSchema = z.object({
+export const updateCaseStatusSchema = z.strictObject({
 	targetStatus: z.enum(["DRAFT", "PUBLISHED"], {
 		message: "Invalid targetStatus. Must be one of: DRAFT, PUBLISHED",
 	}),

--- a/lib/schemas/team.ts
+++ b/lib/schemas/team.ts
@@ -4,7 +4,7 @@ import { optionalString, requiredString } from "./base";
 /**
  * Create team input
  */
-export const createTeamSchema = z.object({
+export const createTeamSchema = z.strictObject({
 	name: requiredString("Team name", 1, 100),
 	description: optionalString(500),
 });
@@ -15,7 +15,7 @@ export type CreateTeamSchemaOutput = z.output<typeof createTeamSchema>;
 /**
  * Base object for update team — usable with zodResolver (no .refine())
  */
-export const updateTeamBaseSchema = z.object({
+export const updateTeamBaseSchema = z.strictObject({
 	name: requiredString("Team name", 1, 100).optional(),
 	description: optionalString(500),
 });
@@ -36,7 +36,7 @@ export type UpdateTeamSchemaOutput = z.output<typeof updateTeamSchema>;
 /**
  * Update team member role input
  */
-export const updateMemberRoleSchema = z.object({
+export const updateMemberRoleSchema = z.strictObject({
 	role: z.enum(["ADMIN", "MEMBER"], {
 		message: "Invalid team role",
 	}),
@@ -49,7 +49,7 @@ export type UpdateMemberRoleSchemaInput = z.input<
 /**
  * Add team member input
  */
-export const addTeamMemberSchema = z.object({
+export const addTeamMemberSchema = z.strictObject({
 	email: z
 		.string()
 		.min(1, "Email is required")

--- a/lib/schemas/tour.ts
+++ b/lib/schemas/tour.ts
@@ -15,7 +15,7 @@ export type TourId = (typeof KNOWN_TOUR_IDS)[number];
 /**
  * Schema for marking a tour as completed.
  */
-export const tourCompletionSchema = z.object({
+export const tourCompletionSchema = z.strictObject({
 	tourId: z.enum(KNOWN_TOUR_IDS, {
 		message: `Invalid tour ID. Expected one of: ${KNOWN_TOUR_IDS.join(", ")}`,
 	}),

--- a/lib/schemas/user.ts
+++ b/lib/schemas/user.ts
@@ -33,7 +33,7 @@ export const passwordSchema = z
 /**
  * Sign-in form — accepts email or username as identifier
  */
-export const signInFormSchema = z.object({
+export const signInFormSchema = z.strictObject({
 	identifier: z.string().min(2, "Please enter your email or username"),
 	password: z.string().min(8, "Password must be at least 8 characters"),
 });
@@ -45,7 +45,7 @@ export type SignInFormOutput = z.output<typeof signInFormSchema>;
  * Reset password form — requires matching passwords
  */
 export const resetPasswordFormSchema = z
-	.object({
+	.strictObject({
 		password: passwordSchema,
 		confirmPassword: z.string(),
 	})
@@ -61,7 +61,7 @@ export type ResetPasswordFormOutput = z.output<typeof resetPasswordFormSchema>;
  * Change password form — requires current password + matching new passwords
  */
 export const changePasswordFormSchema = z
-	.object({
+	.strictObject({
 		currentPassword: z
 			.string()
 			.min(2, "Current password must be at least 2 characters"),
@@ -84,7 +84,7 @@ export type ChangePasswordFormOutput = z.output<
  * Register form validation schema — UI-level constraints for the registration form.
  * Stricter than `registerUserSchema` (which is the API-level schema).
  */
-export const registerFormSchema = z.object({
+export const registerFormSchema = z.strictObject({
 	username: usernameSchema,
 	email: emailSchema,
 	password1: passwordSchema,
@@ -97,7 +97,7 @@ export type RegisterFormOutput = z.output<typeof registerFormSchema>;
 /**
  * Forgot password form schema — validates an email address
  */
-export const forgotPasswordFormSchema = z.object({
+export const forgotPasswordFormSchema = z.strictObject({
 	email: emailSchema,
 });
 
@@ -110,7 +110,7 @@ export type ForgotPasswordFormOutput = z.output<
  * Personal info form schema — UI-level validation for the settings profile form.
  * Stricter than `updateUserProfileSchema` (which is the API-level schema).
  */
-export const personalInfoFormSchema = z.object({
+export const personalInfoFormSchema = z.strictObject({
 	firstName: z.string().optional(),
 	lastName: z.string().optional(),
 	username: usernameSchema,
@@ -124,7 +124,7 @@ export type PersonalInfoFormOutput = z.output<typeof personalInfoFormSchema>;
  * Register user input
  */
 export const registerUserSchema = z
-	.object({
+	.strictObject({
 		username: usernameSchema,
 		email: emailSchema,
 		password: z.string().min(1, "Password is required").optional(),
@@ -156,7 +156,7 @@ export type RegisterUserSchemaOutput = z.output<typeof registerUserSchema>;
  * Update user profile input
  */
 export const updateUserProfileSchema = z
-	.object({
+	.strictObject({
 		username: requiredString("Username", 1, 150).optional(),
 		firstName: optionalString(150),
 		lastName: optionalString(150),

--- a/lint-rules/no-bare-zod-object.grit
+++ b/lint-rules/no-bare-zod-object.grit
@@ -1,0 +1,3 @@
+`z.object($_)` as $o where {
+	register_diagnostic(span=$o, message="Bare z.object() in lib/schemas — use z.strictObject() for request bodies; for a parser of stored/imported JSON, keep z.object() and add a biome-ignore comment with the reason.")
+}

--- a/src/__tests__/integration/api-cases-batch-route.test.ts
+++ b/src/__tests__/integration/api-cases-batch-route.test.ts
@@ -120,3 +120,28 @@ describe("POST /api/cases/[id]/batch — evidence URL validation (nullableUrlSch
 		expect(inDb?.url).toBeNull();
 	});
 });
+
+describe("POST /api/cases/[id]/batch — strict schema (unrecognised key rejection)", () => {
+	it("rejects an update change whose data carries an unrecognised key (URL, uppercase — batchUpdateRequestSchema only declares lowercase url) with 400 naming the key", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const evidence = await createTestElement(testCase.id, owner.id, {
+			elementType: "EVIDENCE",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const response = await postBatch(testCase.id, {
+			changes: [
+				{
+					type: "update",
+					elementId: evidence.id,
+					data: { URL: "https://x.example" },
+				},
+			],
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toContain("URL");
+	});
+});

--- a/src/__tests__/integration/api-cases-batch-route.test.ts
+++ b/src/__tests__/integration/api-cases-batch-route.test.ts
@@ -1,0 +1,122 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	createTestCase,
+	createTestElement,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+/**
+ * Route-level regression tests for POST /api/cases/[id]/batch — the JSON
+ * editor's batch-update path (TEA — Mutation-schema hardening, Part 2).
+ * These exercise the real route handler, not applyBatchUpdate directly
+ * (see case-batch-update-service.test.ts for the service-level suite), to
+ * prove nullableUrlSchema is actually wired into the schema the route
+ * parses against and that the route surfaces its friendly message.
+ */
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/services/sse-connection-manager", () => ({
+	emitSSEEvent: vi.fn(),
+	sseConnectionManager: { broadcast: vi.fn() },
+}));
+
+beforeEach(async () => {
+	await mockNoAuth();
+});
+
+async function postBatch(caseId: string, body: unknown) {
+	const { POST } = await import("@/app/api/cases/[id]/batch/route");
+	const req = new NextRequest(
+		`http://localhost:3000/api/cases/${caseId}/batch`,
+		{
+			method: "POST",
+			body: JSON.stringify(body),
+			headers: { "Content-Type": "application/json" },
+		}
+	);
+	return await POST(req, { params: Promise.resolve({ id: caseId }) });
+}
+
+describe("POST /api/cases/[id]/batch — evidence URL validation (nullableUrlSchema)", () => {
+	it("normalises a schemeless URL and stores it with https:// prepended", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const evidence = await createTestElement(testCase.id, owner.id, {
+			elementType: "EVIDENCE",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const response = await postBatch(testCase.id, {
+			changes: [
+				{
+					type: "update",
+					elementId: evidence.id,
+					data: { url: "example.com/report.pdf" },
+				},
+			],
+		});
+
+		expect(response.status).toBe(200);
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: evidence.id },
+		});
+		expect(inDb?.url).toBe("https://example.com/report.pdf");
+	});
+
+	it("rejects a mailto: address with the friendly message", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const evidence = await createTestElement(testCase.id, owner.id, {
+			elementType: "EVIDENCE",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const response = await postBatch(testCase.id, {
+			changes: [
+				{
+					type: "update",
+					elementId: evidence.id,
+					data: { url: "mailto:x@y" },
+				},
+			],
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toBe(
+			"Enter a web address, such as example.com/report.pdf"
+		);
+	});
+
+	it("clears an existing URL when data.url is null (JSON editor's clear affordance)", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const evidence = await createTestElement(testCase.id, owner.id, {
+			elementType: "EVIDENCE",
+			url: "https://example.com/existing.pdf",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const response = await postBatch(testCase.id, {
+			changes: [
+				{
+					type: "update",
+					elementId: evidence.id,
+					data: { url: null },
+				},
+			],
+		});
+
+		expect(response.status).toBe(200);
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: evidence.id },
+		});
+		expect(inDb?.url).toBeNull();
+	});
+});

--- a/src/__tests__/integration/api-cases-batch-route.test.ts
+++ b/src/__tests__/integration/api-cases-batch-route.test.ts
@@ -119,6 +119,33 @@ describe("POST /api/cases/[id]/batch — evidence URL validation (nullableUrlSch
 		});
 		expect(inDb?.url).toBeNull();
 	});
+
+	it("leaves an existing URL unchanged when data omits url entirely (undefined means leave unchanged, not clear)", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const evidence = await createTestElement(testCase.id, owner.id, {
+			elementType: "EVIDENCE",
+			url: "https://example.com/existing.pdf",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const response = await postBatch(testCase.id, {
+			changes: [
+				{
+					type: "update",
+					elementId: evidence.id,
+					data: { description: "Updated description, no url field at all" },
+				},
+			],
+		});
+
+		expect(response.status).toBe(200);
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: evidence.id },
+		});
+		expect(inDb?.url).toBe("https://example.com/existing.pdf");
+		expect(inDb?.description).toBe("Updated description, no url field at all");
+	});
 });
 
 describe("POST /api/cases/[id]/batch — strict schema (unrecognised key rejection)", () => {

--- a/src/__tests__/integration/api-cases.test.ts
+++ b/src/__tests__/integration/api-cases.test.ts
@@ -213,6 +213,35 @@ describe("PUT /api/cases/[id]", () => {
 		expect(response.status).toBe(400);
 	});
 
+	it("rejects an unrecognised key (snake_case layout_direction) with 400 naming the key — the exact bug that motivated strict schemas", async () => {
+		// layoutDirection (camelCase) is the schema's declared field; a client
+		// sending layout_direction (snake_case) used to have it silently
+		// dropped by the old bare z.object() and return 200 while doing
+		// nothing (TEA — layoutDirection setting silently fails to persist,
+		// the key-case mismatch that motivated this hardening issue).
+		// z.strictObject() now rejects it outright, naming the key.
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id, { name: "Case" });
+		await mockAuth(user.id, user.username, user.email);
+
+		const { PUT } = await import("@/app/api/cases/[id]/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}`,
+			{
+				method: "PUT",
+				body: JSON.stringify({ layout_direction: "LR" }),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toContain("layout_direction");
+	});
+
 	it("returns 401 when the request is not authenticated", async () => {
 		const { PUT } = await import("@/app/api/cases/[id]/route");
 		const req = new NextRequest(

--- a/src/__tests__/integration/api-elements-attach-route.test.ts
+++ b/src/__tests__/integration/api-elements-attach-route.test.ts
@@ -1,0 +1,108 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	createTestCase,
+	createTestElement,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+/**
+ * Route-level regression tests for POST /api/elements/[id]/attach (TEA —
+ * Mutation-schema hardening, commit 00a77f7e). The route used to read
+ * legacy snake_case keys (goal_id, parent_id, strategy_id,
+ * property_claim_id) from the raw body via resolveParentId() before
+ * parsing; that resolver is gone and the body is parsed directly with
+ * attachElementSchema (z.strictObject({ parentId })). These exercise the
+ * real POST handler against real Postgres, mirroring
+ * api-cases-batch-route.test.ts's pattern.
+ */
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/services/sse-connection-manager", () => ({
+	emitSSEEvent: vi.fn(),
+	sseConnectionManager: { broadcast: vi.fn() },
+}));
+
+beforeEach(async () => {
+	await mockNoAuth();
+});
+
+async function postAttach(elementId: string, body: unknown) {
+	const { POST } = await import("@/app/api/elements/[id]/attach/route");
+	const req = new NextRequest(
+		`http://localhost:3000/api/elements/${elementId}/attach`,
+		{
+			method: "POST",
+			body: JSON.stringify(body),
+			headers: { "Content-Type": "application/json" },
+		}
+	);
+	return await POST(req, { params: Promise.resolve({ id: elementId }) });
+}
+
+describe("POST /api/elements/[id]/attach", () => {
+	it("attaches the element to the named parent when the body is a bare { parentId }", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const goal = await createTestElement(testCase.id, owner.id, {
+			elementType: "GOAL",
+		});
+		const orphan = await createTestElement(testCase.id, owner.id, {
+			elementType: "STRATEGY",
+			inSandbox: true,
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const response = await postAttach(orphan.id, { parentId: goal.id });
+
+		expect(response.status).toBe(200);
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: orphan.id },
+		});
+		expect(inDb?.parentId).toBe(goal.id);
+	});
+
+	it("rejects a legacy snake_case body (goal_id) with 400 and does not attach", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const goal = await createTestElement(testCase.id, owner.id, {
+			elementType: "GOAL",
+		});
+		const orphan = await createTestElement(testCase.id, owner.id, {
+			elementType: "STRATEGY",
+			inSandbox: true,
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const response = await postAttach(orphan.id, { goal_id: goal.id });
+
+		expect(response.status).toBe(400);
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: orphan.id },
+		});
+		expect(inDb?.parentId).toBeNull();
+	});
+
+	it("rejects a non-UUID parentId with 400 and the friendly message", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const orphan = await createTestElement(testCase.id, owner.id, {
+			elementType: "STRATEGY",
+			inSandbox: true,
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const response = await postAttach(orphan.id, {
+			parentId: "not-a-uuid",
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toBe("Invalid parent ID format");
+	});
+});

--- a/src/__tests__/integration/api-integration-case-grants.test.ts
+++ b/src/__tests__/integration/api-integration-case-grants.test.ts
@@ -600,7 +600,14 @@ describe("POST /api/integrations/[id]/case-grants", () => {
 		expect(response.status).toBe(400);
 	});
 
-	it("cannot grant access to an arbitrary userId — the body has no such field", async () => {
+	it("rejects a body naming an arbitrary userId outright (grantCaseAccessSchema is strict — userId is not a declared field)", async () => {
+		// Stronger than the old assertion this replaced: grantCaseAccessSchema
+		// went from a bare z.object() (which silently dropped userId and fell
+		// through to granting the integration's own system user) to
+		// z.strictObject() (TEA — Mutation-schema hardening). The attempt is
+		// now rejected at the boundary with 400 before any grant is written —
+		// userId was already undeclared and server-derived (see the schema's
+		// doc comment); nothing here relies on strict mode to stay secure.
 		const owner = await createTestUser();
 		const other = await createTestUser();
 		const { integration, systemUser } =
@@ -611,7 +618,7 @@ describe("POST /api/integrations/[id]/case-grants", () => {
 		const { POST } = await import(
 			"@/app/api/integrations/[id]/case-grants/route"
 		);
-		await POST(
+		const response = await POST(
 			jsonRequest(`/api/integrations/${integration.id}/case-grants`, "POST", {
 				caseId: testCase.id,
 				permission: "VIEW",
@@ -619,8 +626,10 @@ describe("POST /api/integrations/[id]/case-grants", () => {
 			}),
 			idParams(integration.id)
 		);
+		expect(response.status).toBe(400);
 
-		// Only the integration's OWN system user ever gets a grant.
+		// No grant was written for anyone — not the named userId, not even the
+		// integration's own system user (the request never reached the service).
 		const grantedForOther = await prisma.casePermission.findUnique({
 			where: { caseId_userId: { caseId: testCase.id, userId: other.id } },
 		});
@@ -630,7 +639,7 @@ describe("POST /api/integrations/[id]/case-grants", () => {
 				caseId_userId: { caseId: testCase.id, userId: systemUser.id },
 			},
 		});
-		expect(grantedForSystemUser).not.toBeNull();
+		expect(grantedForSystemUser).toBeNull();
 	});
 
 	/**

--- a/src/__tests__/integration/api-integrations.test.ts
+++ b/src/__tests__/integration/api-integrations.test.ts
@@ -155,7 +155,14 @@ describe("POST /api/integrations", () => {
 		expect(body.integration).not.toHaveProperty("token");
 	});
 
-	it("binds ownership to the session user even if the body names a different owner", async () => {
+	it("rejects a body naming a different owner outright (registerIntegrationSchema is strict — ownerId is not a declared field)", async () => {
+		// Stronger than the old assertion this replaced: registerIntegrationSchema
+		// went from a bare z.object() (which silently dropped ownerId and fell
+		// through to the session-derived owner) to z.strictObject() (TEA —
+		// Mutation-schema hardening). A spoofing attempt is now rejected at the
+		// boundary with 400, not silently defused with a 201 — ownerId was
+		// already undeclared and session-derived (see the schema's doc
+		// comment); nothing here relies on strict mode to stay secure.
 		const user = await createTestUser();
 		const other = await createTestUser();
 		await mockAuth(user.id, user.username, user.email);
@@ -169,10 +176,7 @@ describe("POST /api/integrations", () => {
 			})
 		);
 
-		expect(response.status).toBe(201);
-		const body = await response.json();
-		expect(body.integration.ownerId).toBe(user.id);
-		expect(body.integration.ownerId).not.toBe(other.id);
+		expect(response.status).toBe(400);
 	});
 
 	it("rejects an unknown scope with 400", async () => {

--- a/src/__tests__/integration/api-integrations.test.ts
+++ b/src/__tests__/integration/api-integrations.test.ts
@@ -167,16 +167,24 @@ describe("POST /api/integrations", () => {
 		const other = await createTestUser();
 		await mockAuth(user.id, user.username, user.email);
 
+		const attemptedName = `spoof-attempt-${user.id}`;
 		const { POST } = await import("@/app/api/integrations/route");
 		const response = await POST(
 			jsonRequest("/api/integrations", "POST", {
-				name: `spoof-attempt-${user.id}`,
+				name: attemptedName,
 				scopes: ["case:read"],
 				ownerId: other.id,
 			})
 		);
 
 		expect(response.status).toBe(400);
+
+		// No integration row was written at all — the rejection happens at the
+		// schema boundary, before the service (or any owner) is ever reached.
+		const written = await prisma.integration.findFirst({
+			where: { name: attemptedName },
+		});
+		expect(written).toBeNull();
 	});
 
 	it("rejects an unknown scope with 400", async () => {

--- a/src/__tests__/integration/api-user-plugins.test.ts
+++ b/src/__tests__/integration/api-user-plugins.test.ts
@@ -112,7 +112,15 @@ describe("PATCH /api/user/plugins — auth and session-derived identity", () => 
 		expect(response.status).toBe(401);
 	});
 
-	it("ignores a body-supplied userId — the row is written for the session user, never the body's userId", async () => {
+	it("rejects a body-supplied userId outright (pluginToggleSchema is strict — userId is not a declared field)", async () => {
+		// Stronger than the old assertion this replaced: pluginToggleSchema
+		// went from a bare z.object() (which silently dropped userId and fell
+		// through to writing the session user's row) to z.strictObject() (TEA
+		// — Mutation-schema hardening). The request is now rejected at the
+		// boundary with 400 before any row is written — userId was already
+		// undeclared and session-derived (the route derives the acting user
+		// from requireAuth(), never from the body); nothing here relies on
+		// strict mode to stay secure.
 		const actingUser = await createTestUser();
 		const otherUser = await createTestUser();
 		await mockAuth(actingUser.id, actingUser.username, actingUser.email);
@@ -126,7 +134,7 @@ describe("PATCH /api/user/plugins — auth and session-derived identity", () => 
 			})
 		);
 
-		expect(response.status).toBe(200);
+		expect(response.status).toBe(400);
 
 		const actingUserRow = await prisma.pluginState.findUnique({
 			where: {
@@ -147,8 +155,7 @@ describe("PATCH /api/user/plugins — auth and session-derived identity", () => 
 			},
 		});
 
-		expect(actingUserRow).not.toBeNull();
-		expect(actingUserRow?.enabled).toBe(false);
+		expect(actingUserRow).toBeNull();
 		expect(otherUserRow).toBeNull();
 	});
 });

--- a/src/__tests__/integration/element-reference-integrity-adversarial.test.ts
+++ b/src/__tests__/integration/element-reference-integrity-adversarial.test.ts
@@ -244,7 +244,7 @@ describe("parentId same-case scoping — EVIDENCE path specifically", () => {
 				body: JSON.stringify({
 					type: "evidence",
 					name: "Cross-case evidence",
-					propertyClaimId: foreignClaim.id,
+					parentId: foreignClaim.id,
 				}),
 				headers: { "Content-Type": "application/json" },
 			}


### PR DESCRIPTION
## Summary

Two request-validation gaps in `lib/schemas/`, closed together because they share a directory, a route under test and a kind of change (what a request body may contain).

**1. Strict request schemas.** Every request-body schema in `lib/schemas/` now uses `z.strictObject()` (nested objects included), so a write request carrying a field the server does not declare is rejected with a 400 naming the field instead of being silently accepted with the field dropped — the mechanism that hid the `layoutDirection` / `in_sandbox` key-casing bugs. A Biome GritQL rule (`lint-rules/no-bare-zod-object.grit`, scoped by a `biome.json` override to `lib/schemas/**`) fails lint on any bare `z.object()` there; the four parsers of stored/imported JSON that must keep dropping unknown keys (export/import document, frozen publish snapshots, import validation, the `catchall` provenance object) carry a reasoned `biome-ignore` each.

**2. Batch-route URL validation.** `POST /api/cases/[id]/batch` (the JSON editor's save path) now validates and normalises evidence `url` values with the same lenient web-address rule the forms use (`example.com/x` → `https://example.com/x`; `mailto:`/`javascript:` rejected with the friendly message). A new `nullableUrlSchema` keeps `null` meaning "clear the URL", which the editor relies on. The route now surfaces the schema's own message instead of a generic one.

**Client and route clean-up that strict mode required.** The add-element hook and `attachCaseElement` sent parent references under legacy names (`goalId`/`strategyId`/`propertyClaimId`, snake_case variants) that the routes read from the raw body behind the schema. Both clients now send `parentId`; the three legacy raw-body resolvers and the two hand-written route mappers are deleted (routes pass `parsed.data` to the services, which already resolve `url`/`URL`). `CreateNodePayload` is narrowed to an interface so the compiler enforces the shape.

## Tests

- Route-level: unknown key on `PUT /api/cases/[id]` → 400 naming it; `data.URL` in a batch update → 400; batch `url` normalised / rejected / cleared with `null` / unchanged when omitted (real route → DB); attach route accepts `{ parentId }`, rejects the legacy shape and a non-UUID.
- Unit: `nullableUrlSchema`; one test per rewritten add-element payload branch through the real `createElementSchema`; a permanent guard that the lint rule fires (runs Biome on a throwaway probe under `lib/schemas/__tests__/`, fails loudly if Biome does not launch).
- Three integration tests that previously asserted a spoofed `ownerId`/`userId` was silently ignored now assert the request is rejected at the boundary and nothing is written.

Unit 1352 · integration 1053 · typecheck and lint clean · fallow: 0 dead code, 0 complexity introduced. e2e on a production build: discover and publish-journey green; the auth/sharing specs need the seeded password from CI's environment and run there.

## Follow-ups (filed, not in this PR)

- Extract a `parseBody(schema, request)` helper — the `safeParse`-then-400 block now repeats across several routes.
- `CreateElementInput.shortDescription` / `longDescription` are never set on the only create path.
- No e2e clicks the add-element UI (pre-existing; covered here at hook and route level).