### PR TITLE
fix(a11y): small batch A — accessible names, reachable disabled-button reasons, popover focus restoration

### DIFF
--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/case-access-section.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/case-access-section.test.tsx
@@ -109,9 +109,8 @@ describe("CaseAccessSection", () => {
 			);
 
 			const trigger = screen.getByRole("button", { name: GRANT_TRIGGER_REGEX });
-			expect(trigger).toBeDisabled();
-			expect(trigger).toHaveAttribute(
-				"title",
+			expect(trigger).toHaveAttribute("aria-disabled", "true");
+			expect(trigger).toHaveAccessibleDescription(
 				"Only an ACTIVE integration can be granted access to a case"
 			);
 		});
@@ -184,7 +183,7 @@ describe("CaseAccessSection", () => {
 			);
 			expect(
 				screen.getByRole("button", { name: GRANT_TRIGGER_REGEX })
-			).toBeDisabled();
+			).toHaveAttribute("aria-disabled", "true");
 			expect(onGrant).not.toHaveBeenCalled();
 		});
 	});

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
@@ -171,8 +171,8 @@ describe("IntegrationCard", () => {
 			const deleteButton = screen.getByRole("button", {
 				name: DELETE_TRIGGER_REGEX,
 			});
-			expect(deleteButton).toBeDisabled();
-			expect(deleteButton).toHaveAttribute("title", DELETE_TOOLTIP_TEXT);
+			expect(deleteButton).toHaveAttribute("aria-disabled", "true");
+			expect(deleteButton).toHaveAccessibleDescription(DELETE_TOOLTIP_TEXT);
 		});
 
 		it("disables Delete with an explanatory tooltip for a SUSPENDED integration", () => {
@@ -186,8 +186,8 @@ describe("IntegrationCard", () => {
 			const deleteButton = screen.getByRole("button", {
 				name: DELETE_TRIGGER_REGEX,
 			});
-			expect(deleteButton).toBeDisabled();
-			expect(deleteButton).toHaveAttribute("title", DELETE_TOOLTIP_TEXT);
+			expect(deleteButton).toHaveAttribute("aria-disabled", "true");
+			expect(deleteButton).toHaveAccessibleDescription(DELETE_TOOLTIP_TEXT);
 		});
 
 		it("enables Delete with no tooltip for a REVOKED integration", () => {
@@ -201,8 +201,8 @@ describe("IntegrationCard", () => {
 			const deleteButton = screen.getByRole("button", {
 				name: DELETE_TRIGGER_REGEX,
 			});
-			expect(deleteButton).toBeEnabled();
-			expect(deleteButton).not.toHaveAttribute("title");
+			expect(deleteButton).not.toHaveAttribute("aria-disabled");
+			expect(deleteButton).toHaveAccessibleDescription("");
 		});
 
 		it("keeps the destructive confirm button disabled when the typed text doesn't exactly match the integration's name", async () => {
@@ -598,7 +598,7 @@ describe("IntegrationCard", () => {
 
 			expect(
 				screen.getByRole("button", { name: ISSUE_TOKEN_BUTTON_REGEX })
-			).toBeDisabled();
+			).toHaveAttribute("aria-disabled", "true");
 		});
 
 		it("shows a token-shown-once modal after issuing succeeds", async () => {

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
@@ -23,6 +23,7 @@ const DELETE_CONFIRM_REGEX = /delete integration/i;
 const DELETE_TOOLTIP_TEXT = "Revoke first — delete is permanent";
 const TYPE_NAME_LABEL_REGEX = /type.*to confirm/i;
 const ISSUE_TOKEN_BUTTON_REGEX = /issue new token/i;
+const ISSUING_LABEL_REGEX = /^issuing…$/i;
 const PERMANENT_TEXT_REGEX = /permanent/i;
 const CANNOT_BE_UNDONE_TEXT_REGEX = /cannot be undone/i;
 const DONE_BUTTON_REGEX = /done.*stored it/i;
@@ -615,6 +616,23 @@ describe("IntegrationCard", () => {
 			expect(
 				screen.getByRole("button", { name: ISSUE_TOKEN_BUTTON_REGEX })
 			).toHaveAttribute("aria-disabled", "true");
+		});
+
+		it("announces no reason for an ACTIVE integration mid-issue — disabled by the in-flight request, not by needing to be ACTIVE", () => {
+			const integration = makeIntegration({ status: "ACTIVE" });
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					integration={integration}
+					pendingTokenKey={integration.id}
+				/>
+			);
+
+			const issueButton = screen.getByRole("button", {
+				name: ISSUING_LABEL_REGEX,
+			});
+			expect(issueButton).toHaveAttribute("aria-disabled", "true");
+			expect(issueButton).toHaveAccessibleDescription("");
 		});
 
 		it("shows a token-shown-once modal after issuing succeeds", async () => {

--- a/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/__tests__/integration-card.test.tsx
@@ -205,6 +205,22 @@ describe("IntegrationCard", () => {
 			expect(deleteButton).toHaveAccessibleDescription("");
 		});
 
+		it("announces no reason for a REVOKED integration mid-delete — disabled by the in-flight request, not by needing a revoke first", () => {
+			renderWithoutProviders(
+				<IntegrationCard
+					{...baseProps}
+					deleting={true}
+					integration={makeIntegration({ status: "REVOKED" })}
+				/>
+			);
+
+			const deleteButton = screen.getByRole("button", {
+				name: DELETING_LABEL_REGEX,
+			});
+			expect(deleteButton).toHaveAttribute("aria-disabled", "true");
+			expect(deleteButton).toHaveAccessibleDescription("");
+		});
+
 		it("keeps the destructive confirm button disabled when the typed text doesn't exactly match the integration's name", async () => {
 			const onDelete = vi.fn();
 			const user = userEvent.setup();

--- a/app/(authenticated)/dashboard/settings/integrations/_components/case-access-section.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/case-access-section.tsx
@@ -3,6 +3,7 @@
 import { AlertCircle, Plus } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { DisabledButtonHint } from "@/components/ui/disabled-button-hint";
 import type {
 	CaseGrantPermission,
 	IntegrationCaseGrant,
@@ -143,21 +144,17 @@ export function CaseAccessSection({
 						onGrant={handleGrant}
 					/>
 				) : (
-					<Button
+					<DisabledButtonHint
 						disabled={!integrationActive}
+						disabledReason="Only an ACTIVE integration can be granted access to a case"
 						onClick={openForm}
 						size="sm"
-						title={
-							integrationActive
-								? undefined
-								: "Only an ACTIVE integration can be granted access to a case"
-						}
 						type="button"
 						variant="outline"
 					>
 						<Plus aria-hidden="true" className="h-3.5 w-3.5" />
 						Grant access to a case…
-					</Button>
+					</DisabledButtonHint>
 				))}
 		</div>
 	);

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
@@ -245,7 +245,11 @@ export function IntegrationCard({
 					)}
 					<DisabledButtonHint
 						disabled={deleting || !integrationRevoked}
-						disabledReason="Revoke first — delete is permanent"
+						disabledReason={
+							integrationRevoked
+								? undefined
+								: "Revoke first — delete is permanent"
+						}
 						onClick={() => setConfirmDeleteOpen(true)}
 						size="sm"
 						type="button"
@@ -264,7 +268,11 @@ export function IntegrationCard({
 					</h4>
 					<DisabledButtonHint
 						disabled={!integrationActive || isIssuing}
-						disabledReason="Only an ACTIVE integration can issue a token"
+						disabledReason={
+							integrationActive
+								? undefined
+								: "Only an ACTIVE integration can issue a token"
+						}
 						onClick={handleIssueToken}
 						size="sm"
 						type="button"

--- a/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
+++ b/app/(authenticated)/dashboard/settings/integrations/_components/integration-card.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { AlertModal } from "@/components/modals/alert-modal";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { DisabledButtonHint } from "@/components/ui/disabled-button-hint";
 import { useIntegrationCaseGrants } from "@/hooks/use-integration-case-grants";
 import {
 	formatFullDate,
@@ -242,21 +243,17 @@ export function IntegrationCard({
 							Revoke
 						</Button>
 					)}
-					<Button
+					<DisabledButtonHint
 						disabled={deleting || !integrationRevoked}
+						disabledReason="Revoke first — delete is permanent"
 						onClick={() => setConfirmDeleteOpen(true)}
 						size="sm"
-						title={
-							integrationRevoked
-								? undefined
-								: "Revoke first — delete is permanent"
-						}
 						type="button"
 						variant="destructive"
 					>
 						<Trash2 aria-hidden="true" className="h-3.5 w-3.5" />
 						{deleting ? "Deleting…" : "Delete"}
-					</Button>
+					</DisabledButtonHint>
 				</div>
 			</div>
 
@@ -265,21 +262,17 @@ export function IntegrationCard({
 					<h4 className="font-medium text-foreground text-xs uppercase tracking-wide">
 						Tokens
 					</h4>
-					<Button
+					<DisabledButtonHint
 						disabled={!integrationActive || isIssuing}
+						disabledReason="Only an ACTIVE integration can issue a token"
 						onClick={handleIssueToken}
 						size="sm"
-						title={
-							integrationActive
-								? undefined
-								: "Only an ACTIVE integration can issue a token"
-						}
 						type="button"
 						variant="outline"
 					>
 						<KeyRound aria-hidden="true" className="h-3.5 w-3.5" />
 						{isIssuing ? "Issuing…" : "Issue new token"}
-					</Button>
+					</DisabledButtonHint>
 				</div>
 
 				{activeTokens.length === 0 ? (

--- a/app/globals.css
+++ b/app/globals.css
@@ -21,6 +21,15 @@
 	padding-bottom: calc(var(--spacing) * 2.5 + env(safe-area-inset-bottom));
 }
 
+/* Below the smallest step on Tailwind's default scale (text-xs, 0.75rem) —
+   for count badges and similar chrome too small for body text, where
+   text-xs would not fit. Named, not an arbitrary value, so it shows up in
+   token-drift scans as intentional. */
+@utility text-micro {
+	font-size: 0.5625rem;
+	line-height: 1;
+}
+
 /* ========================================================================
    Catppuccin Latte (light) / Mocha (dark) — OKLCH colour tokens
    ======================================================================== */

--- a/components/cases/__tests__/node-add-popover.test.tsx
+++ b/components/cases/__tests__/node-add-popover.test.tsx
@@ -20,10 +20,12 @@ const NODE: Node = {
 
 // NodeAddPopover's `open` is externally controlled — every real caller
 // (goal-node.tsx, strategy-node.tsx, property-node.tsx) owns the boolean in
-// its own local state and flips it from the trigger's onClick, rather than
-// letting Radix manage open state itself. This harness reproduces that
-// wiring instead of driving `open` as a prop directly, since that's the
-// shape the bug actually manifests under.
+// its own local state and passes it through `open`/`onOpenChange`. Opening
+// itself is driven by `PopoverTrigger`'s own composed toggle (merged onto
+// the trigger's own onClick via Radix's `asChild`), not by a manual state
+// flip in the trigger's onClick — no caller does that any more. This harness
+// reproduces the `open`/`onOpenChange` wiring instead of driving `open` as a
+// prop directly, since that's the shape the bug actually manifests under.
 function DismissHarness() {
 	const [open, setOpen] = useState(true);
 	return (
@@ -44,9 +46,10 @@ function DismissHarness() {
 	);
 }
 
-// Starts closed, so the trigger's onClick (not the `open` prop) is what
-// drives the popover open — the same wiring `DismissHarness` above uses,
-// just starting from the closed state so opening-via-trigger and
+// Starts closed, so `PopoverTrigger`'s own composed toggle (not the `open`
+// prop, and not a manual state flip in the trigger's onClick) is what drives
+// the popover open — the same wiring `DismissHarness` above uses, just
+// starting from the closed state so opening-via-trigger and
 // selecting-an-option-closes-it can both be exercised.
 function ControlledHarness() {
 	const [open, setOpen] = useState(false);
@@ -57,7 +60,7 @@ function ControlledHarness() {
 			onOpenChange={setOpen}
 			open={open}
 		>
-			<button onClick={() => setOpen(true)} type="button">
+			<button onClick={(e) => e.stopPropagation()} type="button">
 				Add child element
 			</button>
 		</NodeAddPopover>

--- a/components/cases/__tests__/node-add-popover.test.tsx
+++ b/components/cases/__tests__/node-add-popover.test.tsx
@@ -126,10 +126,19 @@ describe("NodeAddPopover — controlled open/onOpenChange still works under moda
 // `context.triggerRef.current?.focus()`, and `context.triggerRef` is
 // populated exclusively by `<PopoverTrigger>` — `<PopoverAnchor>` is purely a
 // popper positioning primitive and never touched it, which is why focus
-// used to go nowhere on dismiss. Verified against an identical harness for
-// QuickEditPopover (components/docs/curriculum/enhanced/dialogs/
-// quick-edit-popover.tsx — already a real `<PopoverTrigger>`) that this is a
-// real behavioural fact under jsdom, not a jsdom limitation.
+// used to go nowhere on dismiss.
+//
+// What the test below actually proves under jsdom: pre-fix,
+// `document.activeElement` ends up on `<body>` after Escape (nothing left to
+// hold focus); post-fix it's back on the trigger — so the assertion
+// discriminates the regression. That is not the same claim as "Radix's
+// triggerRef restore is exercised here" — jsdom's focus handling doesn't
+// reproduce the browser's own focus-trap/tab-order semantics closely enough
+// to stand as proof of the mechanism itself. The real source of truth is
+// browser behaviour: focus moves into the popover content on open and
+// returns to the trigger on Escape, an outside click, or selecting an
+// option. That is what would need checking in a real browser to confirm
+// the mechanism itself, not just this regression indicator.
 describe("NodeAddPopover — trigger survives a dismiss cycle and regains focus", () => {
 	it("leaves the trigger mounted and reusable after dismissing via Escape", async () => {
 		const user = userEvent.setup();

--- a/components/cases/__tests__/node-add-popover.test.tsx
+++ b/components/cases/__tests__/node-add-popover.test.tsx
@@ -120,36 +120,17 @@ describe("NodeAddPopover — controlled open/onOpenChange still works under moda
 	});
 });
 
-// Focus restoration (review follow-up, PR #885 G3): NOT the same regression
-// vector here as the other modal popovers. Radix's modal PopoverContent only
-// restores focus via `context.triggerRef.current?.focus()` — and
-// `context.triggerRef` is populated exclusively by `<PopoverTrigger>`.
-// NodeAddPopover wires its `children` through `<PopoverAnchor>` instead (the
-// component is externally controlled — every real caller, e.g. goal-node.tsx,
-// opens it from its own `onClick`, not Radix's), which is purely a popper
-// positioning primitive and never touches `triggerRef`. So
-// `triggerRef.current` stays `null` for the lifetime of this component, the
-// optional-chained `.focus()` call is a no-op, and — because
-// `onCloseAutoFocus` also calls `event.preventDefault()` unconditionally —
-// FocusScope's own "focus the previously-focused element" fallback never
-// runs either. Net effect: dismissing this popover restores focus to
-// nothing; the browser's default (the focused node was removed) takes over.
-//
-// Verified this is a real behavioural fact, not a jsdom limitation: an
-// identical harness against QuickEditPopover (components/docs/curriculum/
-// enhanced/dialogs/quick-edit-popover.tsx — a real `<PopoverTrigger>`) DOES
-// land focus back on its trigger button under jsdom. Asserting "focus
-// returns to the trigger" against NodeAddPopover would therefore be
-// asserting something the component doesn't do — a test that's always
-// falsely red, not a true regression guard. Per the brief: documenting why
-// here rather than shipping either a false-failing test or a vacuous one
-// that asserts nothing meaningful. The alternative locked in below is the
-// one thing that IS true and worth guarding: the trigger stays mounted,
-// unbroken and re-clickable after a dismiss cycle (no stale-ref crash, no
-// focus trap on a removed node). Wiring `<PopoverTrigger>` properly (so
-// focus restoration starts working) is production code and out of scope for
-// this test-only commit — worth a follow-up issue.
-describe("NodeAddPopover — trigger survives a dismiss cycle (focus restoration does not apply — see comment above)", () => {
+// Focus restoration (review follow-up, PR #885 G3, fixed): NodeAddPopover
+// now wires its `children` through `<PopoverTrigger asChild>` instead of
+// `<PopoverAnchor>`. Radix's modal PopoverContent restores focus via
+// `context.triggerRef.current?.focus()`, and `context.triggerRef` is
+// populated exclusively by `<PopoverTrigger>` — `<PopoverAnchor>` is purely a
+// popper positioning primitive and never touched it, which is why focus
+// used to go nowhere on dismiss. Verified against an identical harness for
+// QuickEditPopover (components/docs/curriculum/enhanced/dialogs/
+// quick-edit-popover.tsx — already a real `<PopoverTrigger>`) that this is a
+// real behavioural fact under jsdom, not a jsdom limitation.
+describe("NodeAddPopover — trigger survives a dismiss cycle and regains focus", () => {
 	it("leaves the trigger mounted and reusable after dismissing via Escape", async () => {
 		const user = userEvent.setup();
 		render(<ControlledHarness />);
@@ -170,6 +151,24 @@ describe("NodeAddPopover — trigger survives a dismiss cycle (focus restoration
 		await user.click(trigger);
 		await waitFor(() => {
 			expect(screen.getByText("Add Element")).toBeInTheDocument();
+		});
+	});
+
+	it("returns keyboard focus to the trigger after dismissing with Escape", async () => {
+		const user = userEvent.setup();
+		render(<ControlledHarness />);
+
+		const trigger = screen.getByRole("button", { name: "Add child element" });
+		await user.click(trigger);
+		await screen.findByText("Add Element");
+
+		fireEvent.keyDown(document, { key: "Escape" });
+
+		await waitFor(() => {
+			expect(screen.queryByText("Add Element")).not.toBeInTheDocument();
+		});
+		await waitFor(() => {
+			expect(document.activeElement).toBe(trigger);
 		});
 	});
 });

--- a/components/cases/add-child-trigger.tsx
+++ b/components/cases/add-child-trigger.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import type { Node } from "reactflow";
+import type { DiagramNodeType } from "@/components/shared/nodes/node-config";
+import ActionTooltip from "@/components/ui/action-tooltip";
+import NodeAddPopover from "./node-add-popover";
+
+const ADD_CHILD_LABEL = "Add child element";
+
+export interface AddChildTriggerProps {
+	/** The ReactFlow node object this trigger adds a child under */
+	node: Node;
+	/** The type of node (goal, strategy or property — evidence never shows this) */
+	nodeType: DiagramNodeType;
+}
+
+/**
+ * AddChildTrigger - the "Add child element" popover trigger shared by
+ * goal-node.tsx, strategy-node.tsx and property-node.tsx. Owns its own open
+ * state; nothing outside this component needs it.
+ */
+export default function AddChildTrigger({
+	node,
+	nodeType,
+}: AddChildTriggerProps) {
+	const [addPopoverOpen, setAddPopoverOpen] = useState(false);
+
+	return (
+		<NodeAddPopover
+			node={node}
+			nodeType={nodeType}
+			onOpenChange={setAddPopoverOpen}
+			open={addPopoverOpen}
+		>
+			<ActionTooltip label={ADD_CHILD_LABEL}>
+				<button
+					aria-label={ADD_CHILD_LABEL}
+					onClick={(e) => e.stopPropagation()}
+					onMouseDown={(e) => e.stopPropagation()}
+					type="button"
+				>
+					<div className="inline-flex rounded-full p-1 hover:bg-foreground/10">
+						<Plus aria-hidden="true" size={16} />
+					</div>
+				</button>
+			</ActionTooltip>
+		</NodeAddPopover>
+	);
+}

--- a/components/cases/goal-node.tsx
+++ b/components/cases/goal-node.tsx
@@ -10,6 +10,8 @@ import NodeAddPopover from "./node-add-popover";
 import NodeEditDialog from "./node-edit-dialog";
 import ToggleButton from "./toggle-button";
 
+const ADD_CHILD_LABEL = "Add child element";
+
 function GoalNode({ data, ...props }: NodeProps) {
 	const [editDialogOpen, setEditDialogOpen] = useState(false);
 	const [addPopoverOpen, setAddPopoverOpen] = useState(false);
@@ -25,13 +27,10 @@ function GoalNode({ data, ...props }: NodeProps) {
 			onOpenChange={setAddPopoverOpen}
 			open={addPopoverOpen}
 		>
-			<ActionTooltip label="Add child element">
+			<ActionTooltip label={ADD_CHILD_LABEL}>
 				<button
-					aria-label="Add child element"
-					onClick={(e) => {
-						e.stopPropagation();
-						setAddPopoverOpen(true);
-					}}
+					aria-label={ADD_CHILD_LABEL}
+					onClick={(e) => e.stopPropagation()}
 					onMouseDown={(e) => e.stopPropagation()}
 					type="button"
 				>

--- a/components/cases/goal-node.tsx
+++ b/components/cases/goal-node.tsx
@@ -27,6 +27,7 @@ function GoalNode({ data, ...props }: NodeProps) {
 		>
 			<ActionTooltip label="Add child element">
 				<button
+					aria-label="Add child element"
 					onClick={(e) => {
 						e.stopPropagation();
 						setAddPopoverOpen(true);

--- a/components/cases/goal-node.tsx
+++ b/components/cases/goal-node.tsx
@@ -1,46 +1,19 @@
 "use client";
 
-import { Plus } from "lucide-react";
 import { memo, useState } from "react";
 import type { NodeProps } from "reactflow";
 import { BaseNode, NodeActionGroup } from "@/components/shared/nodes";
-import ActionTooltip from "@/components/ui/action-tooltip";
 import { useNodeTopRightActions } from "@/hooks/use-node-top-right-actions";
-import NodeAddPopover from "./node-add-popover";
+import AddChildTrigger from "./add-child-trigger";
 import NodeEditDialog from "./node-edit-dialog";
 import ToggleButton from "./toggle-button";
 
-const ADD_CHILD_LABEL = "Add child element";
-
 function GoalNode({ data, ...props }: NodeProps) {
 	const [editDialogOpen, setEditDialogOpen] = useState(false);
-	const [addPopoverOpen, setAddPopoverOpen] = useState(false);
 
 	const node = { data, position: { x: 0, y: 0 }, ...props };
 
 	const topRightActions = useNodeTopRightActions(data, "goal");
-
-	const addPopover = (
-		<NodeAddPopover
-			node={node}
-			nodeType="goal"
-			onOpenChange={setAddPopoverOpen}
-			open={addPopoverOpen}
-		>
-			<ActionTooltip label={ADD_CHILD_LABEL}>
-				<button
-					aria-label={ADD_CHILD_LABEL}
-					onClick={(e) => e.stopPropagation()}
-					onMouseDown={(e) => e.stopPropagation()}
-					type="button"
-				>
-					<div className="inline-flex rounded-full p-1 hover:bg-foreground/10">
-						<Plus aria-hidden="true" size={16} />
-					</div>
-				</button>
-			</ActionTooltip>
-		</NodeAddPopover>
-	);
 
 	const isDemoGoal = data.isDemo && data.name === "G1";
 	const dataTour = isDemoGoal ? "demo-goal" : undefined;
@@ -51,7 +24,7 @@ function GoalNode({ data, ...props }: NodeProps) {
 				assumption={data.assumption}
 				bottomLeftActions={
 					<NodeActionGroup
-						addPopover={addPopover}
+						addPopover={<AddChildTrigger node={node} nodeType="goal" />}
 						commentCount={
 							Array.isArray(data.comments) ? data.comments.length : 0
 						}

--- a/components/cases/node-add-popover.tsx
+++ b/components/cases/node-add-popover.tsx
@@ -7,8 +7,8 @@ import type { DiagramNodeType } from "@/components/shared/nodes/node-config";
 import { Button } from "@/components/ui/button";
 import {
 	Popover,
-	PopoverAnchor,
 	PopoverContent,
+	PopoverTrigger,
 } from "@/components/ui/popover";
 import NodeAddDialog from "./node-add-dialog";
 
@@ -137,7 +137,7 @@ export default function NodeAddPopover({
 			(`disableOutsidePointerEvents`), so the canvas never intercepts the
 			click in the first place. */}
 			<Popover modal onOpenChange={onOpenChange} open={open}>
-				<PopoverAnchor className="inline-flex">{children}</PopoverAnchor>
+				<PopoverTrigger asChild>{children}</PopoverTrigger>
 				<PopoverContent align="start" className="w-56 p-2" side="top">
 					<div className="flex flex-col gap-1">
 						<p className="mb-1 px-2 font-medium text-muted-foreground text-xs uppercase tracking-wider">

--- a/components/cases/property-node.tsx
+++ b/components/cases/property-node.tsx
@@ -27,6 +27,7 @@ function PropertyNode({ data, ...props }: NodeProps) {
 		>
 			<ActionTooltip label="Add child element">
 				<button
+					aria-label="Add child element"
 					onClick={(e) => {
 						e.stopPropagation();
 						setAddPopoverOpen(true);

--- a/components/cases/property-node.tsx
+++ b/components/cases/property-node.tsx
@@ -10,6 +10,8 @@ import NodeAddPopover from "./node-add-popover";
 import NodeEditDialog from "./node-edit-dialog";
 import ToggleButton from "./toggle-button";
 
+const ADD_CHILD_LABEL = "Add child element";
+
 function PropertyNode({ data, ...props }: NodeProps) {
 	const [editDialogOpen, setEditDialogOpen] = useState(false);
 	const [addPopoverOpen, setAddPopoverOpen] = useState(false);
@@ -25,13 +27,10 @@ function PropertyNode({ data, ...props }: NodeProps) {
 			onOpenChange={setAddPopoverOpen}
 			open={addPopoverOpen}
 		>
-			<ActionTooltip label="Add child element">
+			<ActionTooltip label={ADD_CHILD_LABEL}>
 				<button
-					aria-label="Add child element"
-					onClick={(e) => {
-						e.stopPropagation();
-						setAddPopoverOpen(true);
-					}}
+					aria-label={ADD_CHILD_LABEL}
+					onClick={(e) => e.stopPropagation()}
 					onMouseDown={(e) => e.stopPropagation()}
 					type="button"
 				>

--- a/components/cases/property-node.tsx
+++ b/components/cases/property-node.tsx
@@ -1,46 +1,19 @@
 "use client";
 
-import { Plus } from "lucide-react";
 import { memo, useState } from "react";
 import type { NodeProps } from "reactflow";
 import { BaseNode, NodeActionGroup } from "@/components/shared/nodes";
-import ActionTooltip from "@/components/ui/action-tooltip";
 import { useNodeTopRightActions } from "@/hooks/use-node-top-right-actions";
-import NodeAddPopover from "./node-add-popover";
+import AddChildTrigger from "./add-child-trigger";
 import NodeEditDialog from "./node-edit-dialog";
 import ToggleButton from "./toggle-button";
 
-const ADD_CHILD_LABEL = "Add child element";
-
 function PropertyNode({ data, ...props }: NodeProps) {
 	const [editDialogOpen, setEditDialogOpen] = useState(false);
-	const [addPopoverOpen, setAddPopoverOpen] = useState(false);
 
 	const node = { data, position: { x: 0, y: 0 }, ...props };
 
 	const topRightActions = useNodeTopRightActions(data, "property");
-
-	const addPopover = (
-		<NodeAddPopover
-			node={node}
-			nodeType="property"
-			onOpenChange={setAddPopoverOpen}
-			open={addPopoverOpen}
-		>
-			<ActionTooltip label={ADD_CHILD_LABEL}>
-				<button
-					aria-label={ADD_CHILD_LABEL}
-					onClick={(e) => e.stopPropagation()}
-					onMouseDown={(e) => e.stopPropagation()}
-					type="button"
-				>
-					<div className="inline-flex rounded-full p-1 hover:bg-foreground/10">
-						<Plus aria-hidden="true" size={16} />
-					</div>
-				</button>
-			</ActionTooltip>
-		</NodeAddPopover>
-	);
 
 	const dataTour =
 		data.isDemo && data.name === "P1" ? "demo-claim-1" : undefined;
@@ -51,7 +24,7 @@ function PropertyNode({ data, ...props }: NodeProps) {
 				assumption={data.assumption}
 				bottomLeftActions={
 					<NodeActionGroup
-						addPopover={addPopover}
+						addPopover={<AddChildTrigger node={node} nodeType="property" />}
 						commentCount={
 							Array.isArray(data.comments) ? data.comments.length : 0
 						}

--- a/components/cases/strategy-node.tsx
+++ b/components/cases/strategy-node.tsx
@@ -27,6 +27,7 @@ function StrategyNode({ data, ...props }: NodeProps) {
 		>
 			<ActionTooltip label="Add child element">
 				<button
+					aria-label="Add child element"
 					onClick={(e) => {
 						e.stopPropagation();
 						setAddPopoverOpen(true);

--- a/components/cases/strategy-node.tsx
+++ b/components/cases/strategy-node.tsx
@@ -10,6 +10,8 @@ import NodeAddPopover from "./node-add-popover";
 import NodeEditDialog from "./node-edit-dialog";
 import ToggleButton from "./toggle-button";
 
+const ADD_CHILD_LABEL = "Add child element";
+
 function StrategyNode({ data, ...props }: NodeProps) {
 	const [editDialogOpen, setEditDialogOpen] = useState(false);
 	const [addPopoverOpen, setAddPopoverOpen] = useState(false);
@@ -25,13 +27,10 @@ function StrategyNode({ data, ...props }: NodeProps) {
 			onOpenChange={setAddPopoverOpen}
 			open={addPopoverOpen}
 		>
-			<ActionTooltip label="Add child element">
+			<ActionTooltip label={ADD_CHILD_LABEL}>
 				<button
-					aria-label="Add child element"
-					onClick={(e) => {
-						e.stopPropagation();
-						setAddPopoverOpen(true);
-					}}
+					aria-label={ADD_CHILD_LABEL}
+					onClick={(e) => e.stopPropagation()}
 					onMouseDown={(e) => e.stopPropagation()}
 					type="button"
 				>

--- a/components/cases/strategy-node.tsx
+++ b/components/cases/strategy-node.tsx
@@ -1,46 +1,19 @@
 "use client";
 
-import { Plus } from "lucide-react";
 import { memo, useState } from "react";
 import type { NodeProps } from "reactflow";
 import { BaseNode, NodeActionGroup } from "@/components/shared/nodes";
-import ActionTooltip from "@/components/ui/action-tooltip";
 import { useNodeTopRightActions } from "@/hooks/use-node-top-right-actions";
-import NodeAddPopover from "./node-add-popover";
+import AddChildTrigger from "./add-child-trigger";
 import NodeEditDialog from "./node-edit-dialog";
 import ToggleButton from "./toggle-button";
 
-const ADD_CHILD_LABEL = "Add child element";
-
 function StrategyNode({ data, ...props }: NodeProps) {
 	const [editDialogOpen, setEditDialogOpen] = useState(false);
-	const [addPopoverOpen, setAddPopoverOpen] = useState(false);
 
 	const node = { data, position: { x: 0, y: 0 }, ...props };
 
 	const topRightActions = useNodeTopRightActions(data, "strategy");
-
-	const addPopover = (
-		<NodeAddPopover
-			node={node}
-			nodeType="strategy"
-			onOpenChange={setAddPopoverOpen}
-			open={addPopoverOpen}
-		>
-			<ActionTooltip label={ADD_CHILD_LABEL}>
-				<button
-					aria-label={ADD_CHILD_LABEL}
-					onClick={(e) => e.stopPropagation()}
-					onMouseDown={(e) => e.stopPropagation()}
-					type="button"
-				>
-					<div className="inline-flex rounded-full p-1 hover:bg-foreground/10">
-						<Plus aria-hidden="true" size={16} />
-					</div>
-				</button>
-			</ActionTooltip>
-		</NodeAddPopover>
-	);
 
 	const dataTour =
 		data.isDemo && data.name === "S1" ? "demo-strategy-1" : undefined;
@@ -51,7 +24,7 @@ function StrategyNode({ data, ...props }: NodeProps) {
 				assumption={data.assumption}
 				bottomLeftActions={
 					<NodeActionGroup
-						addPopover={addPopover}
+						addPopover={<AddChildTrigger node={node} nodeType="strategy" />}
 						commentCount={
 							Array.isArray(data.comments) ? data.comments.length : 0
 						}

--- a/components/cases/toggle-button.tsx
+++ b/components/cases/toggle-button.tsx
@@ -145,6 +145,7 @@ const ToggleButton = ({ node }: ToggleButtonProps) => {
 	return (
 		<ActionTooltip label="Show/Hide children">
 			<button
+				aria-label="Show/Hide children"
 				onClick={(e) => handleToggle2(e)}
 				onMouseDown={(e) => e.stopPropagation()}
 				type="button"

--- a/components/cases/toggle-button.tsx
+++ b/components/cases/toggle-button.tsx
@@ -14,6 +14,8 @@ import ActionTooltip from "@/components/ui/action-tooltip";
 import { toggleHiddenForChildren } from "@/lib/case";
 import useStore from "@/store/store";
 
+const TOGGLE_LABEL = "Show/Hide children";
+
 interface ToggleButtonProps {
 	node: Node;
 }
@@ -143,9 +145,9 @@ const ToggleButton = ({ node }: ToggleButtonProps) => {
 	}
 
 	return (
-		<ActionTooltip label="Show/Hide children">
+		<ActionTooltip label={TOGGLE_LABEL}>
 			<button
-				aria-label="Show/Hide children"
+				aria-label={TOGGLE_LABEL}
 				onClick={(e) => handleToggle2(e)}
 				onMouseDown={(e) => e.stopPropagation()}
 				type="button"

--- a/components/shared/nodes/node-action-group.tsx
+++ b/components/shared/nodes/node-action-group.tsx
@@ -101,7 +101,7 @@ export default function NodeActionGroup({
 					<div className="relative inline-flex rounded-full p-1 hover:bg-foreground/10">
 						<MessageCircle aria-hidden="true" size={16} />
 						{commentCount > 0 && (
-							<span className="absolute -top-1 -right-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-info px-0.5 font-bold text-[9px] text-info-foreground">
+							<span className="absolute -top-1 -right-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-info px-0.5 font-bold text-info-foreground text-micro">
 								{commentCount}
 							</span>
 						)}

--- a/components/shared/nodes/node-action-group.tsx
+++ b/components/shared/nodes/node-action-group.tsx
@@ -69,6 +69,7 @@ export default function NodeActionGroup({
 			{/* Edit Button */}
 			<ActionTooltip label={readOnly ? "View details" : "Edit element"}>
 				<button
+					aria-label={readOnly ? "View details" : "Edit element"}
 					onClick={handleEditClick}
 					onMouseDown={(e) => e.stopPropagation()}
 					type="button"
@@ -92,6 +93,11 @@ export default function NodeActionGroup({
 				}
 			>
 				<button
+					aria-label={
+						commentCount > 0
+							? `View comments (${commentCount})`
+							: "View comments"
+					}
 					onClick={handleCommentClick}
 					onMouseDown={(e) => e.stopPropagation()}
 					type="button"

--- a/components/shared/nodes/node-action-group.tsx
+++ b/components/shared/nodes/node-action-group.tsx
@@ -61,15 +61,19 @@ export default function NodeActionGroup({
 		setCommentsSheetOpen(true);
 	};
 
+	const editLabel = readOnly ? "View details" : "Edit element";
+	const commentLabel =
+		commentCount > 0 ? `View comments (${commentCount})` : "View comments";
+
 	return (
 		<div className="flex items-center gap-0.5">
 			{/* Add Button with Popover (not shown for evidence or when read-only) */}
 			{showAdd && nodeType !== "evidence" && !readOnly && addPopover}
 
 			{/* Edit Button */}
-			<ActionTooltip label={readOnly ? "View details" : "Edit element"}>
+			<ActionTooltip label={editLabel}>
 				<button
-					aria-label={readOnly ? "View details" : "Edit element"}
+					aria-label={editLabel}
 					onClick={handleEditClick}
 					onMouseDown={(e) => e.stopPropagation()}
 					type="button"
@@ -87,17 +91,9 @@ export default function NodeActionGroup({
 			{!readOnly && <NodeOptionsMenu node={node} nodeType={nodeType} />}
 
 			{/* Comment Button */}
-			<ActionTooltip
-				label={
-					commentCount > 0 ? `View comments (${commentCount})` : "View comments"
-				}
-			>
+			<ActionTooltip label={commentLabel}>
 				<button
-					aria-label={
-						commentCount > 0
-							? `View comments (${commentCount})`
-							: "View comments"
-					}
+					aria-label={commentLabel}
 					onClick={handleCommentClick}
 					onMouseDown={(e) => e.stopPropagation()}
 					type="button"

--- a/components/shared/nodes/node-options-menu.tsx
+++ b/components/shared/nodes/node-options-menu.tsx
@@ -396,6 +396,7 @@ export default function NodeOptionsMenu({
 				<ActionTooltip label="More options">
 					<DropdownMenuTrigger asChild>
 						<button
+							aria-label="More options"
 							onClick={(e) => e.stopPropagation()}
 							onMouseDown={(e) => e.stopPropagation()}
 							type="button"

--- a/components/shared/nodes/node-options-menu.tsx
+++ b/components/shared/nodes/node-options-menu.tsx
@@ -48,6 +48,8 @@ import { AttachElementDialog } from "./attach-element-dialog";
 import { MoveElementDialog } from "./move-element-dialog";
 import type { DiagramNodeType } from "./node-config";
 
+const MORE_OPTIONS_LABEL = "More options";
+
 interface NodeOptionsMenuProps {
 	/** The ReactFlow node object */
 	node: Node;
@@ -393,10 +395,10 @@ export default function NodeOptionsMenu({
 	return (
 		<>
 			<DropdownMenu>
-				<ActionTooltip label="More options">
+				<ActionTooltip label={MORE_OPTIONS_LABEL}>
 					<DropdownMenuTrigger asChild>
 						<button
-							aria-label="More options"
+							aria-label={MORE_OPTIONS_LABEL}
 							onClick={(e) => e.stopPropagation()}
 							onMouseDown={(e) => e.stopPropagation()}
 							type="button"

--- a/components/ui/action-tooltip.tsx
+++ b/components/ui/action-tooltip.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import {
 	Tooltip,
 	TooltipContent,
@@ -5,21 +6,29 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 
-const ActionTooltip = ({
-	children,
-	label,
-}: {
-	children: React.ReactNode;
-	label: string;
-}) => (
+/**
+ * Forwards ref and any extra props (e.g. from an outer `PopoverTrigger
+ * asChild`) through to the actual trigger element, so ActionTooltip can be
+ * composed inside another Radix `asChild` chain — see node-add-popover.tsx.
+ */
+const ActionTooltip = React.forwardRef<
+	HTMLButtonElement,
+	{
+		children: React.ReactNode;
+		label: string;
+	} & React.HTMLAttributes<HTMLButtonElement>
+>(({ children, label, ...rest }, ref) => (
 	<TooltipProvider>
 		<Tooltip>
-			<TooltipTrigger asChild>{children}</TooltipTrigger>
+			<TooltipTrigger asChild ref={ref} {...rest}>
+				{children}
+			</TooltipTrigger>
 			<TooltipContent>
 				<p>{label}</p>
 			</TooltipContent>
 		</Tooltip>
 	</TooltipProvider>
-);
+));
+ActionTooltip.displayName = "ActionTooltip";
 
 export default ActionTooltip;

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,11 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  // `aria-disabled:` mirrors `disabled:` so a button kept focusable via
+  // aria-disabled (see disabled-button-hint.tsx) still reads as inert.
+  // pointer-events-none also removes its hover state, which is fine here:
+  // the reason it's inert is announced via aria-describedby, not hover.
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/components/ui/disabled-button-hint.test.tsx
+++ b/components/ui/disabled-button-hint.test.tsx
@@ -1,0 +1,123 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import {
+	renderWithoutProviders,
+	screen,
+} from "@/src/__tests__/utils/test-utils";
+import { DisabledButtonHint } from "./disabled-button-hint";
+
+const CLICK_ME_REGEX = /click me/i;
+const REASON = "Only an ACTIVE integration can issue a token";
+
+describe("DisabledButtonHint", () => {
+	it("stays reachable by Tab when inert", async () => {
+		const user = userEvent.setup();
+		renderWithoutProviders(
+			<DisabledButtonHint disabled disabledReason={REASON}>
+				Click me
+			</DisabledButtonHint>
+		);
+
+		await user.tab();
+		expect(screen.getByRole("button", { name: CLICK_ME_REGEX })).toHaveFocus();
+	});
+
+	it("does not call the handler on a mouse click while inert", async () => {
+		const onClick = vi.fn();
+		const user = userEvent.setup();
+		renderWithoutProviders(
+			<DisabledButtonHint disabled onClick={onClick}>
+				Click me
+			</DisabledButtonHint>
+		);
+
+		await user.click(screen.getByRole("button", { name: CLICK_ME_REGEX }));
+		expect(onClick).not.toHaveBeenCalled();
+	});
+
+	it("does not call the handler on Enter while inert", async () => {
+		const onClick = vi.fn();
+		const user = userEvent.setup();
+		renderWithoutProviders(
+			<DisabledButtonHint disabled onClick={onClick}>
+				Click me
+			</DisabledButtonHint>
+		);
+
+		await user.tab();
+		await user.keyboard("{Enter}");
+		expect(onClick).not.toHaveBeenCalled();
+	});
+
+	it("does not call the handler on Space while inert", async () => {
+		const onClick = vi.fn();
+		const user = userEvent.setup();
+		renderWithoutProviders(
+			<DisabledButtonHint disabled onClick={onClick}>
+				Click me
+			</DisabledButtonHint>
+		);
+
+		await user.tab();
+		await user.keyboard(" ");
+		expect(onClick).not.toHaveBeenCalled();
+	});
+
+	it("calls the handler when enabled", async () => {
+		const onClick = vi.fn();
+		const user = userEvent.setup();
+		renderWithoutProviders(
+			<DisabledButtonHint onClick={onClick}>Click me</DisabledButtonHint>
+		);
+
+		await user.click(screen.getByRole("button", { name: CLICK_ME_REGEX }));
+		expect(onClick).toHaveBeenCalledOnce();
+	});
+
+	it("exposes the disabled reason as the button's accessible description", () => {
+		renderWithoutProviders(
+			<DisabledButtonHint disabled disabledReason={REASON}>
+				Click me
+			</DisabledButtonHint>
+		);
+
+		expect(
+			screen.getByRole("button", { name: CLICK_ME_REGEX })
+		).toHaveAccessibleDescription(REASON);
+	});
+
+	it("renders no hint span when disabled with no reason given", () => {
+		renderWithoutProviders(
+			<DisabledButtonHint disabled>Click me</DisabledButtonHint>
+		);
+
+		const button = screen.getByRole("button", { name: CLICK_ME_REGEX });
+		expect(button).not.toHaveAttribute("aria-describedby");
+		expect(button).toHaveAccessibleDescription("");
+	});
+
+	it("carries no aria-disabled attribute when enabled", () => {
+		renderWithoutProviders(
+			<DisabledButtonHint disabledReason={REASON}>
+				Click me
+			</DisabledButtonHint>
+		);
+
+		expect(
+			screen.getByRole("button", { name: CLICK_ME_REGEX })
+		).not.toHaveAttribute("aria-disabled");
+	});
+
+	it("carries the inert styling classes when disabled (button.tsx's aria-disabled: variant)", () => {
+		renderWithoutProviders(
+			<DisabledButtonHint disabled disabledReason={REASON}>
+				Click me
+			</DisabledButtonHint>
+		);
+
+		expect(screen.getByRole("button", { name: CLICK_ME_REGEX })).toHaveClass(
+			"aria-disabled:pointer-events-none",
+			"aria-disabled:opacity-50"
+		);
+	});
+});

--- a/components/ui/disabled-button-hint.tsx
+++ b/components/ui/disabled-button-hint.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { Button, type ButtonProps } from "@/components/ui/button";
+
+export interface DisabledButtonHintProps extends ButtonProps {
+	/**
+	 * Why the button is inert. Rendered as `sr-only` text linked via
+	 * `aria-describedby`, so screen-reader users get the reason a sighted
+	 * user would read from a `title` tooltip. Ignored when `disabled` is
+	 * false.
+	 */
+	disabledReason?: string;
+}
+
+/**
+ * A `Button` that stays focusable and keyboard-reachable when logically
+ * disabled, instead of using the native `disabled` attribute — which pulls
+ * the control out of the tab order and hides `title` from assistive tech.
+ * Uses `aria-disabled` plus a click guard so the button is still inert, and
+ * an `aria-describedby`-linked `sr-only` span so the reason is announced.
+ */
+export const DisabledButtonHint = React.forwardRef<
+	HTMLButtonElement,
+	DisabledButtonHintProps
+>(({ disabled, disabledReason, onClick, id, ...props }, ref) => {
+	const generatedId = React.useId();
+	const hintId = id ? `${id}-disabled-hint` : generatedId;
+	const showHint = !!(disabled && disabledReason);
+
+	return (
+		<>
+			<Button
+				aria-describedby={showHint ? hintId : undefined}
+				aria-disabled={disabled || undefined}
+				id={id}
+				onClick={(event) => {
+					if (disabled) {
+						event.preventDefault();
+						return;
+					}
+					onClick?.(event);
+				}}
+				ref={ref}
+				{...props}
+			/>
+			{showHint && (
+				<span className="sr-only" id={hintId}>
+					{disabledReason}
+				</span>
+			)}
+		</>
+	);
+});
+DisabledButtonHint.displayName = "DisabledButtonHint";

--- a/components/ui/disabled-button-hint.tsx
+++ b/components/ui/disabled-button-hint.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Button, type ButtonProps } from "@/components/ui/button";
 
-export interface DisabledButtonHintProps extends ButtonProps {
+interface DisabledButtonHintProps extends ButtonProps {
 	/**
 	 * Why the button is inert. Rendered as `sr-only` text linked via
 	 * `aria-describedby`, so screen-reader users get the reason a sighted

--- a/e2e/cases.spec.ts
+++ b/e2e/cases.spec.ts
@@ -1,8 +1,25 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "./helpers/auth";
 import { CASE_URL_PATTERN, STATUS_BUTTON_PATTERN } from "./helpers/constants";
 import { DashboardPage } from "./pages/dashboard-page";
 
 const ASSERTION_STATUS_COMBOBOX_PATTERN = /assertion status/i;
+
+// The G1 goal node's Edit button, scoped to that ReactFlow node. React Flow
+// gives every node's own wrapper `role="button"` (for keyboard selection)
+// with no aria-label of its own, so the browser folds every descendant's
+// accessible name — including "Edit element" — into that wrapper's computed
+// name. An unscoped `getByRole("button", { name: "Edit element" })` then
+// matches the wrapper too, since Playwright's name match is substring by
+// default; the wrapper sorts before the real button in DOM order, so
+// `.first()` picks the wrapper, and clicking it just selects the node
+// instead of opening the edit dialog. Scoping to the G1 node plus an exact
+// name avoids both that collision and any reliance on DOM order.
+function g1EditButton(page: Page) {
+	return page
+		.locator(".react-flow__node", { hasText: "G1" })
+		.getByRole("button", { name: "Edit element", exact: true });
+}
 
 test.describe("Case management", () => {
 	test("dashboard shows seeded cases", async ({ page }) => {
@@ -120,9 +137,7 @@ test.describe("Case management", () => {
 		await dashboard.caseCard("Simple Case").click();
 		await page.waitForURL(CASE_URL_PATTERN);
 
-		const editButton = page
-			.getByRole("button", { name: "Edit element" })
-			.first();
+		const editButton = g1EditButton(page);
 		await editButton.waitFor({ state: "visible" });
 		await editButton.click();
 
@@ -173,9 +188,7 @@ test.describe("Case management", () => {
 		await dashboard.caseCard("Simple Case").click();
 		await page.waitForURL(CASE_URL_PATTERN);
 
-		const editButton = page
-			.getByRole("button", { name: "Edit element" })
-			.first();
+		const editButton = g1EditButton(page);
 		await editButton.waitFor({ state: "visible" });
 		await editButton.click();
 
@@ -221,9 +234,7 @@ test.describe("Case management", () => {
 		await dashboard.caseCard("Simple Case").click();
 		await page.waitForURL(CASE_URL_PATTERN);
 
-		const editButton = page
-			.getByRole("button", { name: "Edit element" })
-			.first();
+		const editButton = g1EditButton(page);
 		await editButton.waitFor({ state: "visible" });
 		await editButton.click();
 

--- a/e2e/cases.spec.ts
+++ b/e2e/cases.spec.ts
@@ -120,7 +120,9 @@ test.describe("Case management", () => {
 		await dashboard.caseCard("Simple Case").click();
 		await page.waitForURL(CASE_URL_PATTERN);
 
-		const editButton = page.locator("button:has(svg.lucide-pencil)").first();
+		const editButton = page
+			.getByRole("button", { name: "Edit element" })
+			.first();
 		await editButton.waitFor({ state: "visible" });
 		await editButton.click();
 
@@ -171,7 +173,9 @@ test.describe("Case management", () => {
 		await dashboard.caseCard("Simple Case").click();
 		await page.waitForURL(CASE_URL_PATTERN);
 
-		const editButton = page.locator("button:has(svg.lucide-pencil)").first();
+		const editButton = page
+			.getByRole("button", { name: "Edit element" })
+			.first();
 		await editButton.waitFor({ state: "visible" });
 		await editButton.click();
 
@@ -217,7 +221,9 @@ test.describe("Case management", () => {
 		await dashboard.caseCard("Simple Case").click();
 		await page.waitForURL(CASE_URL_PATTERN);
 
-		const editButton = page.locator("button:has(svg.lucide-pencil)").first();
+		const editButton = page
+			.getByRole("button", { name: "Edit element" })
+			.first();
 		await editButton.waitFor({ state: "visible" });
 		await editButton.click();
 


### PR DESCRIPTION
Three accessibility fixes from the TEA 1.0 small batch.

## Changes

- **Node action buttons have accessible names** — every button in the node action group (Edit / View details, View comments with count, More options, Show/Hide children, Add child element) now carries an `aria-label` that shares its expression with the tooltip label, so the two cannot drift. The e2e spec selects the edit button by role and name instead of an icon class.
- **Disabled‑button reasons reach keyboard and screen‑reader users** — the three integration‑settings buttons that used `disabled` + `title` (Delete, Issue new token, Grant access to a case) now use a small `DisabledButtonHint` wrapper around the shadcn Button: `aria-disabled` keeps them in the tab order, a click/keyboard guard keeps them inert, and the reason is exposed as an `sr-only` description via `aria-describedby`. The Button primitive gains matching `aria-disabled:` styling so an inert button still looks inert. Reasons are conditioned on the single state they describe, so an in‑flight action does not announce a false reason.
- **NodeAddPopover restores focus** — the trigger now goes through `PopoverTrigger asChild` (was `PopoverAnchor`, which left Radix's focus restoration inert). `ActionTooltip` forwards its ref so the trigger can compose through it. The popover's own toggle now owns the open state; the callers no longer set it by hand.

## Review chain

- Code review (two rounds): round 1 found two regressions in the first cut — inert buttons rendered at full opacity, and a static reason could be announced during an in‑flight action; both fixed and covered by tests. Round 2: approve. `aria-disabled` styling confirmed to reach no other component. Fallow on the changed set: complexity 0 introduced; one type‑export flag matching the existing `ButtonProps` convention; the three near‑identical "Add child element" trigger blocks are reported as a clone (pre‑existing shape, not consolidated here).
- QA (two rounds): each fix reverted turns its own tests red. The click guard had no direct coverage in round 1 (a deleted guard passed the whole suite); it now has nine tests, three of which go red with the guard removed. Real Chromium: an inert button computes `opacity: 0.5`, `pointer-events: none`; the popover opens on click, closes on Escape and returns focus to the trigger for all three node types, and times out if the old anchor wiring is restored.
- Final hash: unit 107 files / 1430 passed; integration 72 files / 1100 passed; lint and typecheck clean.
