### PR TITLE
fix: small batch B2 — sharing-dialog select guard, visible screenshot-capture failures

### DIFF
--- a/components/cases/node-edit-dialog.tsx
+++ b/components/cases/node-edit-dialog.tsx
@@ -41,6 +41,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { useElementPanelSlot } from "@/hooks/use-element-panel-slot";
+import { useSelectDismissGuard } from "@/hooks/use-select-dismiss-guard";
 import {
 	ASSERTION_STATUS_LABELS,
 	AUTHOR_ASSERTION_STATUS_VALUES,
@@ -379,69 +380,6 @@ function UrlsSection({
 	);
 }
 
-// Radix's Select and Dialog each open a DismissableLayer with
-// disableOutsidePointerEvents: true. While the assertion-status Select is
-// open, Radix sets pointer-events: none on the Dialog's own content (the
-// lower-priority layer), so a click anywhere in the dialog body falls
-// through to the Dialog's own overlay — which the Dialog's own outside-click
-// detection then reads as a genuine outside click and closes on.
-//
-// The dismissing click is a single pointerdown event. Both DismissableLayers
-// (Select's and Dialog's) react to it through their own document-level
-// listeners registered in the bubbling phase: the Select's runs first and
-// calls its onOpenChange(false), then the Dialog's runs and fires
-// onPointerDownOutside/onInteractOutside. A document listener registered in
-// the capture phase always runs before any bubbling-phase listener for the
-// same event, so it can snapshot whether the Select was open at the start of
-// this specific pointerdown — before either DismissableLayer has reacted to
-// it — with no timer and no assumption about which bubble listener runs
-// first.
-function useAssertionSelectDismissGuard() {
-	const isOpenRef = useRef(false);
-	const selectOpenAtPointerDownRef = useRef(false);
-
-	const onSelectOpenChange = useCallback((nextOpen: boolean) => {
-		isOpenRef.current = nextOpen;
-	}, []);
-
-	useEffect(() => {
-		const handlePointerDownCapture = () => {
-			selectOpenAtPointerDownRef.current = isOpenRef.current;
-		};
-		document.addEventListener("pointerdown", handlePointerDownCapture, {
-			capture: true,
-		});
-		return () => {
-			document.removeEventListener("pointerdown", handlePointerDownCapture, {
-				capture: true,
-			});
-		};
-	}, []);
-
-	// Pointer dismissal: guard only on the per-event snapshot, so a click
-	// that lands after the Select has genuinely closed is never swallowed.
-	const shouldGuardPointerDismiss = useCallback(
-		() => selectOpenAtPointerDownRef.current,
-		[]
-	);
-
-	// Focus dismissal (e.g. Tab out of the Select) has no pointerdown to
-	// snapshot, so it falls back to the Select's live open state. In
-	// practice Radix already blocks focus-outside dismissal on a modal
-	// DialogContent, so this branch is not known to be exercised — it's
-	// kept for consistency with the pointer guard above.
-	const shouldGuardFocusDismiss = useCallback(
-		() => selectOpenAtPointerDownRef.current || isOpenRef.current,
-		[]
-	);
-
-	return {
-		onSelectOpenChange,
-		shouldGuardFocusDismiss,
-		shouldGuardPointerDismiss,
-	};
-}
-
 // --- Main component ---
 
 interface NodeEditDialogProps {
@@ -569,7 +507,7 @@ export default function NodeEditDialog({
 		onSelectOpenChange,
 		shouldGuardFocusDismiss,
 		shouldGuardPointerDismiss,
-	} = useAssertionSelectDismissGuard();
+	} = useSelectDismissGuard();
 
 	// Tracks whether the dialog was open on the previous render, so a
 	// closed→open transition (reopen) can be told apart from staying open

--- a/components/sharing/case-sharing-dialog.tsx
+++ b/components/sharing/case-sharing-dialog.tsx
@@ -31,6 +31,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useCaseSharingModal } from "@/hooks/use-case-sharing-modal";
+import { useSelectDismissGuard } from "@/hooks/use-select-dismiss-guard";
 import {
 	AvailableTeamsList,
 	TeamPermissionRow,
@@ -74,12 +75,34 @@ export function CaseSharingDialog() {
 		form,
 	});
 
+	// Guards against the Permission Level Select (below) closing this dialog
+	// when a click meant to dismiss the open Select falls through to the
+	// dialog's own overlay — see use-select-dismiss-guard.ts for the
+	// mechanism.
+	const {
+		onSelectOpenChange,
+		shouldGuardFocusDismiss,
+		shouldGuardPointerDismiss,
+	} = useSelectDismissGuard();
+
 	return (
 		<Dialog
 			onOpenChange={() => sharingModal.onClose()}
 			open={sharingModal.isOpen}
 		>
-			<DialogContent className="max-w-lg">
+			<DialogContent
+				className="max-w-lg"
+				onInteractOutside={(event) => {
+					if (shouldGuardFocusDismiss()) {
+						event.preventDefault();
+					}
+				}}
+				onPointerDownOutside={(event) => {
+					if (shouldGuardPointerDismiss()) {
+						event.preventDefault();
+					}
+				}}
+			>
 				<DialogHeader>
 					<DialogTitle>Share Case</DialogTitle>
 					<DialogDescription>
@@ -164,6 +187,7 @@ export function CaseSharingDialog() {
 													<FormLabel>Permission Level</FormLabel>
 													<Select
 														defaultValue={field.value}
+														onOpenChange={onSelectOpenChange}
 														onValueChange={field.onChange}
 													>
 														<FormControl>

--- a/e2e/cases.spec.ts
+++ b/e2e/cases.spec.ts
@@ -162,7 +162,7 @@ test.describe("Case management", () => {
 	}) => {
 		// Stability regression: rapid open/close cycling of the Select must
 		// not leave the dialog's outside-dismiss guard (see
-		// `useAssertionSelectDismissGuard` in node-edit-dialog.tsx) stuck
+		// `useSelectDismissGuard` in hooks/use-select-dismiss-guard.ts) stuck
 		// open, since that would make the dialog ignore every subsequent
 		// outside click.
 		const dashboard = new DashboardPage(page);

--- a/e2e/sharing.spec.ts
+++ b/e2e/sharing.spec.ts
@@ -7,6 +7,7 @@ test.use({ storageState: { cookies: [], origins: [] } });
 // Matches NodeEditDialog's Save button ("Update Goal", "Update Evidence",
 // etc.) — must be absent in read-only mode regardless of element type.
 const UPDATE_BUTTON_PATTERN = /^Update /i;
+const PERMISSION_LEVEL_PATTERN = /permission level/i;
 
 test.describe("Sharing and permissions", () => {
 	test("alice sees Medium Case on shared page", async ({
@@ -75,6 +76,88 @@ test.describe("Sharing and permissions", () => {
 		// Click share button
 		await page.getByTestId("toolbar-share").click();
 		await expect(page.getByText("Share Case")).toBeVisible();
+	});
+
+	test("dismissing the Permission Level dropdown by clicking the dialog body leaves the dialog open", async ({
+		page,
+		seedPassword,
+	}) => {
+		// Regression test mirroring cases.spec.ts's assertion-status dismiss
+		// test (PR #914): opening the sharing dialog's "Permission Level"
+		// Select and then clicking elsewhere in the dialog body (without
+		// picking an option) used to close the whole dialog too — jsdom can't
+		// reproduce this, because it relies on real pointer-events hit-testing
+		// falling through the dialog's own (now pointer-events: none) content
+		// to its overlay once a nested Radix Select is open.
+		await signIn(page, "chris", seedPassword);
+
+		await page.goto("/dashboard");
+		await page.getByText("Simple Case").click();
+		await page.waitForURL(CASE_URL_PATTERN);
+
+		await page.getByTestId("toolbar-share").click();
+
+		// A plain text locator, not `getByRole("dialog")`: while the Select
+		// below is open, Radix's `hideOthers` marks the whole dialog
+		// `aria-hidden="true"`, which would make any role-based query against
+		// the dialog time out for the rest of this test even though the
+		// dialog is still visibly on screen.
+		const dialogTitle = page.getByText("Share Case", { exact: true });
+		await expect(dialogTitle).toBeVisible();
+
+		const permissionTrigger = page.getByRole("combobox", {
+			name: PERMISSION_LEVEL_PATTERN,
+		});
+		await permissionTrigger.click();
+		await expect(page.getByRole("listbox")).toBeVisible();
+
+		// Click the dialog description — well clear of the open dropdown's
+		// own popper — without choosing an option. `force: true` because,
+		// pre-fix, Radix sets `pointer-events: none` on the dialog's own
+		// content while the Select is open — Playwright's default click
+		// would otherwise wait forever for a target that (correctly, per the
+		// bug) never becomes clickable; a real user's click still lands there
+		// and falls through to the dialog's own overlay underneath.
+		const dialogDescription = page.getByText(
+			"Share this case with individuals or teams",
+			{ exact: true }
+		);
+		await dialogDescription.click({ force: true });
+
+		await expect(page.getByRole("listbox")).not.toBeVisible();
+		await expect(dialogTitle).toBeVisible();
+	});
+
+	test("Escape-closing the Permission Level dropdown still lets the dialog dismiss normally", async ({
+		page,
+		seedPassword,
+	}) => {
+		// Complements the test above: the dismiss guard must only swallow the
+		// outside click that the open Select itself caused. Once the Select
+		// is closed (via Escape here), the dialog's own overlay-click and
+		// Escape dismissal must keep working.
+		await signIn(page, "chris", seedPassword);
+
+		await page.goto("/dashboard");
+		await page.getByText("Simple Case").click();
+		await page.waitForURL(CASE_URL_PATTERN);
+
+		await page.getByTestId("toolbar-share").click();
+		const dialogTitle = page.getByText("Share Case", { exact: true });
+		await expect(dialogTitle).toBeVisible();
+
+		const permissionTrigger = page.getByRole("combobox", {
+			name: PERMISSION_LEVEL_PATTERN,
+		});
+		await permissionTrigger.click();
+		await expect(page.getByRole("listbox")).toBeVisible();
+		await page.keyboard.press("Escape");
+		await expect(page.getByRole("listbox")).not.toBeVisible();
+
+		// No artificial pause: this click must be indistinguishable from a
+		// genuine outside click landing right after the Select's own close.
+		await page.mouse.click(5, 5);
+		await expect(dialogTitle).not.toBeVisible();
 	});
 
 	test("viewer can see shared case but cannot edit", async ({

--- a/hooks/__tests__/use-auto-screenshot.test.ts
+++ b/hooks/__tests__/use-auto-screenshot.test.ts
@@ -1,0 +1,94 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type LogEntry, resetLogSink, setLogSink } from "@/lib/logger";
+import { useAutoScreenshot } from "../use-auto-screenshot";
+
+vi.mock("html2canvas", () => ({
+	default: vi.fn(),
+}));
+
+import html2canvas from "html2canvas";
+
+const CASE_ID = "case-1";
+const TARGET_SELECTOR = "#screenshot-target";
+
+function capture(): LogEntry[] {
+	const entries: LogEntry[] = [];
+	setLogSink((entry) => {
+		entries.push(entry);
+	});
+	return entries;
+}
+
+describe("useAutoScreenshot — capture failure handling", () => {
+	let target: HTMLDivElement;
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		target = document.createElement("div");
+		target.id = "screenshot-target";
+		document.body.appendChild(target);
+		vi.stubEnv("LOG_LEVEL", "debug");
+		fetchSpy = vi.spyOn(global, "fetch");
+	});
+
+	afterEach(() => {
+		target.remove();
+		resetLogSink();
+		vi.unstubAllEnvs();
+		vi.mocked(html2canvas).mockReset();
+		fetchSpy.mockRestore();
+	});
+
+	it("logs an error carrying the caseId when html2canvas throws, and never uploads", async () => {
+		vi.mocked(html2canvas).mockRejectedValue(
+			new Error('Attempting to parse an unsupported color function "oklch"')
+		);
+		const entries = capture();
+
+		const { result } = renderHook(() =>
+			useAutoScreenshot({
+				caseId: CASE_ID,
+				canEdit: true,
+				selector: TARGET_SELECTOR,
+			})
+		);
+
+		await result.current.captureScreenshot();
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(entries).toContainEqual(
+			expect.objectContaining({
+				level: "error",
+				msg: "Screenshot capture failed",
+				caseId: CASE_ID,
+			})
+		);
+	});
+
+	it("skips the upload and logs a warning when html2canvas returns a degenerate capture", async () => {
+		vi.mocked(html2canvas).mockResolvedValue({
+			toDataURL: () => "",
+		} as unknown as HTMLCanvasElement);
+		const entries = capture();
+
+		const { result } = renderHook(() =>
+			useAutoScreenshot({
+				caseId: CASE_ID,
+				canEdit: true,
+				selector: TARGET_SELECTOR,
+			})
+		);
+
+		await result.current.captureScreenshot();
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(entries).toContainEqual(
+			expect.objectContaining({
+				level: "warn",
+				msg: "Skipped upload of a degenerate screenshot capture",
+				caseId: CASE_ID,
+			})
+		);
+	});
+});

--- a/hooks/use-auto-screenshot.ts
+++ b/hooks/use-auto-screenshot.ts
@@ -1,5 +1,21 @@
 import html2canvas from "html2canvas";
 import { useCallback, useEffect, useRef } from "react";
+import { logger } from "@/lib/logger";
+
+const log = logger.child({ component: "use-auto-screenshot" });
+
+/**
+ * `canvas.toDataURL()` never returns a literal empty string — even a 0x0
+ * canvas encodes to the placeholder `"data:,"` — so this is the guard
+ * against ever writing a degenerate result as an `<img src>`, not evidence
+ * that one has been observed in practice.
+ */
+function isUsableDataUrl(dataUrl: string): boolean {
+	return (
+		dataUrl.startsWith("data:image/") &&
+		dataUrl.length > "data:image/png;base64,".length
+	);
+}
 
 interface UseAutoScreenshotOptions {
 	/** Whether the user has edit permission */
@@ -48,13 +64,21 @@ export function useAutoScreenshot({
 			const canvas = await html2canvas(target as HTMLElement);
 			const base64Image = canvas.toDataURL("image/png");
 
+			if (!isUsableDataUrl(base64Image)) {
+				log.warn("Skipped upload of a degenerate screenshot capture", {
+					caseId,
+					dataUrlLength: base64Image.length,
+				});
+				return;
+			}
+
 			await fetch(`/api/cases/${caseId}/image`, {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ image: base64Image }),
 			});
-		} catch (_error) {
-			// Silently fail - screenshot capture is non-critical
+		} catch (error) {
+			log.error("Screenshot capture failed", { caseId, error });
 		} finally {
 			isCapturingRef.current = false;
 			hasChangedRef.current = false;
@@ -101,13 +125,27 @@ export function useAutoScreenshot({
 				// Use sendBeacon for reliable delivery during page unload
 				const target = document.querySelector(selector);
 				if (target) {
-					html2canvas(target as HTMLElement).then((canvas) => {
-						const base64Image = canvas.toDataURL("image/png");
-						navigator.sendBeacon(
-							`/api/cases/${caseId}/image`,
-							JSON.stringify({ image: base64Image })
-						);
-					});
+					html2canvas(target as HTMLElement)
+						.then((canvas) => {
+							const base64Image = canvas.toDataURL("image/png");
+							if (!isUsableDataUrl(base64Image)) {
+								log.warn(
+									"Skipped beacon upload of a degenerate screenshot capture",
+									{ caseId, dataUrlLength: base64Image.length }
+								);
+								return;
+							}
+							navigator.sendBeacon(
+								`/api/cases/${caseId}/image`,
+								JSON.stringify({ image: base64Image })
+							);
+						})
+						.catch((error) => {
+							log.error("Screenshot capture failed on unload", {
+								caseId,
+								error,
+							});
+						});
 				}
 			}
 		};

--- a/hooks/use-select-dismiss-guard.ts
+++ b/hooks/use-select-dismiss-guard.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef } from "react";
+
+// Radix's Select and Dialog each open a DismissableLayer with
+// disableOutsidePointerEvents: true. While a Select nested inside a Dialog
+// is open, Radix sets pointer-events: none on the Dialog's own content (the
+// lower-priority layer), so a click anywhere in the dialog body falls
+// through to the Dialog's own overlay — which the Dialog's own outside-click
+// detection then reads as a genuine outside click and closes on.
+//
+// The dismissing click is a single pointerdown event. Both DismissableLayers
+// (Select's and Dialog's) react to it through their own document-level
+// listeners registered in the bubbling phase: the Select's runs first and
+// calls its onOpenChange(false), then the Dialog's runs and fires
+// onPointerDownOutside/onInteractOutside. A document listener registered in
+// the capture phase always runs before any bubbling-phase listener for the
+// same event, so it can snapshot whether the Select was open at the start of
+// this specific pointerdown — before either DismissableLayer has reacted to
+// it — with no timer and no assumption about which bubble listener runs
+// first.
+//
+// Extracted from node-edit-dialog.tsx (originally
+// useAssertionSelectDismissGuard, PR #914) once a second Dialog+Select site
+// needed the same guard (case-sharing-dialog.tsx's Permission Level Select).
+export function useSelectDismissGuard() {
+	const isOpenRef = useRef(false);
+	const selectOpenAtPointerDownRef = useRef(false);
+
+	const onSelectOpenChange = useCallback((nextOpen: boolean) => {
+		isOpenRef.current = nextOpen;
+	}, []);
+
+	useEffect(() => {
+		const handlePointerDownCapture = () => {
+			selectOpenAtPointerDownRef.current = isOpenRef.current;
+		};
+		document.addEventListener("pointerdown", handlePointerDownCapture, {
+			capture: true,
+		});
+		return () => {
+			document.removeEventListener("pointerdown", handlePointerDownCapture, {
+				capture: true,
+			});
+		};
+	}, []);
+
+	// Pointer dismissal: guard only on the per-event snapshot, so a click
+	// that lands after the Select has genuinely closed is never swallowed.
+	const shouldGuardPointerDismiss = useCallback(
+		() => selectOpenAtPointerDownRef.current,
+		[]
+	);
+
+	// Focus dismissal (e.g. Tab out of the Select) has no pointerdown to
+	// snapshot, so it falls back to the Select's live open state. In
+	// practice Radix already blocks focus-outside dismissal on a modal
+	// DialogContent, so this branch is not known to be exercised — it's
+	// kept for consistency with the pointer guard above.
+	const shouldGuardFocusDismiss = useCallback(
+		() => selectOpenAtPointerDownRef.current || isOpenRef.current,
+		[]
+	);
+
+	return {
+		onSelectOpenChange,
+		shouldGuardFocusDismiss,
+		shouldGuardPointerDismiss,
+	};
+}


### PR DESCRIPTION
Two frontend fixes from the TEA 1.0 small batch, both reproduced in a real browser before fixing.

## Changes

- **Sharing dialog closes when the Permission Level dropdown is dismissed** — same Radix mechanism as the assertion‑status fix in #914: while a nested Select is open, the dialog content has `pointer-events: none`, so the click that closes the Select lands on the overlay and dismisses the dialog. The #914 guard (`useAssertionSelectDismissGuard`) is extracted unchanged into `hooks/use-select-dismiss-guard.ts` as `useSelectDismissGuard`; `node-edit-dialog.tsx` imports it, and `case-sharing-dialog.tsx` now uses it too. Two real‑browser e2e tests added.
- **Case screenshot capture fails silently** — `html2canvas` throws `Attempting to parse an unsupported color function "oklch"` on every capture under Tailwind v4, and the catch swallowed it, so no case thumbnail has been generated on this stack. This change does not fix capture; it makes the failure visible and safe: both capture paths (debounced, and the `beforeunload` beacon path, which had no error handling) log through the structured logger with the case id, and a degenerate result is never uploaded. The library replacement is tracked separately.

## Review chain

- Code review: approve. Extracted hook diffed against the removed function: identical apart from the name and a generalised doc comment; no dead imports left behind; the sharing dialog has no other Radix layer to interfere with. Fallow on the changed set: 0 dead code, 0 duplication, 0 complexity introduced.
- QA: sharing fix shown red with the dialog file reverted and green on the branch; adversarial runs on the production build (five open/Escape cycles then body click; pick option then immediate body click) 10/10 each; overlay click, Escape and Tab‑out with the Select closed still dismiss normally. Existing #914 tests and node‑edit‑dialog unit tests unchanged and green. Screenshot log line captured verbatim on the branch and confirmed absent on staging.
- Final hash: unit 107 files / 1420 passed; integration 72 files / 1100 passed; lint and typecheck clean.
