### PR TITLE
fix: small batch D — Google Drive error codes, tunable pool timeout with a distinct 503

### DIFF
--- a/app/api/cases/[id]/status/route.ts
+++ b/app/api/cases/[id]/status/route.ts
@@ -24,8 +24,9 @@ import type { PublishStatus as PrismaPublishStatus } from "@/src/generated/prism
 //
 // The two timeouts therefore cover different failure shapes, on purpose:
 // pool-acquisition contention surfaces as the pool's own fast error (pg
-// rejects at ~5s, mapped to a generic 500/INTERNAL — see
-// `api-status-pool-starvation.test.ts`), while this 15s `withTimeout` is
+// rejects at ~5s), which `handleError`'s `isPoolAcquireTimeoutError` check
+// (`lib/errors.ts`) matches and maps to 503/DB_UNAVAILABLE — see
+// `api-status-pool-starvation.test.ts` — while this 15s `withTimeout` is
 // the backstop for slow-but-not-erroring work with no bounded wait of its
 // own (mapped to 504/GATEWAY_TIMEOUT). Pool exhaustion never reaches the
 // 504 path, because the pool errors out first.

--- a/app/api/cases/backup/gdrive/route.ts
+++ b/app/api/cases/backup/gdrive/route.ts
@@ -6,27 +6,14 @@ import {
 	requireAuth,
 	serviceErrorToAppError,
 } from "@/lib/api-response";
-import type { ErrorCode } from "@/lib/errors";
 import { AppError, forbidden } from "@/lib/errors";
 import { backupToDriveSchema } from "@/lib/schemas/google-drive";
 import { exportCase } from "@/lib/services/case-export-service";
 import {
-	type GoogleDriveErrorCode,
+	DRIVE_ERROR_MAP,
 	hasGoogleToken,
 	uploadBackupToDrive,
 } from "@/lib/services/google-drive-service";
