### PR TITLE
chore(fallow): enable the coverage-gaps rule at warn

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -60,5 +60,8 @@
   "audit": {
     "deadCodeBaseline": ".fallow-baseline.dead-code.json",
     "dupesBaseline": ".fallow-baseline.dupes.json"
+  },
+  "rules": {
+    "coverage-gaps": "warn"
   }
 }


### PR DESCRIPTION
## What

Adds `"rules": { "coverage-gaps": "warn" }` to `.fallowrc.json`. The PR audit (Structural Quality job) will now report, for changed files only, any runtime file or export that no test can reach — without failing the build.

## Why

fallow 3.18 changed how complexity findings are attributed between base and head; a complexity regression on an untested function can now be labelled inherited and pass the gate. The maintainer's advice is to watch `coverage-gaps` alongside. Measured on staging 879e93bf with fallow 3.20.0: 210 untested files of 584 runtime files (64% file coverage) and 377 untested exports — components/docs 51, app/api 30, authenticated pages 26, components/cases 18. Too many to gate at `error` today; the right thing to surface per PR so new untested routes and exports are named on the PR that adds them.

## Follow-up

Revisit for `error` after 1.0, once the docs tree is rebuilt and the API-route gaps have a plan. Reviewers treat a coverage-gaps warning on a changed file as should-fix, not blocking.