### PR TITLE
test: small batch C — standalone unit run, status-route permission matrix, import-route discrimination, script URL check

### DIFF
--- a/lib/services/__tests__/case-import-service.test.ts
+++ b/lib/services/__tests__/case-import-service.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { isCitedElementIdForeignKeyError } from "@/lib/services/case-import-service";
+import { Prisma } from "@/src/generated/prisma";
+
+// case-import-service.ts imports @/lib/prisma at module scope, which throws
+// at load without DATABASE_URL (the same module-load dependency
+// slug-service.ts had — see "TEA — slug-service unit test fails standalone").
+// isCitedElementIdForeignKeyError doesn't touch prisma at all, so mocking it
+// at the boundary (issue's own documented fallback, option (b)) is enough to
+// let this file load and run with no DATABASE_URL set.
+vi.mock("@/lib/prisma", () => ({ prisma: {} }));
+
+const CITED_ELEMENT_ID_FK_CONSTRAINT =
+	"assurance_elements_cited_element_id_fkey";
+const MODULE_REFERENCE_ID_FK_CONSTRAINT =
+	"assurance_elements_module_reference_id_fkey";
+
+function p2003(constraintName: string): Prisma.PrismaClientKnownRequestError {
+	return new Prisma.PrismaClientKnownRequestError(
+		`Foreign key constraint violated on the constraint: \`${constraintName}\``,
+		{ code: "P2003", clientVersion: "test" }
+	);
+}
+
+/**
+ * Pins isCitedElementIdForeignKeyError's discrimination directly, rather than
+ * via a real insert: case-import.test.ts's "still fails the whole import on
+ * a P2003 from an unrelated foreign key" doesn't actually distinguish an
+ * anchored guard from a broadened one (its retry path fails again on any
+ * non-citedElementId FK regardless of anchoring, so the end-to-end outcome
+ * is identical either way — see that test's revised comment).
+ */
+describe("isCitedElementIdForeignKeyError", () => {
+	it("returns true for a P2003 naming the citedElementId constraint", () => {
+		expect(
+			isCitedElementIdForeignKeyError(p2003(CITED_ELEMENT_ID_FK_CONSTRAINT))
+		).toBe(true);
+	});
+
+	it("returns false for a P2003 naming a different constraint (moduleReferenceId)", () => {
+		expect(
+			isCitedElementIdForeignKeyError(p2003(MODULE_REFERENCE_ID_FK_CONSTRAINT))
+		).toBe(false);
+	});
+
+	it("returns false for a non-P2003 error code", () => {
+		const error = new Prisma.PrismaClientKnownRequestError(
+			`Foreign key constraint violated on the constraint: \`${CITED_ELEMENT_ID_FK_CONSTRAINT}\``,
+			{ code: "P2002", clientVersion: "test" }
+		);
+		expect(isCitedElementIdForeignKeyError(error)).toBe(false);
+	});
+
+	it("returns false for a plain Error", () => {
+		expect(
+			isCitedElementIdForeignKeyError(
+				new Error("Foreign key constraint violated")
+			)
+		).toBe(false);
+	});
+});

--- a/lib/services/__tests__/slug-service.test.ts
+++ b/lib/services/__tests__/slug-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { slugify } from "../slug-service";
+import { slugify } from "../slug";
 
 // ---------------------------------------------------------------------------
 // slugify

--- a/lib/services/case-import-service.ts
+++ b/lib/services/case-import-service.ts
@@ -303,7 +303,7 @@ const CITED_ELEMENT_ID_FK_CONSTRAINT =
  * "Foreign key constraint violated on the constraint: `<name>`"), not on
  * `error.meta`'s shape, which is adapter-internal and not a stable contract.
  */