-
-/**
- * Maps Google Drive error codes to application error codes.
- */
-const DRIVE_ERROR_MAP: Record<GoogleDriveErrorCode, ErrorCode> = {
-	NO_TOKEN: "FORBIDDEN",
-	TOKEN_EXPIRED: "UNAUTHORISED",
-	REFRESH_FAILED: "UNAUTHORISED",
-	NOT_FOUND: "NOT_FOUND",
-	FORBIDDEN: "FORBIDDEN",
-	API_ERROR: "INTERNAL",
-};
 
 /**
  * POST /api/cases/backup/gdrive

--- a/app/api/cases/import/gdrive/route.ts
+++ b/app/api/cases/import/gdrive/route.ts
@@ -6,28 +6,15 @@ import {
 	requireAuth,
 	serviceErrorToAppError,
 } from "@/lib/api-response";
-import type { ErrorCode } from "@/lib/errors";
 import { AppError, forbidden, validationError } from "@/lib/errors";
 import { importFromDriveSchema } from "@/lib/schemas/google-drive";
 import { importCase } from "@/lib/services/case-import-service";
 import {
+	DRIVE_ERROR_MAP,
 	downloadFileFromDrive,
-	type GoogleDriveErrorCode,
 	hasGoogleToken,
 	listBackupFiles,
 } from "@/lib/services/google-drive-service";
-
-/**
- * Maps Google Drive error codes to application error codes.
- */
-const DRIVE_ERROR_MAP: Record<GoogleDriveErrorCode, ErrorCode> = {
-	NO_TOKEN: "FORBIDDEN",
-	TOKEN_EXPIRED: "UNAUTHORISED",
-	REFRESH_FAILED: "UNAUTHORISED",
-	NOT_FOUND: "NOT_FOUND",
-	FORBIDDEN: "FORBIDDEN",
-	API_ERROR: "INTERNAL",
-};
 
 /**
  * POST /api/cases/import/gdrive
@@ -112,12 +99,15 @@ export async function GET() {
 			return apiSuccess({ connected: false, files: [] });
 		}
 
-		try {
-			const files = await listBackupFiles(userId);
-			return apiSuccess({ connected: true, files });
-		} catch {
-			return apiSuccess({ connected: true, files: [] });
-		}
+		// `listBackupFiles` never throws — it swallows Drive/folder failures
+		// and returns [] itself (see its docstring), so a try/catch here could
+		// never fire. Removed rather than converted to a ServiceResult: an
+		// empty-list-on-failure contract is what this GET wants (a Drive
+		// hiccup shouldn't turn "list my backups" into a hard error), and
+		// changing that contract would be a bigger change than this route
+		// asked for.
+		const files = await listBackupFiles(userId);
+		return apiSuccess({ connected: true, files });
 	} catch (error) {
 		return apiErrorFromUnknown(error);
 	}

--- a/content/technical-guide/deployment/database-management.mdx
+++ b/content/technical-guide/deployment/database-management.mdx
@@ -198,6 +198,11 @@ postgresql://tea:secret@localhost:5432/tea
 
 The application connects using the `DATABASE_URL` environment variable. The Prisma client is configured in `lib/prisma.ts`.
 
+The connection pool waits up to `DB_POOL_TIMEOUT_MS` (default 5000ms) for a
+free connection before failing fast with a 503 rather than hanging
+indefinitely. Raise it if the database is remote or under heavy load and
+requests are failing with `DB_UNAVAILABLE` under normal traffic.
+
 ### Direct Database Access
 
 #### Prisma Studio (GUI)

--- a/content/technical-guide/deployment/index.mdx
+++ b/content/technical-guide/deployment/index.mdx
@@ -63,6 +63,7 @@ The TEA Platform is configured through environment variables. Here's a reference
 | `POSTGRES_USER` | Database user | `tea` |
 | `POSTGRES_PASSWORD` | Database password | (required) |
 | `POSTGRES_DB` | Database name | `tea` |
+| `DB_POOL_TIMEOUT_MS` | How long (ms) a request waits for a free Postgres connection before failing with a 503, instead of hanging — see [Database Management](./database-management) | `5000` |
 
 ## Security Considerations
 

--- a/lib/__tests__/db-pool-config.test.ts
+++ b/lib/__tests__/db-pool-config.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	DEFAULT_DB_POOL_TIMEOUT_MS,
+	resolveDbPoolTimeoutMs,
+} from "../db-pool-config";
+import { type LogEntry, resetLogSink, setLogSink } from "../logger";
+
+function captureLogs(): LogEntry[] {
+	const entries: LogEntry[] = [];
+	setLogSink((entry) => {
+		entries.push(entry);
+	});
+	return entries;
+}
+
+describe("resolveDbPoolTimeoutMs", () => {
+	afterEach(() => {
+		resetLogSink();
+		vi.unstubAllEnvs();
+	});
+
+	it("defaults to DEFAULT_DB_POOL_TIMEOUT_MS when unset", () => {
+		vi.stubEnv("DB_POOL_TIMEOUT_MS", "");
+		expect(resolveDbPoolTimeoutMs()).toBe(DEFAULT_DB_POOL_TIMEOUT_MS);
+	});
+
+	it("honours a tiny configured value", () => {
+		vi.stubEnv("DB_POOL_TIMEOUT_MS", "1");
+		expect(resolveDbPoolTimeoutMs()).toBe(1);
+	});
+
+	it("honours a larger configured value", () => {
+		vi.stubEnv("DB_POOL_TIMEOUT_MS", "12000");
+		expect(resolveDbPoolTimeoutMs()).toBe(12_000);
+	});
+
+	it("falls back to the default and warns once for a non-numeric value", () => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		vi.stubEnv("DB_POOL_TIMEOUT_MS", "not-a-number");
+		const entries = captureLogs();
+
+		expect(resolveDbPoolTimeoutMs()).toBe(DEFAULT_DB_POOL_TIMEOUT_MS);
+		resolveDbPoolTimeoutMs();
+		resolveDbPoolTimeoutMs();
+
+		expect(entries).toHaveLength(1);
+		expect(entries[0]).toMatchObject({
+			level: "warn",
+			event: "db.pool.invalid_timeout_config",
+			value: "not-a-number",
+		});
+	});
+
+	it("falls back to the default for a non-positive value", () => {
+		vi.stubEnv("DB_POOL_TIMEOUT_MS", "0");
+		expect(resolveDbPoolTimeoutMs()).toBe(DEFAULT_DB_POOL_TIMEOUT_MS);
+
+		vi.stubEnv("DB_POOL_TIMEOUT_MS", "-100");
+		expect(resolveDbPoolTimeoutMs()).toBe(DEFAULT_DB_POOL_TIMEOUT_MS);
+	});
+});

--- a/lib/__tests__/errors.test.ts
+++ b/lib/__tests__/errors.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { serviceErrorToAppError } from "../api-response";
 import {
 	AppError,
+	dbUnavailable,
 	forbidden,
 	gatewayTimeout,
 	handleError,
@@ -10,7 +11,16 @@ import {
 	unauthorised,
 	validationError,
 } from "../errors";
+import { type LogEntry, resetLogSink, setLogSink } from "../logger";
 import { TimeoutError } from "../with-timeout";
+
+function captureLogs(): LogEntry[] {
+	const entries: LogEntry[] = [];
+	setLogSink((entry) => {
+		entries.push(entry);
+	});
+	return entries;
+}
 
 describe("AppError", () => {
 	it("stores code, message, and fieldErrors", () => {
@@ -51,6 +61,9 @@ describe("AppError", () => {
 		expect(
 			new AppError({ code: "GATEWAY_TIMEOUT", message: "" }).statusCode
 		).toBe(504);
+		expect(
+			new AppError({ code: "DB_UNAVAILABLE", message: "" }).statusCode
+		).toBe(503);
 	});
 
 	it("preserves cause", () => {
@@ -108,9 +121,25 @@ describe("factory functions", () => {
 		const err = gatewayTimeout("Status check timed out");
 		expect(err.message).toBe("Status check timed out");
 	});
+
+	it("dbUnavailable() creates a 503 error", () => {
+		const err = dbUnavailable();
+		expect(err.code).toBe("DB_UNAVAILABLE");
+		expect(err.statusCode).toBe(503);
+	});
+
+	it("dbUnavailable() accepts a custom message", () => {
+		const err = dbUnavailable("Pool exhausted");
+		expect(err.message).toBe("Pool exhausted");
+	});
 });
 
 describe("handleError", () => {
+	afterEach(() => {
+		resetLogSink();
+		vi.unstubAllEnvs();
+	});
+
 	it("passes through AppError instances", () => {
 		const original = forbidden();
 		const result = handleError(original);
@@ -153,6 +182,47 @@ describe("handleError", () => {
 		expect(result).toBeInstanceOf(AppError);
 		expect(result.code).toBe("INTERNAL");
 		consoleSpy.mockRestore();
+	});
+
+	it("maps pg-pool's queued-wait timeout message to DB_UNAVAILABLE (503), not INTERNAL", () => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		const entries = captureLogs();
+		const original = new Error("timeout exceeded when trying to connect");
+
+		const result = handleError(original);
+
+		expect(result).toBeInstanceOf(AppError);
+		expect(result.code).toBe("DB_UNAVAILABLE");
+		expect(result.statusCode).toBe(503);
+		expect(entries).toHaveLength(1);
+		expect(entries[0]).toMatchObject({
+			level: "error",
+			event: "db.pool.acquire_timeout",
+		});
+		expect(typeof entries[0]?.timeoutMs).toBe("number");
+	});
+
+	it("maps pg-pool's new-connection timeout message to DB_UNAVAILABLE too", () => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		captureLogs();
+		const original = new Error(
+			"Connection terminated due to connection timeout"
+		);
+
+		const result = handleError(original);
+
+		expect(result.code).toBe("DB_UNAVAILABLE");
+		expect(result.statusCode).toBe(503);
+	});
+
+	it("honours a tiny DB_POOL_TIMEOUT_MS in the logged timeoutMs field", () => {
+		vi.stubEnv("LOG_LEVEL", "debug");
+		vi.stubEnv("DB_POOL_TIMEOUT_MS", "1");
+		const entries = captureLogs();
+
+		handleError(new Error("timeout exceeded when trying to connect"));
+
+		expect(entries[0]?.timeoutMs).toBe(1);
 	});
 });
 

--- a/lib/__tests__/errors.test.ts
+++ b/lib/__tests__/errors.test.ts
@@ -224,6 +224,21 @@ describe("handleError", () => {
 
 		expect(entries[0]?.timeoutMs).toBe(1);
 	});
+
+	it("stays INTERNAL/500 for an unrelated error whose message merely contains the pool-timeout string", () => {
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {
+			/* suppress */
+		});
+		const original = new Error(
+			"Upstream vendor API said: timeout exceeded when trying to connect to their sandbox"
+		);
+
+		const result = handleError(original);
+
+		expect(result.code).toBe("INTERNAL");
+		expect(result.statusCode).toBe(500);
+		consoleSpy.mockRestore();
+	});
 });
 
 describe("toActionResult", () => {

--- a/lib/db-pool-config.ts
+++ b/lib/db-pool-config.ts
@@ -1,0 +1,47 @@
+/**
+ * Resolves the Postgres connection-pool acquisition timeout
+ * (`connectionTimeoutMillis`, see `lib/prisma.ts`) from `DB_POOL_TIMEOUT_MS`.
+ *
+ * Kept in its own module, with no other project imports besides the logger,
+ * so both `lib/prisma.ts` (which needs it to build the `pg.Pool`) and
+ * `lib/errors.ts` (which needs the same value to log alongside a detected
+ * pool-acquisition timeout) can read it without pulling Prisma/pg into
+ * `lib/errors.ts`'s import graph — `lib/errors.ts` has no other dependency
+ * on the database.
+ */
+import { logger } from "@/lib/logger";
+
+export const DEFAULT_DB_POOL_TIMEOUT_MS = 5000;
+
+let warnedInvalidValueOnce = false;
+
+/**
+ * Parses `DB_POOL_TIMEOUT_MS` defensively: unset, non-numeric, or
+ * non-positive all fall back to `DEFAULT_DB_POOL_TIMEOUT_MS` rather than
+ * disabling the timeout (an unset `connectionTimeoutMillis` makes `pg-pool`
+ * wait forever for a connection — see the comment in `lib/prisma.ts`, and
+ * "TEA — Status endpoint can hang indefinitely"). An invalid (present but
+ * unusable) value logs a warning once per process, so a typo in the env var
+ * is visible without failing startup.
+ */
+export function resolveDbPoolTimeoutMs(): number {
+	const raw = process.env.DB_POOL_TIMEOUT_MS;
+	if (raw === undefined || raw.trim() === "") {
+		return DEFAULT_DB_POOL_TIMEOUT_MS;
+	}
+
+	const parsed = Number(raw);
+	if (Number.isFinite(parsed) && parsed > 0) {
+		return parsed;
+	}
+
+	if (!warnedInvalidValueOnce) {
+		warnedInvalidValueOnce = true;
+		logger.warn("Invalid DB_POOL_TIMEOUT_MS — falling back to the default", {
+			event: "db.pool.invalid_timeout_config",
+			value: raw,
+			fallbackMs: DEFAULT_DB_POOL_TIMEOUT_MS,
+		});
+	}
+	return DEFAULT_DB_POOL_TIMEOUT_MS;
+}

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -108,17 +108,21 @@ export function dbUnavailable(
 
 /**
  * Messages `pg-pool` throws as a plain `Error` (no `.code`, no `.cause` in
- * the common case) when `connectionTimeoutMillis` elapses:
- * - "timeout exceeded when trying to connect" — every pool slot was already
- *   checked out and the wait for one to free up timed out (the queued-wait
- *   path, `pg-pool/index.js`'s `_pendingQueue` timeout — this is the shape
+ * the common case) when `connectionTimeoutMillis` elapses — verified against
+ * `pg-pool/index.js` (v3.14.0) as the two exact, complete messages below,
+ * not prefixes or fragments of a longer string:
+ * - "timeout exceeded when trying to connect" (`index.js:224`) — every pool
+ *   slot was already checked out and the wait for one to free up timed out
+ *   (the queued-wait path, `_pendingQueue`'s timeout — this is the shape
  *   `api-status-pool-starvation.test.ts` reproduces).
- * - "Connection terminated due to connection timeout" — a brand-new
- *   connection (pool below `max`) didn't finish establishing within the
- *   timeout. Different code path, same configured value, same "the database
- *   isn't responding fast enough" signal.
- * Matched by substring, not exact equality, since the second message is
- * pg-pool's own `new Error(..., { cause })` wrapping and could gain a suffix.
+ * - "Connection terminated due to connection timeout" (`index.js:276`) — a
+ *   brand-new connection (pool below `max`) didn't finish establishing
+ *   within the timeout. Different code path, same configured value, same
+ *   "the database isn't responding fast enough" signal.
+ * Matched by exact equality (after trimming), not substring: an unrelated
+ * error whose message merely *contains* one of these strings — e.g. an
+ * upstream API's own error text quoting a timeout — must not be
+ * misclassified as this application's pool exhaustion.
  */
 const POOL_ACQUIRE_TIMEOUT_MESSAGES = [
 	"timeout exceeded when trying to connect",
@@ -126,9 +130,8 @@ const POOL_ACQUIRE_TIMEOUT_MESSAGES = [
 ];
 
 function isPoolAcquireTimeoutError(error: Error): boolean {
-	return POOL_ACQUIRE_TIMEOUT_MESSAGES.some((message) =>
-		error.message.includes(message)
-	);
+	const message = error.message.trim();
+	return POOL_ACQUIRE_TIMEOUT_MESSAGES.includes(message);
 }
 
 /**

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,3 +1,6 @@
+import { resolveDbPoolTimeoutMs } from "@/lib/db-pool-config";
+import { logger } from "@/lib/logger";
+
 /**
  * Classifies errors for consistent handling across API routes, server actions, and services.
  */
@@ -10,6 +13,7 @@ export type ErrorCode =
 	| "RATE_LIMITED"
 	| "PAYLOAD_TOO_LARGE"
 	| "GATEWAY_TIMEOUT"
+	| "DB_UNAVAILABLE"
 	| "INTERNAL";
 
 /**
@@ -29,6 +33,7 @@ const STATUS_MAP: Record<ErrorCode, number> = {
 	RATE_LIMITED: 429,
 	PAYLOAD_TOO_LARGE: 413,
 	GATEWAY_TIMEOUT: 504,
+	DB_UNAVAILABLE: 503,
 	INTERNAL: 500,
 };
 
@@ -91,9 +96,40 @@ export function payloadTooLarge(message = "Request body too large"): AppError {
 	return new AppError({ code: "PAYLOAD_TOO_LARGE", message });
 }
 
+export function dbUnavailable(
+	message = "The database is temporarily unavailable. Please try again."
+): AppError {
+	return new AppError({ code: "DB_UNAVAILABLE", message });
+}
+
 // ---------------------------------------------------------------------------
 // Conversion helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Messages `pg-pool` throws as a plain `Error` (no `.code`, no `.cause` in
+ * the common case) when `connectionTimeoutMillis` elapses:
+ * - "timeout exceeded when trying to connect" — every pool slot was already
+ *   checked out and the wait for one to free up timed out (the queued-wait
+ *   path, `pg-pool/index.js`'s `_pendingQueue` timeout — this is the shape
+ *   `api-status-pool-starvation.test.ts` reproduces).
+ * - "Connection terminated due to connection timeout" — a brand-new
+ *   connection (pool below `max`) didn't finish establishing within the
+ *   timeout. Different code path, same configured value, same "the database
+ *   isn't responding fast enough" signal.
+ * Matched by substring, not exact equality, since the second message is
+ * pg-pool's own `new Error(..., { cause })` wrapping and could gain a suffix.
+ */
+const POOL_ACQUIRE_TIMEOUT_MESSAGES = [
+	"timeout exceeded when trying to connect",
+	"Connection terminated due to connection timeout",
+];
+
+function isPoolAcquireTimeoutError(error: Error): boolean {
+	return POOL_ACQUIRE_TIMEOUT_MESSAGES.some((message) =>
+		error.message.includes(message)
+	);
+}
 
 /**
  * Wraps an unknown caught value into an `AppError`.
@@ -113,6 +149,20 @@ export function handleError(error: unknown): AppError {
 		return gatewayTimeout(
 			"The request took too long to complete. Please try again."
 		);
+	}
+
+	// A pg-pool connection-acquisition timeout is a distinct, expected
+	// failure shape (the pool is saturated or Postgres is slow to accept new
+	// connections) — not an unexpected bug. Without this check it fell
+	// through to the generic INTERNAL/500 branch below, indistinguishable in
+	// production logs from any other unhandled error (see "TEA —
+	// Pool-timeout errors indistinguishable from generic 500s").
+	if (error instanceof Error && isPoolAcquireTimeoutError(error)) {
+		logger.error("Database connection pool acquisition timed out", {
+			event: "db.pool.acquire_timeout",
+			timeoutMs: resolveDbPoolTimeoutMs(),
+		});
+		return dbUnavailable();
 	}
 
 	const message =

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,5 +1,6 @@
 import { PrismaPg } from "@prisma/adapter-pg";
 import { Pool } from "pg";
+import { resolveDbPoolTimeoutMs } from "@/lib/db-pool-config";
 import {
 	cleanElementDataForType,
 	validateElementData,
@@ -128,9 +129,17 @@ function createExtendedPrismaClient() {
 	// erroring at ~3000ms with it set. Any transient contention for
 	// connections — not just this route — was previously invisible until it
 	// resolved or the client itself gave up.
+	//
+	// The value is env-tunable via `DB_POOL_TIMEOUT_MS` (default 5000,
+	// `lib/db-pool-config.ts`), so a deployment with slower/further-away
+	// Postgres can widen it without a code change. `lib/errors.ts` reads the
+	// same resolved value when it logs a detected pool-acquisition timeout.
 	const pool =
 		globalForPrisma.pgPool ||
-		new Pool({ connectionString: databaseUrl, connectionTimeoutMillis: 5000 });
+		new Pool({
+			connectionString: databaseUrl,
+			connectionTimeoutMillis: resolveDbPoolTimeoutMs(),
+		});
 	if (process.env.NODE_ENV !== "production") {
 		globalForPrisma.pgPool = pool;
 	}

--- a/lib/services/google-drive-service.ts
+++ b/lib/services/google-drive-service.ts
@@ -5,8 +5,10 @@
  * OAuth tokens. Used for backing up and importing assurance cases.
  */
 
+import { Readable } from "node:stream";
 import { google } from "googleapis";
 import type { ErrorCode } from "@/lib/errors";
+import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
 
 const FOLDER_NAME = "TEA Platform Backups";
@@ -49,7 +51,9 @@ export interface DownloadResult {
 
 /**
  * Maps Google Drive error codes to application error codes.
- * Moved here from the route layer so callers can use it without coupling to the route.
+ * The single definition — routes import this rather than keeping their own
+ * copy (previously duplicated in `app/api/cases/backup/gdrive/route.ts` and
+ * `app/api/cases/import/gdrive/route.ts`).
  */
 export const DRIVE_ERROR_MAP: Record<GoogleDriveErrorCode, ErrorCode> = {
 	NO_TOKEN: "FORBIDDEN",
@@ -72,13 +76,80 @@ function createDriveError(
 }
 
 /**
- * Retrieves and potentially refreshes the user's Google tokens.
- * Returns null if no token or refresh fails.
+ * Extracts an HTTP status code from a thrown Drive API error, when the SDK
+ * (`googleapis`, via `gaxios`) attaches one — either directly on the error
+ * (`GaxiosError#status`) or on a nested `response.status`. Returns
+ * `undefined` for anything else (network errors, non-HTTP failures), so
+ * callers fall back to the generic `API_ERROR` code.
  */
-async function getUserGoogleTokens(userId: string): Promise<{
-	accessToken: string;
-	refreshToken: string | null;
-} | null> {
+function extractHttpStatus(error: unknown): number | undefined {
+	if (typeof error !== "object" || error === null) {
+		return undefined;
+	}
+	// Cast is explained: `error` is an SDK-thrown value of unknown shape, not
+	// a type this module defines — narrowing by reading fields defensively is
+	// the only option.
+	const record = error as Record<string, unknown>;
+	if (typeof record.status === "number") {
+		return record.status;
+	}
+	const response = record.response;
+	if (typeof response === "object" && response !== null) {
+		const responseStatus = (response as Record<string, unknown>).status;
+		if (typeof responseStatus === "number") {
+			return responseStatus;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Maps a thrown Drive API error to the truthful `GoogleDriveErrorCode`: a
+ * 403 is FORBIDDEN, a 404 is NOT_FOUND, everything else stays the generic
+ * API_ERROR every catch block here used unconditionally before this existed.
+ */
+function classifyGoogleApiError(error: unknown): GoogleDriveErrorCode {
+	const status = extractHttpStatus(error);
+	if (status === 403) {
+		return "FORBIDDEN";
+	}
+	if (status === 404) {
+		return "NOT_FOUND";
+	}
+	return "API_ERROR";
+}
+
+/** Builds a `GoogleDriveError` from a caught value, classifying its code. */
+function driveErrorFromCaught(
+	error: unknown,
+	fallbackMessage: string
+): GoogleDriveError {
+	return createDriveError(
+		classifyGoogleApiError(error),
+		error instanceof Error ? error.message : fallbackMessage
+	);
+}
+
+type TokenFetchResult =
+	| { accessToken: string; refreshToken: string | null }
+	| {
+			tokenError: Extract<
+				GoogleDriveErrorCode,
+				"NO_TOKEN" | "TOKEN_EXPIRED" | "REFRESH_FAILED"
+			>;
+	  };
+
+/**
+ * Retrieves and potentially refreshes the user's Google tokens.
+ *
+ * Distinguishes three failure shapes so callers can produce the truthful
+ * `GoogleDriveErrorCode` instead of collapsing every failure into one code:
+ * - no access token stored at all -> NO_TOKEN
+ * - token expired/expiring soon, and no refresh token to try -> TOKEN_EXPIRED
+ * - token expired/expiring soon, refresh attempted and failed (threw, or
+ *   returned a response with no access_token) -> REFRESH_FAILED
+ */
+async function getUserGoogleTokens(userId: string): Promise<TokenFetchResult> {
 	const user = await prisma.user.findUnique({
 		where: { id: userId },
 		select: {
@@ -89,7 +160,7 @@ async function getUserGoogleTokens(userId: string): Promise<{
 	});
 
 	if (!user?.googleAccessToken) {
-		return null;
+		return { tokenError: "NO_TOKEN" };
 	}
 
 	// Check if token is expired or will expire soon (5 min buffer)
@@ -100,7 +171,7 @@ async function getUserGoogleTokens(userId: string): Promise<{
 	if (expiresAt && expiresAt.getTime() - bufferMs < now.getTime()) {
 		// Token expired or expiring soon - attempt refresh
 		if (!user.googleRefreshToken) {
-			return null;
+			return { tokenError: "TOKEN_EXPIRED" };
 		}
 
 		try {
@@ -134,8 +205,11 @@ async function getUserGoogleTokens(userId: string): Promise<{
 				refreshToken: user.googleRefreshToken,
 			};
 		} catch (error) {
-			console.error("Failed to refresh Google token:", error);
-			return null;
+			logger.warn("Failed to refresh Google token", {
+				userId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return { tokenError: "REFRESH_FAILED" };
 		}
 	}
 
@@ -144,6 +218,21 @@ async function getUserGoogleTokens(userId: string): Promise<{
 		refreshToken: user.googleRefreshToken,
 	};
 }
+
+const TOKEN_ERROR_MESSAGES: Record<
+	Extract<
+		GoogleDriveErrorCode,
+		"NO_TOKEN" | "TOKEN_EXPIRED" | "REFRESH_FAILED"
+	>,
+	string
+> = {
+	NO_TOKEN:
+		"No Google token found. Please sign in with Google to connect your account.",
+	TOKEN_EXPIRED:
+		"Google token has expired and no refresh token is available. Please sign in with Google again.",
+	REFRESH_FAILED:
+		"Failed to refresh the Google token. Please sign in with Google again.",
+};
 
 /**
  * Creates an authenticated Google Drive client for the specified user.
@@ -156,11 +245,11 @@ async function createDriveClient(
 > {
 	const tokens = await getUserGoogleTokens(userId);
 
-	if (!tokens) {
+	if ("tokenError" in tokens) {
 		return {
 			driveError: createDriveError(
-				"NO_TOKEN",
-				"No Google token found. Please sign in with Google to connect your account."
+				tokens.tokenError,
+				TOKEN_ERROR_MESSAGES[tokens.tokenError]
 			),
 		};
 	}
@@ -210,11 +299,9 @@ async function getOrCreateBackupFolder(
 		return { folderId: folder.data.id as string };
 	} catch (error) {
 		return {
-			driveError: createDriveError(
-				"API_ERROR",
-				error instanceof Error
-					? error.message
-					: "Failed to find or create backup folder"
+			driveError: driveErrorFromCaught(
+				error,
+				"Failed to find or create backup folder"
 			),
 		};
 	}
@@ -271,7 +358,6 @@ export async function uploadBackupToDrive(
 		};
 
 		// Use a readable stream for the media body
-		const { Readable } = require("node:stream");
 		const stream = Readable.from([jsonContent]);
 
 		const file = await drive.files.create({
@@ -291,11 +377,9 @@ export async function uploadBackupToDrive(
 			},
 		};
 	} catch (error) {
-		const driveError = createDriveError(
-			"API_ERROR",
-			error instanceof Error
-				? error.message
-				: "Failed to upload to Google Drive"
+		const driveError = driveErrorFromCaught(
+			error,
+			"Failed to upload to Google Drive"
 		);
 		return { error: driveError.message, driveError };
 	}
@@ -353,11 +437,9 @@ export async function downloadFileFromDrive(
 			},
 		};
 	} catch (error) {
-		const driveError = createDriveError(
-			"API_ERROR",
-			error instanceof Error
-				? error.message
-				: "Failed to download from Google Drive"
+		const driveError = driveErrorFromCaught(
+			error,
+			"Failed to download from Google Drive"
 		);
 		return { error: driveError.message, driveError };
 	}
@@ -417,5 +499,5 @@ export async function listBackupFiles(
  */
 export async function hasGoogleToken(userId: string): Promise<boolean> {
 	const tokens = await getUserGoogleTokens(userId);
-	return tokens !== null;
+	return !("tokenError" in tokens);
 }

--- a/src/__tests__/integration/api-cases-backup-gdrive.test.ts
+++ b/src/__tests__/integration/api-cases-backup-gdrive.test.ts
@@ -227,6 +227,35 @@ describe("POST /api/cases/backup/gdrive", () => {
 		});
 	});
 
+	// TOKEN_EXPIRED and REFRESH_FAILED have no route-level test: this route
+	// (and the import route) calls `hasGoogleToken()` first and returns its
+	// own 403 "not connected" before ever reaching `uploadBackupToDrive`, and
+	// `hasGoogleToken()` fails on exactly the same condition that would
+	// produce either code — so a route request can never observe them in
+	// normal operation. They're proven at the service level instead, calling
+	// `uploadBackupToDrive` directly:
+	// `google-drive-service.test.ts` > "createDriveClient — TOKEN_EXPIRED / REFRESH_FAILED".
+
+	it("maps a Drive 403 on folder lookup to FORBIDDEN (403)", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		const testCase = await createTestCaseWithGoal(user.id);
+		await mockAuth(user.id, user.username, user.email);
+		mockFilesList.mockRejectedValueOnce(
+			Object.assign(
+				new Error("The user does not have sufficient permissions"),
+				{
+					status: 403,
+				}
+			)
+		);
+
+		const { POST } = await import("@/app/api/cases/backup/gdrive/route");
+		const response = await POST(buildRequest({ caseId: testCase.id }));
+
+		expect(response.status).toBe(403);
+	});
+
 	it("maps a Drive API_ERROR upload failure to 500", async () => {
 		const user = await createTestUser();
 		await setGoogleTokens(user.id);

--- a/src/__tests__/integration/api-cases-backup-gdrive.test.ts
+++ b/src/__tests__/integration/api-cases-backup-gdrive.test.ts
@@ -253,7 +253,11 @@ describe("POST /api/cases/backup/gdrive", () => {
 		const { POST } = await import("@/app/api/cases/backup/gdrive/route");
 		const response = await POST(buildRequest({ caseId: testCase.id }));
 
+		// 403 alone doesn't distinguish this from NO_TOKEN, which also maps to
+		// 403 — assert the envelope's code to pin FORBIDDEN specifically.
 		expect(response.status).toBe(403);
+		const body = await response.json();
+		expect(body.code).toBe("FORBIDDEN");
 	});
 
 	it("maps a Drive API_ERROR upload failure to 500", async () => {

--- a/src/__tests__/integration/api-cases-import-gdrive.test.ts
+++ b/src/__tests__/integration/api-cases-import-gdrive.test.ts
@@ -122,6 +122,20 @@ describe("POST /api/cases/import/gdrive", () => {
 		expect(response.status).toBe(400);
 	});
 
+	it("maps a Drive 404 on the metadata fetch to NOT_FOUND (404)", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+		await mockAuth(user.id, user.username, user.email);
+		mockFilesGet.mockRejectedValueOnce(
+			Object.assign(new Error("File not found"), { status: 404 })
+		);
+
+		const { POST } = await import("@/app/api/cases/import/gdrive/route");
+		const response = await POST(buildRequest({ fileId: "missing-file-id" }));
+
+		expect(response.status).toBe(404);
+	});
+
 	it("maps a Drive API_ERROR download failure to 500", async () => {
 		const user = await createTestUser();
 		await setGoogleTokens(user.id);

--- a/src/__tests__/integration/api-status-pool-starvation.test.ts
+++ b/src/__tests__/integration/api-status-pool-starvation.test.ts
@@ -87,7 +87,7 @@ describe("GET /api/cases/[id]/status — pool-starvation regression", () => {
 		});
 	});
 
-	it("pool exhaustion surfaces as 500/INTERNAL — the pool's own fast error — not 504", async () => {
+	it("pool exhaustion surfaces as 503/DB_UNAVAILABLE — distinct from a generic 500 — not 504", async () => {
 		const user = await createTestUser();
 		const testCase = await createTestCaseWithGoal(user.id);
 		await mockAuth(user.id, user.username, user.email);
@@ -98,22 +98,22 @@ describe("GET /api/cases/[id]/status — pool-starvation regression", () => {
 				params: Promise.resolve({ id: testCase.id }),
 			});
 
-			// This is DELIBERATE current behaviour, not a bug (vincent's review,
-			// nanaki's QA, 2026-08-20). Pool-acquisition contention throws pg's
-			// own plain `Error('timeout exceeded when trying to connect')` —
-			// `handleError` (`lib/errors.ts`) only special-cases `TimeoutError`
-			// (`lib/with-timeout.ts`, matched by `.name`), so this falls through
-			// to the generic 500/INTERNAL branch. The route's 504/GATEWAY_TIMEOUT
-			// path is a *different* backstop that only fires when `withTimeout`
-			// itself elapses (slow-but-not-erroring work) — pool exhaustion never
-			// reaches it because the pool errors out first, well inside the 15s
-			// budget. This is loud and fast (the fix's goal), but indistinguishable
-			// from any other internal error in production logs — tracked
-			// internally as a follow-up (a tagged pool-timeout ErrorCode /
-			// structured log, per vincent's review).
-			expect(response.status).toBe(500);
+			// Pool-acquisition contention throws pg's own plain
+			// `Error('timeout exceeded when trying to connect')`. `handleError`
+			// (`lib/errors.ts`) now recognises that message (and pg-pool's other
+			// connection-timeout message) before falling through to the generic
+			// INTERNAL branch, and maps it to the dedicated DB_UNAVAILABLE code
+			// (503) — distinguishable in the API envelope and in logs (a
+			// `db.pool.acquire_timeout` structured log line) from an unrelated
+			// bug, which a generic 500/INTERNAL was not. See "TEA — Pool-timeout
+			// errors indistinguishable from generic 500s". The route's
+			// 504/GATEWAY_TIMEOUT path remains a *different* backstop that only
+			// fires when `withTimeout` itself elapses (slow-but-not-erroring
+			// work) — pool exhaustion never reaches it because the pool errors
+			// out first, well inside the 15s budget.
+			expect(response.status).toBe(503);
 			const body = await response.json();
-			expect(body.code).toBe("INTERNAL");
+			expect(body.code).toBe("DB_UNAVAILABLE");
 		});
 	});
 });

--- a/src/__tests__/integration/google-drive-service.test.ts
+++ b/src/__tests__/integration/google-drive-service.test.ts
@@ -304,6 +304,55 @@ describe("createDriveClient (via uploadBackupToDrive)", () => {
 	});
 });
 
+// TOKEN_EXPIRED and REFRESH_FAILED are produced inside
+// createDriveClient/getUserGoogleTokens, downstream of the exact check
+// `hasGoogleToken()` performs. Every route (`app/api/cases/backup/gdrive`,
+// `app/api/cases/import/gdrive`) calls `hasGoogleToken()` first and returns
+// its own 403 "not connected" before ever calling uploadBackupToDrive/
+// downloadFileFromDrive — so a route request can't observe either code in
+// normal operation; hasGoogleToken() would already have failed on the same
+// underlying condition. Tested here, calling the service directly, rather
+// than at the route (see `api-cases-backup-gdrive.test.ts`'s comment).
+describe("createDriveClient — TOKEN_EXPIRED / REFRESH_FAILED (via uploadBackupToDrive)", () => {
+	it("returns TOKEN_EXPIRED when the token is expired and no refresh token is stored", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id, {
+			googleTokenExpiresAt: new Date(Date.now() - 60 * 1000),
+			googleRefreshToken: null,
+		});
+
+		const { uploadBackupToDrive } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		const result = await uploadBackupToDrive(user.id, "Case", "{}");
+
+		expect("error" in result).toBe(true);
+		if (!("error" in result)) {
+			throw new Error("expected failure");
+		}
+		expect(result.driveError.code).toBe("TOKEN_EXPIRED");
+	});
+
+	it("returns REFRESH_FAILED when refreshing an expired token throws", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id, {
+			googleTokenExpiresAt: new Date(Date.now() - 60 * 1000),
+		});
+		mockRefreshAccessToken.mockRejectedValueOnce(new Error("refresh failed"));
+
+		const { uploadBackupToDrive } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		const result = await uploadBackupToDrive(user.id, "Case", "{}");
+
+		expect("error" in result).toBe(true);
+		if (!("error" in result)) {
+			throw new Error("expected failure");
+		}
+		expect(result.driveError.code).toBe("REFRESH_FAILED");
+	});
+});
+
 describe("getOrCreateBackupFolder (via uploadBackupToDrive)", () => {
 	it("reuses an existing 'TEA Platform Backups' folder without creating one", async () => {
 		const user = await createTestUser();
@@ -613,13 +662,13 @@ describe("listBackupFiles", () => {
 });
 
 describe("DRIVE_ERROR_MAP", () => {
-	// TOKEN_EXPIRED, REFRESH_FAILED, FORBIDDEN and NOT_FOUND are declared on
-	// GoogleDriveErrorCode and mapped here, but nothing in this service ever
-	// constructs a GoogleDriveError with those codes (only NO_TOKEN and
-	// API_ERROR are ever produced — confirmed by reading every
-	// `createDriveError` call site). This test pins the map's own data
-	// rather than a route response, since the unreachable codes can't be
-	// exercised through a live request. See the QA report's follow-ups.
+	// All six codes are now produced somewhere in this service: TOKEN_EXPIRED
+	// (expired token, no refresh token) and REFRESH_FAILED (refresh attempted
+	// and failed) from `getUserGoogleTokens`/`createDriveClient`; FORBIDDEN
+	// and NOT_FOUND from a 403/404 thrown by the Drive SDK, classified by
+	// `classifyGoogleApiError`. Route-level tests proving each maps to the
+	// right status live in `api-cases-backup-gdrive.test.ts` and
+	// `api-cases-import-gdrive.test.ts`. This test pins the map's own data.
 	it("maps every GoogleDriveErrorCode to the documented ErrorCode", async () => {
 		const { DRIVE_ERROR_MAP } = await import(
 			"@/lib/services/google-drive-service"


### PR DESCRIPTION
Two backend tidy-ups from the TEA 1.0 small batch.

## Changes

- **Google Drive error path** — `DRIVE_ERROR_MAP` is defined once (the service's export; the two route copies are gone). The four declared-but-never-produced codes are now produced where they are the truthful outcome: `TOKEN_EXPIRED` (expired token, no refresh token), `REFRESH_FAILED` (refresh threw or returned no access token), `FORBIDDEN` (Drive 403), `NOT_FOUND` (Drive 404). `getUserGoogleTokens` returns a discriminated result instead of `null`. A dead try/catch in the import route's GET is removed; the CommonJS `require("node:stream")` is a top-level import. Tests added per code (service-level for the two the routes cannot reach, because both routes check `hasGoogleToken()` first; route-level for 403/404).
- **Pool-acquisition timeouts** — `DB_POOL_TIMEOUT_MS` (default 5000; invalid values fall back with a once-only warning) sets pg-pool's `connectionTimeoutMillis`. A pool-acquisition timeout now returns `DB_UNAVAILABLE` (503) with a structured `db.pool.acquire_timeout` log event carrying the configured timeout, instead of a generic 500. Detection is by exact match on pg-pool's two timeout messages (verified against pg-pool 3.14.0), so an unrelated error that merely quotes the text stays a 500. Documented under the deployment guide.

**Deployment note:** the example env file should gain `DB_POOL_TIMEOUT_MS=5000` (left for a maintainer; not touched here).

## Review chain

- Code review: approve after one change (a status-route comment that still described the old 500 behaviour). Import graph checked: `lib/errors.ts` gains no client-unsafe or Prisma dependencies; no `"use client"` importer. Fallow on the changed set: dead code 0, duplication 0, one complexity finding (`getUserGoogleTokens`, from the added branches).
- QA: pass. Each fix reverted turns exactly its own tests red. The pool timeout was reproduced with a real `pg.Pool` (both slots held, third connect rejects with pg-pool's own message in ~50 ms); `DB_POOL_TIMEOUT_MS=50` cuts the starvation suite from ~10 s to ~350 ms; invalid value warns once. QA's false-positive finding (substring match) is what motivated the exact-match tightening.
- Final hash: unit 107 files / 1429 passed; integration 72 files / 1104 passed; lint and typecheck clean.
