### PR TITLE
feat: structured logger and persistent security audit events

### DIFF
--- a/lib/__tests__/logger.test.ts
+++ b/lib/__tests__/logger.test.ts
@@ -124,6 +124,54 @@ describe("logger", () => {
 		expect(() => logger.info("x")).not.toThrow();
 	});
 
+	it("does not throw and still emits when a field holds a circular reference", () => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		resetLogSink();
+
+		// A class instance, not a plain object — `serialiseValue` deliberately
+		// passes these through unchanged, so this exercises the JSON.stringify
+		// replacer's own cycle-breaking, not the earlier plain-object guard
+		// already covered by the "nested inside a plain-object field" test.
+		class Node {
+			self?: Node;
+		}
+		const node = new Node();
+		node.self = node;
+
+		const writeSpy = vi
+			.spyOn(process.stdout, "write")
+			.mockImplementation(() => true);
+		try {
+			expect(() => logger.info("circular", { node })).not.toThrow();
+			expect(writeSpy).toHaveBeenCalledTimes(1);
+			const line = writeSpy.mock.calls[0]?.[0] as string;
+			const parsed = JSON.parse(line);
+			expect(parsed.msg).toBe("circular");
+			expect(parsed.node.self).toBe("[Circular]");
+		} finally {
+			writeSpy.mockRestore();
+		}
+	});
+
+	it("does not throw and still emits when a field holds a BigInt", () => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		resetLogSink();
+
+		const writeSpy = vi
+			.spyOn(process.stdout, "write")
+			.mockImplementation(() => true);
+		try {
+			expect(() => logger.info("bigint", { big: BigInt(10) })).not.toThrow();
+			expect(writeSpy).toHaveBeenCalledTimes(1);
+			const line = writeSpy.mock.calls[0]?.[0] as string;
+			const parsed = JSON.parse(line);
+			expect(parsed.msg).toBe("bigint");
+			expect(parsed.big).toBe("10");
+		} finally {
+			writeSpy.mockRestore();
+		}
+	});
+
 	it("falls back to console[level] when process.stdout.write is unavailable", () => {
 		vi.stubEnv("LOG_LEVEL", "debug");
 		resetLogSink();

--- a/lib/__tests__/logger.test.ts
+++ b/lib/__tests__/logger.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type LogEntry, logger, resetLogSink, setLogSink } from "@/lib/logger";
+
+function capture(): LogEntry[] {
+	const entries: LogEntry[] = [];
+	setLogSink((entry) => {
+		entries.push(entry);
+	});
+	return entries;
+}
+
+describe("logger", () => {
+	afterEach(() => {
+		resetLogSink();
+		vi.unstubAllEnvs();
+	});
+
+	it("emits one JSON-shaped entry with ts/level/msg plus fields", () => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		const entries = capture();
+
+		logger.info("hello", { a: 1 });
+
+		expect(entries).toHaveLength(1);
+		expect(entries[0]).toMatchObject({ level: "info", msg: "hello", a: 1 });
+		expect(typeof entries[0]!.ts).toBe("string");
+		expect(Number.isNaN(Date.parse(entries[0]!.ts))).toBe(false);
+	});
+
+	it("suppresses entries below the LOG_LEVEL threshold", () => {
+		vi.stubEnv("LOG_LEVEL", "warn");
+		const entries = capture();
+
+		logger.debug("suppressed");
+		logger.info("also suppressed");
+		logger.warn("kept");
+
+		expect(entries.map((entry) => entry.msg)).toEqual(["kept"]);
+	});
+
+	it("defaults to the info threshold outside a test environment", () => {
+		vi.stubEnv("LOG_LEVEL", "");
+		vi.stubEnv("NODE_ENV", "production");
+		const entries = capture();
+
+		logger.debug("suppressed");
+		logger.info("kept");
+
+		expect(entries.map((entry) => entry.msg)).toEqual(["kept"]);
+	});
+
+	it("is silent under NODE_ENV=test unless LOG_LEVEL is set", () => {
+		vi.stubEnv("LOG_LEVEL", "");
+		vi.stubEnv("NODE_ENV", "test");
+		const entries = capture();
+
+		logger.error("should not appear");
+
+		expect(entries).toHaveLength(0);
+	});
+
+	it("child() merges bindings into every entry alongside per-call fields", () => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		const entries = capture();
+
+		const child = logger.child({ component: "security" });
+		child.warn("event happened", { userId: "u1" });
+
+		expect(entries[0]).toMatchObject({
+			component: "security",
+			userId: "u1",
+			msg: "event happened",
+			level: "warn",
+		});
+	});
+
+	it("serialises an Error field to {name, message, stack}", () => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		const entries = capture();
+
+		logger.error("failed", { error: new Error("boom") });
+
+		expect(entries[0]!.error).toMatchObject({ name: "Error", message: "boom" });
+		expect(typeof (entries[0]!.error as { stack: string }).stack).toBe(
+			"string"
+		);
+	});
+
+	it("serialises an Error nested inside a plain-object field", () => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		const entries = capture();
+
+		logger.error("failed", { context: { cause: new Error("nested") } });
+
+		expect((entries[0]!.context as { cause: unknown }).cause).toMatchObject({
+			name: "Error",
+			message: "nested",
+		});
+	});
+
+	it("setLogSink swaps the sink and resetLogSink restores the default", () => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		const entries = capture();
+		resetLogSink();
+
+		const writeSpy = vi
+			.spyOn(process.stdout, "write")
+			.mockImplementation(() => true);
+		try {
+			logger.info("via default sink");
+			expect(writeSpy).toHaveBeenCalledTimes(1);
+			expect(entries).toHaveLength(0);
+		} finally {
+			writeSpy.mockRestore();
+		}
+	});
+
+	it("never throws even when the sink itself throws", () => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		setLogSink(() => {
+			throw new Error("sink exploded");
+		});
+
+		expect(() => logger.info("x")).not.toThrow();
+	});
+
+	it("falls back to console[level] when process.stdout.write is unavailable", () => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		resetLogSink();
+		const originalWrite = process.stdout.write;
+		// @ts-expect-error — simulating an edge/browser runtime with no stdout.write
+		process.stdout.write = undefined;
+		const consoleInfoSpy = vi
+			.spyOn(console, "info")
+			.mockImplementation(() => undefined);
+
+		try {
+			logger.info("edge path", { runtime: "edge" });
+
+			expect(consoleInfoSpy).toHaveBeenCalledTimes(1);
+			const line = consoleInfoSpy.mock.calls[0]?.[0] as string;
+			const parsed = JSON.parse(line);
+			expect(parsed).toMatchObject({ level: "info", msg: "edge path" });
+		} finally {
+			process.stdout.write = originalWrite;
+			consoleInfoSpy.mockRestore();
+		}
+	});
+});

--- a/lib/__tests__/logger.test.ts
+++ b/lib/__tests__/logger.test.ts
@@ -172,6 +172,46 @@ describe("logger", () => {
 		}
 	});
 