-function isCitedElementIdForeignKeyError(error: unknown): boolean {
+export function isCitedElementIdForeignKeyError(error: unknown): boolean {
 	return (
 		error instanceof Prisma.PrismaClientKnownRequestError &&
 		error.code === "P2003" &&

--- a/lib/services/slug-service.ts
+++ b/lib/services/slug-service.ts
@@ -1,8 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import { slugify } from "@/lib/services/slug";
 
-export { slugify } from "@/lib/services/slug";
-
 // Derived from `prisma.$transaction`'s own callback parameter, the same
 // pattern `case-batch-update-service.ts` uses — `Prisma.TransactionClient`
 // (the generated client's own type) does not structurally match this

--- a/lib/services/slug-service.ts
+++ b/lib/services/slug-service.ts
@@ -1,4 +1,7 @@
 import { prisma } from "@/lib/prisma";
+import { slugify } from "@/lib/services/slug";
+
+export { slugify } from "@/lib/services/slug";
 
 // Derived from `prisma.$transaction`'s own callback parameter, the same
 // pattern `case-batch-update-service.ts` uses — `Prisma.TransactionClient`
@@ -11,23 +14,6 @@ type TransactionClient = TransactionCallback extends (
 ) => Promise<unknown>
 	? T
 	: never;
-
-/**
- * Converts a name into a URL-safe slug base: lowercase, non-alphanumerics
- * collapsed to single hyphens, leading/trailing hyphens trimmed. An
- * all-punctuation/empty input falls back to "item" so a slug is always
- * produced (ADR 0003 §6 requires every published item to have one). Kept in
- * lockstep with the equivalent backfill expression in this feature's
- * migration (`prisma/migrations/20260716000000_publishing_schema_and_state_model`).
- */
-export function slugify(name: string): string {
-	const base = name
-		.toLowerCase()
-		.trim()
-		.replace(/[^a-z0-9]+/g, "-")
-		.replace(/^-+|-+$/g, "");
-	return base || "item";
-}
 
 /**
  * Generates a slug for `name` that is unique among existing CURRENT

--- a/lib/services/slug.ts
+++ b/lib/services/slug.ts
@@ -1,0 +1,24 @@
+/**
+ * Pure slug helper, split out from `slug-service.ts` so it has no Prisma
+ * import. `slug-service.ts` imports `@/lib/prisma`, which throws at module
+ * load when `DATABASE_URL` is unset — that made `slugify` untestable in
+ * isolation even though it touches no database. Keep this file free of any
+ * import that reaches `@/lib/prisma`.
+ */
+
+/**
+ * Converts a name into a URL-safe slug base: lowercase, non-alphanumerics
+ * collapsed to single hyphens, leading/trailing hyphens trimmed. An
+ * all-punctuation/empty input falls back to "item" so a slug is always
+ * produced (ADR 0003 §6 requires every published item to have one). Kept in
+ * lockstep with the equivalent backfill expression in this feature's
+ * migration (`prisma/migrations/20260716000000_publishing_schema_and_state_model`).
+ */
+export function slugify(name: string): string {
+	const base = name
+		.toLowerCase()
+		.trim()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return base || "item";
+}

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -16,10 +16,18 @@ set -euo pipefail
 DEFAULT_URL="postgresql://tea_user:tea_password@localhost:5433/tea_test_admin"
 DB_URL="${INTEGRATION_TEST_ADMIN_DATABASE_URL:-$DEFAULT_URL}"
 
-read -r PG_HOST PG_PORT <<< "$(node -e '
+# Command substitution swallows node's exit status, so a malformed URL would
+# otherwise fall through with PG_HOST/PG_PORT empty and print the generic
+# "not running" skip message below. Capture the parse separately and check
+# it first, so a bad INTEGRATION_TEST_ADMIN_DATABASE_URL gets its own message.
+if ! PARSED_HOST_PORT="$(node -e '
 const u = new URL(process.argv[1]);
 console.log(u.hostname, u.port || "5432");
-' "$DB_URL")"
+' "$DB_URL" 2>/dev/null)"; then
+  echo "⚠ Skipping integration tests — INTEGRATION_TEST_ADMIN_DATABASE_URL is not a valid URL: $DB_URL"
+  exit 0
+fi
+read -r PG_HOST PG_PORT <<< "$PARSED_HOST_PORT"
 
 if ! pg_isready -h "$PG_HOST" -p "$PG_PORT" -q 2>/dev/null; then
   echo "⚠ Skipping integration tests — PostgreSQL not running on $PG_HOST:$PG_PORT"

--- a/src/__tests__/integration/api-elements-module-reference-id.test.ts
+++ b/src/__tests__/integration/api-elements-module-reference-id.test.ts
@@ -244,4 +244,42 @@ describe("PUT /api/elements/[id] — moduleReferenceId", () => {
 		});
 		expect(inDb?.moduleReferenceId).toBeNull();
 	});
+
+	it("rejects a nonexistent moduleReferenceId target case through the route handler", async () => {
+		const owner = await createTestUser();
+		const homeCase = await createTestCase(owner.id);
+		const awayCase = await createTestCase(owner.id);
+		const awayGoal = await createTestElement(homeCase.id, owner.id, {
+			elementType: "AWAY_GOAL",
+			name: "Reference",
+			moduleReferenceId: awayCase.id,
+		});
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const { PUT } = await import("@/app/api/elements/[id]/route");
+		const req = new NextRequest(
+			`http://localhost:3000/api/elements/${awayGoal.id}`,
+			{
+				method: "PUT",
+				body: JSON.stringify({
+					moduleReferenceId: "00000000-0000-0000-0000-000000000000",
+				}),
+				headers: { "Content-Type": "application/json" },
+			}
+		);
+		const response = await PUT(req, {
+			params: Promise.resolve({ id: awayGoal.id }),
+		});
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toMatch(NOT_FOUND_PATTERN);
+
+		// The element's original moduleReferenceId is untouched — the rejected
+		// update didn't partially apply.
+		const inDb = await prisma.assuranceElement.findUnique({
+			where: { id: awayGoal.id },
+		});
+		expect(inDb?.moduleReferenceId).toBe(awayCase.id);
+	});
 });

