### PR TITLE
fix(auth): build account-link redirects from NEXTAUTH_URL

### DIFF
--- a/app/api/auth/link/[provider]/__tests__/route.test.ts
+++ b/app/api/auth/link/[provider]/__tests__/route.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LINK_COOKIE_NAME } from "@/lib/auth/config";
+import type { ValidatedSession } from "@/lib/auth/validate-session";
+
+/**
+ * Route-level coverage for GET /api/auth/link/[provider].
+ *
+ * On Azure App Service, `request.url` reflects the container's internal
+ * hostname and port (see the linked bug), so both cases here build a
+ * request whose host is NOT the public one — the request host must never
+ * leak into the redirect. `next/headers`'s `cookies()` is mocked because it
+ * throws when called outside a real Next.js request context, matching
+ * api-auth-forgot-password-route.test.ts's mocking of `headers()` for the
+ * same reason.
+ */
+
+const { mockCookieStore } = vi.hoisted(() => ({
+	mockCookieStore: { set: vi.fn(), get: vi.fn(), delete: vi.fn() },
+}));
+
+vi.mock("next/headers", () => ({
+	cookies: vi.fn().mockResolvedValue(mockCookieStore),
+}));
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn(),
+}));
+
+import { GET } from "@/app/api/auth/link/[provider]/route";
+import { validateSession } from "@/lib/auth/validate-session";
+
+const PUBLIC_ORIGIN = "https://public.example";
+// The request's own host is the container's internal hostname, standing in
+// for what Azure App Service actually puts on `request.url`.
+const CONTAINER_REQUEST_URL = "http://container:3000/api/auth/link/google";
+
+const VALID_SESSION: ValidatedSession = {
+	userId: "user-1",
+	username: "chris",
+	email: "chris@example.com",
+};
+
+function linkRequest(url: string = CONTAINER_REQUEST_URL): Request {
+	return new Request(url);
+}
+
+function routeParams(provider: string) {
+	return { params: Promise.resolve({ provider }) };
+}
+
+describe("GET /api/auth/link/[provider]", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.stubEnv("NEXTAUTH_URL", PUBLIC_ORIGIN);
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("redirects to the public sign-in URL for a valid session and a supported provider", async () => {
+		vi.mocked(validateSession).mockResolvedValue(VALID_SESSION);
+
+		const response = await GET(linkRequest(), routeParams("google"));
+
+		const location = response.headers.get("location");
+		expect(location).not.toBeNull();
+		expect(location?.startsWith(PUBLIC_ORIGIN)).toBe(true);
+
+		const locationUrl = new URL(location as string);
+		expect(locationUrl.pathname).toBe("/api/auth/signin/google");
+		expect(locationUrl.searchParams.get("callbackUrl")).toBe(
+			"/dashboard/settings"
+		);
+		expect(mockCookieStore.set).toHaveBeenCalledWith(
+			LINK_COOKIE_NAME,
+			VALID_SESSION.userId,
+			expect.objectContaining({ httpOnly: true, maxAge: 300 })
+		);
+	});
+
+	it("redirects to the public login page when there is no session", async () => {
+		vi.mocked(validateSession).mockResolvedValue(null);
+
+		const response = await GET(linkRequest(), routeParams("google"));
+
+		expect(response.headers.get("location")).toBe(
+			`${PUBLIC_ORIGIN}/login?error=SessionRequired`
+		);
+		expect(mockCookieStore.set).not.toHaveBeenCalled();
+	});
+
+	it("returns 400 for an unsupported provider", async () => {
+		vi.mocked(validateSession).mockResolvedValue(VALID_SESSION);
+
+		const response = await GET(linkRequest(), routeParams("facebook"));
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toBe("Invalid provider: facebook");
+	});
+
+	it("throws rather than redirecting to the request host when NEXTAUTH_URL is unset", async () => {
+		vi.stubEnv("NEXTAUTH_URL", "");
+		vi.mocked(validateSession).mockResolvedValue(null);
+
+		await expect(GET(linkRequest(), routeParams("google"))).rejects.toThrow(
+			"NEXTAUTH_URL must be configured for authentication redirects"
+		);
+	});
+});