+	it.each([
+		"ts",
+		"level",
+		"msg",
+	] as const)("keeps the entry's own %s when a field collides, under caller_%s", (key) => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		const entries = capture();
+
+		logger.info("hello", { [key]: "spoofed" });
+
+		expect(entries[0]?.[key]).not.toBe("spoofed");
+		expect(entries[0]?.[`caller_${key}`]).toBe("spoofed");
+	});
+
+	it.each([
+		"ts",
+		"level",
+		"msg",
+	] as const)("keeps the entry's own %s when a binding collides, under caller_%s", (key) => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		const entries = capture();
+
+		const child = logger.child({ [key]: "spoofed" });
+		child.info("hello");
+
+		expect(entries[0]?.[key]).not.toBe("spoofed");
+		expect(entries[0]?.[`caller_${key}`]).toBe("spoofed");
+	});
+
+	it("keeps a bound component when a per-call field collides, under caller_component", () => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		const entries = capture();
+
+		const child = logger.child({ component: "security" });
+		child.info("hello", { component: "spoofed" });
+
+		expect(entries[0]?.component).toBe("security");
+		expect(entries[0]?.caller_component).toBe("spoofed");
+	});
+
 	it("falls back to console[level] when process.stdout.write is unavailable", () => {
 		vi.stubEnv("LOG_LEVEL", "debug");
 		resetLogSink();

--- a/lib/audit/__tests__/security-log.test.ts
+++ b/lib/audit/__tests__/security-log.test.ts
@@ -75,4 +75,22 @@ describe("logSecurityEvent", () => {
 			level: "error",
 		});
 	});
+
+	it("keeps its own severity when metadata.severity collides, under caller_severity", () => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		const entries = capture();
+
+		logSecurityEvent({
+			event: "privilege_escalation_attempt",
+			severity: "critical",
+			metadata: { severity: "low" },
+		});
+
+		expect(entries).toHaveLength(1);
+		expect(entries[0]).toMatchObject({
+			severity: "critical",
+			caller_severity: "low",
+			level: "error",
+		});
+	});
 });

--- a/lib/audit/__tests__/security-log.test.ts
+++ b/lib/audit/__tests__/security-log.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { logSecurityEvent } from "@/lib/audit/security-log";
+import { type LogEntry, resetLogSink, setLogSink } from "@/lib/logger";
+
+function capture(): LogEntry[] {
+	const entries: LogEntry[] = [];
+	setLogSink((entry) => {
+		entries.push(entry);
+	});
+	return entries;
+}
+
+describe("logSecurityEvent", () => {
+	afterEach(() => {
+		resetLogSink();
+		vi.unstubAllEnvs();
+	});
+
+	it.each([
+		"low",
+		"medium",
+	] as const)("logs %s severity at warn", (severity) => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		const entries = capture();
+
+		logSecurityEvent({ event: "some_event", severity });
+
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.level).toBe("warn");
+	});
+
+	it.each([
+		"high",
+		"critical",
+	] as const)("logs %s severity at error", (severity) => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		const entries = capture();
+
+		logSecurityEvent({ event: "some_event", severity });
+
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.level).toBe("error");
+	});
+
+	it("carries event as msg, severity and metadata as fields, and the security binding", () => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		const entries = capture();
+
+		logSecurityEvent({
+			event: "password_reset_completed",
+			severity: "low",
+			metadata: { userId: "u1", ipAddress: "127.0.0.1" },
+		});
+
+		expect(entries).toHaveLength(1);
+		expect(entries[0]).toMatchObject({
+			component: "security",
+			msg: "password_reset_completed",
+			severity: "low",
+			userId: "u1",
+			ipAddress: "127.0.0.1",
+		});
+	});
+
+	it("carries the security binding and severity field even with no metadata", () => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		const entries = capture();
+
+		logSecurityEvent({ event: "token_revoked", severity: "high" });
+
+		expect(entries[0]).toMatchObject({
+			component: "security",
+			msg: "token_revoked",
+			severity: "high",
+			level: "error",
+		});
+	});
+});

--- a/lib/audit/security-log.ts
+++ b/lib/audit/security-log.ts
@@ -1,16 +1,27 @@
+import { logger } from "@/lib/logger";
+
 interface SecurityEventParams {
 	event: string;
 	metadata?: Record<string, unknown>;
 	severity: "low" | "medium" | "high" | "critical";
 }
 
+const securityLogger = logger.child({ component: "security" });
+
+/**
+ * Logs a security-relevant event via the structured logger. `low`/`medium`
+ * severity logs at `warn`, `high`/`critical` at `error`; `severity` is kept
+ * as a field either way, so a sink or query can select on it directly
+ * without depending on which level it was logged at.
+ */
 export function logSecurityEvent({
 	event,
 	severity,
 	metadata,
 }: SecurityEventParams): void {
-	console.warn(
-		`[SECURITY] [${severity.toUpperCase()}] ${event}`,
-		metadata ?? ""
-	);
+	const log =
+		severity === "high" || severity === "critical"
+			? securityLogger.error
+			: securityLogger.warn;
+	log(event, { severity, ...metadata });
 }

--- a/lib/audit/security-log.ts
+++ b/lib/audit/security-log.ts
@@ -13,6 +13,12 @@ const securityLogger = logger.child({ component: "security" });
  * severity logs at `warn`, `high`/`critical` at `error`; `severity` is kept
  * as a field either way, so a sink or query can select on it directly
  * without depending on which level it was logged at.
