### PR TITLE
fix(ci): seed-staging sanity check looks for the renamed P1 claim

### DIFF
--- a/.github/workflows/seed-staging.yml
+++ b/.github/workflows/seed-staging.yml
@@ -64,4 +64,4 @@ jobs:
         run: npx tsx prisma/seed/dev-seed.ts | tee seed.log
 
       - name: Verify expected seed content ran
-        run: grep -q "claim C1 id=" seed.log || { echo "::error::seed log missing the demo-case line — wrong seed script/tree ran"; exit 1; }
+        run: grep -q "claim P1 id=" seed.log || { echo "::error::seed log missing the demo-case line — wrong seed script/tree ran"; exit 1; }


### PR DESCRIPTION
## What

One-line change to `.github/workflows/seed-staging.yml`: the "Verify expected seed content ran" step now greps the seed log for `claim P1 id=` instead of `claim C1 id=`.

## Why

The check was added in 49ec0fdc to catch a wrong-tree reseed (2026-07-05). Commit 121e385d (3 Sept) renamed the seeded property claims from C1–C4 to P1–P4, so the seed now prints `claim P1 id=`. Every seed-staging run since 4 Sept has reported failure at this step after a successful reseed (eight runs, e.g. 33890171524), which makes a real reseed failure indistinguishable from the noise.

## Verification

- The failing runs' seed step prints `claim P1 id=9bec0b72…` and `1 machine integration: darter-pipeline`, so the new pattern matches the current seed output.
- The check's purpose is unchanged: a seed from the wrong tree still fails it.
- After merge, the next Build on `staging` triggers seed-staging; expect green.