### PR TITLE
fix: small batch B1 — insecure-context diagram ids, change-detection race guard, feedback banner

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -14,6 +14,13 @@
 	}
 }
 
+/* Bottom padding for elements fixed to the viewport bottom (e.g. the
+   feedback banner): the usual `pb-2.5` plus the iOS home-indicator safe
+   area, so content isn't flush against it on notched devices. */
+@utility pb-safe {
+	padding-bottom: calc(var(--spacing) * 2.5 + env(safe-area-inset-bottom));
+}
+
 /* ========================================================================
    Catppuccin Latte (light) / Mocha (dark) — OKLCH colour tokens
    ======================================================================== */

--- a/components/cases/flow.tsx
+++ b/components/cases/flow.tsx
@@ -18,6 +18,7 @@ import { useAutoScreenshot } from "@/hooks/use-auto-screenshot";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { convertAssuranceCase } from "@/lib/case/convert-case";
 import { getLayoutedElements } from "@/lib/case/layout-helper";
+import { logger } from "@/lib/logger";
 import { toast } from "@/lib/toast";
 import useStore from "@/store/store";
 import { Button } from "../ui/button";
@@ -121,7 +122,11 @@ function Flow() {
 			} else {
 				setLoading(false);
 			}
-		} catch (_error) {
+		} catch (error) {
+			logger.error("Failed to convert assurance case to diagram", {
+				error,
+				caseId: assuranceCase?.id,
+			});
 			toast({
 				variant: "destructive",
 				title: "Diagram error",

--- a/components/cases/flow.tsx
+++ b/components/cases/flow.tsx
@@ -18,7 +18,6 @@ import { useAutoScreenshot } from "@/hooks/use-auto-screenshot";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { convertAssuranceCase } from "@/lib/case/convert-case";
 import { getLayoutedElements } from "@/lib/case/layout-helper";
-import { logger } from "@/lib/logger";
 import { toast } from "@/lib/toast";
 import useStore from "@/store/store";
 import { Button } from "../ui/button";
@@ -122,11 +121,7 @@ function Flow() {
 			} else {
 				setLoading(false);
 			}
-		} catch (error) {
-			logger.error("Failed to convert assurance case to diagram", {
-				error,
-				caseId: assuranceCase?.id,
-			});
+		} catch (_error) {
 			toast({
 				variant: "destructive",
 				title: "Diagram error",

--- a/components/navigation/__tests__/feedback-banner.test.tsx
+++ b/components/navigation/__tests__/feedback-banner.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	renderWithoutProviders,
+	screen,
+	userEvent,
+	waitFor,
+} from "@/src/__tests__/utils/test-utils";
+import FeedbackBanner from "../feedback-banner";
+
+const DISMISSED_STORAGE_KEY = "tea.feedback-banner.dismissed";
+const DISMISS_REGEX = /dismiss/i;
+
+// jsdom in this workspace doesn't provide a working `localStorage` (Node
+// starts it with `--localstorage-file` unset, so the global throws/is
+// undefined) — stub a minimal in-memory implementation for the duration of
+// each test instead of relying on the real one.
+function createMemoryStorage(): Storage {
+	const store = new Map<string, string>();
+	return {
+		getItem: (key: string) => store.get(key) ?? null,
+		setItem: (key: string, value: string) => {
+			store.set(key, value);
+		},
+		removeItem: (key: string) => {
+			store.delete(key);
+		},
+		clear: () => {
+			store.clear();
+		},
+		key: (index: number) => Array.from(store.keys())[index] ?? null,
+		get length() {
+			return store.size;
+		},
+	} as Storage;
+}
+
+beforeEach(() => {
+	vi.stubGlobal("localStorage", createMemoryStorage());
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("FeedbackBanner", () => {
+	it("dismisses via the button, not the icon, and persists across remount", async () => {
+		const user = userEvent.setup();
+		const { unmount } = renderWithoutProviders(<FeedbackBanner />);
+
+		const dismissButton = await screen.findByRole("button", {
+			name: DISMISS_REGEX,
+		});
+
+		await user.click(dismissButton);
+
+		// The banner is gone immediately after clicking the button.
+		await waitFor(() =>
+			expect(screen.queryByRole("button", { name: DISMISS_REGEX })).toBeNull()
+		);
+		expect(localStorage.getItem(DISMISSED_STORAGE_KEY)).toBe("true");
+
+		unmount();
+
+		// A fresh mount reads the persisted flag and never renders the banner.
+		renderWithoutProviders(<FeedbackBanner />);
+		await waitFor(() =>
+			expect(
+				screen.queryByRole("button", { name: DISMISS_REGEX })
+			).not.toBeInTheDocument()
+		);
+	});
+
+	it("stays visible until the button is actually clicked", async () => {
+		renderWithoutProviders(<FeedbackBanner />);
+
+		const dismissButton = await screen.findByRole("button", {
+			name: DISMISS_REGEX,
+		});
+
+		expect(dismissButton).toBeInTheDocument();
+		expect(localStorage.getItem(DISMISSED_STORAGE_KEY)).toBeNull();
+	});
+});

--- a/components/navigation/feedback-banner.tsx
+++ b/components/navigation/feedback-banner.tsx
@@ -48,7 +48,7 @@ export default function FeedbackBanner() {
 	};
 
 	return (
-		<div className="fixed inset-x-0 bottom-0 z-30 flex items-center gap-x-6 bg-primary px-6 py-2.5 pb-[calc(0.625rem+env(safe-area-inset-bottom))] sm:px-3.5 sm:before:flex-1">
+		<div className="fixed inset-x-0 bottom-0 z-30 flex items-center gap-x-6 bg-primary px-6 pt-2.5 pb-safe sm:px-3.5 sm:before:flex-1">
 			<div className="w-full text-primary-foreground text-sm leading-6">
 				<Link
 					className="flex w-full flex-col items-center justify-center gap-2 py-3 md:flex-row md:py-0"

--- a/components/navigation/feedback-banner.tsx
+++ b/components/navigation/feedback-banner.tsx
@@ -1,17 +1,54 @@
+"use client";
+
 import { XMarkIcon } from "@heroicons/react/20/solid";
 import { MessageSquareMore } from "lucide-react";
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+
+const DISMISSED_STORAGE_KEY = "tea.feedback-banner.dismissed";
+
+function readDismissed(): boolean {
+	try {
+		return localStorage.getItem(DISMISSED_STORAGE_KEY) === "true";
+	} catch {
+		// Storage can throw (private browsing, disabled storage, quota) — treat
+		// as not dismissed rather than breaking the banner.
+		return false;
+	}
+}
+
+function persistDismissed(): void {
+	try {
+		localStorage.setItem(DISMISSED_STORAGE_KEY, "true");
+	} catch {
+		// Best-effort only — the banner still dismisses for this session even
+		// if it can't be remembered for the next one.
+	}
+}
 
 export default function FeedbackBanner() {
-	const [showBanner, setShowBanner] = useState<boolean>(true);
+	// Render nothing until mounted so the server-rendered markup (which can't
+	// read localStorage) matches the client's first render, then swap in the
+	// real dismissed state — avoids a hydration mismatch.
+	const [mounted, setMounted] = useState(false);
+	const [dismissed, setDismissed] = useState(false);
 
-	if (!showBanner) {
+	useEffect(() => {
+		setDismissed(readDismissed());
+		setMounted(true);
+	}, []);
+
+	if (!mounted || dismissed) {
 		return null;
 	}
 
+	const handleDismiss = () => {
+		setDismissed(true);
+		persistDismissed();
+	};
+
 	return (
-		<div className="flex items-center gap-x-6 bg-primary px-6 py-2.5 sm:px-3.5 sm:before:flex-1">
+		<div className="fixed inset-x-0 bottom-0 z-30 flex items-center gap-x-6 bg-primary px-6 py-2.5 pb-[calc(0.625rem+env(safe-area-inset-bottom))] sm:px-3.5 sm:before:flex-1">
 			<div className="w-full text-primary-foreground text-sm leading-6">
 				<Link
 					className="flex w-full flex-col items-center justify-center gap-2 py-3 md:flex-row md:py-0"
@@ -37,13 +74,13 @@ export default function FeedbackBanner() {
 			<div className="flex flex-1 justify-end">
 				<button
 					className="-m-3 p-3 focus-visible:-outline-offset-4"
+					onClick={handleDismiss}
 					type="button"
 				>
 					<span className="sr-only">Dismiss</span>
 					<XMarkIcon
 						aria-hidden="true"
-						className="hidden h-5 w-5 text-primary-foreground md:block"
-						onClick={() => setShowBanner(false)}
+						className="h-5 w-5 text-primary-foreground"
 					/>
 				</button>
 			</div>

--- a/components/navigation/navbar.tsx
+++ b/components/navigation/navbar.tsx
@@ -74,12 +74,17 @@ export const Navbar = ({ children, teams }: NavbarProps) => {
 				</div>
 
 				<main className="bg-background text-foreground">
-					<div>
-						{children}
-						<FeedbackBanner />
-					</div>
+					{/* Bottom padding reserves room for the fixed FeedbackBanner below
+					 * so it doesn't sit over the last of the scrollable content. Applied
+					 * unconditionally (not just while the banner is visible) to avoid
+					 * lifting its dismissed/mounted state up into this layout. */}
+					<div className="pb-28 md:pb-14">{children}</div>
 				</main>
 			</div>
+			{/* Rendered as a sibling of the main content, not nested inside <main>,
+			 * so its `fixed` positioning can't be broken by a transform or
+			 * overflow-hidden that main picks up later. */}
+			<FeedbackBanner />
 		</div>
 	);
 };

--- a/hooks/__tests__/use-change-detection-race-guard.test.ts
+++ b/hooks/__tests__/use-change-detection-race-guard.test.ts
@@ -1,8 +1,17 @@
 import { renderHook, waitFor } from "@testing-library/react";
+import { act } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useChangeDetection } from "../use-change-detection";
 
 const CASE_ID = "case-1";
+
+// How long, and how often, to keep re-checking a value that's expected to
+// hold steady. A single tick isn't enough here: the unguarded code clobbers
+// state a couple of microtask hops after a stale response resolves, later
+// than one `setTimeout(0)` — this polls across real time instead of trusting
+// one snapshot.
+const STAYS_DURATION_MS = 100;
+const STAYS_STEP_MS = 20;
 
 afterEach(() => {
 	vi.unstubAllGlobals();
@@ -22,18 +31,38 @@ function createDeferred<T>(): Deferred<T> {
 	return { promise, resolve };
 }
 
-function jsonResponse(hasChanges: boolean): Response {
+function jsonResponse(body: Record<string, unknown>): Response {
 	return {
 		ok: true,
 		text: () =>
 			Promise.resolve(
 				JSON.stringify({
-					hasChanges,
+					hasChanges: false,
 					publishedAt: null,
 					publishedId: null,
+					...body,
 				})
 			),
 	} as Response;
+}
+
+/**
+ * Repeatedly samples `getValue()` across `STAYS_DURATION_MS` of real time,
+ * including an immediate first sample. A test that only checks once,
+ * immediately after a value first becomes true, can pass even when a later
+ * microtask clobbers the state — the caller asserts every sample stayed the
+ * same, which catches that.
+ */
+async function sampleOverTime(getValue: () => unknown): Promise<unknown[]> {
+	const samples = [getValue()];
+	const iterations = Math.ceil(STAYS_DURATION_MS / STAYS_STEP_MS);
+	for (let i = 0; i < iterations; i++) {
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, STAYS_STEP_MS));
+		});
+		samples.push(getValue());
+	}
+	return samples;
 }
 
 describe("useChangeDetection — stale-response guard", () => {
@@ -60,14 +89,55 @@ describe("useChangeDetection — stale-response guard", () => {
 		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
 
 		// The LATER (second) request resolves FIRST.
-		second.resolve(jsonResponse(true));
+		second.resolve(jsonResponse({ hasChanges: true }));
 		await waitFor(() => expect(result.current.hasChanges).toBe(true));
 
 		// The EARLIER (first, now-stale) request resolves AFTER — must be
-		// ignored rather than clobbering the newer state.
-		first.resolve(jsonResponse(false));
-		await new Promise((resolveTick) => setTimeout(resolveTick, 0));
+		// ignored rather than clobbering the newer state. Sample over time
+		// rather than checking once.
+		first.resolve(jsonResponse({ hasChanges: false }));
+		const samples = await sampleOverTime(() => result.current.hasChanges);
+		expect(samples.every((value) => value === true)).toBe(true);
+	});
 
-		expect(result.current.hasChanges).toBe(true);
+	it("keeps state from the latest of three overlapping requests, whatever order they resolve in", async () => {
+		const requestOne = createDeferred<Response>();
+		const requestTwo = createDeferred<Response>();
+		const requestThree = createDeferred<Response>();
+		const fetchMock = vi
+			.fn()
+			.mockImplementationOnce(() => requestOne.promise)
+			.mockImplementationOnce(() => requestTwo.promise)
+			.mockImplementationOnce(() => requestThree.promise);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const { result, rerender } = renderHook(
+			({ refreshKey }: { refreshKey: unknown }) =>
+				useChangeDetection({ caseId: CASE_ID, enabled: true, refreshKey }),
+			{ initialProps: { refreshKey: { rev: 1 } } }
+		);
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+		rerender({ refreshKey: { rev: 2 } });
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+		rerender({ refreshKey: { rev: 3 } });
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+
+		// All three requests are already in flight before any of them resolve
+		// (three rerenders fired synchronously above), so by the time request 2
+		// resolves, request 3 has already been issued and is the latest — its
+		// resolution must be ignored outright, not just superseded later.
+		requestTwo.resolve(jsonResponse({ publishedId: "req-2" }));
+		await new Promise((resolveTick) => setTimeout(resolveTick, 0));
+		expect(result.current.publishedId).not.toBe("req-2");
+
+		requestThree.resolve(jsonResponse({ publishedId: "req-3" }));
+		await waitFor(() => expect(result.current.publishedId).toBe("req-3"));
+
+		// The earliest (first, now doubly-stale) request resolves last — must
+		// still be ignored, and the state must stay on request 3's response.
+		requestOne.resolve(jsonResponse({ publishedId: "req-1" }));
+		const samples = await sampleOverTime(() => result.current.publishedId);
+		expect(samples.every((value) => value === "req-3")).toBe(true);
 	});
 });

--- a/hooks/__tests__/use-change-detection-race-guard.test.ts
+++ b/hooks/__tests__/use-change-detection-race-guard.test.ts
@@ -1,0 +1,73 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useChangeDetection } from "../use-change-detection";
+
+const CASE_ID = "case-1";
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+function jsonResponse(hasChanges: boolean): Response {
+	return {
+		ok: true,
+		text: () =>
+			Promise.resolve(
+				JSON.stringify({
+					hasChanges,
+					publishedAt: null,
+					publishedId: null,
+				})
+			),
+	} as Response;
+}
+
+describe("useChangeDetection — stale-response guard", () => {
+	it("keeps state from the later request when overlapping fetches resolve in reverse order", async () => {
+		const first = createDeferred<Response>();
+		const second = createDeferred<Response>();
+		const fetchMock = vi
+			.fn()
+			.mockImplementationOnce(() => first.promise)
+			.mockImplementationOnce(() => second.promise);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const { result, rerender } = renderHook(
+			({ refreshKey }: { refreshKey: unknown }) =>
+				useChangeDetection({ caseId: CASE_ID, enabled: true, refreshKey }),
+			{ initialProps: { refreshKey: { rev: 1 } } }
+		);
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+		// A second fetch fires before the first resolves — the refreshKey
+		// invalidation path, which can overlap requests for the same caseId.
+		rerender({ refreshKey: { rev: 2 } });
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+		// The LATER (second) request resolves FIRST.
+		second.resolve(jsonResponse(true));
+		await waitFor(() => expect(result.current.hasChanges).toBe(true));
+
+		// The EARLIER (first, now-stale) request resolves AFTER — must be
+		// ignored rather than clobbering the newer state.
+		first.resolve(jsonResponse(false));
+		await new Promise((resolveTick) => setTimeout(resolveTick, 0));
+
+		expect(result.current.hasChanges).toBe(true);
+	});
+});

--- a/hooks/use-change-detection.ts
+++ b/hooks/use-change-detection.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 interface ChangeSummary {
 	addedElements: number;
@@ -132,15 +132,30 @@ export function useChangeDetection({
 }: UseChangeDetectionOptions): UseChangeDetectionReturn {
 	const [state, setState] = useState<ChangeDetectionState>(initialState);
 
+	// Tracks the most recently *requested* fetch so a response that resolves
+	// after a newer request has already been issued (overlapping fetches
+	// firing out of order) doesn't clobber the newer state with stale data.
+	// caseId alone can't serve as this token here — refreshKey can trigger
+	// several overlapping fetches for the *same* caseId — so this is a
+	// monotonically increasing counter instead, mirroring the ref-guard
+	// pattern in use-case-information.ts's latestRequestedCaseIdRef.
+	const latestRequestIdRef = useRef(0);
+
 	const fetchChanges = useCallback(async () => {
 		if (!caseId) {
 			return;
 		}
 
+		const requestId = latestRequestIdRef.current + 1;
+		latestRequestIdRef.current = requestId;
+
 		setState((prev) => ({ ...prev, isLoading: true, error: null }));
 
 		try {
 			const result = await fetchChangeDetection(caseId, includeDetails);
+			if (latestRequestIdRef.current !== requestId) {
+				return; // A newer request has since superseded this one.
+			}
 			setState({
 				hasChanges: result.hasChanges,
 				publishedAt: result.publishedAt,
@@ -150,6 +165,9 @@ export function useChangeDetection({
 				error: null,
 			});
 		} catch (err) {
+			if (latestRequestIdRef.current !== requestId) {
+				return;
+			}
 			const message =
 				err instanceof Error ? err.message : "Failed to detect changes";
 			setState((prev) => ({ ...prev, isLoading: false, error: message }));

--- a/lib/__tests__/generate-uuid.test.ts
+++ b/lib/__tests__/generate-uuid.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { generateUuid } from "../generate-uuid";
+
+const UUID_V4_REGEX =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe("generateUuid", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("returns a UUID v4-shaped string via crypto.randomUUID", () => {
+		expect(generateUuid()).toMatch(UUID_V4_REGEX);
+	});
+
+	it("falls back to crypto.getRandomValues when randomUUID is absent (insecure context)", () => {
+		vi.stubGlobal("crypto", {
+			getRandomValues: (arr: Uint8Array) => {
+				for (let i = 0; i < arr.length; i++) {
+					arr[i] = Math.floor(Math.random() * 256);
+				}
+				return arr;
+			},
+		});
+
+		expect(generateUuid()).toMatch(UUID_V4_REGEX);
+	});
+
+	it("falls back to Math.random when crypto is entirely unavailable", () => {
+		vi.stubGlobal("crypto", undefined);
+
+		expect(generateUuid()).toMatch(UUID_V4_REGEX);
+	});
+
+	it("generates unique ids across repeated calls", () => {
+		const ids = new Set(Array.from({ length: 200 }, () => generateUuid()));
+		expect(ids.size).toBe(200);
+	});
+});

--- a/lib/case/__tests__/convert-case.test.ts
+++ b/lib/case/__tests__/convert-case.test.ts
@@ -13,6 +13,9 @@ import {
 	createNodesRecursively,
 } from "../convert-case";
 
+const UUID_V4_EDGE_ID_REGEX =
+	/^e[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 describe("convert-case utilities", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -437,6 +440,29 @@ describe("convert-case utilities", () => {
 			const uniqueIds = new Set(edgeIds);
 
 			expect(uniqueIds.size).toBe(edgeIds.length);
+		});
+
+		it("should create unique edge IDs when crypto.randomUUID is unavailable (insecure context)", () => {
+			vi.stubGlobal("crypto", {
+				getRandomValues: (arr: Uint8Array) => {
+					for (let i = 0; i < arr.length; i++) {
+						arr[i] = Math.floor(Math.random() * 256);
+					}
+					return arr;
+				},
+			});
+
+			try {
+				const edges = createEdgesFromNodes(mockNodes);
+				const edgeIds = edges.map((edge) => edge.id);
+
+				expect(new Set(edgeIds).size).toBe(edgeIds.length);
+				for (const id of edgeIds) {
+					expect(id).toMatch(UUID_V4_EDGE_ID_REGEX);
+				}
+			} finally {
+				vi.unstubAllGlobals();
+			}
 		});
 
 		it("should not create edges for root nodes", () => {

--- a/lib/case/__tests__/convert-case.test.ts
+++ b/lib/case/__tests__/convert-case.test.ts
@@ -1,5 +1,7 @@
 import type { Node } from "reactflow";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateUuid } from "@/lib/generate-uuid";
+import { type LogEntry, resetLogSink, setLogSink } from "@/lib/logger";
 import type {
 	EvidenceResponse,
 	GoalResponse,
@@ -12,6 +14,17 @@ import {
 	createEdgesFromNodes,
 	createNodesRecursively,
 } from "../convert-case";
+
+// Wraps the real implementation by default (see the factory below), so every
+// other test in this file still gets real UUIDs — only the error-logging
+// test below overrides it, once, with `mockImplementationOnce`.
+vi.mock("@/lib/generate-uuid", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/generate-uuid")>();
+	return {
+		...actual,
+		generateUuid: vi.fn(actual.generateUuid),
+	};
+});
 
 const UUID_V4_EDGE_ID_REGEX =
 	/^e[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -821,6 +834,51 @@ describe("convert-case utilities", () => {
 			// Should handle deep nesting without stack overflow
 			expect(result.caseNodes.length).toBeGreaterThan(1);
 			expect(result.caseEdges.length).toBeGreaterThan(0);
+		});
+
+		it("logs the thrown error with caseId via the structured logger, then rethrows unchanged", () => {
+			const conversionError = new Error("generateUuid unavailable");
+			vi.mocked(generateUuid).mockImplementationOnce(() => {
+				throw conversionError;
+			});
+			vi.stubEnv("LOG_LEVEL", "error");
+			const entries: LogEntry[] = [];
+			setLogSink((entry) => entries.push(entry));
+
+			try {
+				const brokenCase = {
+					id: "case-42",
+					goals: [
+						{
+							id: "goal-1",
+							type: "goal",
+							name: "Goal 1",
+							propertyClaims: [
+								{ id: "claim-1", type: "property_claim", name: "Claim 1" },
+							],
+						},
+					],
+				} as unknown as AssuranceCaseWithGoals;
+
+				// The thrown error still propagates to the caller (flow.tsx's catch).
+				expect(() => convertAssuranceCase(brokenCase)).toThrow(
+					"generateUuid unavailable"
+				);
+
+				expect(entries).toHaveLength(1);
+				expect(entries[0]).toMatchObject({
+					level: "error",
+					msg: "Case conversion failed",
+					caseId: "case-42",
+				});
+				expect(entries[0]?.error).toMatchObject({
+					name: "Error",
+					message: "generateUuid unavailable",
+				});
+			} finally {
+				vi.unstubAllEnvs();
+				resetLogSink();
+			}
 		});
 	});
 });

--- a/lib/case/convert-case.ts
+++ b/lib/case/convert-case.ts
@@ -1,4 +1,5 @@
 import type { Edge, Node } from "reactflow";
+import { generateUuid } from "@/lib/generate-uuid";
 import type {
 	EvidenceResponse,
 	GoalResponse,
@@ -246,7 +247,7 @@ export const createEdgesFromNodes = (nodes: Node[]): Edge[] => {
 			}
 
 			// Create an edge from the parent node to the current node
-			const edgeId = `e${crypto.randomUUID()}`;
+			const edgeId = `e${generateUuid()}`;
 			const edge: Edge = {
 				id: edgeId,
 				source: node.data.parentId as string,

--- a/lib/case/convert-case.ts
+++ b/lib/case/convert-case.ts
@@ -1,5 +1,6 @@
 import type { Edge, Node } from "reactflow";
 import { generateUuid } from "@/lib/generate-uuid";
+import { logger } from "@/lib/logger";
 import type {
 	EvidenceResponse,
 	GoalResponse,
@@ -38,34 +39,46 @@ export interface AssuranceCaseWithGoals {
  *
  */
 export const convertAssuranceCase = (assuranceCase: AssuranceCaseWithGoals) => {
-	let caseNodes: Node[] = [],
-		caseEdges: Edge[] = [];
+	try {
+		let caseNodes: Node[] = [],
+			caseEdges: Edge[] = [];
 
-	// Handle null/undefined assurance case or goals
-	if (!(assuranceCase?.goals && Array.isArray(assuranceCase.goals))) {
+		// Handle null/undefined assurance case or goals
+		if (!(assuranceCase?.goals && Array.isArray(assuranceCase.goals))) {
+			return { caseNodes, caseEdges };
+		}
+
+		// Create nodes for each child array item
+		const goals = assuranceCase.goals;
+
+		// Propagate isDemo flag from case to each goal (and recursively to descendants)
+		const isDemo = !!(assuranceCase as Record<string, unknown>).isDemo;
+
+		// Create nodes recursively for goals and their children
+		caseNodes = createNodesRecursively(
+			goals as unknown as ConvertibleItem[],
+			"goal",
+			null,
+			undefined,
+			undefined,
+			isDemo
+		);
+
+		// Create edges for every node
+		caseEdges = createEdgesFromNodes(caseNodes);
+
 		return { caseNodes, caseEdges };
+	} catch (error) {
+		// The real cause of a conversion failure (e.g. edge-id generation)
+		// otherwise only surfaces as flow.tsx's generic "Failed to render
+		// diagram" toast — log it here, at the point it's thrown, then rethrow
+		// unchanged so callers' error handling is untouched.
+		logger.error("Case conversion failed", {
+			caseId: (assuranceCase as Record<string, unknown> | undefined)?.id,
+			error,
+		});
+		throw error;
 	}
-
-	// Create nodes for each child array item
-	const goals = assuranceCase.goals;
-
-	// Propagate isDemo flag from case to each goal (and recursively to descendants)
-	const isDemo = !!(assuranceCase as Record<string, unknown>).isDemo;
-
-	// Create nodes recursively for goals and their children
-	caseNodes = createNodesRecursively(
-		goals as unknown as ConvertibleItem[],
-		"goal",
-		null,
-		undefined,
-		undefined,
-		isDemo
-	);
-
-	// Create edges for every node
-	caseEdges = createEdgesFromNodes(caseNodes);
-
-	return { caseNodes, caseEdges };
 };
 
 // Helper function to create a single node

--- a/lib/case/convert-case.ts
+++ b/lib/case/convert-case.ts
@@ -74,7 +74,7 @@ export const convertAssuranceCase = (assuranceCase: AssuranceCaseWithGoals) => {
 		// diagram" toast — log it here, at the point it's thrown, then rethrow
 		// unchanged so callers' error handling is untouched.
 		logger.error("Case conversion failed", {
-			caseId: (assuranceCase as Record<string, unknown> | undefined)?.id,
+			caseId: assuranceCase?.id,
 			error,
 		});
 		throw error;

--- a/lib/generate-uuid.ts
+++ b/lib/generate-uuid.ts
@@ -1,0 +1,64 @@
+/**
+ * UUID v4 generator that also works outside secure contexts.
+ *
+ * `crypto.randomUUID()` is spec-gated to secure contexts (HTTPS or
+ * localhost) — see
+ * https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID. Over
+ * plain HTTP from another host (e.g. a LAN IP), `crypto.randomUUID` is
+ * `undefined`, so calling it throws `TypeError: crypto.randomUUID is not a
+ * function`. This falls back through `crypto.getRandomValues` — part of the
+ * same Web Crypto API but not secure-context-gated — and finally to
+ * `Math.random` if `crypto` itself is unavailable.
+ *
+ * All three paths return a UUID v4-shaped string
+ * (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`) so callers that treat the result
+ * as UUID-shaped (schema validation, tests, prefixed ids) see the same
+ * shape regardless of which path produced it.
+ */
+export function generateUuid(): string {
+	if (
+		typeof crypto !== "undefined" &&
+		typeof crypto.randomUUID === "function"
+	) {
+		return crypto.randomUUID();
+	}
+
+	if (
+		typeof crypto !== "undefined" &&
+		typeof crypto.getRandomValues === "function"
+	) {
+		return uuidFromBytes(crypto.getRandomValues(new Uint8Array(16)));
+	}
+
+	return uuidFromBytes(
+		Uint8Array.from({ length: 16 }, () => Math.floor(Math.random() * 256))
+	);
+}
+
+const VARIANT_NIBBLES = ["8", "9", "a", "b"];
+
+/**
+ * Sets the RFC 4122 version (4) and variant nibbles, then hex-formats.
+ * Works on the hex digits rather than bitwise-masking the bytes — bitwise
+ * operators are banned by lint/suspicious/noBitwiseOperators here.
+ */
+function uuidFromBytes(bytes: Uint8Array): string {
+	const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+
+	// Version nibble: force to "4", keep the byte's low nibble.
+	hex[6] = `4${hex[6]?.[1] ?? "0"}`;
+
+	// Variant nibble: RFC 4122 requires the top two bits to be "10" (hex
+	// 8/9/a/b); the low two bits carry through from the source byte.
+	const highNibble = Number.parseInt(hex[8]?.[0] ?? "0", 16);
+	const variant = VARIANT_NIBBLES[highNibble % 4] ?? "8";
+	hex[8] = `${variant}${hex[8]?.[1] ?? "0"}`;
+
+	return [
+		hex.slice(0, 4).join(""),
+		hex.slice(4, 6).join(""),
+		hex.slice(6, 8).join(""),
+		hex.slice(8, 10).join(""),
+		hex.slice(10, 16).join(""),
+	].join("-");
+}


### PR DESCRIPTION
Three frontend fixes from the TEA 1.0 small batch.

## Changes

- **Diagram fails to render over plain HTTP** — `crypto.randomUUID()` exists only in secure contexts (HTTPS or localhost), so any case opened over `http://<lan-host>` showed "Failed to render diagram", and the catch in `flow.tsx` swallowed the real error. Edge ids now come from `lib/generate-uuid.ts` (`randomUUID` → `getRandomValues` → `Math.random`, always UUID‑v4 shaped), and the conversion error is logged through the structured logger before the toast.
- **Stale response race in `useChangeDetection`** — overlapping fetches could resolve out of order and an older response overwrite a newer one. A monotonic request id now discards any response that is no longer the latest, on both the success and error paths.
- **Feedback banner** — pinned to the bottom of the viewport (`fixed inset-x-0 bottom-0`), dismissal persisted in `localStorage` (`tea.feedback-banner.dismissed`) behind a mounted guard, and the dismiss handler moved from the icon (hidden below `md`) to the button, so it works on mobile. Content wrapper gets bottom padding so the banner never covers the last element.

## Review chain

- Code review: approve. UUID nibble positions traced by hand; helper used only for client‑side edge ids; logger confirmed browser‑safe; `loading` cannot get stuck when a stale response is dropped. Fallow on the changed set: dead code 0, duplication 0, complexity 0 introduced.
- QA: the original defect reproduced end to end — production builds served on the machine's LAN IP over HTTP (Chromium reports `isSecureContext=false`): the staging build shows the toast with 0 nodes, this branch renders 5 nodes with no console errors. 10,000 generated ids under each fallback all valid v4 and unique. Banner verified in a real browser at desktop and 375 px widths, across reload, with a toast rendering above it. QA found the race‑guard test passed against the unfixed hook (it checked one tick too early); the test now samples over 100 ms and fails 2/2 when the guard is reverted.
- Final hash: unit 109 files / 1427 passed; lint and typecheck clean.