+ *
+ * `severity` is reserved: this function's own argument always wins, and a
+ * colliding `metadata.severity` is kept under `caller_severity` rather than
+ * dropped. Any other reserved key in `metadata` (`ts`/`level`/`msg`/
+ * `component`) flows through to `emit`, which applies the same
+ * caller_-namespacing rule — see `lib/logger.ts`.
  */
 export function logSecurityEvent({
 	event,
@@ -23,5 +29,10 @@ export function logSecurityEvent({
 		severity === "high" || severity === "critical"
 			? securityLogger.error
 			: securityLogger.warn;
-	log(event, { severity, ...metadata });
+	const fields: Record<string, unknown> = { ...metadata };
+	if ("severity" in fields) {
+		fields.caller_severity = fields.severity;
+	}
+	fields.severity = severity;
+	log(event, fields);
 }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -50,12 +50,57 @@ function hasNodeStdoutWrite(): boolean {
 }
 
 /**
+ * `JSON.stringify` replacer: renders any `BigInt` that reached this point as
+ * a string (values are also converted earlier in `serialiseValue`, but this
+ * is the last line of defence for anything that bypassed it — e.g. a BigInt
+ * nested inside a non-plain-object class instance) and breaks reference
+ * cycles with a `"[Circular]"` marker. `serialiseFields` already breaks
+ * cycles among plain objects/arrays before an entry is built; this replacer
+ * additionally covers class instances and Maps/Sets, which `serialiseValue`
+ * deliberately passes through unchanged.
+ */
+function jsonReplacer(): (key: string, value: unknown) => unknown {
+	const seen = new WeakSet<object>();
+	return (_key: string, value: unknown): unknown => {
+		if (typeof value === "bigint") {
+			return value.toString();
+		}
+		if (typeof value === "object" && value !== null) {
+			if (seen.has(value)) {
+				return "[Circular]";
+			}
+			seen.add(value);
+		}
+		return value;
+	};
+}
+
+/**
+ * Never throws: an entry that still can't be stringified (the replacer
+ * above should prevent this, but a getter that throws or similar is always
+ * possible) falls back to a minimal line carrying `msg` and a
+ * `serialisationError` field instead of dropping the entry entirely.
+ */
+function stringifyEntry(entry: LogEntry): string {
+	try {
+		return JSON.stringify(entry, jsonReplacer());
+	} catch {
+		return JSON.stringify({
+			ts: entry.ts,
+			level: entry.level,
+			msg: entry.msg,
+			serialisationError: "Failed to serialise log entry",
+		});
+	}
+}
+
+/**
  * Default sink: JSON on `process.stdout` when it exists (Node), otherwise
  * `console[level]` (Next.js edge runtime / browser). Checked at call time,
  * not import time, so the same module serves every runtime.
  */
 function defaultSink(entry: LogEntry): void {
-	const line = JSON.stringify(entry);
+	const line = stringifyEntry(entry);
 	if (hasNodeStdoutWrite()) {
 		process.stdout.write(`${line}\n`);
 		return;
@@ -107,8 +152,15 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return proto === Object.prototype || proto === null;
 }
 
-/** Serialises `Error` instances anywhere in a value to `{name, message, stack}`. */
+/**
+ * Serialises `Error` instances anywhere in a value to `{name, message,
+ * stack}`, and `BigInt`s to strings (`JSON.stringify` throws on a raw
+ * `BigInt`, and there's no upside to waiting for the sink to find that out).
+ */
 function serialiseValue(value: unknown, seen: WeakSet<object>): unknown {
+	if (typeof value === "bigint") {
+		return value.toString();
+	}
 	if (value instanceof Error) {
 		return { name: value.name, message: value.message, stack: value.stack };
 	}

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -13,6 +13,15 @@
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
+/**
+ * `ts`/`level`/`msg` are always the emitter's own values — nothing a caller
+ * passes via `bindings` or per-call `fields` can change them. `component` is
+ * reserved too, but its one legitimate source is `bindings` (set at
+ * `createLogger`/`child()` creation); a per-call `fields.component` can't
+ * override it. In every case, a caller-supplied value that collides with a
+ * reserved key is kept, not dropped — under `caller_<key>` — so `emit` never
+ * silently discards data. See `namespaceReservedKeys`.
+ */
 export type LogEntry = {
 	ts: string;
 	level: LogLevel;
@@ -192,6 +201,33 @@ function serialiseFields(
 	return result;
 }
 
+const RESERVED_LOGGER_KEYS = ["ts", "level", "msg", "component"] as const;
+type ReservedLoggerKey = (typeof RESERVED_LOGGER_KEYS)[number];
+
+/**
+ * Renames any of `keys` that are present in `fields` to `caller_<key>`, so
+ * the entry's own reserved values can be written afterwards without a
+ * caller value silently overwriting them — and without silently dropping
+ * the caller's original value either. Returns `fields` unchanged (same
+ * reference) when none of `keys` are present.
+ */
+function namespaceReservedKeys(
+	fields: Record<string, unknown>,
+	keys: readonly ReservedLoggerKey[]
+): Record<string, unknown> {
+	let result = fields;
+	for (const key of keys) {
+		if (key in result) {
+			if (result === fields) {
+				result = { ...fields };
+			}
+			result[`caller_${key}`] = result[key];
+			delete result[key];
+		}
+	}
+	return result;
+}
+
 function emit(
 	level: LogLevel,
 	bindings: Record<string, unknown>,
@@ -202,12 +238,24 @@ function emit(
 		if (LEVEL_ORDER[level] < currentThreshold()) {
 			return;
 		}
+		// `component` is bindings' one legitimate reserved key (from `child()`),
+		// so only ts/level/msg are namespaced here — a real bound component must
+		// survive into the entry. Per-call fields have no legitimate reserved
+		// key at all, so all four are namespaced there.
+		const safeBindings = namespaceReservedKeys(serialiseFields(bindings), [
+			"ts",
+			"level",
+			"msg",
+		]);
+		const safeFields = fields
+			? namespaceReservedKeys(serialiseFields(fields), RESERVED_LOGGER_KEYS)
+			: {};
 		const entry: LogEntry = {
+			...safeBindings,
+			...safeFields,
 			ts: new Date().toISOString(),
 			level,
 			msg: message,
-			...serialiseFields(bindings),
-			...(fields ? serialiseFields(fields) : {}),
 		};
 		(sink ?? defaultSink)(entry);
 	} catch {

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,176 @@
+/**
+ * Bespoke structured logger — no vendor SDK, one JSON line per entry on
+ * stdout. Runs in every runtime our code runs in: Node server code
+ * (services, routes), the Next.js edge runtime (`middleware.ts`), and the
+ * browser (components, hooks, store). See the "TEA — Structured logging &
+ * OpenTelemetry" issue's Design (G0) section for the rationale.
+ *
+ * `setLogSink`/`resetLogSink` are the single seam: the post-1.0
+ * `instrumentation.ts` swaps the sink for the OpenTelemetry logs bridge
+ * without touching any call site, and tests capture entries through the
+ * sink instead of spying on `console.*`.
+ */
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export type LogEntry = {
+	ts: string;
+	level: LogLevel;
+	msg: string;
+} & Record<string, unknown>;
+
+export interface Logger {
+	/** Returns a logger whose entries also carry `bindings`. */
+	child(bindings: Record<string, unknown>): Logger;
+	debug(message: string, fields?: Record<string, unknown>): void;
+	error(message: string, fields?: Record<string, unknown>): void;
+	info(message: string, fields?: Record<string, unknown>): void;
+	warn(message: string, fields?: Record<string, unknown>): void;
+}
+
+type LogSink = (entry: LogEntry) => void;
+
+const LEVEL_ORDER: Record<LogLevel, number> = {
+	debug: 10,
+	info: 20,
+	warn: 30,
+	error: 40,
+};
+
+/** Above every real level — nothing is emitted when the threshold is this. */
+const SILENT_THRESHOLD = 100;
+
+let sink: LogSink | null = null;
+
+function hasNodeStdoutWrite(): boolean {
+	return (
+		typeof process !== "undefined" &&
+		typeof process.stdout?.write === "function"
+	);
+}
+
+/**
+ * Default sink: JSON on `process.stdout` when it exists (Node), otherwise
+ * `console[level]` (Next.js edge runtime / browser). Checked at call time,
+ * not import time, so the same module serves every runtime.
+ */
+function defaultSink(entry: LogEntry): void {
+	const line = JSON.stringify(entry);
+	if (hasNodeStdoutWrite()) {
+		process.stdout.write(`${line}\n`);
+		return;
+	}
+	console[entry.level](line);
+}
+
+/** Installs a replacement sink — the OpenTelemetry seam, and the test seam. */
+export function setLogSink(fn: LogSink): void {
+	sink = fn;
+}
+
+/** Restores the default stdout/console sink. */
+export function resetLogSink(): void {
+	sink = null;
+}
+
+function isValidLevel(value: string | undefined): value is LogLevel {
+	return (
+		value === "debug" ||
+		value === "info" ||
+		value === "warn" ||
+		value === "error"
+	);
+}
+
+/**
+ * Threshold is read fresh on every call (not cached at import time) so it
+ * follows whatever `LOG_LEVEL`/`NODE_ENV` are at the moment of the call —
+ * this is what lets tests toggle it with plain `process.env` writes.
+ */
+function currentThreshold(): number {
+	const env = typeof process === "undefined" ? undefined : process.env;
+	const configured = env?.LOG_LEVEL;
+	if (isValidLevel(configured)) {
+		return LEVEL_ORDER[configured];
+	}
+	if (env?.NODE_ENV === "test") {
+		return SILENT_THRESHOLD;
+	}
+	return LEVEL_ORDER.info;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	if (value === null || typeof value !== "object") {
+		return false;
+	}
+	const proto = Object.getPrototypeOf(value);
+	return proto === Object.prototype || proto === null;
+}
+
+/** Serialises `Error` instances anywhere in a value to `{name, message, stack}`. */
+function serialiseValue(value: unknown, seen: WeakSet<object>): unknown {
+	if (value instanceof Error) {
+		return { name: value.name, message: value.message, stack: value.stack };
+	}
+	if (Array.isArray(value)) {
+		return value.map((item) => serialiseValue(item, seen));
+	}
+	if (isPlainObject(value)) {
+		if (seen.has(value)) {
+			return "[Circular]";
+		}
+		seen.add(value);
+		const result: Record<string, unknown> = {};
+		for (const [key, val] of Object.entries(value)) {
+			result[key] = serialiseValue(val, seen);
+		}
+		return result;
+	}
+	return value;
+}
+
+function serialiseFields(
+	fields: Record<string, unknown>
+): Record<string, unknown> {
+	const seen = new WeakSet<object>();
+	const result: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(fields)) {
+		result[key] = serialiseValue(value, seen);
+	}
+	return result;
+}
+
+function emit(
+	level: LogLevel,
+	bindings: Record<string, unknown>,
+	message: string,
+	fields?: Record<string, unknown>
+): void {
+	try {
+		if (LEVEL_ORDER[level] < currentThreshold()) {
+			return;
+		}
+		const entry: LogEntry = {
+			ts: new Date().toISOString(),
+			level,
+			msg: message,
+			...serialiseFields(bindings),
+			...(fields ? serialiseFields(fields) : {}),
+		};
+		(sink ?? defaultSink)(entry);
+	} catch {
+		// Never throw from the logger.
+	}
+}
+
+function createLogger(bindings: Record<string, unknown>): Logger {
+	return {
+		debug: (message, fields) => emit("debug", bindings, message, fields),
+		info: (message, fields) => emit("info", bindings, message, fields),
+		warn: (message, fields) => emit("warn", bindings, message, fields),
+		error: (message, fields) => emit("error", bindings, message, fields),
+		child: (childBindings) => createLogger({ ...bindings, ...childBindings }),
+	};
+}
+
+export const logger: Logger = createLogger({});

--- a/lib/plugins/health/__tests__/register.test.ts
+++ b/lib/plugins/health/__tests__/register.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { elementBadgeSlot, elementPanelSlot } from "@/lib/plugins/slots";
+import { captureLogs } from "@/src/__tests__/helpers/capture-logs";
 import { HealthBadge } from "../health-badge";
 import { HealthPanel } from "../health-panel";
 import { registerHealthPlugin } from "../register";
@@ -48,23 +49,29 @@ describe("registerHealthPlugin — bootstrap safety (review forward-note v4)", (
 	it("catches a throwing registration instead of propagating — degrades to unregistered", () => {
 		elementBadgeSlot.resetForTests();
 		elementPanelSlot.resetForTests();
-		const consoleErrorSpy = vi
-			.spyOn(console, "error")
-			.mockImplementation(() => undefined);
+		const logs = captureLogs();
 		vi.spyOn(elementBadgeSlot, "register").mockImplementation(() => {
 			throw new Error("simulated registration failure");
 		});
 
-		expect(() => registerHealthPlugin()).not.toThrow();
+		try {
+			expect(() => registerHealthPlugin()).not.toThrow();
 
-		expect(consoleErrorSpy).toHaveBeenCalledWith(
-			expect.stringContaining("[tea.health]"),
-			expect.any(Error)
-		);
-		// The badge registration threw before it could be recorded, and the
-		// panel registration never ran (the try/catch wraps both calls) —
-		// both slots end up exactly as unregistered as a disabled plugin.
-		expect(elementBadgeSlot.list()).toEqual([]);
-		expect(elementPanelSlot.list()).toEqual([]);
+			const errorEntry = logs.entries.find(
+				(entry) => entry.level === "error" && entry.msg.includes("[tea.health]")
+			);
+			expect(errorEntry).toBeDefined();
+			expect(errorEntry?.error).toMatchObject({
+				name: "Error",
+				message: "simulated registration failure",
+			});
+			// The badge registration threw before it could be recorded, and the
+			// panel registration never ran (the try/catch wraps both calls) —
+			// both slots end up exactly as unregistered as a disabled plugin.
+			expect(elementBadgeSlot.list()).toEqual([]);
+			expect(elementPanelSlot.list()).toEqual([]);
+		} finally {
+			logs.restore();
+		}
 	});
 });

--- a/lib/plugins/health/register.ts
+++ b/lib/plugins/health/register.ts
@@ -26,6 +26,7 @@
  * appear — the same observable behaviour as the plugin being disabled).
  */
 
+import { logger } from "@/lib/logger";
 import { elementBadgeSlot, elementPanelSlot } from "@/lib/plugins/slots";
 import { HealthBadge } from "./health-badge";
 import { HealthPanel } from "./health-panel";
@@ -45,13 +46,9 @@ export function registerHealthPlugin(): void {
 			Component: HealthPanel,
 		});
 	} catch (error) {
-		// No structured logger exists in this codebase yet (CLAUDE.md names
-		// one; none of the merged health-plugin server-core files use it
-		// either) — console.error matches the prevailing actual pattern, not a
-		// deviation introduced here.
-		console.error(
-			"[tea.health] UI slot registration failed — badge/panel will not render:",
-			error
+		logger.error(
+			"[tea.health] UI slot registration failed — badge/panel will not render",
+			{ error }
 		);
 	}
 }

--- a/lib/services/blob-storage-service.ts
+++ b/lib/services/blob-storage-service.ts
@@ -15,6 +15,9 @@ import {
 	BlobServiceClient,
 	StorageSharedKeyCredential,
 } from "@azure/storage-blob";
+import { logger } from "@/lib/logger";
+
+const log = logger.child({ service: "blob-storage-service" });
 
 const CONTAINER_NAME = "media";
 const LOCAL_UPLOAD_DIR = "public/uploads";
@@ -87,10 +90,10 @@ export function uploadToLocalStorage(
 
 		// Return a URL relative to the public directory
 		const url = `/uploads/${blobPath}`;
-		console.log(`[Dev] File saved locally: ${url}`);
+		log.info("Dev file saved locally", { url });
 		return { success: true, url };
 	} catch (error) {
-		console.error("Failed to save file locally:", error);
+		log.error("Failed to save file locally", { error });
 		return {
 			success: false,
 			error: error instanceof Error ? error.message : "Local upload failed",
@@ -118,8 +121,8 @@ export async function uploadToBlob(
 	// Fall back to local storage when Azure isn't configured
 	if (!blobServiceClient) {
 		if (process.env.NODE_ENV === "development") {
-			console.log(
-				"[Dev] Azure Blob Storage not configured, using local file storage"
+			log.info(
+				"Dev Azure Blob Storage not configured, using local file storage"
 			);
 			const localResult = uploadToLocalStorage(buffer, blobPath);
 			if (!localResult.success) {
@@ -127,7 +130,7 @@ export async function uploadToBlob(
 			}
 			return { data: { url: localResult.url } };
 		}
-		console.error("Azure Blob Storage credentials not configured");
+		log.error("Azure Blob Storage credentials not configured");
 		return { error: "Storage not configured" };
 	}
 
@@ -143,7 +146,7 @@ export async function uploadToBlob(
 		const imageUrl = `https://${accountName}.blob.core.windows.net/${CONTAINER_NAME}/${blobPath}`;
 		return { data: { url: imageUrl } };
 	} catch (error) {
-		console.error("Failed to upload to Azure Blob Storage:", error);
+		log.error("Failed to upload to Azure Blob Storage", { error });
 		return {
 			error: error instanceof Error ? error.message : "Upload failed",
 		};
@@ -167,10 +170,10 @@ export async function deleteBlob(blobPath: string): Promise<boolean> {
 				const { unlink } = await import("node:fs/promises");
 				const fullPath = join(process.cwd(), LOCAL_UPLOAD_DIR, blobPath);
 				await unlink(fullPath);
-				console.log(`[Dev] File deleted locally: ${blobPath}`);
+				log.info("Dev file deleted locally", { blobPath });
 				return true;
 			} catch (error) {
-				console.error("Failed to delete local file:", error);
+				log.error("Failed to delete local file", { error });
 				return false;
 			}
 		}
@@ -184,7 +187,7 @@ export async function deleteBlob(blobPath: string): Promise<boolean> {
 		await blockBlobClient.delete();
 		return true;
 	} catch (error) {
-		console.error("Failed to delete blob:", error);
+		log.error("Failed to delete blob", { error });
 		return false;
 	}
 }

--- a/lib/services/case-invite-service.ts
+++ b/lib/services/case-invite-service.ts
@@ -1,8 +1,11 @@
 import { randomBytes } from "node:crypto";
+import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
 import { recordSecurityEvent } from "@/lib/services/security-audit-service";
 import type { PermissionLevel } from "@/src/generated/prisma";
 import type { ServiceResult } from "@/types/service";
+
+const log = logger.child({ service: "case-invite-service" });
 
 // ============================================
 // Types
@@ -70,7 +73,7 @@ export async function createCaseInvite(params: {
 
 		return { data: { invite_token: token } };
 	} catch (error) {
-		console.error("Failed to create case invite:", error);
+		log.error("Failed to create case invite", { error });
 		return { error: "Failed to create invite" };
 	}
 }
@@ -217,7 +220,7 @@ export async function acceptInvite(
 
 		return { data: { caseId: result.caseId } };
 	} catch (error) {
-		console.error("Failed to accept invite:", error);
+		log.error("Failed to accept invite", { error });
 
 		await recordSecurityEvent({
 			event: "invite_acceptance_failed",

--- a/lib/services/case-invite-service.ts
+++ b/lib/services/case-invite-service.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
-import { logSecurityEvent } from "@/lib/audit/security-log";
 import { prisma } from "@/lib/prisma";
+import { recordSecurityEvent } from "@/lib/services/security-audit-service";
 import type { PermissionLevel } from "@/src/generated/prisma";
 import type { ServiceResult } from "@/types/service";
 
@@ -97,15 +97,13 @@ export async function acceptInvite(
 		});
 
 		if (user === null) {
-			logSecurityEvent({
+			await recordSecurityEvent({
 				event: "invite_acceptance_user_not_found",
 				severity: "medium",
-				metadata: {
-					userId,
-					inviteToken: `${inviteToken.substring(0, 8)}...`,
-					ipAddress,
-					userAgent,
-				},
+				userId,
+				ipAddress,
+				userAgent,
+				metadata: { inviteToken: `${inviteToken.substring(0, 8)}...` },
 			});
 			return { error: "User not found" };
 		}
@@ -190,17 +188,17 @@ export async function acceptInvite(
 				email_mismatch: "invite_acceptance_email_mismatch",
 			} as const;
 
-			logSecurityEvent({
+			await recordSecurityEvent({
 				event: eventTypeMap[errorKey],
 				severity: "medium",
+				userId,
+				ipAddress,
+				userAgent,
 				metadata: {
-					userId,
 					inviteToken: `${inviteToken.substring(0, 8)}...`,
 					...("inviteId" in result && { inviteId: result.inviteId }),
 					...("inviteEmail" in result && { inviteEmail: result.inviteEmail }),
 					userEmail: user.email,
-					ipAddress,
-					userAgent,
 				},
 			});
 
@@ -208,25 +206,28 @@ export async function acceptInvite(
 		}
 
 		// Log successful acceptance
-		logSecurityEvent({
+		await recordSecurityEvent({
 			event: "invite_acceptance_completed",
 			severity: "low",
-			metadata: { userId, caseId: result.caseId, ipAddress, userAgent },
+			userId,
+			ipAddress,
+			userAgent,
+			metadata: { caseId: result.caseId },
 		});
 
 		return { data: { caseId: result.caseId } };
 	} catch (error) {
 		console.error("Failed to accept invite:", error);
 
-		logSecurityEvent({
+		await recordSecurityEvent({
 			event: "invite_acceptance_failed",
 			severity: "high",
+			userId,
+			ipAddress,
+			userAgent,
 			metadata: {
-				userId,
 				error: error instanceof Error ? error.message : "Unknown error",
 				inviteToken: `${inviteToken.substring(0, 8)}...`,
-				ipAddress,
-				userAgent,
 			},
 		});
 

--- a/lib/services/file-storage-service.ts
+++ b/lib/services/file-storage-service.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { access, mkdir, rm, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { logger } from "@/lib/logger";
 import {
 	deleteBlob,
 	getExtensionFromMimeType,
@@ -8,6 +9,8 @@ import {
 	isAzureStorageConfigured,
 	uploadToBlob,
 } from "./blob-storage-service";
+
+const log = logger.child({ service: "file-storage-service" });
 
 /**
  * File Storage Service
@@ -84,11 +87,11 @@ async function saveFileLocally(
 		await writeFile(filePath, buffer);
 
 		const relativePath = `/uploads/${subDirectory}/${uniqueFilename}`;
-		console.log(`[Dev] File saved locally: ${relativePath}`);
+		log.info("Dev file saved locally", { relativePath });
 
 		return { data: { path: relativePath } };
 	} catch (error) {
-		console.error("Error saving file locally:", error);
+		log.error("Error saving file locally", { error });
 		return { error: "Failed to save file" };
 	}
 }
@@ -136,7 +139,7 @@ export async function saveFile(
 	}
 
 	// Production without Azure configured and local storage not enabled
-	console.error(
+	log.error(
 		"Storage not configured. Set USE_LOCAL_STORAGE=true for local filesystem storage, or configure Azure Blob Storage."
 	);
 	return { error: "Storage not configured" };
@@ -164,7 +167,7 @@ export async function deleteFile(filePath: string): Promise<boolean> {
 			const blobPath = pathParts.slice(2).join("/");
 			return deleteBlob(blobPath);
 		} catch (error) {
-			console.error("Failed to parse blob URL:", error);
+			log.error("Failed to parse blob URL", { error });
 			return false;
 		}
 	}
@@ -174,15 +177,15 @@ export async function deleteFile(filePath: string): Promise<boolean> {
 		try {
 			const fullPath = join(process.cwd(), "public", filePath.slice(1));
 			await unlink(fullPath);
-			console.log(`[Dev] File deleted locally: ${filePath}`);
+			log.info("Dev file deleted locally", { filePath });
 			return true;
 		} catch (error) {
-			console.error("Error deleting local file:", error);
+			log.error("Error deleting local file", { error });
 			return false;
 		}
 	}
 
-	console.warn("Unknown file path format:", filePath);
+	log.warn("Unknown file path format", { filePath });
 	return false;
 }
 
@@ -200,7 +203,7 @@ export async function deleteDirectory(subDirectory: string): Promise<boolean> {
 		await rm(dirPath, { recursive: true, force: true });
 		return true;
 	} catch (error) {
-		console.error("Error deleting directory:", error);
+		log.error("Error deleting directory", { error });
 		return false;
 	}
 }

--- a/lib/services/integration-registry-service.ts
+++ b/lib/services/integration-registry-service.ts
@@ -1,4 +1,3 @@
-import { logSecurityEvent } from "@/lib/audit/security-log";
 import {
 	generateApiTokenSecret,
 	hashApiTokenSecret,
@@ -14,6 +13,7 @@ import {
 	RATE_LIMIT_CONFIGS,
 	recordAttempt,
 } from "@/lib/services/rate-limit-service";
+import { recordSecurityEvent } from "@/lib/services/security-audit-service";
 import {
 	type ApiToken,
 	type Integration,
@@ -131,55 +131,25 @@ interface AuditLogInput {
 }
 
 /**
- * Records a security-relevant machine-auth event: `logSecurityEvent` for
- * dev-console visibility (existing pattern) plus a persisted
- * `SecurityAuditLog` row (the pattern's call shape has no DB write yet —
- * this service adds one, scoped to its own events, all Prisma access
- * staying inside this service per house rule).
- *
- * Contract: this function NEVER throws. The calling operation has already
- * committed by the time this runs, so a failure here must never be allowed
- * to surface as the operation's own failure (a caller told "Failed to
- * delete integration" after the delete actually committed would retry and
- * hit a confusing not-found). If the `SecurityAuditLog` write itself fails,
- * that failure is logged as its own `audit_log_write_failed` event —
- * carrying the event that was meant to be recorded — and swallowed here,
- * not propagated to the caller's `try/catch`.
+ * Records a security-relevant machine-auth event via the shared
+ * `recordSecurityEvent` (`lib/services/security-audit-service.ts`) — kept as
+ * a thin wrapper so this file's many call sites don't each have to pass
+ * `severity: "medium"` (this module's events are all medium; the one
+ * exception, `audit_log_write_failed`, is `recordSecurityEvent`'s own
+ * concern, not this module's). Was originally the module that inlined the
+ * `logSecurityEvent` + `prisma.securityAuditLog.create` pattern directly;
+ * that pattern now lives in `security-audit-service.ts` so every caller
+ * shares it (`TEA — Persist security audit events`).
  */
 async function writeAuditLog(input: AuditLogInput): Promise<void> {
-	logSecurityEvent({
+	await recordSecurityEvent({
 		event: input.eventType,
 		severity: "medium",
-		metadata: {
-			...input.metadata,
-			userId: input.userId,
-			ipAddress: input.ipAddress,
-		},
+		userId: input.userId,
+		ipAddress: input.ipAddress,
+		userAgent: input.userAgent,
+		metadata: input.metadata,
 	});
-	try {
-		await prisma.securityAuditLog.create({
-			data: {
-				userId: input.userId ?? null,
-				eventType: input.eventType,
-				ipAddress: input.ipAddress ?? null,
-				userAgent: input.userAgent ?? null,
-				// biome-ignore lint/suspicious/noExplicitAny: Prisma JSON type requires any
-				metadata: (input.metadata ?? null) as any,
-			},
-		});
-	} catch (error) {
-		logSecurityEvent({
-			event: "audit_log_write_failed",
-			severity: "high",
-			metadata: {
-				intendedEventType: input.eventType,
-				intendedMetadata: input.metadata,
-				userId: input.userId,
-				ipAddress: input.ipAddress,
-				error: error instanceof Error ? error.message : String(error),
-			},
-		});
-	}
 }
 
 /**

--- a/lib/services/password-reset-service.ts
+++ b/lib/services/password-reset-service.ts
@@ -1,8 +1,8 @@
 import crypto from "node:crypto";
-import { logSecurityEvent } from "@/lib/audit/security-log";
 import { hashPassword } from "@/lib/auth/password-service";
 import { prisma } from "@/lib/prisma";
 import { sendPasswordResetEmail } from "@/lib/services/email-service";
+import { recordSecurityEvent } from "@/lib/services/security-audit-service";
 import { validatePassword } from "@/lib/validation/validators";
 
 // Configuration
@@ -104,15 +104,12 @@ export async function requestPasswordReset(
 	// Check rate limit first
 	const rateLimitCheck = await checkRateLimit(normalizedEmail, ipAddress);
 	if (!rateLimitCheck.allowed) {
-		logSecurityEvent({
+		await recordSecurityEvent({
 			event: "password_reset_rate_limited",
 			severity: "medium",
-			metadata: {
-				email: normalizedEmail,
-				ipAddress,
-				userAgent: userAgent ?? null,
-				reason: rateLimitCheck.reason,
-			},
+			ipAddress,
+			userAgent,
+			metadata: { email: normalizedEmail, reason: rateLimitCheck.reason },
 		});
 		return {
 			error: rateLimitCheck.reason ?? "Rate limit exceeded",
@@ -131,13 +128,13 @@ export async function requestPasswordReset(
 
 	// If user doesn't exist or uses OAuth, pretend success to prevent enumeration
 	if (!user || user.authProvider !== "LOCAL") {
-		logSecurityEvent({
+		await recordSecurityEvent({
 			event: "password_reset_requested_invalid_user",
 			severity: "low",
+			ipAddress,
+			userAgent,
 			metadata: {
 				email: normalizedEmail,
-				ipAddress,
-				userAgent: userAgent ?? null,
 				reason: user ? "oauth_user" : "user_not_found",
 			},
 		});
@@ -169,29 +166,25 @@ export async function requestPasswordReset(
 	});
 
 	if ("error" in emailResult) {
-		logSecurityEvent({
+		await recordSecurityEvent({
 			event: "password_reset_email_failed",
 			severity: "high",
-			metadata: {
-				userId: user.id,
-				ipAddress,
-				userAgent: userAgent ?? null,
-				error: emailResult.error,
-			},
+			userId: user.id,
+			ipAddress,
+			userAgent,
+			metadata: { error: emailResult.error },
 		});
 		// Still return success to prevent enumeration
 		return { data: null };
 	}
 
-	logSecurityEvent({
+	await recordSecurityEvent({
 		event: "password_reset_requested",
 		severity: "low",
-		metadata: {
-			userId: user.id,
-			ipAddress,
-			userAgent: userAgent ?? null,
-			emailSent: true,
-		},
+		userId: user.id,
+		ipAddress,
+		userAgent,
+		metadata: { emailSent: true },
 	});
 
 	return { data: null };
@@ -234,14 +227,12 @@ export async function resetPassword(
 	// Validate the token first
 	const validation = await validateResetToken(token);
 	if ("error" in validation) {
-		logSecurityEvent({
+		await recordSecurityEvent({
 			event: "password_reset_invalid_token",
 			severity: "medium",
-			metadata: {
-				ipAddress,
-				userAgent: userAgent ?? null,
-				tokenLength: token?.length,
-			},
+			ipAddress,
+			userAgent,
+			metadata: { tokenLength: token?.length },
 		});
 		return { error: validation.error };
 	}
@@ -279,10 +270,12 @@ export async function resetPassword(
 		},
 	});
 
-	logSecurityEvent({
+	await recordSecurityEvent({
 		event: "password_reset_completed",
 		severity: "low",
-		metadata: { userId, ipAddress, userAgent: userAgent ?? null },
+		userId,
+		ipAddress,
+		userAgent,
 	});
 
 	return { data: null };

--- a/lib/services/rate-limit-service.ts
+++ b/lib/services/rate-limit-service.ts
@@ -1,5 +1,5 @@
-import { logSecurityEvent } from "@/lib/audit/security-log";
 import { prisma } from "@/lib/prisma";
+import { recordSecurityEvent } from "@/lib/services/security-audit-service";
 
 // ============================================
 // TYPES
@@ -238,10 +238,13 @@ export async function checkAndRecordRateLimit(
 		// Record the blocked attempt
 		await recordAttempt(config, identifiers, true);
 
-		// Log security event
-		logSecurityEvent({
+		// Record the security event (logs + persists)
+		await recordSecurityEvent({
 			event: `${config.endpoint}_rate_limited`,
 			severity: "medium",
+			userId: securityContext?.userId,
+			ipAddress: securityContext?.ipAddress ?? identifiers.ipAddress,
+			userAgent: securityContext?.userAgent,
 			metadata: {
 				reason: result.reason,
 				identifiers: {

--- a/lib/services/security-audit-service.ts
+++ b/lib/services/security-audit-service.ts
@@ -1,5 +1,6 @@
 import { logSecurityEvent } from "@/lib/audit/security-log";
 import { prisma } from "@/lib/prisma";
+import { Prisma } from "@/src/generated/prisma";
 
 export interface RecordSecurityEventParams {
 	event: string;
@@ -45,8 +46,8 @@ export async function recordSecurityEvent(
 				eventType: event,
 				ipAddress: ipAddress ?? null,
 				userAgent: userAgent ?? null,
-				// biome-ignore lint/suspicious/noExplicitAny: Prisma JSON type requires any
-				metadata: (metadata ?? null) as any,
+				metadata: (metadata ??
+					Prisma.JsonNull) as unknown as Prisma.InputJsonValue,
 			},
 		});
 	} catch (error) {

--- a/lib/services/security-audit-service.ts
+++ b/lib/services/security-audit-service.ts
@@ -1,0 +1,65 @@
+import { logSecurityEvent } from "@/lib/audit/security-log";
+import { prisma } from "@/lib/prisma";
+
+export interface RecordSecurityEventParams {
+	event: string;
+	ipAddress?: string | null;
+	metadata?: Record<string, unknown>;
+	severity: "low" | "medium" | "high" | "critical";
+	userAgent?: string | null;
+	userId?: string | null;
+}
+
+/**
+ * The one shared way to record a security-relevant event: `logSecurityEvent`
+ * for structured stdout visibility (`lib/audit/security-log.ts`, Prisma-free
+ * by house rule — Prisma is imported only by services and `lib/prisma.ts`)
+ * plus a persisted `SecurityAuditLog` row. Originally written inline in
+ * `integration-registry-service.ts`'s `writeAuditLog`; lifted out here so
+ * every caller shares one pattern instead of each service growing its own
+ * copy (`TEA — Persist security audit events`).
+ *
+ * Contract: this function NEVER throws. By the time a caller reaches this
+ * point its own operation has already committed (or is otherwise done), so a
+ * failure recording the audit trail must never surface as the calling
+ * operation's own failure. If the `SecurityAuditLog` write itself fails,
+ * that failure is logged as its own `audit_log_write_failed` event —
+ * carrying the event that was meant to be recorded — and swallowed here, not
+ * propagated to the caller.
+ */
+export async function recordSecurityEvent(
+	params: RecordSecurityEventParams
+): Promise<void> {
+	const { event, severity, userId, ipAddress, userAgent, metadata } = params;
+
+	logSecurityEvent({
+		event,
+		severity,
+		metadata: { ...metadata, userId, ipAddress, userAgent },
+	});
+
+	try {
+		await prisma.securityAuditLog.create({
+			data: {
+				userId: userId ?? null,
+				eventType: event,
+				ipAddress: ipAddress ?? null,
+				userAgent: userAgent ?? null,
+				// biome-ignore lint/suspicious/noExplicitAny: Prisma JSON type requires any
+				metadata: (metadata ?? null) as any,
+			},
+		});
+	} catch (error) {
+		logSecurityEvent({
+			event: "audit_log_write_failed",
+			severity: "high",
+			metadata: {
+				intendedEventType: event,
+				intendedMetadata: metadata,
+				userId,
+				ipAddress,
+				error: error instanceof Error ? error.message : String(error),
+			},
+		});
+	}
+}

--- a/src/__tests__/helpers/capture-logs.ts
+++ b/src/__tests__/helpers/capture-logs.ts
@@ -1,0 +1,30 @@
+import { type LogEntry, resetLogSink, setLogSink } from "@/lib/logger";
+
+/**
+ * Test seam for the structured logger: installs a sink that pushes every
+ * emitted entry into `entries`, and temporarily raises `LOG_LEVEL` so the
+ * suite's default `NODE_ENV=test` silence (see `lib/logger.ts`) doesn't
+ * swallow the very entries the test wants to assert on. Call `restore()` in
+ * a `finally`/`afterEach` to put both back.
+ */
+export function captureLogs(): { entries: LogEntry[]; restore: () => void } {
+	const entries: LogEntry[] = [];
+	const previousLogLevel = process.env.LOG_LEVEL;
+
+	process.env.LOG_LEVEL = "debug";
+	setLogSink((entry) => {
+		entries.push(entry);
+	});
+
+	return {
+		entries,
+		restore(): void {
+			resetLogSink();
+			if (previousLogLevel === undefined) {
+				Reflect.deleteProperty(process.env, "LOG_LEVEL");
+			} else {
+				process.env.LOG_LEVEL = previousLogLevel;
+			}
+		},
+	};
+}

--- a/src/__tests__/integration/machine-auth.test.ts
+++ b/src/__tests__/integration/machine-auth.test.ts
@@ -25,6 +25,7 @@ import {
 	validateApiToken,
 } from "@/lib/services/integration-registry-service";
 import { RATE_LIMIT_CONFIGS } from "@/lib/services/rate-limit-service";
+import { captureLogs } from "../helpers/capture-logs";
 import {
 	expectError,
 	expectSameError,
@@ -548,9 +549,7 @@ describe("integration-registry-service — owner-deletion flow", () => {
 		const createSpy = vi
 			.spyOn(prisma.securityAuditLog, "create")
 			.mockRejectedValueOnce(new Error("simulated audit write failure"));
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
-			// suppress expected [SECURITY] log noise for this test
-		});
+		const logs = captureLogs();
 
 		try {
 			const result = await deleteIntegrationRegistration(
@@ -565,16 +564,16 @@ describe("integration-registry-service — owner-deletion flow", () => {
 			});
 			expect(gone).toBeNull();
 
-			const failureLogCall = warnSpy.mock.calls.find((call) =>
-				String(call[0]).includes("audit_log_write_failed")
+			const failureEntry = logs.entries.find(
+				(entry) => entry.msg === "audit_log_write_failed"
 			);
-			expect(failureLogCall).toBeDefined();
-			expect(failureLogCall?.[1]).toMatchObject({
+			expect(failureEntry).toBeDefined();
+			expect(failureEntry).toMatchObject({
 				intendedEventType: "integration_deleted",
 			});
 		} finally {
 			createSpy.mockRestore();
-			warnSpy.mockRestore();
+			logs.restore();
 		}
 	});
 

--- a/src/__tests__/integration/security-audit-persistence.test.ts
+++ b/src/__tests__/integration/security-audit-persistence.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import prisma from "@/lib/prisma";
+import {
+	acceptInvite,
+	createCaseInvite,
+} from "@/lib/services/case-invite-service";
+import {
+	requestPasswordReset,
+	resetPassword,
+} from "@/lib/services/password-reset-service";
+import {
+	checkAndRecordRateLimit,
+	RATE_LIMIT_CONFIGS,
+} from "@/lib/services/rate-limit-service";
+import { expectSuccess } from "../utils/assertion-helpers";
+import {
+	createTestCase,
+	createTestUser,
+	getTestPasswordResetToken,
+} from "../utils/prisma-factories";
+
+const TEST_IP = "127.0.0.1";
+
+/**
+ * `TEA — Persist security audit events`: the three pre-existing
+ * `logSecurityEvent`-only call sites (case-invite, password-reset,
+ * rate-limit) now go through `recordSecurityEvent`
+ * (`lib/services/security-audit-service.ts`) alongside
+ * `integration-registry-service.ts`, which already had its own persisted
+ * audit trail covered in `machine-auth.test.ts`. Each test below proves one
+ * call site's event actually lands a `SecurityAuditLog` row — the DB write
+ * failure/`audit_log_write_failed` path is shared code, already covered
+ * once (against `integration-registry-service`) in `machine-auth.test.ts`,
+ * so it is not repeated per call site here.
+ */
+describe("security audit persistence — case-invite-service", () => {
+	it("persists a row for a successfully accepted invite", async () => {
+		const owner = await createTestUser();
+		const invitee = await createTestUser();
+		const testCase = await createTestCase(owner.id);
+
+		const { invite_token: inviteToken } = expectSuccess(
+			await createCaseInvite({
+				caseId: testCase.id,
+				email: invitee.email,
+				permission: "VIEW",
+				invitedById: owner.id,
+			})
+		);
+
+		expectSuccess(
+			await acceptInvite(invitee.id, inviteToken, {
+				ipAddress: TEST_IP,
+				userAgent: "vitest",
+			})
+		);
+
+		const row = await prisma.securityAuditLog.findFirst({
+			where: { eventType: "invite_acceptance_completed", userId: invitee.id },
+		});
+		expect(row).not.toBeNull();
+		expect(row?.ipAddress).toBe(TEST_IP);
+	});
+});
+
+describe("security audit persistence — password-reset-service", () => {
+	it("persists a row for a completed password reset", async () => {
+		const user = await createTestUser({ authProvider: "LOCAL" });
+		await requestPasswordReset(user.email, TEST_IP);
+		const token = await getTestPasswordResetToken(user.id);
+		if (!token) {
+			throw new Error("Token was not created");
+		}
+
+		expectSuccess(await resetPassword(token, "StrongP@ss1", TEST_IP));
+
+		const row = await prisma.securityAuditLog.findFirst({
+			where: { eventType: "password_reset_completed", userId: user.id },
+		});
+		expect(row).not.toBeNull();
+	});
+});
+
+describe("security audit persistence — rate-limit-service", () => {
+	it("persists a row when a blocked attempt is recorded", async () => {
+		const user = await createTestUser();
+		// One past the ip limit's maxAttempts: each call before this one is
+		// allowed (and merely recorded), so the (maxAttempts + 1)-th is the
+		// first one `checkRateLimit` actually blocks.
+		const callsToExceedLimit =
+			RATE_LIMIT_CONFIGS.register.limits[0]!.maxAttempts + 1;
+
+		for (let i = 0; i < callsToExceedLimit; i++) {
+			await checkAndRecordRateLimit(
+				RATE_LIMIT_CONFIGS.register,
+				{ ipAddress: "10.9.9.9" },
+				{ userId: user.id, ipAddress: "10.9.9.9" }
+			);
+		}
+
+		const row = await prisma.securityAuditLog.findFirst({
+			where: { eventType: "register_rate_limited", userId: user.id },
+		});
+		expect(row).not.toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

Makes the structured logger the repo's `CLAUDE.md` describes actually exist, and makes security audit events persistent rather than console-only.

**Part A — logger** (`lib/logger.ts`, no dependency)
- `logger.debug|info|warn|error(message, fields?)` and `logger.child(bindings)`; one JSON line per entry (`ts`, `level`, `msg`, bindings, fields) on `process.stdout` under Node, `console[level]` in the edge runtime or browser, detected at call time.
- Level threshold from `LOG_LEVEL` (default `info`); silent under `NODE_ENV=test` unless `LOG_LEVEL` is set.
- `Error` values serialise to `{name, message, stack}`; BigInts become strings; reference cycles become `"[Circular]"`; a last-resort fallback still emits the line with a `serialisationError` field. The logger never throws.
- `setLogSink` / `resetLogSink` is the single seam for the post-1.0 OpenTelemetry wiring; nothing vendor-specific is imported.
- First consumers: `logSecurityEvent` (severity low/medium → warn, high/critical → error, severity kept as a field), the blob and file storage services, the health plugin registration, and the two remaining console calls in the invite service. Tests that spied on `console.*` now capture entries through a shared `captureLogs` helper.

**Part B — persistent security audit** (`lib/services/security-audit-service.ts`)
- `recordSecurityEvent` logs the event and writes a `SecurityAuditLog` row; it never throws, and a failed write is itself logged as `audit_log_write_failed`.
- Used by the invite, password-reset, rate-limit and integration-registry services; the integration registry's inline copy of this logic is removed in favour of the shared function.

Deliberately out of scope: the remaining console sites elsewhere in the app, `instrumentation.ts`, OpenTelemetry packages and the App Insights exporter (post-1.0), and any alerting.

## Tests

Unit: logger (threshold, silence under test, child bindings, Error serialisation, circular and BigInt fields, sink swap and reset, console fallback, line shape); `logSecurityEvent` severity mapping and fields. Integration (real Postgres): a persisted row for each of the four call sites; the write-failure path logs and does not throw. At the landing commit: unit 1386/1386, integration 1076/1076; lint and typecheck clean; fallow pass with nothing introduced.

## Review chain

Implementation, QA and code review with two small fix rounds; both reviewers' findings addressed and verified against the reviewed commits. Follow-ups tracked separately: the post-1.0 console sweep (including `element-service.ts`); a pre-existing duplicated block in `integration-registry-service.ts`.
