### PR TITLE
fix(ci): seed-staging sanity check looks for the renamed P1 claim (main)

### DIFF
--- a/.github/workflows/seed-staging.yml
+++ b/.github/workflows/seed-staging.yml
@@ -64,4 +64,4 @@ jobs:
         run: npx tsx prisma/seed/dev-seed.ts | tee seed.log
 
       - name: Verify expected seed content ran
-        run: grep -q "claim C1 id=" seed.log || { echo "::error::seed log missing the demo-case line — wrong seed script/tree ran"; exit 1; }
+        run: grep -q "claim P1 id=" seed.log || { echo "::error::seed log missing the demo-case line — wrong seed script/tree ran"; exit 1; }


### PR DESCRIPTION
## What

The same one-line change as #935 (merged to `staging` this morning), landed on `main` directly: the seed-staging "Verify expected seed content ran" step greps for `claim P1 id=` instead of `claim C1 id=`.

## Why a second PR

`seed-staging.yml` is triggered by `workflow_run`, and GitHub executes the **default branch's** copy of a `workflow_run` workflow regardless of which branch's Build triggered it. #935 fixed the file on `staging`, but this morning's automatic run (34100532184, after the Build for #935's merge) still ran `main`'s copy and failed at the check while the reseed itself completed. The fix has to be on `main` to cure the automatic path; #935 keeps the two branches consistent for the next promotion.

## Verification

- `git diff origin/main origin/staging -- .github/workflows/seed-staging.yml` differs only in this line, so the cherry-pick is exact.
- After merge, the next Build on `staging` triggers seed-staging with `main`'s corrected file; expect green.