### PR TITLE
feat: element-name prefix validation with plugin-extensible registry and name backfill

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -543,7 +543,11 @@ jobs:
     # practice.
     if: ${{ !cancelled() && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Matches the test and lint jobs. The audit itself takes seconds; the
+    # budget is for the npm registry, which this job hits twice (pnpm
+    # setup, then `npx fallow`) with no cache, and which can be slow
+    # enough to exceed a 10-minute cap on its own.
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write

--- a/docs/database/schema.dbml
+++ b/docs/database/schema.dbml
@@ -264,6 +264,22 @@ Table assurance_elements {
   Note: 'Node in the assurance case hierarchy: GOAL, STRATEGY, PROPERTY_CLAIM, EVIDENCE, CONTEXT, MODULE, etc.'
 }
 
+Table element_name_backfill {
+  id String [pk]
+  elementId String [not null]
+  oldName String [not null]
+  newName String [not null]
+  migratedAt DateTime [default: `now()`, not null]
+
+  Note: 'Audit trail for the one-off element-name-prefix backfill migration
+(`prisma/migrations/*_element_name_prefix_backfill`): every element whose
+stored name didn\'t conform to its type\'s TEA-syntax prefix format got a
+row here recording old_name -> new_name before the rename, so a support
+query (or a down-migration) can restore it. No FK to AssuranceElement
+deliberately — this is an audit trail, not a live relation, and should
+survive even if the source element is later hard-purged.'
+}
+
 Table evidence_links {
   id String [pk]
   evidenceId String [not null, note: 'The evidence element']

--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -151,6 +151,14 @@ const ERROR_MAPPINGS: Array<{
 	// self-reference target) is a validation failure (400), not a 500 —
 	// same shape as citedElementId/moduleReferenceId above.
 	{ pattern: /^defeatsElementId /, factory: () => validationError("") },
+	// `lib/schemas/element-validation.ts`'s `validateElementName` (TEA-syntax
+	// element-name prefix validation): a name that doesn't match its type's
+	// registered prefix format is a validation failure (400), not a 500.
+	// Anchored to `describeExpectedFormat`'s exact message shape ("<Type>
+	// names must look like ...") rather than a generic word, so an unrelated
+	// service error mentioning "names" for a different reason isn't
+	// misclassified.
+	{ pattern: / names must look like /, factory: () => validationError("") },
 	// Lifecycle/state-guard errors from the integration registry service —
 	// the integration or token exists and is owned by the caller, but its
 	// current status makes the requested action a no-op or a terminal-state

--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -129,6 +129,13 @@ const ERROR_MAPPINGS: Array<{
 	// (integration management API, work item 7): an unknown scope is a
 	// validation failure (400), not an unmapped 500.
 	{ pattern: /^Unknown scope/, factory: () => validationError("") },
+	// `element-service.ts`'s `createElement`: an unrecognised `type`/
+	// `elementType` (schema-level, `lib/schemas/element.ts`'s
+	// `elementTypeSchema`, only checks it's a non-empty string — a bad value
+	// reaches the service) is a validation failure (400), not a 500. Without
+	// this guard the bad type used to reach `generateElementName` -> `toPrefix`,
+	// which throws for anything the prefix registry doesn't know.
+	{ pattern: /^Unknown element type/, factory: () => validationError("") },
 	// `element-service.ts`'s `rejectDeclaredAsCited` (ADR 0004 D3): AS_CITED
 	// is machine-derived from the cited element's own status, never author-
 	// declared — a rejected write is a validation failure (400), not a 500.
@@ -154,11 +161,19 @@ const ERROR_MAPPINGS: Array<{
 	// `lib/schemas/element-validation.ts`'s `validateElementName` (TEA-syntax
 	// element-name prefix validation): a name that doesn't match its type's
 	// registered prefix format is a validation failure (400), not a 500.
-	// Anchored to `describeExpectedFormat`'s exact message shape ("<Type>
-	// names must look like ...") rather than a generic word, so an unrelated
-	// service error mentioning "names" for a different reason isn't
-	// misclassified.
-	{ pattern: / names must look like /, factory: () => validationError("") },
+	// `describeExpectedFormat` (prefix-registry.ts) produces one of two exact
+	// shapes depending on whether the type is one of the ten known core
+	// types — "<Type> names must look like ..." normally, or the generic
+	// "Names must follow this element type's registered format" fallback for
+	// a type it doesn't recognise — both matched here rather than a single
+	// pattern, so an unrecognised element type's name error doesn't fall
+	// through to an unmapped 500 the way the type itself once did. Neither
+	// alternative is a generic word, so an unrelated service error
+	// mentioning "names" for a different reason isn't misclassified.
+	{
+		pattern: / names must look like | element type's registered format/,
+		factory: () => validationError(""),
+	},
 	// Lifecycle/state-guard errors from the integration registry service —
 	// the integration or token exists and is owned by the caller, but its
 	// current status makes the requested action a no-op or a terminal-state

--- a/lib/element-names/__tests__/prefix-registry.test.ts
+++ b/lib/element-names/__tests__/prefix-registry.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	describeExpectedFormat,
+	getAcceptedPatterns,
+	getCorePrefix,
+	isValidElementName,
+	registerPluginNamePatterns,
+	resetPluginNamePatternsForTests,
+} from "../prefix-registry";
+
+const CONFLICTING_REGISTRATION_MESSAGE = /conflicting registration/i;
+const REGISTERED_FORMAT_MESSAGE = /registered format/;
+const FAKE_GSN_EVIDENCE_PATTERN = /^Sn[0-9]+$/;
+const FAKE_GSN_EVIDENCE_PATTERN_ALT = /^Different[0-9]+$/;
+const OTHER_PLUGIN_EVIDENCE_PATTERN = /^Ev[0-9]+$/;
+
+describe("prefix-registry", () => {
+	afterEach(() => {
+		resetPluginNamePatternsForTests();
+	});
+
+	describe("getCorePrefix", () => {
+		it("returns the ruled prefix for each of the ten core element types", () => {
+			expect(getCorePrefix("GOAL")).toBe("G");
+			expect(getCorePrefix("PROPERTY_CLAIM")).toBe("P");
+			expect(getCorePrefix("STRATEGY")).toBe("S");
+			expect(getCorePrefix("EVIDENCE")).toBe("E");
+			expect(getCorePrefix("CONTEXT")).toBe("C");
+			expect(getCorePrefix("JUSTIFICATION")).toBe("J");
+			expect(getCorePrefix("ASSUMPTION")).toBe("A");
+			expect(getCorePrefix("MODULE")).toBe("M");
+			expect(getCorePrefix("AWAY_GOAL")).toBe("AG");
+			expect(getCorePrefix("CONTRACT")).toBe("Ct");
+		});
+
+		it("returns undefined for a type it doesn't know", () => {
+			expect(getCorePrefix("NOT_A_REAL_TYPE")).toBeUndefined();
+		});
+	});
+
+	describe("isValidElementName — full format", () => {
+		it("accepts each core type's own prefix format", () => {
+			expect(isValidElementName("GOAL", "G1")).toBe(true);
+			expect(isValidElementName("PROPERTY_CLAIM", "P1")).toBe(true);
+			expect(isValidElementName("STRATEGY", "S1")).toBe(true);
+			expect(isValidElementName("EVIDENCE", "E1")).toBe(true);
+			expect(isValidElementName("CONTEXT", "C1")).toBe(true);
+			expect(isValidElementName("JUSTIFICATION", "J1")).toBe(true);
+			expect(isValidElementName("ASSUMPTION", "A1")).toBe(true);
+			expect(isValidElementName("MODULE", "M1")).toBe(true);
+			expect(isValidElementName("AWAY_GOAL", "AG1")).toBe(true);
+			expect(isValidElementName("CONTRACT", "Ct1")).toBe(true);
+		});
+
+		it("rejects another type's prefix — P1 on a GOAL fails", () => {
+			expect(isValidElementName("GOAL", "P1")).toBe(false);
+		});
+
+		it("rejects a name that only starts with the right letter (prefix-only would pass, full format must not)", () => {
+			expect(isValidElementName("PROPERTY_CLAIM", "Precision claim")).toBe(
+				false
+			);
+		});
+
+		it("accepts dotted sub-numbering to any depth", () => {
+			expect(isValidElementName("PROPERTY_CLAIM", "P1.2.3")).toBe(true);
+		});
+
+		it("rejects a bare prefix with no number, and a trailing dot with no number after it", () => {
+			expect(isValidElementName("PROPERTY_CLAIM", "P")).toBe(false);
+			expect(isValidElementName("PROPERTY_CLAIM", "P1.")).toBe(false);
+		});
+	});
+
+	describe("getAcceptedPatterns / registerPluginNamePatterns — plugin seam", () => {
+		it("a plugin-registered pattern is accepted only when its plugin id is in the enabled set", () => {
+			registerPluginNamePatterns(
+				"tea.fake-gsn",
+				"EVIDENCE",
+				FAKE_GSN_EVIDENCE_PATTERN
+			);
+
+			expect(isValidElementName("EVIDENCE", "Sn1", ["tea.fake-gsn"])).toBe(
+				true
+			);
+			expect(isValidElementName("EVIDENCE", "Sn1", [])).toBe(false);
+			expect(isValidElementName("EVIDENCE", "Sn1", ["tea.other"])).toBe(false);
+			// The core pattern is unaffected either way.
+			expect(isValidElementName("EVIDENCE", "E1", [])).toBe(true);
+		});
+
+		it("is additive only — a plugin's pattern never displaces the core pattern", () => {
+			registerPluginNamePatterns(
+				"tea.fake-gsn",
+				"EVIDENCE",
+				FAKE_GSN_EVIDENCE_PATTERN
+			);
+
+			const patterns = getAcceptedPatterns("EVIDENCE", ["tea.fake-gsn"]);
+			expect(patterns.some((p) => p.test("E1"))).toBe(true);
+			expect(patterns.some((p) => p.test("Sn1"))).toBe(true);
+		});
+
+		it("first-registration-wins on an identical re-registration (no throw)", () => {
+			registerPluginNamePatterns(
+				"tea.fake-gsn",
+				"EVIDENCE",
+				FAKE_GSN_EVIDENCE_PATTERN
+			);
+
+			expect(() =>
+				registerPluginNamePatterns(
+					"tea.fake-gsn",
+					"EVIDENCE",
+					FAKE_GSN_EVIDENCE_PATTERN
+				)
+			).not.toThrow();
+			expect(getAcceptedPatterns("EVIDENCE", ["tea.fake-gsn"])).toHaveLength(2);
+		});
+
+		it("throws on a conflicting re-registration for the same plugin and type", () => {
+			registerPluginNamePatterns(
+				"tea.fake-gsn",
+				"EVIDENCE",
+				FAKE_GSN_EVIDENCE_PATTERN
+			);
+
+			expect(() =>
+				registerPluginNamePatterns(
+					"tea.fake-gsn",
+					"EVIDENCE",
+					FAKE_GSN_EVIDENCE_PATTERN_ALT
+				)
+			).toThrow(CONFLICTING_REGISTRATION_MESSAGE);
+		});
+
+		it("lets two different plugins register independently for the same type", () => {
+			registerPluginNamePatterns(
+				"tea.fake-gsn",
+				"EVIDENCE",
+				FAKE_GSN_EVIDENCE_PATTERN
+			);
+			registerPluginNamePatterns(
+				"tea.other-plugin",
+				"EVIDENCE",
+				OTHER_PLUGIN_EVIDENCE_PATTERN
+			);
+
+			expect(isValidElementName("EVIDENCE", "Sn1", ["tea.fake-gsn"])).toBe(
+				true
+			);
+			expect(isValidElementName("EVIDENCE", "Ev1", ["tea.other-plugin"])).toBe(
+				true
+			);
+			// Enabling only one plugin doesn't grant the other's pattern.
+			expect(isValidElementName("EVIDENCE", "Ev1", ["tea.fake-gsn"])).toBe(
+				false
+			);
+		});
+	});
+
+	describe("describeExpectedFormat", () => {
+		it("names the type and shows both a flat and a dotted example", () => {
+			expect(describeExpectedFormat("PROPERTY_CLAIM")).toBe(
+				"Property Claim names must look like P1 or P1.1"
+			);
+		});
+
+		it("falls back to a generic message for an unknown type", () => {
+			expect(describeExpectedFormat("NOT_A_REAL_TYPE")).toMatch(
+				REGISTERED_FORMAT_MESSAGE
+			);
+		});
+	});
+});

--- a/lib/element-names/prefix-registry.ts
+++ b/lib/element-names/prefix-registry.ts
@@ -1,0 +1,201 @@
+/**
+ * TEA-syntax element-name prefix registry (design note: "TEA — Element Name
+ * Prefix Validation", ADR 0002 amendment — validation extension point).
+ *
+ * Core rule (Chris, ruled 2026-09-03): a named element's `name` must be the
+ * full TEA-syntax format for its type — `<prefix><n>(.<n>)*`, e.g. `P1`,
+ * `P1.1`, `G2`. Names stay optional; the rule applies only when a name is
+ * given. `getCorePrefix`'s ten-entry table is the single source of prefixes —
+ * `toPrefix` (`lib/element-types.ts`) and `identifier-service.ts` read from
+ * it rather than keeping their own copies, so the two can't drift again.
+ *
+ * The plugin override seam mirrors `lib/plugins/slots/registry.ts`'s
+ * additive-only, first-registration-wins-on-identical, conflict-throws
+ * shape: a plugin may register EXTRA accepted patterns for a type (e.g. a
+ * future GSN plugin adding `Sn<n>` alongside Evidence's `E<n>`), but can
+ * never remove a core pattern or another plugin's. Unlike the slot
+ * registry, this module does not check the pluginId against
+ * `PLUGIN_MANIFEST` — no shipped plugin registers a pattern in this PR (the
+ * seam is proven by a test-registered fake plugin id), and the manifest's
+ * `PluginSurface` union has no entry for name-pattern extension yet; adding
+ * one is a follow-up if/when a real plugin uses this seam.
+ *
+ * Server-safe: no React, no Prisma. Plain strings in, so callers pass
+ * whatever representation of an element type they already have (Prisma's
+ * UPPERCASE `ElementType` enum values, in practice).
+ */
+
+/** The ten element types the platform's Prisma `ElementType` enum defines, each with its ruled prefix. */
+const CORE_PREFIXES = {
+	GOAL: "G",
+	STRATEGY: "S",
+	PROPERTY_CLAIM: "P",
+	EVIDENCE: "E",
+	CONTEXT: "C",
+	JUSTIFICATION: "J",
+	ASSUMPTION: "A",
+	MODULE: "M",
+	AWAY_GOAL: "AG",
+	CONTRACT: "Ct",
+} as const;
+
+type CoreElementType = keyof typeof CORE_PREFIXES;
+
+/** Human-readable label per core type, for error messages (`describeExpectedFormat`). */
+const TYPE_LABELS: Record<CoreElementType, string> = {
+	GOAL: "Goal",
+	STRATEGY: "Strategy",
+	PROPERTY_CLAIM: "Property Claim",
+	EVIDENCE: "Evidence",
+	CONTEXT: "Context",
+	JUSTIFICATION: "Justification",
+	ASSUMPTION: "Assumption",
+	MODULE: "Module",
+	AWAY_GOAL: "Away Goal",
+	CONTRACT: "Contract",
+};
+
+function isCoreElementType(type: string): type is CoreElementType {
+	return Object.hasOwn(CORE_PREFIXES, type);
+}
+
+/** Escapes regex metacharacters — defensive only; no current prefix contains one. */
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Builds the anchored full-format pattern for a prefix: `<prefix><n>(.<n>)*`, start to end. */
+function buildFullFormatPattern(prefix: string): RegExp {
+	return new RegExp(`^${escapeRegExp(prefix)}[0-9]+(\\.[0-9]+)*$`);
+}
+
+/**
+ * Returns the ruled prefix for a core element type, or `undefined` if `type`
+ * isn't one of the ten known types (e.g. a plugin-only type, or a typo).
+ */
+export function getCorePrefix(type: string): string | undefined {
+	return isCoreElementType(type) ? CORE_PREFIXES[type] : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin override seam
+// ---------------------------------------------------------------------------
+
+/** elementType -> pluginId -> that plugin's registered patterns for the type. */
+const pluginPatternsByType = new Map<string, Map<string, RegExp[]>>();
+
+function isSamePatternList(
+	a: readonly RegExp[],
+	b: readonly RegExp[]
+): boolean {
+	if (a.length !== b.length) {
+		return false;
+	}
+	return a.every(
+		(re, i) => re.source === b[i]?.source && re.flags === b[i]?.flags
+	);
+}
+
+/**
+ * Registers one or more additional accepted name patterns for `type`,
+ * attributed to `pluginId`. Additive only — nothing here can remove a core
+ * pattern or a pattern registered by a different plugin. Call once per
+ * plugin module, at bootstrap (mirrors `SlotRegistry.register`):
+ *
+ * - A second call for the same `pluginId` + `type` with an identical pattern
+ *   list (same regex sources and flags) is a silent no-op — safe against a
+ *   bootstrap module whose top-level `register()` calls run more than once
+ *   in a process (e.g. HMR, or a test importing the real bootstrap).
+ * - A second call for the same `pluginId` + `type` with a DIFFERENT pattern
+ *   list throws — a first-party programming error, not a legitimate re-run.
+ */
+export function registerPluginNamePatterns(
+	pluginId: string,
+	type: string,
+	pattern: RegExp | readonly RegExp[]
+): void {
+	const patterns = Array.isArray(pattern) ? pattern : [pattern as RegExp];
+
+	let byPlugin = pluginPatternsByType.get(type);
+	if (!byPlugin) {
+		byPlugin = new Map();
+		pluginPatternsByType.set(type, byPlugin);
+	}
+
+	const existing = byPlugin.get(pluginId);
+	if (existing) {
+		if (isSamePatternList(existing, patterns)) {
+			return;
+		}
+		throw new Error(
+			`Cannot register name pattern(s) for plugin '${pluginId}' on element type '${type}': a conflicting registration already exists for this plugin and type`
+		);
+	}
+
+	byPlugin.set(pluginId, patterns);
+}
+
+/**
+ * Every pattern accepted for `type`: the core full-format pattern (if `type`
+ * is one of the ten known types) plus any plugin-registered pattern whose
+ * plugin id is in `enabledPluginIds`. A plugin's patterns are invisible to
+ * every caller that doesn't pass its id — disabling a plugin stops its
+ * patterns validating NEW names without touching names already stored in
+ * that format (back-compat, per the design note).
+ */
+export function getAcceptedPatterns(
+	type: string,
+	enabledPluginIds: readonly string[] = []
+): RegExp[] {
+	const patterns: RegExp[] = [];
+
+	const corePrefix = getCorePrefix(type);
+	if (corePrefix) {
+		patterns.push(buildFullFormatPattern(corePrefix));
+	}
+
+	const byPlugin = pluginPatternsByType.get(type);
+	if (byPlugin) {
+		for (const [pluginId, pluginPatterns] of byPlugin) {
+			if (enabledPluginIds.includes(pluginId)) {
+				patterns.push(...pluginPatterns);
+			}
+		}
+	}
+
+	return patterns;
+}
+
+/** Does `name` match at least one pattern accepted for `type`, given `enabledPluginIds`? */
+export function isValidElementName(
+	type: string,
+	name: string,
+	enabledPluginIds: readonly string[] = []
+): boolean {
+	return getAcceptedPatterns(type, enabledPluginIds).some((pattern) =>
+		pattern.test(name)
+	);
+}
+
+/**
+ * Human-readable description of the expected name format for `type`, for use
+ * directly in a validation error message (e.g. "Property Claim names must
+ * look like P1 or P1.1"). Falls back to a generic message for a type this
+ * registry doesn't know a core prefix for.
+ */
+export function describeExpectedFormat(type: string): string {
+	const prefix = getCorePrefix(type);
+	if (!(prefix && isCoreElementType(type))) {
+		return "Names must follow this element type's registered format";
+	}
+	return `${TYPE_LABELS[type]} names must look like ${prefix}1 or ${prefix}1.1`;
+}
+
+/**
+ * Test-only: clears every plugin-registered pattern so each test file starts
+ * from a clean slate. Production code must never call this — plugin
+ * registrations live for the process lifetime, same as `SlotRegistry.resetForTests`.
+ */
+export function resetPluginNamePatternsForTests(): void {
+	pluginPatternsByType.clear();
+}

--- a/lib/element-types.ts
+++ b/lib/element-types.ts
@@ -8,6 +8,7 @@
  *   - Collection plural: "goals", "strategies", "propertyclaims", "evidence"
  */
 
+import { getCorePrefix } from "@/lib/element-names/prefix-registry";
 import type { ElementType as PrismaElementType } from "@/src/generated/prisma";
 
 // Re-export from element-validation for backward compatibility
@@ -60,17 +61,22 @@ export function toDisplayType(prismaType: string): string {
 /**
  * Prisma UPPERCASE → prefix for auto-generated names.
  *
- * "GOAL" → "G", "STRATEGY" → "S", "PROPERTY_CLAIM" → "P", "EVIDENCE" → "E"
+ * "GOAL" → "G", "STRATEGY" → "S", "PROPERTY_CLAIM" → "P", "EVIDENCE" → "E",
+ * and so on for all ten element types — reads from the single-source
+ * prefix table (`lib/element-names/prefix-registry.ts`) rather than keeping
+ * its own copy. Throws for a type that table doesn't know, rather than the
+ * old silent "X" fallback: every value of the Prisma `ElementType` enum has
+ * a registered prefix, so reaching this branch means a genuinely unknown
+ * type reached element-naming code, which is a bug worth surfacing.
  */
 export function toPrefix(prismaType: string): string {
-	const prefixes: Record<string, string> = {
-		GOAL: "G",
-		STRATEGY: "S",
-		PROPERTY_CLAIM: "P",
-		EVIDENCE: "E",
-		CONTEXT: "C",
-	};
-	return prefixes[prismaType] ?? "X";
+	const prefix = getCorePrefix(prismaType);
+	if (!prefix) {
+		throw new Error(
+			`toPrefix: no prefix registered for element type '${prismaType}'`
+		);
+	}
+	return prefix;
 }
 
 /**

--- a/lib/schemas/element-validation.ts
+++ b/lib/schemas/element-validation.ts
@@ -6,6 +6,10 @@
  */
 
 import { z } from "zod";
+import {
+	describeExpectedFormat,
+	isValidElementName,
+} from "@/lib/element-names/prefix-registry";
 import { AssertionStatusSchema } from "./case-export";
 
 // ============================================
@@ -389,4 +393,38 @@ export function getValidFieldsForType(elementType: string): string[] {
 	}
 
 	return [...baseFields, ...typeSpecificFields];
+}
+
+// ============================================
+// NAME FORMAT VALIDATION (TEA-syntax prefixes)
+// ============================================
+
+export type ElementNameValidationResult =
+	| { valid: true }
+	| { valid: false; error: string };
+
+/**
+ * Validates an element's `name` against its type's TEA-syntax prefix format
+ * (`lib/element-names/prefix-registry.ts` — `<prefix><n>(.<n>)*`, e.g. `P1`,
+ * `P1.1`). Names are optional: `null`, `undefined`, and empty string all
+ * pass, since the rule only applies when a name is actually given (Chris's
+ * ruling, design note "TEA — Element Name Prefix Validation", Decision 2).
+ *
+ * `enabledPluginIds` is resolved by the caller (the service layer, via
+ * `getEnabledPluginIdsForUser` in `lib/services/plugin-enablement-service.ts`)
+ * and passed in — this function stays pure, with no Prisma access, matching
+ * every other rule in this file.
+ */
+export function validateElementName(
+	elementType: string,
+	name: string | null | undefined,
+	enabledPluginIds: readonly string[] = []
+): ElementNameValidationResult {
+	if (!name) {
+		return { valid: true };
+	}
+	if (isValidElementName(elementType, name, enabledPluginIds)) {
+		return { valid: true };
+	}
+	return { valid: false, error: describeExpectedFormat(elementType) };
 }

--- a/lib/services/case-batch-update-service.ts
+++ b/lib/services/case-batch-update-service.ts
@@ -11,11 +11,13 @@ import type {
 	UpdateElementData,
 } from "@/lib/case/tree-diff";
 import { prisma } from "@/lib/prisma";
+import { validateElementName } from "@/lib/schemas/element-validation";
 import {
 	calculateLevelFromParentChain,
 	enforceAssertionStatusRules,
 	isSystemUserPrincipal,
 } from "@/lib/services/element-service";
+import { getEnabledPluginIdsForUser } from "@/lib/services/plugin-enablement-service";
 import { getDescendantIdsForRoots } from "@/lib/utils/tree-traversal";
 import type {
 	ElementRole,
@@ -69,6 +71,85 @@ async function validateAssertionStatusChanges(
 			return error;
 		}
 	}
+	return null;
+}
+
+/**
+ * TEA-syntax element-name prefix validation (design note "TEA — Element
+ * Name Prefix Validation", Chris's ruling: enforce on create AND rename).
+ * Applies the same `validateElementName` check the single-element route
+ * enforces (element-service.ts's `createElement`/`updateElement`) to every
+ * create/update this batch carries a name for — a batch containing even one
+ * non-conforming name is rejected in full, before anything is written,
+ * matching this file's other pre-transaction validators
+ * (`validateCreateParents`, `validateElementOwnership`). Names stay
+ * optional: a create/update that doesn't touch `name` (or sets it to
+ * null/empty) is never checked.
+ *
+ * The offending element's id is named in the error message, never the case
+ * — same convention as `validateElementOwnership`'s error shape.
+ */
+async function validateElementNames(
+	userId: string,
+	creates: CreateChange[],
+	updates: UpdateChange[]
+): Promise<string | null> {
+	const namedCreates = creates.filter((c) => c.data.name);
+	const namedUpdates = updates.filter((c) => c.data.name);
+
+	if (namedCreates.length === 0 && namedUpdates.length === 0) {
+		return null;
+	}
+
+	// An update's data only ever carries the fields that changed — its
+	// elementType isn't part of the diff payload at all — so a named
+	// update's target type has to be read back from the database. One
+	// batched fetch for every such update, instead of one findUnique per
+	// update that sets a name.
+	const updateTypeRows =
+		namedUpdates.length > 0
+			? await prisma.assuranceElement.findMany({
+					where: { id: { in: namedUpdates.map((c) => c.elementId) } },
+					select: { id: true, elementType: true },
+				})
+			: [];
+	const updateTypeById = new Map(
+		updateTypeRows.map((r) => [r.id, r.elementType])
+	);
+
+	const enabledPluginIds = await getEnabledPluginIdsForUser(userId);
+
+	for (const change of namedCreates) {
+		const elementType = mapElementType(change.data.type);
+		const validation = validateElementName(
+			elementType,
+			change.data.name,
+			enabledPluginIds
+		);
+		if (!validation.valid) {
+			return `${validation.error} (element ${change.elementId})`;
+		}
+	}
+
+	for (const change of namedUpdates) {
+		const elementType = updateTypeById.get(change.elementId);
+		// Absent from the lookup means this id doesn't exist, or belongs to a
+		// different case — validateElementOwnership (which runs before this)
+		// already rejects both, so this is unreachable in practice; skipping
+		// keeps this validator side-effect-free rather than throwing.
+		if (!elementType) {
+			continue;
+		}
+		const validation = validateElementName(
+			elementType,
+			change.data.name,
+			enabledPluginIds
+		);
+		if (!validation.valid) {
+			return `${validation.error} (element ${change.elementId})`;
+		}
+	}
+
 	return null;
 }
 
@@ -1081,6 +1162,15 @@ export async function applyBatchUpdate(
 	const updateParentError = await validateUpdateParents(updates);
 	if (updateParentError) {
 		return { error: updateParentError };
+	}
+
+	// TEA-syntax element-name prefix validation — same rule, same choke
+	// point shape as the single-element route (element-service.ts's
+	// createElement/updateElement), applied here so a rename or create
+	// through the JSON editor can't bypass it.
+	const nameFormatError = await validateElementNames(userId, creates, updates);
+	if (nameFormatError) {
+		return { error: nameFormatError };
 	}
 
 	try {

--- a/lib/services/element-service.ts
+++ b/lib/services/element-service.ts
@@ -1,3 +1,4 @@
+import { getCorePrefix } from "@/lib/element-names/prefix-registry";
 import { toPrefix, toPrismaType } from "@/lib/element-types";
 import { prisma } from "@/lib/prisma";
 import type {
@@ -883,6 +884,17 @@ export async function createElement(
 	}
 
 	const elementType = toPrismaType(input.elementType);
+	// `elementTypeSchema` (lib/schemas/element.ts) only checks `type`/
+	// `elementType` is a non-empty string, and `toPrismaType` casts anything
+	// it doesn't recognise straight through (upper-cased) — so an
+	// unrecognised type reaches here as a value that LOOKS like a
+	// PrismaElementType but isn't one the prefix registry knows. Reject it
+	// now, before it reaches `generateElementName` -> `toPrefix`, which
+	// throws for exactly this case (an uncaught throw here would surface as
+	// an unmapped 500, not a validation error).
+	if (!getCorePrefix(elementType)) {
+		return { error: `Unknown element type '${input.elementType}'` };
+	}
 	const parentId = resolveParentId(input);
 
 	const referenceError = await validateElementReferences(
@@ -1065,6 +1077,129 @@ async function validateParentChange(
 }
 
 /**
+ * Validates and applies a parentId change to `updateData` IN PLACE, for
+ * `updateElement`'s move-operation branch: existence/soft-delete/same-case
+ * checks, then the circular-reference guard, then (for a property claim)
+ * recalculating level. Only called when `newParentId !== undefined` —
+ * `updateElement` itself still owns that "is this change present at all"
+ * decision, since `undefined` (no parentId field in the input) means
+ * nothing here should run at all, not even the null/detach branch.
+ */
+async function applyParentChangeForUpdate(
+	elementId: string,
+	existing: { caseId: string; elementType: PrismaElementType },
+	newParentId: string | null,
+	updateData: Record<string, unknown>
+): Promise<{ error: string } | undefined> {
+	if (newParentId === null) {
+		// Detaching — allowed unconditionally.
+		updateData.parentId = null;
+		return;
+	}
+
+	// Validate new parent exists, is not deleted, and belongs to the same case
+	const newParent = await prisma.assuranceElement.findUnique({
+		where: { id: newParentId },
+		select: { caseId: true, deletedAt: true },
+	});
+	if (
+		!newParent ||
+		newParent.deletedAt ||
+		newParent.caseId !== existing.caseId
+	) {
+		return { error: "Element not found" };
+	}
+
+	const validationError = await validateParentChange(elementId, newParentId);
+	if (validationError) {
+		return { error: validationError };
+	}
+
+	updateData.parentId = newParentId;
+
+	// Recalculate level if it's a property claim
+	if (existing.elementType === "PROPERTY_CLAIM") {
+		updateData.level = await calculateNewLevel(newParentId);
+	}
+
+	return;
+}
+
+/**
+ * Runs every field-level validation guard `updateElement` needs before it
+ * touches the update itself, in the exact order it previously ran them
+ * inline: assertionStatus, moduleReferenceId, citedElementId,
+ * defeatsElementId, then name format. Extracted (mirroring
+ * `validateElementReferences`'s role for `createElement`) to keep
+ * `updateElement` under the cognitive-complexity budget; order is preserved
+ * byte-for-byte because nothing here changes which check fires first when
+ * more than one would fail.
+ */
+async function validateUpdateElementFields(
+	elementId: string,
+	existing: { caseId: string; elementType: PrismaElementType },
+	input: UpdateElementInput,
+	userId: string
+): Promise<{ error: string } | undefined> {
+	// ADR 0004 D3 write rule: assertionStatus is author-declared only —
+	// see guardAssertionStatusWrite's docstring for why case-level EDIT
+	// access alone isn't a sufficient gate.
+	const assertionStatusError = await enforceAssertionStatusRules(
+		input.assertionStatus,
+		userId
+	);
+	if (assertionStatusError) {
+		return { error: assertionStatusError };
+	}
+
+	// moduleReferenceId is MODULE/AWAY_GOAL-only and must reference an
+	// existing case. No requiredness check on update — mirrors the batch
+	// update path (case-batch-update-service.ts), see
+	// enforceModuleReferenceIdRules's docstring.
+	const moduleReferenceIdError = await enforceModuleReferenceIdRules(
+		existing.elementType,
+		input.moduleReferenceId,
+		{ requireOnCreate: false }
+	);
+	if (moduleReferenceIdError) {
+		return { error: moduleReferenceIdError };
+	}
+
+	// ADR 0004 D5: citedElementId is AWAY_GOAL-only, must reference an
+	// existing element, and cannot reference the element itself.
+	const citedElementIdError = await enforceCitedElementIdRules(
+		existing.elementType,
+		input.citedElementId,
+		elementId
+	);
+	if (citedElementIdError) {
+		return { error: citedElementIdError };
+	}
+
+	// Dialogical reasoning (defeaters): defeatsElementId must stay inside
+	// the element's own case (existing.caseId), unlike citedElementId
+	// above — see enforceDefeatsElementIdRules's docstring.
+	const defeatsElementIdError = await enforceDefeatsElementIdRules(
+		existing.caseId,
+		input.defeatsElementId,
+		elementId
+	);
+	if (defeatsElementIdError) {
+		return { error: defeatsElementIdError };
+	}
+
+	// Name-format validation (TEA-syntax prefix). `enforceElementNameFormat`
+	// is a no-op when `input.name` is `undefined` — the "not changing it"
+	// case (and, per `optionalString`'s transform, also what an explicit
+	// clear collapses to), so there's nothing new to validate.
+	return await enforceElementNameFormat(
+		existing.elementType,
+		input.name,
+		userId
+	);
+}
+
+/**
  * Updates an existing element
  */
 export async function updateElement(
@@ -1093,104 +1228,32 @@ export async function updateElement(
 			return { error: "Element not found" };
 		}
 
-		// ADR 0004 D3 write rule: assertionStatus is author-declared only —
-		// see guardAssertionStatusWrite's docstring for why case-level EDIT
-		// access alone isn't a sufficient gate.
-		const assertionStatusError = await enforceAssertionStatusRules(
-			input.assertionStatus,
+		const fieldError = await validateUpdateElementFields(
+			elementId,
+			existing,
+			input,
 			userId
 		);
-		if (assertionStatusError) {
-			return { error: assertionStatusError };
-		}
-
-		// moduleReferenceId is MODULE/AWAY_GOAL-only and must reference an
-		// existing case. No requiredness check on update — mirrors the batch
-		// update path (case-batch-update-service.ts), see
-		// enforceModuleReferenceIdRules's docstring.
-		const moduleReferenceIdError = await enforceModuleReferenceIdRules(
-			existing.elementType,
-			input.moduleReferenceId,
-			{ requireOnCreate: false }
-		);
-		if (moduleReferenceIdError) {
-			return { error: moduleReferenceIdError };
-		}
-
-		// ADR 0004 D5: citedElementId is AWAY_GOAL-only, must reference an
-		// existing element, and cannot reference the element itself.
-		const citedElementIdError = await enforceCitedElementIdRules(
-			existing.elementType,
-			input.citedElementId,
-			elementId
-		);
-		if (citedElementIdError) {
-			return { error: citedElementIdError };
-		}
-
-		// Dialogical reasoning (defeaters): defeatsElementId must stay inside
-		// the element's own case (existing.caseId), unlike citedElementId
-		// above — see enforceDefeatsElementIdRules's docstring.
-		const defeatsElementIdError = await enforceDefeatsElementIdRules(
-			existing.caseId,
-			input.defeatsElementId,
-			elementId
-		);
-		if (defeatsElementIdError) {
-			return { error: defeatsElementIdError };
-		}
-
-		// Name-format validation (TEA-syntax prefix). `enforceElementNameFormat`
-		// is a no-op when `input.name` is `undefined` — the "not changing it"
-		// case (and, per `optionalString`'s transform, also what an explicit
-		// clear collapses to), so there's nothing new to validate.
-		const nameFormatError = await enforceElementNameFormat(
-			existing.elementType,
-			input.name,
-			userId
-		);
-		if (nameFormatError) {
-			return nameFormatError;
+		if (fieldError) {
+			return fieldError;
 		}
 
 		// Build update data from input fields
 		const updateData = buildUpdateData(input);
 
-		// Handle parent change (for move operations)
+		// Handle parent change (for move operations) — `undefined` means the
+		// input didn't touch parentId at all, so nothing runs.
 		const newParentId = resolveParentId(input);
-		if (newParentId !== undefined && newParentId !== null) {
-			// Validate new parent exists, is not deleted, and belongs to the same case
-			const newParent = await prisma.assuranceElement.findUnique({
-				where: { id: newParentId },
-				select: { caseId: true, deletedAt: true },
-			});
-
-			if (
-				!newParent ||
-				newParent.deletedAt ||
-				newParent.caseId !== existing.caseId
-			) {
-				return { error: "Element not found" };
-			}
-
-			// Validate parent change doesn't create circular reference
-			const validationError = await validateParentChange(
+		if (newParentId !== undefined) {
+			const parentChangeError = await applyParentChangeForUpdate(
 				elementId,
-				newParentId
+				existing,
+				newParentId,
+				updateData
 			);
-			if (validationError) {
-				return { error: validationError };
+			if (parentChangeError) {
+				return parentChangeError;
 			}
-
-			updateData.parentId = newParentId;
-
-			// Recalculate level if it's a property claim
-			if (existing.elementType === "PROPERTY_CLAIM" && newParentId) {
-				updateData.level = await calculateNewLevel(newParentId);
-			}
-		} else if (newParentId === null) {
-			// Allow setting parent to null (detaching)
-			updateData.parentId = null;
 		}
 
 		const element = await prisma.assuranceElement.update({

--- a/lib/services/element-service.ts
+++ b/lib/services/element-service.ts
@@ -7,7 +7,9 @@ import type {
 import {
 	fieldAppliesTo,
 	fieldRequiredFor,
+	validateElementName,
 } from "@/lib/schemas/element-validation";
+import { getEnabledPluginIdsForUser } from "@/lib/services/plugin-enablement-service";
 import { transformToResponse } from "@/lib/transforms/element-response";
 import {
 	getDeletedDescendantIds,
@@ -828,6 +830,34 @@ async function validateElementReferences(
 }
 
 /**
+ * TEA-syntax name-format guard (design note "TEA — Element Name Prefix
+ * Validation"), shared by `createElement` and `updateElement` — the two
+ * choke points every element mutation flows through. A no-op when `name` is
+ * falsy (null/undefined/empty): names stay optional, and the rule only
+ * applies when one is actually given. Resolves the acting user's enabled
+ * plugin set itself so both call sites stay a single `if` check.
+ */
+async function enforceElementNameFormat(
+	elementType: string,
+	name: string | null | undefined,
+	userId: string
+): Promise<{ error: string } | undefined> {
+	if (!name) {
+		return;
+	}
+	const enabledPluginIds = await getEnabledPluginIdsForUser(userId);
+	const nameValidation = validateElementName(
+		elementType,
+		name,
+		enabledPluginIds
+	);
+	if (!nameValidation.valid) {
+		return { error: nameValidation.error };
+	}
+	return;
+}
+
+/**
  * Creates a new element in a case
  */
 export async function createElement(
@@ -869,6 +899,15 @@ export async function createElement(
 		elementType === "PROPERTY_CLAIM" && parentId
 			? await calculatePropertyClaimLevel(parentId)
 			: { level: undefined, parentInfo: null };
+
+	const nameFormatError = await enforceElementNameFormat(
+		elementType,
+		input.name,
+		userId
+	);
+	if (nameFormatError) {
+		return nameFormatError;
+	}
 
 	const elementName =
 		input.name ||
@@ -1099,6 +1138,19 @@ export async function updateElement(
 		);
 		if (defeatsElementIdError) {
 			return { error: defeatsElementIdError };
+		}
+
+		// Name-format validation (TEA-syntax prefix). `enforceElementNameFormat`
+		// is a no-op when `input.name` is `undefined` — the "not changing it"
+		// case (and, per `optionalString`'s transform, also what an explicit
+		// clear collapses to), so there's nothing new to validate.
+		const nameFormatError = await enforceElementNameFormat(
+			existing.elementType,
+			input.name,
+			userId
+		);
+		if (nameFormatError) {
+			return nameFormatError;
 		}
 
 		// Build update data from input fields

--- a/lib/services/identifier-service.ts
+++ b/lib/services/identifier-service.ts
@@ -1,4 +1,5 @@
 import { compareIdentifiers } from "@/lib/case/identifier-utils";
+import { getCorePrefix } from "@/lib/element-names/prefix-registry";
 import { canAccessCase } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import { emitSSEEvent } from "@/lib/services/sse-connection-manager";
@@ -7,13 +8,21 @@ import { emitSSEEvent } from "@/lib/services/sse-connection-manager";
 // Constants & types
 // ---------------------------------------------------------------------------
 
-const TYPE_PREFIXES: Record<string, string> = {
-	GOAL: "G",
-	STRATEGY: "S",
-	PROPERTY_CLAIM: "P",
-	EVIDENCE: "E",
-	CONTEXT: "C",
-};
+/**
+ * Looks up an element type's prefix in the single-source registry
+ * (`lib/element-names/prefix-registry.ts`), throwing rather than falling
+ * back to "X" — every value of the Prisma `ElementType` enum has a
+ * registered prefix, so an unknown type here is a bug, not expected input.
+ */
+function corePrefixOrThrow(elementType: string): string {
+	const prefix = getCorePrefix(elementType);
+	if (!prefix) {
+		throw new Error(
+			`identifier-service: no prefix registered for element type '${elementType}'`
+		);
+	}
+	return prefix;
+}
 
 interface ElementWithChildren {
 	children: ElementWithChildren[];
@@ -161,7 +170,7 @@ function collectEffectivePropertyClaimChildren(
  */
 function generatePropertyClaimName(options: PropertyClaimNameOptions): string {
 	const { node, parentName, parentType, roots, globalCounters } = options;
-	const prefix = TYPE_PREFIXES.PROPERTY_CLAIM;
+	const prefix = corePrefixOrThrow("PROPERTY_CLAIM");
 
 	if (parentType === "PROPERTY_CLAIM" && parentName) {
 		// Sub-property claim: use parent's name as base
@@ -223,7 +232,7 @@ function generateHierarchicalNames(
 				globalCounters,
 			});
 		} else {
-			const prefix = TYPE_PREFIXES[node.elementType] || "X";
+			const prefix = corePrefixOrThrow(node.elementType);
 			const count = (globalCounters[node.elementType] || 0) + 1;
 			globalCounters[node.elementType] = count;
 			newName = `${prefix}${count}`;

--- a/lib/services/plugin-enablement-service.ts
+++ b/lib/services/plugin-enablement-service.ts
@@ -1,6 +1,7 @@
 import {
 	getManifestEntry,
 	isPluginAvailableForDeployment,
+	listManifestPluginIds,
 } from "@/lib/plugins/manifest";
 import { prisma } from "@/lib/prisma";
 import type {
@@ -152,6 +153,25 @@ export async function isPluginEnabledForUser(
 ): Promise<boolean> {
 	const result = await assertPluginEnabledForUser(pluginId, userId);
 	return "data" in result;
+}
+
+/**
+ * Every official plugin id currently enabled for `userId` — deployment
+ * availability plus the full ORGANISATION -> TEAM -> USER scope chain, one
+ * check per manifest entry. Convenience for callers that need the whole
+ * enabled set rather than a yes/no on a single plugin id: the element-name-
+ * prefix validation seam (`lib/element-names/prefix-registry.ts`) accepts a
+ * plugin's extra name patterns only when its id is in this set, and passes
+ * the result straight through — it never queries plugin state itself.
+ */
+export async function getEnabledPluginIdsForUser(
+	userId: string
+): Promise<string[]> {
+	const pluginIds = listManifestPluginIds();
+	const enabledFlags = await Promise.all(
+		pluginIds.map((pluginId) => isPluginEnabledForUser(pluginId, userId))
+	);
+	return pluginIds.filter((_, index) => enabledFlags[index]);
 }
 
 /**

--- a/prisma/migrations/20260903000000_element_name_prefix_backfill/migration.sql
+++ b/prisma/migrations/20260903000000_element_name_prefix_backfill/migration.sql
@@ -1,0 +1,124 @@
+-- TEA — Element Name Prefix Validation (design note, Chris's ruling
+-- 2026-09-03): every non-deleted, named element must carry its type's
+-- TEA-syntax prefix (<prefix><n>(.<n>)*, e.g. P1, P1.1). This migration
+-- brings existing data into line BEFORE the application-level check
+-- (lib/schemas/element-validation.ts's validateElementName) starts
+-- enforcing it, so the check never rejects the platform's own data.
+--
+-- Scope: every element with deleted_at IS NULL and a non-null name whose
+-- name does not already match its type's pattern. Null names are left
+-- null (names are optional); conforming names are left untouched.
+--
+-- Rename rule (Chris's ruling, same day): rename ONLY the non-conforming
+-- elements. Each gets <prefix><n>, where n continues from the highest
+-- integer already used by a CONFORMING name of that type in that case (a
+-- sub-numbered name like "P1.1" counts by its leading integer, 1) —
+-- assigned consecutively in creation order. This is a flat renumbering,
+-- not the platform's hierarchical numbering (that's `resetIdentifiers`,
+-- a separate, user-triggered action, and out of scope here).
+--
+-- Reversibility: every rename is logged to element_name_backfill
+-- (old_name -> new_name) before it's applied, so a support query can
+-- restore it.
+--
+-- Idempotency: re-running this script renames nothing. After the first
+-- run, every previously non-conforming name now conforms, so the WHERE
+-- clause that selects "does not conform" no longer matches it.
+
+-- CreateTable
+CREATE TABLE "element_name_backfill" (
+    "id" TEXT NOT NULL,
+    "element_id" TEXT NOT NULL,
+    "old_name" TEXT NOT NULL,
+    "new_name" TEXT NOT NULL,
+    "migrated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "element_name_backfill_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "element_name_backfill_element_id_idx" ON "element_name_backfill"("element_id");
+
+-- Backfill: rename every non-conforming stored name to its type's prefix
+-- format, logging the old -> new mapping first.
+WITH prefixes(element_type, prefix) AS (
+    -- Mirrors lib/element-names/prefix-registry.ts's CORE_PREFIXES table —
+    -- the single source of prefixes; keep the two in sync if either changes.
+    VALUES
+        ('GOAL', 'G'),
+        ('STRATEGY', 'S'),
+        ('PROPERTY_CLAIM', 'P'),
+        ('EVIDENCE', 'E'),
+        ('CONTEXT', 'C'),
+        ('JUSTIFICATION', 'J'),
+        ('ASSUMPTION', 'A'),
+        ('MODULE', 'M'),
+        ('AWAY_GOAL', 'AG'),
+        ('CONTRACT', 'Ct')
+),
+-- Every live, named element, tagged with its type's prefix and whether its
+-- current name already conforms to ^<prefix>[0-9]+(\.[0-9]+)*$.
+candidates AS (
+    SELECT
+        e.id,
+        e.case_id,
+        e.element_type,
+        e.name,
+        e.created_at,
+        p.prefix,
+        (e.name ~ ('^' || p.prefix || '[0-9]+(\.[0-9]+)*$')) AS conforms,
+        -- Leading integer of the name (valid only when it conforms) — seeds
+        -- the per-case/type counter below.
+        CASE
+            WHEN e.name ~ ('^' || p.prefix || '[0-9]+(\.[0-9]+)*$')
+                THEN (regexp_match(e.name, '^' || p.prefix || '([0-9]+)'))[1]::INT
+            ELSE NULL
+        END AS leading_int
+    FROM "assurance_elements" e
+    JOIN prefixes p ON p.element_type = e.element_type::TEXT
+    WHERE e.deleted_at IS NULL
+      AND e.name IS NOT NULL
+),
+-- Highest already-conforming leading integer per (case, type) — the new
+-- numbers for that group start one past this, so they never collide with
+-- an existing conforming name.
+existing_max AS (
+    SELECT case_id, element_type, MAX(leading_int) AS max_n
+    FROM candidates
+    WHERE conforms
+    GROUP BY case_id, element_type
+),
+-- Non-conforming elements, numbered consecutively within their (case, type)
+-- group in creation order.
+to_rename AS (
+    SELECT
+        c.id,
+        c.case_id,
+        c.element_type,
+        c.name AS old_name,
+        c.prefix,
+        ROW_NUMBER() OVER (
+            PARTITION BY c.case_id, c.element_type
+            ORDER BY c.created_at
+        ) AS rn
+    FROM candidates c
+    WHERE NOT c.conforms
+),
+renamed AS (
+    SELECT
+        t.id,
+        t.old_name,
+        t.prefix || (COALESCE(m.max_n, 0) + t.rn) AS new_name
+    FROM to_rename t
+    LEFT JOIN existing_max m
+        ON m.case_id = t.case_id AND m.element_type = t.element_type
+),
+logged AS (
+    INSERT INTO "element_name_backfill" ("id", "element_id", "old_name", "new_name")
+    SELECT gen_random_uuid(), id, old_name, new_name FROM renamed
+    RETURNING "element_id", "new_name"
+)
+UPDATE "assurance_elements" e
+SET "name" = logged."new_name"
+FROM logged
+WHERE e.id = logged."element_id";

--- a/prisma/migrations/20260903000000_element_name_prefix_backfill/migration.sql
+++ b/prisma/migrations/20260903000000_element_name_prefix_backfill/migration.sql
@@ -5,9 +5,13 @@
 -- (lib/schemas/element-validation.ts's validateElementName) starts
 -- enforcing it, so the check never rejects the platform's own data.
 --
--- Scope: every element with deleted_at IS NULL and a non-null name whose
--- name does not already match its type's pattern. Null names are left
--- null (names are optional); conforming names are left untouched.
+-- Scope: every element with deleted_at IS NULL, belonging to a case that
+-- ALSO has deleted_at IS NULL (trashing a case, case-trash-service.ts,
+-- only sets deleted_at on assurance_cases — its elements are untouched, so
+-- both checks are needed to exclude a trashed case's elements), with a
+-- non-null name that does not already match its type's pattern. Null
+-- names are left null (names are optional); conforming names are left
+-- untouched.
 --
 -- Rename rule (Chris's ruling, same day): rename ONLY the non-conforming
 -- elements. Each gets <prefix><n>, where n continues from the highest
@@ -76,6 +80,13 @@ candidates AS (
         END AS leading_int
     FROM "assurance_elements" e
     JOIN prefixes p ON p.element_type = e.element_type::TEXT
+    -- Trashing a case (case-trash-service.ts) only sets deleted_at on
+    -- assurance_cases — its elements keep deleted_at = NULL, so
+    -- e.deleted_at IS NULL alone would still pick up every element sitting
+    -- in a trashed case. This join excludes them; the production blast-
+    -- radius count (296 live cases, 148 non-conforming) was run with the
+    -- same join, so this keeps the migration's scope matching that count.
+    JOIN "assurance_cases" c ON c.id = e.case_id AND c.deleted_at IS NULL
     WHERE e.deleted_at IS NULL
       AND e.name IS NOT NULL
 ),

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -513,6 +513,24 @@ enum ModuleEmbedType {
   REFERENCE
 }
 
+/// Audit trail for the one-off element-name-prefix backfill migration
+/// (`prisma/migrations/*_element_name_prefix_backfill`): every element whose
+/// stored name didn't conform to its type's TEA-syntax prefix format got a
+/// row here recording old_name -> new_name before the rename, so a support
+/// query (or a down-migration) can restore it. No FK to AssuranceElement
+/// deliberately — this is an audit trail, not a live relation, and should
+/// survive even if the source element is later hard-purged.
+model ElementNameBackfill {
+  id         String   @id @default(uuid())
+  elementId  String   @map("element_id")
+  oldName    String   @map("old_name")
+  newName    String   @map("new_name")
+  migratedAt DateTime @default(now()) @map("migrated_at")
+
+  @@index([elementId])
+  @@map("element_name_backfill")
+}
+
 /// Links evidence elements to claims (many-to-many). One piece of evidence can support multiple claims.
 model EvidenceLink {
   id         String           @id @default(uuid())

--- a/prisma/seed/dev-seed.ts
+++ b/prisma/seed/dev-seed.ts
@@ -272,7 +272,7 @@ async function main() {
 					elementType: "PROPERTY_CLAIM",
 					role: "SUPPORTING",
 					parentId: simpleGoal.id,
-					name: "C1",
+					name: "P1",
 					description: "All inputs are validated",
 					createdById: chris.id,
 				},
@@ -284,7 +284,7 @@ async function main() {
 					elementType: "PROPERTY_CLAIM",
 					role: "SUPPORTING",
 					parentId: simpleGoal.id,
-					name: "C2",
+					name: "P2",
 					description: "Error handling is comprehensive",
 					createdById: chris.id,
 				},
@@ -385,7 +385,7 @@ async function main() {
 					elementType: "PROPERTY_CLAIM",
 					role: "SUPPORTING",
 					parentId: strategy1.id,
-					name: "C1",
+					name: "P1",
 					description: "Model achieves >95% accuracy on test set",
 					createdById: chris.id,
 				},
@@ -397,7 +397,7 @@ async function main() {
 					elementType: "PROPERTY_CLAIM",
 					role: "SUPPORTING",
 					parentId: strategy1.id,
-					name: "C2",
+					name: "P2",
 					description: "Model performance is consistent across validation sets",
 					createdById: chris.id,
 				},
@@ -409,7 +409,7 @@ async function main() {
 					elementType: "PROPERTY_CLAIM",
 					role: "SUPPORTING",
 					parentId: strategy2.id,
-					name: "C3",
+					name: "P3",
 					description: "No significant bias across protected characteristics",
 					createdById: chris.id,
 				},
@@ -421,7 +421,7 @@ async function main() {
 					elementType: "PROPERTY_CLAIM",
 					role: "SUPPORTING",
 					parentId: strategy2.id,
-					name: "C4",
+					name: "P4",
 					description: "Bias testing follows industry best practices",
 					createdById: chris.id,
 				},
@@ -527,7 +527,7 @@ async function main() {
 					elementType: "PROPERTY_CLAIM",
 					role: "SUPPORTING",
 					parentId: aliceGoal.id,
-					name: "C1",
+					name: "P1",
 					description: "All team members can access shared resources",
 					createdById: alice.id,
 				},
@@ -589,7 +589,7 @@ async function main() {
 					elementType: "PROPERTY_CLAIM",
 					role: "SUPPORTING",
 					parentId: bobGoal.id,
-					name: "C1",
+					name: "P1",
 					description: "External users can view shared cases",
 					createdById: bob.id,
 				},
@@ -626,7 +626,7 @@ async function main() {
 			// 3e. DARTER Demo Case (chris) - Draft, keystone demo target.
 			// Deterministic name/description so the demo documentation and the
 			// DARTER integration registration (below, after this transaction
-			// commits) can point at this case and its C1 claim by name. C1 is
+			// commits) can point at this case and its P1 claim by name. P1 is
 			// deliberately left WITHOUT a static EvidenceLink — it's the
 			// keystone claim whose badge flips live when the DARTER pipeline
 			// posts its first evidence-format-v0.1 item through the health
@@ -689,7 +689,7 @@ async function main() {
 				},
 			});
 
-			// C1 is the keystone evidence target for the DARTER integration —
+			// P1 is the keystone evidence target for the DARTER integration —
 			// intentionally created with NO EvidenceLink below.
 			const demoClaim1 = await tx.assuranceElement.create({
 				data: {
@@ -697,7 +697,7 @@ async function main() {
 					elementType: "PROPERTY_CLAIM",
 					role: "SUPPORTING",
 					parentId: demoStrategy1.id,
-					name: "C1",
+					name: "P1",
 					description:
 						"Defect detection recall remains above the operational threshold in production monitoring",
 					createdById: chris.id,
@@ -710,7 +710,7 @@ async function main() {
 					elementType: "PROPERTY_CLAIM",
 					role: "SUPPORTING",
 					parentId: demoStrategy1.id,
-					name: "C2",
+					name: "P2",
 					description: "False-positive rate remains within acceptable bounds",
 					createdById: chris.id,
 				},
@@ -722,7 +722,7 @@ async function main() {
 					elementType: "PROPERTY_CLAIM",
 					role: "SUPPORTING",
 					parentId: demoStrategy2.id,
-					name: "C3",
+					name: "P3",
 					description:
 						"Low-confidence detections are escalated to human review",
 					createdById: chris.id,
@@ -735,7 +735,7 @@ async function main() {
 					elementType: "PROPERTY_CLAIM",
 					role: "SUPPORTING",
 					parentId: demoStrategy2.id,
-					name: "C4",
+					name: "P4",
 					description: "Operators can override automated detections",
 					createdById: chris.id,
 				},
@@ -786,7 +786,7 @@ async function main() {
 			});
 
 			console.log(
-				"Created: DARTER Demo — Automated Inspection Assurance (Draft, chris, C1 reserved for live health-plugin evidence)"
+				"Created: DARTER Demo — Automated Inspection Assurance (Draft, chris, P1 reserved for live health-plugin evidence)"
 			);
 
 			// ============================================
@@ -922,7 +922,7 @@ async function main() {
 	console.log("    - Alice's Case (alice, Draft, team shared)");
 	console.log("    - Bob's Case (bob, Draft, shared with charlie)");
 	console.log(
-		`    - DARTER Demo — Automated Inspection Assurance (chris, Draft, id=${demoCaseId}, claim C1 id=${demoClaim1Id} is the live evidence target)`
+		`    - DARTER Demo — Automated Inspection Assurance (chris, Draft, id=${demoCaseId}, claim P1 id=${demoClaim1Id} is the live evidence target)`
 	);
 	console.log("  - 2 comments on Medium Case");
 	console.log(

--- a/src/__tests__/integration/api-elements-assertion-status.test.ts
+++ b/src/__tests__/integration/api-elements-assertion-status.test.ts
@@ -52,7 +52,7 @@ describe("POST /api/cases/[id]/elements — assertionStatus (ADR 0004 D3)", () =
 				method: "POST",
 				body: JSON.stringify({
 					type: "goal",
-					name: "Root Goal",
+					name: "G1",
 					description: "Top-level goal",
 					assertionStatus: "NEEDS_SUPPORT",
 				}),

--- a/src/__tests__/integration/api-elements-cited-element-id.test.ts
+++ b/src/__tests__/integration/api-elements-cited-element-id.test.ts
@@ -65,7 +65,7 @@ describe("POST /api/cases/[id]/elements — citedElementId (ADR 0004 D5)", () =>
 				method: "POST",
 				body: JSON.stringify({
 					type: "away_goal",
-					name: "Reference",
+					name: "AG1",
 					description: "Cites a specific element in another case",
 					moduleReferenceId: awayCase.id,
 					citedElementId: citedGoal.id,

--- a/src/__tests__/integration/api-elements-defeats-element-id.test.ts
+++ b/src/__tests__/integration/api-elements-defeats-element-id.test.ts
@@ -52,7 +52,7 @@ describe("POST /api/cases/[id]/elements — defeatsElementId", () => {
 				method: "POST",
 				body: JSON.stringify({
 					type: "property_claim",
-					name: "Rebuttal",
+					name: "P2",
 					description: "Defeats the original claim",
 					isDefeater: true,
 					defeatsElementId: target.id,
@@ -71,7 +71,7 @@ describe("POST /api/cases/[id]/elements — defeatsElementId", () => {
 
 		// Separate refetch — proves DB persistence, not just an echoed response.
 		const inDb = await prisma.assuranceElement.findFirst({
-			where: { caseId: testCase.id, name: "Rebuttal" },
+			where: { caseId: testCase.id, name: "P2" },
 		});
 		expect(inDb?.defeatsElementId).toBe(target.id);
 		expect(inDb?.isDefeater).toBe(true);

--- a/src/__tests__/integration/api-elements-module-reference-id.test.ts
+++ b/src/__tests__/integration/api-elements-module-reference-id.test.ts
@@ -55,7 +55,7 @@ describe("POST /api/cases/[id]/elements — moduleReferenceId", () => {
 				method: "POST",
 				body: JSON.stringify({
 					type: "away_goal",
-					name: "Reference",
+					name: "AG1",
 					description: "Cites another case",
 					moduleReferenceId: awayCase.id,
 				}),

--- a/src/__tests__/integration/api-elements-name-format-validation.test.ts
+++ b/src/__tests__/integration/api-elements-name-format-validation.test.ts
@@ -1,0 +1,143 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	createTestCase,
+	createTestElement,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+/**
+ * Route-level coverage for the TEA-syntax element-name prefix validation
+ * (design note "TEA — Element Name Prefix Validation") reaching all the way
+ * out to the HTTP layer, proving the `lib/api-response.ts` error mapping end
+ * to end rather than just at the service layer
+ * (src/__tests__/integration/element-service.test.ts carries that). Two
+ * related send-back items share this file because both are "a bad create
+ * payload used to surface as an unmapped 500, not a clean 400":
+ *
+ * - An unrecognised `type`: before the fix, a bad type with no name reached
+ *   `generateElementName` -> `toPrefix`, which throws for a type the prefix
+ *   registry doesn't know.
+ * - A non-conforming `name`: proves `validateElementName`'s rejection is
+ *   mapped to 400 by `serviceErrorToAppError`, not left to fall through to
+ *   INTERNAL.
+ */
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/services/sse-connection-manager", () => ({
+	emitSSEEvent: vi.fn(),
+	sseConnectionManager: { broadcast: vi.fn() },
+}));
+
+const UNKNOWN_TYPE_PATTERN = /Unknown element type/;
+const GOAL_FORMAT_PATTERN = /Goal names must look like G1 or G1\.1/;
+
+beforeEach(async () => {
+	await mockNoAuth();
+});
+
+describe("POST /api/cases/[id]/elements — unrecognised element type", () => {
+	it("rejects an unrecognised type with 400, not an unmapped 500", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import("@/app/api/cases/[id]/elements/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/elements`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					type: "banana",
+					description: "Should never reach naming",
+				}),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await POST(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toMatch(UNKNOWN_TYPE_PATTERN);
+
+		const elements = await prisma.assuranceElement.findMany({
+			where: { caseId: testCase.id },
+		});
+		expect(elements).toHaveLength(0);
+	});
+});
+
+describe("POST /api/cases/[id]/elements — non-conforming element name", () => {
+	it("rejects a create with a non-conforming name with 400, naming the expected format", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { POST } = await import("@/app/api/cases/[id]/elements/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/cases/${testCase.id}/elements`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					type: "goal",
+					name: "Root Goal",
+					description: "Free-text name, should be rejected",
+				}),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await POST(req, {
+			params: Promise.resolve({ id: testCase.id }),
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toMatch(GOAL_FORMAT_PATTERN);
+
+		const elements = await prisma.assuranceElement.findMany({
+			where: { caseId: testCase.id },
+		});
+		expect(elements).toHaveLength(0);
+	});
+});
+
+describe("PUT /api/elements/[id] — non-conforming element name", () => {
+	it("rejects a rename to a non-conforming name with 400, leaving the stored name unchanged", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+		const element = await createTestElement(testCase.id, owner.id, {
+			elementType: "GOAL",
+			name: "G1",
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await import("@/app/api/elements/[id]/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/elements/${element.id}`,
+			{
+				method: "PUT",
+				body: JSON.stringify({ name: "Renamed Freely" }),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: element.id }),
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toMatch(GOAL_FORMAT_PATTERN);
+
+		const unchanged = await prisma.assuranceElement.findUnique({
+			where: { id: element.id },
+		});
+		expect(unchanged?.name).toBe("G1");
+	});
+});

--- a/src/__tests__/integration/batch-ownership-adversarial.test.ts
+++ b/src/__tests__/integration/batch-ownership-adversarial.test.ts
@@ -563,7 +563,7 @@ describe("batch ownership — adversarial (QA G3)", () => {
 				data: {
 					id: foreignEvidence.id,
 					type: "EVIDENCE",
-					name: "Attempted id collision",
+					name: "E1",
 					description: "Should never persist — unique constraint + rollback",
 					inSandbox: false,
 				},

--- a/src/__tests__/integration/case-batch-update-service.test.ts
+++ b/src/__tests__/integration/case-batch-update-service.test.ts
@@ -83,7 +83,7 @@ describe("applyBatchUpdate", () => {
 				data: {
 					id: newId,
 					type: "GOAL",
-					name: "New Goal",
+					name: "G1",
 					description: "A goal created via batch",
 					inSandbox: false,
 					role: "TOP_LEVEL",
@@ -102,7 +102,7 @@ describe("applyBatchUpdate", () => {
 			where: { id: newId },
 		});
 		expect(created).not.toBeNull();
-		expect(created?.name).toBe("New Goal");
+		expect(created?.name).toBe("G1");
 	});
 
 	it("updates elements via a batch update", async () => {
@@ -122,7 +122,7 @@ describe("applyBatchUpdate", () => {
 			{
 				type: "update",
 				elementId: element.id,
-				data: { name: "Updated Name" },
+				data: { name: "G2" },
 			},
 		];
 
@@ -134,7 +134,7 @@ describe("applyBatchUpdate", () => {
 		const updated = await prisma.assuranceElement.findUnique({
 			where: { id: element.id },
 		});
-		expect(updated?.name).toBe("Updated Name");
+		expect(updated?.name).toBe("G2");
 	});
 
 	it("deletes elements via a batch update", async () => {
@@ -201,7 +201,7 @@ describe("applyBatchUpdate", () => {
 				data: {
 					id: newId,
 					type: "GOAL",
-					name: "Brand New Goal",
+					name: "G1",
 					description: "Created in mixed batch",
 					inSandbox: false,
 					role: "TOP_LEVEL",
@@ -210,7 +210,7 @@ describe("applyBatchUpdate", () => {
 			{
 				type: "update",
 				elementId: toUpdate.id,
-				data: { name: "Now Updated" },
+				data: { name: "G2" },
 			},
 			{
 				type: "delete",
@@ -229,12 +229,12 @@ describe("applyBatchUpdate", () => {
 		const created = await prisma.assuranceElement.findUnique({
 			where: { id: newId },
 		});
-		expect(created?.name).toBe("Brand New Goal");
+		expect(created?.name).toBe("G1");
 
 		const updated = await prisma.assuranceElement.findUnique({
 			where: { id: toUpdate.id },
 		});
-		expect(updated?.name).toBe("Now Updated");
+		expect(updated?.name).toBe("G2");
 
 		const deleted = await prisma.assuranceElement.findUnique({
 			where: { id: toDelete.id },
@@ -426,7 +426,7 @@ describe("applyBatchUpdate", () => {
 			{
 				type: "update",
 				elementId: element.id,
-				data: { name: "Changed Name" },
+				data: { name: "G2" },
 			},
 			// Delete a non-existent element — this will throw inside the transaction
 			{
@@ -473,7 +473,7 @@ describe("applyBatchUpdate", () => {
 					type: "update",
 					elementId: element.id,
 					data: {
-						name: "Batch Target Renamed",
+						name: "G2",
 						assertionStatus: "DEFEATED",
 					},
 				},
@@ -487,7 +487,7 @@ describe("applyBatchUpdate", () => {
 			const afterBatch = await prisma.assuranceElement.findUnique({
 				where: { id: element.id },
 			});
-			expect(afterBatch?.name).toBe("Batch Target Renamed");
+			expect(afterBatch?.name).toBe("G2");
 			expect(afterBatch?.assertionStatus).toBe("DEFEATED");
 		});
 
@@ -512,7 +512,7 @@ describe("applyBatchUpdate", () => {
 				{
 					type: "update",
 					elementId: element.id,
-					data: { name: "Renamed, Status Untouched" },
+					data: { name: "G2" },
 				},
 			];
 
@@ -524,7 +524,7 @@ describe("applyBatchUpdate", () => {
 			const afterBatch = await prisma.assuranceElement.findUnique({
 				where: { id: element.id },
 			});
-			expect(afterBatch?.name).toBe("Renamed, Status Untouched");
+			expect(afterBatch?.name).toBe("G2");
 			// The stored value survives the omission — omission must never
 			// be conflated with an explicit clear (null).
 			expect(afterBatch?.assertionStatus).toBe("ASSUMED");
@@ -713,7 +713,7 @@ describe("applyBatchUpdate", () => {
 				type: "update",
 				elementId: awayGoal.id,
 				data: {
-					name: "Updated Name",
+					name: "AG1",
 					citedElementId: smuggledCitedGoal.id,
 				},
 			},
@@ -725,7 +725,7 @@ describe("applyBatchUpdate", () => {
 			where: { id: awayGoal.id },
 		});
 		// Allowlisted change applied.
-		expect(updated?.name).toBe("Updated Name");
+		expect(updated?.name).toBe("AG1");
 		// Smuggled field had no effect — original citation is untouched.
 		expect(updated?.citedElementId).toBe(originalCitedGoal.id);
 	});
@@ -1639,7 +1639,7 @@ describe("applyBatchUpdate", () => {
 				{
 					type: "update",
 					elementId: evidence.id,
-					data: { name: "Renamed Evidence" },
+					data: { name: "E1" },
 				},
 				{
 					type: "link_evidence",
@@ -1656,7 +1656,7 @@ describe("applyBatchUpdate", () => {
 			const afterEvidence = await prisma.assuranceElement.findUnique({
 				where: { id: evidence.id },
 			});
-			expect(afterEvidence?.name).toBe("Renamed Evidence");
+			expect(afterEvidence?.name).toBe("E1");
 			// Never entered level resolution or the cascade — stays null and
 			// unparented, evidence-link table carries the association.
 			expect(afterEvidence?.level).toBeNull();
@@ -1810,14 +1810,14 @@ describe("applyBatchUpdate", () => {
 				{ length: 5 },
 				(_, i) => `el-create-count-${Date.now()}-${i}`
 			);
-			const changes: ElementChange[] = ids.map((id) => ({
+			const changes: ElementChange[] = ids.map((id, i) => ({
 				type: "create",
 				elementId: id,
 				parentId: parent.id,
 				data: {
 					id,
 					type: "GOAL",
-					name: `Created ${id}`,
+					name: `G${i + 1}`,
 					description: "batched create",
 					inSandbox: false,
 					role: "SUPPORTING",
@@ -2028,7 +2028,7 @@ describe("applyBatchUpdate", () => {
 					data: {
 						id: childId,
 						type: "PROPERTY_CLAIM",
-						name: "Child Claim",
+						name: "P1",
 						description: "Parented to an element already in the database",
 						inSandbox: false,
 					},
@@ -2040,7 +2040,7 @@ describe("applyBatchUpdate", () => {
 					data: {
 						id: grandchildId,
 						type: "PROPERTY_CLAIM",
-						name: "Grandchild Claim",
+						name: "P1.1",
 						description:
 							"Parented to another element created earlier in this same batch",
 						inSandbox: false,
@@ -2347,7 +2347,7 @@ describe("applyBatchUpdate", () => {
 					data: {
 						id: parentId,
 						type: "GOAL",
-						name: "Batch Parent",
+						name: "G1",
 						description: "Created earlier in this same batch",
 						inSandbox: false,
 					},
@@ -2359,7 +2359,7 @@ describe("applyBatchUpdate", () => {
 					data: {
 						id: childId,
 						type: "STRATEGY",
-						name: "Batch Child",
+						name: "S1",
 						description: "Parented to a sibling create in this same batch",
 						inSandbox: false,
 					},
@@ -2423,7 +2423,7 @@ describe("applyBatchUpdate", () => {
 					data: {
 						id: newId,
 						type: "PROPERTY_CLAIM",
-						name: "Claim Under Strategy",
+						name: "P1",
 						description: "Should skip the strategy and use the grandparent",
 						inSandbox: false,
 					},
@@ -2521,7 +2521,7 @@ describe("applyBatchUpdate", () => {
 					data: {
 						id: element.id,
 						type: "GOAL",
-						name: "Recreated",
+						name: "G1",
 						description: "Legitimate delete+recreate within the owning case",
 						inSandbox: false,
 					},
@@ -2537,7 +2537,7 @@ describe("applyBatchUpdate", () => {
 			const recreated = await prisma.assuranceElement.findUnique({
 				where: { id: element.id },
 			});
-			expect(recreated?.name).toBe("Recreated");
+			expect(recreated?.name).toBe("G1");
 			expect(recreated?.caseId).toBe(testCase.id);
 		});
 	});
@@ -2646,7 +2646,7 @@ describe("applyBatchUpdate", () => {
 					data: {
 						id: targetId,
 						type: "PROPERTY_CLAIM",
-						name: "Defeated Claim",
+						name: "P1",
 						description: "Created in the same batch as its defeater",
 						inSandbox: false,
 					},
@@ -2658,7 +2658,7 @@ describe("applyBatchUpdate", () => {
 					data: {
 						id: defeaterId,
 						type: "PROPERTY_CLAIM",
-						name: "Defeater Claim",
+						name: "P2",
 						description: "References a sibling create as its defeats target",
 						inSandbox: false,
 						isDefeater: true,
@@ -2676,6 +2676,191 @@ describe("applyBatchUpdate", () => {
 				where: { id: defeaterId },
 			});
 			expect(defeater?.defeatsElementId).toBe(targetId);
+		});
+	});
+
+	/**
+	 * TEA — Element name prefix validation (G, P, S, E) with plugin override
+	 * seam, send-back: the batch/JSON-editor path wrote element names via raw
+	 * Prisma calls (buildCreateData/buildUpdateData), bypassing the
+	 * name-format check createElement/updateElement enforce — a user could
+	 * rename an element to anything through the JSON editor. validateElementNames
+	 * closes that gap; these pin it rejects the whole batch atomically (one
+	 * bad name among several changes) and that conforming names still work.
+	 */
+	describe("element-name prefix validation (TEA-syntax)", () => {
+		it("rejects a batch containing one non-conforming create name, writing nothing", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const goodId = `element-name-good-${Date.now()}`;
+			const badId = `element-name-bad-${Date.now()}`;
+			const changes: ElementChange[] = [
+				{
+					type: "create",
+					elementId: goodId,
+					parentId: null,
+					data: {
+						id: goodId,
+						type: "GOAL",
+						name: "G1",
+						description: "Conforms — should never be persisted either",
+						inSandbox: false,
+						role: "TOP_LEVEL",
+					},
+				},
+				{
+					type: "create",
+					elementId: badId,
+					parentId: goodId,
+					data: {
+						id: badId,
+						type: "STRATEGY",
+						name: "Not A Conforming Name",
+						description: "Fails the prefix check",
+						inSandbox: false,
+					},
+				},
+			];
+
+			const result = await applyBatchUpdate(user.id, testCase.id, changes);
+			expectError(
+				result,
+				new RegExp(
+					`Strategy names must look like S1 or S1\\.1 \\(element ${badId}\\)`
+				)
+			);
+
+			const goodElement = await prisma.assuranceElement.findUnique({
+				where: { id: goodId },
+			});
+			const badElement = await prisma.assuranceElement.findUnique({
+				where: { id: badId },
+			});
+			// Whole batch rejected atomically — the conforming create is not
+			// persisted either, just like validateElementOwnership/
+			// validateCreateParents' existing all-or-nothing behaviour.
+			expect(goodElement).toBeNull();
+			expect(badElement).toBeNull();
+		});
+
+		it("rejects a batch containing one non-conforming update name, leaving the existing element untouched", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const element = await createTestElement(testCase.id, user.id, {
+				elementType: "PROPERTY_CLAIM",
+				name: "P1",
+			});
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const changes: ElementChange[] = [
+				{
+					type: "update",
+					elementId: element.id,
+					data: { name: "Renamed Freely" },
+				},
+			];
+
+			expectError(
+				await applyBatchUpdate(user.id, testCase.id, changes),
+				new RegExp(
+					`Property Claim names must look like P1 or P1\\.1 \\(element ${element.id}\\)`
+				)
+			);
+
+			const unchanged = await prisma.assuranceElement.findUnique({
+				where: { id: element.id },
+			});
+			expect(unchanged?.name).toBe("P1");
+		});
+
+		it("accepts a batch of creates and an update whose names all conform", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const existingClaim = await createTestElement(testCase.id, user.id, {
+				elementType: "PROPERTY_CLAIM",
+				name: "P1",
+			});
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const goalId = `element-name-conforming-goal-${Date.now()}`;
+			const changes: ElementChange[] = [
+				{
+					type: "create",
+					elementId: goalId,
+					parentId: null,
+					data: {
+						id: goalId,
+						type: "GOAL",
+						name: "G1",
+						description: "Conforms to the GOAL prefix",
+						inSandbox: false,
+						role: "TOP_LEVEL",
+					},
+				},
+				{
+					type: "update",
+					elementId: existingClaim.id,
+					data: { name: "P1.1" },
+				},
+			];
+
+			const data = expectSuccess(
+				await applyBatchUpdate(user.id, testCase.id, changes)
+			);
+			expect(data.summary.created).toBe(1);
+			expect(data.summary.updated).toBe(1);
+
+			const created = await prisma.assuranceElement.findUnique({
+				where: { id: goalId },
+			});
+			const updated = await prisma.assuranceElement.findUnique({
+				where: { id: existingClaim.id },
+			});
+			expect(created?.name).toBe("G1");
+			expect(updated?.name).toBe("P1.1");
+		});
+
+		it("passes a name through unchecked when the create/update doesn't touch it (null/absent stay optional)", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const element = await createTestElement(testCase.id, user.id, {
+				elementType: "GOAL",
+				name: "G1",
+			});
+
+			const { applyBatchUpdate } = await import(
+				"@/lib/services/case-batch-update-service"
+			);
+
+			const changes: ElementChange[] = [
+				{
+					type: "update",
+					elementId: element.id,
+					data: { description: "Only the description changes" },
+				},
+			];
+
+			const data = expectSuccess(
+				await applyBatchUpdate(user.id, testCase.id, changes)
+			);
+			expect(data.summary.updated).toBe(1);
+
+			const updated = await prisma.assuranceElement.findUnique({
+				where: { id: element.id },
+			});
+			expect(updated?.name).toBe("G1");
+			expect(updated?.description).toBe("Only the description changes");
 		});
 	});
 });

--- a/src/__tests__/integration/element-name-prefix-backfill.test.ts
+++ b/src/__tests__/integration/element-name-prefix-backfill.test.ts
@@ -1,0 +1,238 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import prisma from "@/lib/prisma";
+import { createTestCase, createTestUser } from "../utils/prisma-factories";
+
+/**
+ * Pins the hand-written data migration
+ * `prisma/migrations/20260903000000_element_name_prefix_backfill/migration.sql`
+ * (TEA — Element Name Prefix Validation, Chris's ruling 2026-09-03: enforce
+ * on create/rename AND migrate stored names).
+ *
+ * The migration file's CREATE TABLE/CREATE INDEX statements already ran once
+ * against this worker's database — as part of the normal `prisma migrate
+ * deploy` the integration suite's setup applies to every migration in
+ * `prisma/migrations/` — so replaying the whole file here would fail with
+ * "relation already exists". Only the backfill statement itself (the single
+ * `WITH ... UPDATE` starting at `WITH prefixes(`) is re-runnable, and is
+ * exactly what "idempotent" means for this migration: sliced out and sent
+ * verbatim via `$executeRawUnsafe`, the same text `prisma migrate deploy`
+ * applied, not a hand-copied predicate that could drift from it.
+ */
+const MIGRATION_SQL = readFileSync(
+	path.join(
+		import.meta.dirname,
+		"../../../prisma/migrations/20260903000000_element_name_prefix_backfill/migration.sql"
+	),
+	"utf8"
+);
+
+const BACKFILL_MARKER = "WITH prefixes(";
+const backfillMarkerIndex = MIGRATION_SQL.indexOf(BACKFILL_MARKER);
+if (backfillMarkerIndex === -1) {
+	throw new Error(
+		`Could not find backfill statement marker '${BACKFILL_MARKER}' in the migration file — has it been rewritten?`
+	);
+}
+const BACKFILL_SQL = MIGRATION_SQL.slice(backfillMarkerIndex);
+
+async function runBackfill(): Promise<void> {
+	await prisma.$executeRawUnsafe(BACKFILL_SQL);
+}
+
+/**
+ * Raw SQL insert with explicit `createdAt`, so ordering is deterministic
+ * rather than relying on wall-clock gaps between factory calls. Raw SQL
+ * (not `prisma.assuranceElement.create`) for the same reason
+ * `identifier-service.test.ts`'s CONTEXT fixture uses `$executeRaw`: the
+ * Prisma client's element-validation extension (`lib/prisma.ts`) runs
+ * `validateElementData` on every `.create()` call, which rejects CONTEXT
+ * outright (absent from `ELEMENT_TYPES` — see the design note's Decision 1
+ * correction) — this fixture needs to create exactly the pre-migration
+ * shapes the migration targets, several of which the application-level
+ * validation would never let through the normal service path.
+ */
+async function insertElement(params: {
+	caseId: string;
+	createdById: string;
+	elementType:
+		| "GOAL"
+		| "CONTEXT"
+		| "STRATEGY"
+		| "PROPERTY_CLAIM"
+		| "EVIDENCE"
+		| "JUSTIFICATION"
+		| "ASSUMPTION"
+		| "MODULE"
+		| "AWAY_GOAL"
+		| "CONTRACT";
+	name: string | null;
+	createdAt: Date;
+	parentId?: string;
+	deletedAt?: Date;
+}): Promise<{ id: string }> {
+	const id = randomUUID();
+	await prisma.$executeRaw`
+		INSERT INTO assurance_elements
+			(id, case_id, element_type, parent_id, name, description, created_by_id, created_at, updated_at, deleted_at)
+		VALUES
+			(${id}, ${params.caseId}, ${params.elementType}::"ElementType", ${params.parentId ?? null}, ${params.name}, 'fixture', ${params.createdById}, ${params.createdAt}, ${params.createdAt}, ${params.deletedAt ?? null})
+	`;
+	return { id };
+}
+
+const HOUR = 60 * 60 * 1000;
+
+describe("migration: element_name_prefix_backfill", () => {
+	it("renames only non-conforming names, continuing the counter from the highest conforming number, in creation order", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+		const base = new Date("2026-01-01T00:00:00Z");
+
+		const goal = await insertElement({
+			caseId: testCase.id,
+			createdById: user.id,
+			elementType: "GOAL",
+			name: "G1",
+			createdAt: base,
+		});
+		const conformingClaim = await insertElement({
+			caseId: testCase.id,
+			createdById: user.id,
+			elementType: "PROPERTY_CLAIM",
+			name: "P1",
+			createdAt: new Date(base.getTime() + HOUR),
+			parentId: goal.id,
+		});
+		const placeholderClaim1 = await insertElement({
+			caseId: testCase.id,
+			createdById: user.id,
+			elementType: "PROPERTY_CLAIM",
+			name: "Property claim",
+			createdAt: new Date(base.getTime() + 2 * HOUR),
+			parentId: goal.id,
+		});
+		const placeholderClaim2 = await insertElement({
+			caseId: testCase.id,
+			createdById: user.id,
+			elementType: "PROPERTY_CLAIM",
+			name: "Property claim",
+			createdAt: new Date(base.getTime() + 3 * HOUR),
+			parentId: goal.id,
+		});
+		const placeholderContext = await insertElement({
+			caseId: testCase.id,
+			createdById: user.id,
+			elementType: "CONTEXT",
+			name: "Context",
+			createdAt: new Date(base.getTime() + 4 * HOUR),
+			parentId: goal.id,
+		});
+		const unnamedEvidence = await insertElement({
+			caseId: testCase.id,
+			createdById: user.id,
+			elementType: "EVIDENCE",
+			name: null,
+			createdAt: new Date(base.getTime() + 5 * HOUR),
+		});
+		const deletedPlaceholder = await insertElement({
+			caseId: testCase.id,
+			createdById: user.id,
+			elementType: "PROPERTY_CLAIM",
+			name: "Property claim",
+			createdAt: new Date(base.getTime() + 6 * HOUR),
+			parentId: goal.id,
+			deletedAt: new Date(),
+		});
+
+		await runBackfill();
+
+		const byId = new Map(
+			(
+				await prisma.assuranceElement.findMany({
+					where: { caseId: testCase.id },
+					select: { id: true, name: true },
+				})
+			).map((e) => [e.id, e.name])
+		);
+
+		// Conforming names untouched.
+		expect(byId.get(goal.id)).toBe("G1");
+		expect(byId.get(conformingClaim.id)).toBe("P1");
+		// Non-conforming claims renamed in creation order, continuing from the
+		// existing conforming max (P1 -> next is P2, P3).
+		expect(byId.get(placeholderClaim1.id)).toBe("P2");
+		expect(byId.get(placeholderClaim2.id)).toBe("P3");
+		// Context has no prior conforming name in this case, so it starts at 1.
+		expect(byId.get(placeholderContext.id)).toBe("C1");
+		// Null name left null.
+		expect(byId.get(unnamedEvidence.id)).toBeNull();
+		// Soft-deleted element left untouched even though its name doesn't conform.
+		expect(byId.get(deletedPlaceholder.id)).toBe("Property claim");
+
+		// Every rename logged, old -> new, nothing extra.
+		const backfillRows = await prisma.elementNameBackfill.findMany({
+			where: {
+				elementId: {
+					in: [
+						placeholderClaim1.id,
+						placeholderClaim2.id,
+						placeholderContext.id,
+					],
+				},
+			},
+		});
+		expect(backfillRows).toHaveLength(3);
+		const byElementId = new Map(backfillRows.map((r) => [r.elementId, r]));
+		expect(byElementId.get(placeholderClaim1.id)).toMatchObject({
+			oldName: "Property claim",
+			newName: "P2",
+		});
+		expect(byElementId.get(placeholderClaim2.id)).toMatchObject({
+			oldName: "Property claim",
+			newName: "P3",
+		});
+		expect(byElementId.get(placeholderContext.id)).toMatchObject({
+			oldName: "Context",
+			newName: "C1",
+		});
+	});
+
+	it("is idempotent — re-running renames nothing and logs no further rows", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+		const base = new Date("2026-01-01T00:00:00Z");
+
+		const placeholder = await insertElement({
+			caseId: testCase.id,
+			createdById: user.id,
+			elementType: "STRATEGY",
+			name: "Strategy",
+			createdAt: base,
+		});
+
+		await runBackfill();
+		const afterFirstRun = await prisma.assuranceElement.findUniqueOrThrow({
+			where: { id: placeholder.id },
+			select: { name: true },
+		});
+		expect(afterFirstRun.name).toBe("S1");
+		const rowsAfterFirstRun = await prisma.elementNameBackfill.count({
+			where: { elementId: placeholder.id },
+		});
+		expect(rowsAfterFirstRun).toBe(1);
+
+		await runBackfill();
+		const afterSecondRun = await prisma.assuranceElement.findUniqueOrThrow({
+			where: { id: placeholder.id },
+			select: { name: true },
+		});
+		expect(afterSecondRun.name).toBe("S1");
+		const rowsAfterSecondRun = await prisma.elementNameBackfill.count({
+			where: { elementId: placeholder.id },
+		});
+		expect(rowsAfterSecondRun).toBe(1);
+	});
+});

--- a/src/__tests__/integration/element-name-prefix-backfill.test.ts
+++ b/src/__tests__/integration/element-name-prefix-backfill.test.ts
@@ -200,6 +200,85 @@ describe("migration: element_name_prefix_backfill", () => {
 		});
 	});
 
+	it("continues the counter from a dotted conforming name's LEADING integer, not its full number", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+		const base = new Date("2026-01-01T00:00:00Z");
+
+		// The only conforming claim in this case is sub-numbered — leading
+		// integer 1, not 2 — so the stray placeholder must continue from 1
+		// (-> P2), never from a naive read of the "2" in "P1.2".
+		const dottedClaim = await insertElement({
+			caseId: testCase.id,
+			createdById: user.id,
+			elementType: "PROPERTY_CLAIM",
+			name: "P1.2",
+			createdAt: base,
+		});
+		const placeholder = await insertElement({
+			caseId: testCase.id,
+			createdById: user.id,
+			elementType: "PROPERTY_CLAIM",
+			name: "Property claim",
+			createdAt: new Date(base.getTime() + HOUR),
+		});
+
+		await runBackfill();
+
+		const afterBackfill = await prisma.assuranceElement.findMany({
+			where: { caseId: testCase.id },
+			select: { id: true, name: true },
+		});
+		const byId = new Map(afterBackfill.map((e) => [e.id, e.name]));
+
+		expect(byId.get(dottedClaim.id)).toBe("P1.2");
+		expect(byId.get(placeholder.id)).toBe("P2");
+
+		const backfillRow = await prisma.elementNameBackfill.findFirst({
+			where: { elementId: placeholder.id },
+		});
+		expect(backfillRow).toMatchObject({
+			oldName: "Property claim",
+			newName: "P2",
+		});
+	});
+
+	it("leaves a non-conforming name untouched inside a trashed case, and logs no backfill row for it", async () => {
+		const user = await createTestUser();
+		const testCase = await createTestCase(user.id);
+		const base = new Date("2026-01-01T00:00:00Z");
+
+		const placeholder = await insertElement({
+			caseId: testCase.id,
+			createdById: user.id,
+			elementType: "PROPERTY_CLAIM",
+			name: "Property claim",
+			createdAt: base,
+		});
+
+		// Trashing a case (case-trash-service.ts's deleteCase) sets deletedAt
+		// only on assurance_cases — it never touches its elements' own
+		// deletedAt. Mirrors that exact shape rather than soft-deleting the
+		// element itself, which a different (already-covered) branch handles.
+		await prisma.assuranceCase.update({
+			where: { id: testCase.id },
+			data: { deletedAt: new Date(), deletedById: user.id },
+		});
+
+		await runBackfill();
+
+		const afterBackfill = await prisma.assuranceElement.findUniqueOrThrow({
+			where: { id: placeholder.id },
+			select: { name: true },
+		});
+		expect(afterBackfill.name).toBe("Property claim");
+
+		const backfillRows = await prisma.elementNameBackfill.count({
+			where: { elementId: placeholder.id },
+		});
+		expect(backfillRows).toBe(0);
+	});
+
 	it("is idempotent — re-running renames nothing and logs no further rows", async () => {
 		const user = await createTestUser();
 		const testCase = await createTestCase(user.id);

--- a/src/__tests__/integration/element-reference-integrity-adversarial.test.ts
+++ b/src/__tests__/integration/element-reference-integrity-adversarial.test.ts
@@ -161,7 +161,7 @@ describe("defeatsElementId — cases barret's suite didn't cover", () => {
 		// Update an unrelated field only — defeatsElementId is not in the input.
 		const data = expectSuccess(
 			await updateElement(owner.id, element.id, {
-				name: "Renamed, defeatsElementId untouched",
+				name: "P2",
 			})
 		);
 		expect(data.defeatsElementId).toBe(target.id);
@@ -435,7 +435,7 @@ describe("id-reuse-class bypass check (style of batch-ownership-adversarial.test
 			// @ts-expect-error — id is not part of CreateElementInput; this is
 			// exactly the adversarial payload shape to probe for.
 			id: victim.id,
-			name: "Attempted collision",
+			name: "S1",
 		});
 
 		expectSuccess(result);

--- a/src/__tests__/integration/element-service.test.ts
+++ b/src/__tests__/integration/element-service.test.ts
@@ -263,6 +263,164 @@ describe("element-service", () => {
 				"Element not found"
 			);
 		});
+
+		describe("parent change", () => {
+			it("detaches the element when parentId is set to null", async () => {
+				const user = await createTestUser();
+				const testCase = await createTestCase(user.id);
+				const goal = expectSuccess(
+					await createElement(user.id, {
+						caseId: testCase.id,
+						elementType: "goal",
+					})
+				);
+				const strategy = expectSuccess(
+					await createElement(user.id, {
+						caseId: testCase.id,
+						elementType: "strategy",
+						parentId: goal.id,
+					})
+				);
+
+				expectSuccess(
+					await updateElement(user.id, strategy.id, { parentId: null })
+				);
+
+				const inDb = await prisma.assuranceElement.findUnique({
+					where: { id: strategy.id },
+				});
+				expect(inDb?.parentId).toBeNull();
+			});
+
+			it("returns 'Element not found' when the new parent doesn't exist or is in a different case, leaving the parent unchanged", async () => {
+				const user = await createTestUser();
+				const testCase = await createTestCase(user.id);
+				const otherCase = await createTestCase(user.id);
+
+				const goal = expectSuccess(
+					await createElement(user.id, {
+						caseId: testCase.id,
+						elementType: "goal",
+					})
+				);
+				const strategy = expectSuccess(
+					await createElement(user.id, {
+						caseId: testCase.id,
+						elementType: "strategy",
+						parentId: goal.id,
+					})
+				);
+				const otherGoal = expectSuccess(
+					await createElement(user.id, {
+						caseId: otherCase.id,
+						elementType: "goal",
+					})
+				);
+
+				// Non-existent parent id
+				expectError(
+					await updateElement(user.id, strategy.id, {
+						parentId: "00000000-0000-0000-0000-000000000000",
+					}),
+					"Element not found"
+				);
+
+				// Parent id from a different case
+				expectError(
+					await updateElement(user.id, strategy.id, {
+						parentId: otherGoal.id,
+					}),
+					"Element not found"
+				);
+
+				const inDb = await prisma.assuranceElement.findUnique({
+					where: { id: strategy.id },
+				});
+				expect(inDb?.parentId).toBe(goal.id);
+			});
+
+			it("rejects moving an element under its own descendant", async () => {
+				const user = await createTestUser();
+				const testCase = await createTestCase(user.id);
+				const goal = expectSuccess(
+					await createElement(user.id, {
+						caseId: testCase.id,
+						elementType: "goal",
+					})
+				);
+				const strategy = expectSuccess(
+					await createElement(user.id, {
+						caseId: testCase.id,
+						elementType: "strategy",
+						parentId: goal.id,
+					})
+				);
+				const claim = expectSuccess(
+					await createElement(user.id, {
+						caseId: testCase.id,
+						elementType: "property_claim",
+						parentId: strategy.id,
+					})
+				);
+
+				expectError(
+					await updateElement(user.id, strategy.id, { parentId: claim.id }),
+					"Cannot move element to one of its descendants"
+				);
+
+				const inDb = await prisma.assuranceElement.findUnique({
+					where: { id: strategy.id },
+				});
+				expect(inDb?.parentId).toBe(goal.id);
+			});
+
+			it("moves a PROPERTY_CLAIM to a new PROPERTY_CLAIM parent and recalculates its level", async () => {
+				const user = await createTestUser();
+				const testCase = await createTestCase(user.id);
+				const goal = expectSuccess(
+					await createElement(user.id, {
+						caseId: testCase.id,
+						elementType: "goal",
+					})
+				);
+				const strategy = expectSuccess(
+					await createElement(user.id, {
+						caseId: testCase.id,
+						elementType: "strategy",
+						parentId: goal.id,
+					})
+				);
+				// Top-level claim (parent is a strategy-under-goal) — level 1
+				const movingClaim = expectSuccess(
+					await createElement(user.id, {
+						caseId: testCase.id,
+						elementType: "property_claim",
+						parentId: strategy.id,
+					})
+				);
+				// Another top-level claim, to become the new parent — level 1
+				const newParentClaim = expectSuccess(
+					await createElement(user.id, {
+						caseId: testCase.id,
+						elementType: "property_claim",
+						parentId: strategy.id,
+					})
+				);
+
+				expectSuccess(
+					await updateElement(user.id, movingClaim.id, {
+						parentId: newParentClaim.id,
+					})
+				);
+
+				const inDb = await prisma.assuranceElement.findUnique({
+					where: { id: movingClaim.id },
+				});
+				expect(inDb?.parentId).toBe(newParentClaim.id);
+				// calculateNewLevel: PROPERTY_CLAIM parent -> parent.level + 1
+				expect(inDb?.level).toBe(2);
+			});
+		});
 	});
 
 	describe("deleteElement", () => {

--- a/src/__tests__/integration/element-service.test.ts
+++ b/src/__tests__/integration/element-service.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	registerPluginNamePatterns,
+	resetPluginNamePatternsForTests,
+} from "@/lib/element-names/prefix-registry";
 import prisma from "@/lib/prisma";
 import {
 	attachElement,
@@ -11,6 +15,7 @@ import {
 	restoreElement,
 	updateElement,
 } from "@/lib/services/element-service";
+import { setPluginEnabledForUser } from "@/lib/services/plugin-enablement-service";
 import { expectError, expectSuccess } from "../utils/assertion-helpers";
 import {
 	createTestCase,
@@ -20,6 +25,8 @@ import {
 
 const GOAL_NAME_PATTERN = /^G\d+$/;
 const STRATEGY_NAME_PATTERN = /^S\d+$/;
+const EVIDENCE_NAME_PATTERN = /^E\d+$/;
+const GSN_PATTERN = /^GSN\d+$/;
 const PARENT_DELETED_PATTERN = /parent element is deleted/;
 
 describe("element-service", () => {
@@ -777,6 +784,195 @@ describe("element-service", () => {
 				await moveElement(user.id, strategy.id, evidence.id),
 				"strategy cannot be a child of evidence"
 			);
+		});
+	});
+
+	/**
+	 * Review send-back (TEA — Element Name Prefix Validation): the batch
+	 * path's name-format enforcement was pinned
+	 * (case-batch-update-service.test.ts), but `enforceElementNameFormat`'s
+	 * two call sites here — `createElement` and `updateElement` — had zero
+	 * coverage of their own. These pin the single-element route's service
+	 * layer directly: rejection with the expected-format message, a
+	 * left-unchanged rename, the plugin override seam honoured only when
+	 * enabled, optionality (null/empty pass), and case-sensitivity.
+	 */
+	describe("name-format validation (TEA-syntax prefix)", () => {
+		it("createElement rejects a non-conforming name with the type's expected-format message", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+
+			expectError(
+				await createElement(user.id, {
+					caseId: testCase.id,
+					elementType: "goal",
+					name: "Not A Conforming Name",
+				}),
+				"Goal names must look like G1 or G1.1"
+			);
+
+			const elements = await prisma.assuranceElement.findMany({
+				where: { caseId: testCase.id },
+			});
+			expect(elements).toHaveLength(0);
+		});
+
+		it("updateElement rejects a non-conforming rename, leaving the stored name unchanged", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const claim = expectSuccess(
+				await createElement(user.id, {
+					caseId: testCase.id,
+					elementType: "property_claim",
+					name: "P1",
+				})
+			);
+
+			expectError(
+				await updateElement(user.id, claim.id, { name: "Renamed Freely" }),
+				"Property Claim names must look like P1 or P1.1"
+			);
+
+			const unchanged = await prisma.assuranceElement.findUnique({
+				where: { id: claim.id },
+			});
+			expect(unchanged?.name).toBe("P1");
+		});
+
+		it("rejects a lowercase name even when the letters and digits otherwise match (case-sensitive)", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+
+			expectError(
+				await createElement(user.id, {
+					caseId: testCase.id,
+					elementType: "goal",
+					name: "g1",
+				}),
+				"Goal names must look like G1 or G1.1"
+			);
+		});
+
+		it("treats an explicit null name the same as omitting it — falls back to auto-generation", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+
+			// `name: null` bypasses createElementSchema's optionalString
+			// transform (which collapses null to `undefined` before the
+			// service ever sees it) — cast to simulate a hand-built payload
+			// that skips schema validation, so this proves the SERVICE layer
+			// itself (not just the schema) treats null as "no name given".
+			const data = expectSuccess(
+				await createElement(user.id, {
+					caseId: testCase.id,
+					elementType: "evidence",
+					name: null,
+				} as unknown as Parameters<typeof createElement>[1])
+			);
+			expect(data.name).toMatch(EVIDENCE_NAME_PATTERN);
+		});
+
+		it("treats an explicit empty-string name the same as omitting it — falls back to auto-generation", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+
+			const data = expectSuccess(
+				await createElement(user.id, {
+					caseId: testCase.id,
+					elementType: "evidence",
+					name: "",
+				})
+			);
+			expect(data.name).toMatch(EVIDENCE_NAME_PATTERN);
+		});
+
+		it("updateElement leaves the stored name untouched when the input omits name entirely", async () => {
+			const user = await createTestUser();
+			const testCase = await createTestCase(user.id);
+			const goal = expectSuccess(
+				await createElement(user.id, {
+					caseId: testCase.id,
+					elementType: "goal",
+					name: "G1",
+				})
+			);
+
+			const data = expectSuccess(
+				await updateElement(user.id, goal.id, {
+					description: "Only the description changes",
+				})
+			);
+			expect(data.name).toBe("G1");
+		});
+
+		/**
+		 * The plugin override seam (lib/element-names/prefix-registry.ts):
+		 * an additional pattern is only honoured for a user with that plugin
+		 * enabled. No shipped plugin registers a pattern yet, so this
+		 * registers a throwaway one under the one real manifest entry
+		 * (`tea.health`) rather than inventing an unregistered plugin id —
+		 * `getEnabledPluginIdsForUser` only ever resolves ids the manifest
+		 * knows, so a made-up id could never appear "enabled" no matter what
+		 * `PluginState` said.
+		 */
+		describe("plugin override seam", () => {
+			afterEach(() => {
+				resetPluginNamePatternsForTests();
+			});
+
+			it("honours a plugin-registered pattern for a user with the plugin enabled (the default)", async () => {
+				registerPluginNamePatterns("tea.health", "GOAL", GSN_PATTERN);
+				const user = await createTestUser();
+				const testCase = await createTestCase(user.id);
+
+				const data = expectSuccess(
+					await createElement(user.id, {
+						caseId: testCase.id,
+						elementType: "goal",
+						name: "GSN1",
+					})
+				);
+				expect(data.name).toBe("GSN1");
+			});
+
+			it("rejects the same plugin-format name once the plugin is disabled for that user", async () => {
+				registerPluginNamePatterns("tea.health", "GOAL", GSN_PATTERN);
+				const user = await createTestUser();
+				const testCase = await createTestCase(user.id);
+				const disableResult = await setPluginEnabledForUser(
+					"tea.health",
+					user.id,
+					{ enabled: false }
+				);
+				expect("data" in disableResult).toBe(true);
+
+				expectError(
+					await createElement(user.id, {
+						caseId: testCase.id,
+						elementType: "goal",
+						name: "GSN1",
+					}),
+					"Goal names must look like G1 or G1.1"
+				);
+			});
+
+			it("honours the plugin pattern through updateElement too, when enabled", async () => {
+				registerPluginNamePatterns("tea.health", "GOAL", GSN_PATTERN);
+				const user = await createTestUser();
+				const testCase = await createTestCase(user.id);
+				const goal = expectSuccess(
+					await createElement(user.id, {
+						caseId: testCase.id,
+						elementType: "goal",
+						name: "G1",
+					})
+				);
+
+				const data = expectSuccess(
+					await updateElement(user.id, goal.id, { name: "GSN2" })
+				);
+				expect(data.name).toBe("GSN2");
+			});
 		});
 	});
 });

--- a/src/__tests__/setup.integration.tsx
+++ b/src/__tests__/setup.integration.tsx
@@ -52,6 +52,7 @@ afterEach(async () => {
         case_team_permissions,
         case_permissions,
         plugin_data,
+        element_name_backfill,
         assurance_elements,
         assurance_cases,
         pattern_permissions,


### PR DESCRIPTION
## Summary

Enforces TEA-syntax element-name format on create and rename, with a plugin-extensible prefix registry, and backfills stored names that do not conform.

- **Prefix registry** (`lib/element-names/prefix-registry.ts`): the single source for the ten element-type prefixes — G, P, S, E, C, J, A, M, AG, Ct. `toPrefix` and the identifier (reset-identifiers) service now read from it; the old duplicated maps and the `"X"` fallback are gone.
- **Validation**: a name, when given, must be `<prefix><number>` with optional dotted sub-numbers (`P1`, `P1.1`). Enforced in `createElement`, `updateElement` and the batch/JSON-editor path, with a message naming the expected format (HTTP 400). Names remain optional. An unrecognised element type is rejected before naming (400, not 500).
- **Plugin seam**: official plugins may register additional accepted patterns for a type, additive only, honoured only for users with that plugin enabled (same semantics as the slot registry). No shipped plugin uses it yet.
- **Migration** (`20260903000000_element_name_prefix_backfill`): renames non-conforming names in live cases to the next free number for their type in that case, continuing from the highest conforming leading integer; records `old → new` in a new `element_name_backfill` table; leaves conforming and null names, deleted elements, and trashed cases untouched; idempotent. Measured production scope: 148 names in 41 of 296 live cases, almost all form placeholders ("Goal", "Context", "Property claim", "Name").
- **Own data**: dev-seed property claims `C1`–`C4` → `P1`–`P4`.
- `updateElement` split into two helpers to keep it under the complexity threshold.

## Tests

- Unit: registry (every prefix for its type, cross-type rejection, format edge cases, plugin enablement, additive-only and conflict semantics).
- Integration (real Postgres): service-level create/update rejection and pass-through, plugin seam through the real path (enabled and disabled), batch-path rejection, route-level 400s (bad name on create and rename, unknown type), migration behaviour (rename, backfill rows, idempotency, dotted-name numbering, deleted elements, trashed cases).
- Suites at the landing commit: unit 1382/1382, integration 1093/1093; lint and typecheck clean; fallow pass with nothing introduced.

## Review chain

Implementation, QA and code review with two fix rounds; both reviewers approved the final commit (`0836b8c8`). Follow-ups tracked separately: auto-naming produces `PNaN.1` when a parent name is non-numeric; a stale `PC1` example in the architecture docs; `plugin_health_evidence` missing from the integration truncate list.