--- a/app/api/auth/link/[provider]/__tests__/route.test.ts
+++ b/app/api/auth/link/[provider]/__tests__/route.test.ts
@@ -33,6 +33,9 @@ const PUBLIC_ORIGIN = "https://public.example";
 // The request's own host is the container's internal hostname, standing in
 // for what Azure App Service actually puts on `request.url`.
 const CONTAINER_REQUEST_URL = "http://container:3000/api/auth/link/google";
+// Matches a `/` immediately followed by one or more further `/`s, as long as
+// the character before it isn't `:` (so `https://` itself doesn't match).
+const DOUBLED_SLASH_REGEX = /([^:]\/)\/+/;
 
 const VALID_SESSION: ValidatedSession = {
 	userId: "user-1",
@@ -106,6 +109,83 @@ describe("GET /api/auth/link/[provider]", () => {
 
 		await expect(GET(linkRequest(), routeParams("google"))).rejects.toThrow(
 			"NEXTAUTH_URL must be configured for authentication redirects"
+		);
+	});
+
+	it("redirects to the public origin for github, and lower-cases a mixed-case provider in the path", async () => {
+		vi.mocked(validateSession).mockResolvedValue(VALID_SESSION);
+
+		const githubResponse = await GET(linkRequest(), routeParams("github"));
+		const githubLocation = githubResponse.headers.get("location");
+		expect(githubLocation).toBe(
+			`${PUBLIC_ORIGIN}/api/auth/signin/github?callbackUrl=%2Fdashboard%2Fsettings`
+		);
+		expect(new URL(githubLocation as string).host).not.toBe("container:3000");
+
+		const mixedCaseResponse = await GET(linkRequest(), routeParams("Google"));
+		const mixedCaseLocation = mixedCaseResponse.headers.get("location");
+		expect(mixedCaseLocation).toBe(
+			`${PUBLIC_ORIGIN}/api/auth/signin/google?callbackUrl=%2Fdashboard%2Fsettings`
+		);
+	});
+
+	it("does not set the link cookie when the provider is invalid", async () => {
+		vi.mocked(validateSession).mockResolvedValue(VALID_SESSION);
+
+		const response = await GET(linkRequest(), routeParams("facebook"));
+
+		expect(response.status).toBe(400);
+		expect(mockCookieStore.set).not.toHaveBeenCalled();
+	});
+
+	it("sets the link cookie with the full expected shape before redirecting", async () => {
+		vi.mocked(validateSession).mockResolvedValue(VALID_SESSION);
+
+		const response = await GET(linkRequest(), routeParams("google"));
+
+		expect(mockCookieStore.set).toHaveBeenCalledWith(
+			LINK_COOKIE_NAME,
+			VALID_SESSION.userId,
+			expect.objectContaining({
+				httpOnly: true,
+				sameSite: "lax",
+				maxAge: 300,
+				path: "/",
+			})
+		);
+		// Ordering: the mock records the call synchronously before GET returns,
+		// and the redirect Location is already the final signIn URL, so the
+		// cookie call happened strictly before the redirect was constructed.
+		expect(response.headers.get("location")).toContain(
+			"/api/auth/signin/google"
+		);
+	});
+
+	it("throws on the valid-session branch too, after the cookie is already set", async () => {
+		// publicBaseUrl() is only evaluated when building signInUrl, which is
+		// AFTER the link cookie is already set — so this branch throws having
+		// already set the cookie, unlike the no-session case above, which
+		// throws before the cookie code is ever reached.
+		vi.stubEnv("NEXTAUTH_URL", "");
+		vi.mocked(validateSession).mockResolvedValue(VALID_SESSION);
+
+		await expect(GET(linkRequest(), routeParams("google"))).rejects.toThrow(
+			"NEXTAUTH_URL must be configured for authentication redirects"
+		);
+		expect(mockCookieStore.set).toHaveBeenCalledTimes(1);
+	});
+
+	it("produces a well-formed single-slash URL when NEXTAUTH_URL has a trailing slash", async () => {
+		vi.stubEnv("NEXTAUTH_URL", `${PUBLIC_ORIGIN}/`);
+		vi.mocked(validateSession).mockResolvedValue(VALID_SESSION);
+
+		const response = await GET(linkRequest(), routeParams("google"));
+		const location = response.headers.get("location") as string;
+
+		expect(location).not.toBeNull();
+		expect(location).not.toMatch(DOUBLED_SLASH_REGEX);
+		expect(location).toBe(
+			`${PUBLIC_ORIGIN}/api/auth/signin/google?callbackUrl=%2Fdashboard%2Fsettings`
 		);
 	});
 });