--- a/src/__tests__/integration/api-status-permissions.test.ts
+++ b/src/__tests__/integration/api-status-permissions.test.ts
@@ -1,0 +1,227 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import {
+	addTeamMember,
+	createTestCaseInformation,
+	createTestCaseWithGoal,
+	createTestPermission,
+	createTestTeam,
+	createTestTeamPermission,
+	createTestUser,
+} from "../utils/prisma-factories";
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("next/cache", () => ({
+	revalidatePath: vi.fn(),
+}));
+
+beforeEach(async () => {
+	await mockNoAuth();
+});
+
+const NON_EXISTENT_CASE_ID = "00000000-0000-0000-0000-000000000000";
+
+function patchStatusRequest(caseId: string) {
+	return new NextRequest(`http://localhost:3000/api/cases/${caseId}/status`, {
+		method: "PATCH",
+		body: JSON.stringify({ targetStatus: "PUBLISHED" }),
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+async function callPatchStatus(caseId: string) {
+	const { PATCH } = await import("@/app/api/cases/[id]/status/route");
+	return await PATCH(patchStatusRequest(caseId), {
+		params: Promise.resolve({ id: caseId }),
+	});
+}
+
+/**
+ * Full permission matrix for PATCH /api/cases/[id]/status — this route only
+ * had completeness-gate coverage (`api-status.test.ts`), not access-control
+ * coverage (repo convention: every secured endpoint gets the full matrix,
+ * see CLAUDE.md "Testing"). All cases below carry complete case information
+ * (`createTestCaseInformation`'s defaults) so every attempt clears the
+ * completeness gate in `route.ts` and the response reflects the access
+ * check in `transitionStatus` -> `publishAssuranceCase`, which requires
+ * EDIT or higher (`publish-service.ts`).
+ */
+describe("PATCH /api/cases/[id]/status — permission matrix", () => {
+	it("owner can transition the case", async () => {
+		const owner = await createTestUser();
+		const testCase = await createTestCaseWithGoal(owner.id);
+		await createTestCaseInformation(testCase.id);
+		await mockAuth(owner.id, owner.username, owner.email);
+
+		const response = await callPatchStatus(testCase.id);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.newStatus).toBe("PUBLISHED");
+	});
+
+	it("a direct EDIT share can transition the case", async () => {
+		const owner = await createTestUser();
+		const editor = await createTestUser();
+		const testCase = await createTestCaseWithGoal(owner.id);
+		await createTestCaseInformation(testCase.id);
+		await createTestPermission(testCase.id, editor.id, owner.id, "EDIT");
+		await mockAuth(editor.id, editor.username, editor.email);
+
+		const response = await callPatchStatus(testCase.id);
+
+		expect(response.status).toBe(200);
+	});
+
+	it("a direct ADMIN share can transition the case", async () => {
+		const owner = await createTestUser();
+		const admin = await createTestUser();
+		const testCase = await createTestCaseWithGoal(owner.id);
+		await createTestCaseInformation(testCase.id);
+		await createTestPermission(testCase.id, admin.id, owner.id, "ADMIN");
+		await mockAuth(admin.id, admin.username, admin.email);
+
+		const response = await callPatchStatus(testCase.id);
+
+		expect(response.status).toBe(200);
+	});
+
+	it("EDIT via team can transition the case", async () => {
+		const owner = await createTestUser();
+		const teamMember = await createTestUser();
+		const testCase = await createTestCaseWithGoal(owner.id);
+		await createTestCaseInformation(testCase.id);
+		const team = await createTestTeam(owner.id);
+		await addTeamMember(team.id, teamMember.id);
+		await createTestTeamPermission(testCase.id, team.id, owner.id, "EDIT");
+		await mockAuth(teamMember.id, teamMember.username, teamMember.email);
+
+		const response = await callPatchStatus(testCase.id);
+
+		expect(response.status).toBe(200);
+	});
+
+	it("ADMIN via team can transition the case", async () => {
+		const owner = await createTestUser();
+		const teamMember = await createTestUser();
+		const testCase = await createTestCaseWithGoal(owner.id);
+		await createTestCaseInformation(testCase.id);
+		const team = await createTestTeam(owner.id);
+		await addTeamMember(team.id, teamMember.id);
+		await createTestTeamPermission(testCase.id, team.id, owner.id, "ADMIN");
+		await mockAuth(teamMember.id, teamMember.username, teamMember.email);
+
+		const response = await callPatchStatus(testCase.id);
+
+		expect(response.status).toBe(200);
+	});
+
+	it("a direct VIEW share is refused (EDIT required)", async () => {
+		const owner = await createTestUser();
+		const viewer = await createTestUser();
+		const testCase = await createTestCaseWithGoal(owner.id);
+		await createTestCaseInformation(testCase.id);
+		await createTestPermission(testCase.id, viewer.id, owner.id, "VIEW");
+		await mockAuth(viewer.id, viewer.username, viewer.email);
+
+		const response = await callPatchStatus(testCase.id);
+
+		expect(response.status).toBe(403);
+		const body = await response.json();
+		expect(body.code).toBe("FORBIDDEN");
+		expect(body.error).toBe("Permission denied");
+	});
+
+	it("a direct COMMENT share is refused (EDIT required)", async () => {
+		const owner = await createTestUser();
+		const commenter = await createTestUser();
+		const testCase = await createTestCaseWithGoal(owner.id);
+		await createTestCaseInformation(testCase.id);
+		await createTestPermission(testCase.id, commenter.id, owner.id, "COMMENT");
+		await mockAuth(commenter.id, commenter.username, commenter.email);
+
+		const response = await callPatchStatus(testCase.id);
+
+		expect(response.status).toBe(403);
+		const body = await response.json();
+		expect(body.code).toBe("FORBIDDEN");
+		expect(body.error).toBe("Permission denied");
+	});
+
+	it("VIEW via team is refused (EDIT required)", async () => {
+		const owner = await createTestUser();
+		const teamMember = await createTestUser();
+		const testCase = await createTestCaseWithGoal(owner.id);
+		await createTestCaseInformation(testCase.id);
+		const team = await createTestTeam(owner.id);
+		await addTeamMember(team.id, teamMember.id);
+		await createTestTeamPermission(testCase.id, team.id, owner.id, "VIEW");
+		await mockAuth(teamMember.id, teamMember.username, teamMember.email);
+
+		const response = await callPatchStatus(testCase.id);
+
+		expect(response.status).toBe(403);
+		const body = await response.json();
+		expect(body.code).toBe("FORBIDDEN");
+		expect(body.error).toBe("Permission denied");
+	});
+
+	it("COMMENT via team is refused (EDIT required)", async () => {
+		const owner = await createTestUser();
+		const teamMember = await createTestUser();
+		const testCase = await createTestCaseWithGoal(owner.id);
+		await createTestCaseInformation(testCase.id);
+		const team = await createTestTeam(owner.id);
+		await addTeamMember(team.id, teamMember.id);
+		await createTestTeamPermission(testCase.id, team.id, owner.id, "COMMENT");
+		await mockAuth(teamMember.id, teamMember.username, teamMember.email);
+
+		const response = await callPatchStatus(testCase.id);
+
+		expect(response.status).toBe(403);
+		const body = await response.json();
+		expect(body.code).toBe("FORBIDDEN");
+		expect(body.error).toBe("Permission denied");
+	});
+
+	it("a user with no permission on the case is refused", async () => {
+		const owner = await createTestUser();
+		const stranger = await createTestUser();
+		const testCase = await createTestCaseWithGoal(owner.id);
+		await createTestCaseInformation(testCase.id);
+		await mockAuth(stranger.id, stranger.username, stranger.email);
+
+		const response = await callPatchStatus(testCase.id);
+
+		expect(response.status).toBe(403);
+		const body = await response.json();
+		expect(body.code).toBe("FORBIDDEN");
+		expect(body.error).toBe("Permission denied");
+	});
+
+	it("an unauthenticated request is refused with 401", async () => {
+		await mockNoAuth();
+
+		const response = await callPatchStatus(NON_EXISTENT_CASE_ID);
+
+		expect(response.status).toBe(401);
+		const body = await response.json();
+		expect(body.code).toBe("UNAUTHORISED");
+	});
+
+	it("a non-existent case returns the same status and error as no-permission (anti-enumeration)", async () => {
+		const stranger = await createTestUser();
+		await mockAuth(stranger.id, stranger.username, stranger.email);
+
+		const response = await callPatchStatus(NON_EXISTENT_CASE_ID);
+
+		expect(response.status).toBe(403);
+		const body = await response.json();
+		expect(body.code).toBe("FORBIDDEN");
+		expect(body.error).toBe("Permission denied");
+	});
+});

--- a/src/__tests__/integration/api-status-permissions.test.ts
+++ b/src/__tests__/integration/api-status-permissions.test.ts
@@ -46,9 +46,12 @@ async function callPatchStatus(caseId: string) {
  * coverage (repo convention: every secured endpoint gets the full matrix,
  * see CLAUDE.md "Testing"). All cases below carry complete case information
  * (`createTestCaseInformation`'s defaults) so every attempt clears the
- * completeness gate in `route.ts` and the response reflects the access
- * check in `transitionStatus` -> `publishAssuranceCase`, which requires
- * EDIT or higher (`publish-service.ts`).
+ * completeness gate in `route.ts`. The VIEW/COMMENT-refused cells prove the
+ * EDIT-or-higher check in `transitionStatus` -> `publishAssuranceCase`
+ * (`publish-service.ts`); the no-permission and non-existent-case cells are
+ * refused earlier, by the VIEW check inside `requireCaseInformationComplete`
+ * -> `getCaseInformation`, which runs before `transitionStatus` for any
+ * PUBLISHED target.
  */
 describe("PATCH /api/cases/[id]/status — permission matrix", () => {
 	it("owner can transition the case", async () => {

--- a/src/__tests__/integration/case-import.test.ts
+++ b/src/__tests__/integration/case-import.test.ts
@@ -632,13 +632,17 @@ describe("validateImportData", () => {
 	});
 
 	/**
-	 * The P2003 catch in createElements is anchored to the exact
-	 * `assurance_elements_cited_element_id_fkey` constraint name specifically
-	 * so it does NOT swallow a P2003 on a DIFFERENT foreign key on the same
-	 * createMany insert. moduleReferenceId is a convenient other FK to exploit
-	 * here: it isn't part of the resolve-before-insert machinery at all, so a
-	 * value that never existed reaches the insert unresolved and must fail
-	 * the whole import loudly, same as before this fix.
+	 * moduleReferenceId is a foreign key on the same createMany insert as
+	 * citedElementId, but isn't part of the resolve-before-insert machinery:
+	 * a value that never existed reaches the insert unresolved and produces a
+	 * P2003 on a different constraint. This proves the whole import still
+	 * fails and rolls back in that case. It does NOT exercise
+	 * `isCitedElementIdForeignKeyError`'s constraint-name discrimination:
+	 * createElements' retry only re-resolves citedElementId, so a
+	 * moduleReferenceId P2003 fails again on retry and propagates the same
+	 * way whether the guard is anchored to the exact constraint name or
+	 * matches any P2003 — that discrimination is pinned directly in
+	 * `lib/services/__tests__/case-import-service.test.ts`.
 	 */
 	it("still fails the whole import on a P2003 from an unrelated foreign key (moduleReferenceId)", async () => {
 		const nonExistentCaseId = crypto.randomUUID();


### PR DESCRIPTION
Four test-hygiene items from the TEA 1.0 small batch. No application behaviour changes beyond one import split.

## Changes

- **slug-service unit test fails standalone** — `slugify` moved to a Prisma-free module `lib/services/slug.ts`; `slug-service.ts` imports it. `pnpm test:unit` now passes with no `DATABASE_URL` set.
- **Permission matrix for `PATCH /api/cases/[id]/status`** — new `api-status-permissions.test.ts`, 12 cells: owner; EDIT/ADMIN direct and via team (succeed); VIEW/COMMENT direct and via team; no permission; unauthenticated (401); non-existent case returns the same status and code as no-permission.
- **Import-route test discrimination** — PUT nonexistent `moduleReferenceId` → 400 test added; `isCitedElementIdForeignKeyError` exported and pinned directly by constraint name (the existing real-insert test could not distinguish an anchored guard from a broadened one; its comment now says what it does prove).
- **`run-integration-tests.sh`** — a malformed `INTEGRATION_TEST_ADMIN_DATABASE_URL` now prints a distinct message instead of the generic "PostgreSQL not running on :" skip.

## Review chain

- Code review: approve after one change (a dead `slugify` re-export removed). Fallow on the changed set: dead code 0, complexity 0, duplication 0.
- Independent QA: pass. Each new test shown to fail when the behaviour it protects is broken (permission check loosened → exactly the four VIEW/COMMENT cells red; guard broadened → exactly the different-constraint case red; PUT test pointed at a real case → 200 not 400). Incomplete case information yields 400, not 403, so the refusal cells discriminate permission from completeness.
- Final hash: unit 107 files / 1422 passed (no `DATABASE_URL`); integration 73 files / 1113 passed; lint and typecheck clean.