--- a/app/api/auth/link/[provider]/route.ts
+++ b/app/api/auth/link/[provider]/route.ts
@@ -10,6 +10,25 @@ interface RouteParams {
 }
 
 /**
+ * Returns the app's public origin for building redirects.
+ *
+ * On Azure App Service, `request.url` reflects the container's internal
+ * hostname and port, not the public hostname. NEXTAUTH_URL is the app's
+ * established source of truth for its public origin (see the `redirect`
+ * callback in lib/auth/config.ts, email-service.ts, and the case-permissions
+ * invite route) — this joins that convention rather than trusting the request.
+ */
+function publicBaseUrl(): string {
+	const baseUrl = process.env.NEXTAUTH_URL;
+	if (!baseUrl) {
+		throw new Error(
+			"NEXTAUTH_URL must be configured for authentication redirects"
+		);
+	}
+	return baseUrl;
+}
+
+/**
  * GET /api/auth/link/[provider]
  *
  * Initiates the OAuth linking flow for an existing authenticated user.
@@ -17,14 +36,14 @@ interface RouteParams {
  * NextAuth OAuth endpoint. The signIn callback in auth-options.ts will
  * check for this cookie and merge the OAuth credentials into the existing account.
  */
-export async function GET(request: Request, { params }: RouteParams) {
+export async function GET(_request: Request, { params }: RouteParams) {
 	const { provider } = await params;
 
 	// Validate that user is signed in
 	const validated = await validateSession();
 	if (!validated) {
 		return NextResponse.redirect(
-			new URL("/login?error=SessionRequired", request.url)
+			new URL("/login?error=SessionRequired", publicBaseUrl())
 		);
 	}
 
@@ -52,7 +71,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 	const callbackUrl = "/dashboard/settings";
 	const signInUrl = new URL(
 		`/api/auth/signin/${provider.toLowerCase()}`,
-		request.url
+		publicBaseUrl()
 	);
 	signInUrl.searchParams.set("callbackUrl", callbackUrl);
 


### PR DESCRIPTION
## What

`app/api/auth/link/[provider]/route.ts` built both of its redirects with `new URL(path, request.url)`. On Azure App Service, a Route Handler's `request.url` carries the container's own hostname and internal port (Next's standalone server builds it from its bind host and port, ignoring the incoming `Host` header), so "Link Google" in Settings sent users to `https://<container-id>:3000/api/auth/signin/google` — unreachable. GitHub linking failed the same way. Found live on staging 2026-09-07.

Both redirects now come from `NEXTAUTH_URL` via a small module-level helper that throws the same error as the `redirect` callback in `lib/auth/config.ts` when it is unset. Order of operations is unchanged (session check → provider check → link cookie → redirect). New unit test file, 9 tests.

## Review chain

- QA (nanaki): PASS — behaviours proven incl. github/mixed-case provider, no cookie on invalid provider, full cookie shape, throw-after-cookie on unset env, trailing-slash normalisation; five probes folded into the permanent file.
- Code review (vincent): APPROVE — no open-redirect surface (constant callbackUrl, allow-listed provider); throw-on-unset is not a new failure surface (same secret already gates the redirect callback). Nits noted, no action: four `NEXTAUTH_URL` call sites with three behaviours — a shared helper when the next one is touched.
- Reviewed commit b15d188a; final 57f68d50 adds tests only (`route.ts` byte-identical).
- Full unit project 1466/1466, lint and typecheck clean at 57f68d50.
- Local fallow audit could not parse the local coverage map (tooling issue filed); the Structural Quality job here is the authoritative run.

Middleware's two `req.url` redirects are unaffected: middleware never runs on `/api/auth/*`, and Next builds its URL from the `Host` header.