### PR TITLE
feat(retention): inactive-account deletion with two warnings, and the keep-or-trash rule for a deleted user's cases

### DIFF
--- a/.github/workflows/retention-sweep.yml
+++ b/.github/workflows/retention-sweep.yml
@@ -1,0 +1,28 @@
+name: Data retention sweep
+
+on:
+  schedule:
+    # Run daily at 3:17 AM UTC (off-minute from the other cron jobs)
+    - cron: "17 3 * * *"
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call retention-sweep endpoint
+        run: |
+          response=$(curl -s -w "\n%{http_code}" -X POST "${{ secrets.APP_URL }}/api/cron/retention-sweep" \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            -H "Content-Type: application/json")
+
+          http_code=$(echo "$response" | tail -n1)
+          body=$(echo "$response" | sed '$d')
+
+          echo "Response: $body"
+          echo "HTTP Status: $http_code"
+
+          if [ "$http_code" -ne 200 ]; then
+            echo "::error::Retention sweep failed with status $http_code"
+            exit 1
+          fi

--- a/.github/workflows/retention-sweep.yml
+++ b/.github/workflows/retention-sweep.yml
@@ -2,17 +2,30 @@ name: Data retention sweep
 
 on:
   schedule:
-    # Run daily at 3:17 AM UTC (off-minute from the other cron jobs)
+    # Run daily at 3:17 AM UTC (off-minute from the other cron jobs). Always
+    # a real run — dry_run only applies to a manual workflow_dispatch.
     - cron: "17 3 * * *"
-  workflow_dispatch: # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview counts only — send no emails, write no state, delete nobody"
+        type: boolean
+        default: true
 
 jobs:
   sweep:
     runs-on: ubuntu-latest
     steps:
       - name: Call retention-sweep endpoint
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}
         run: |
-          response=$(curl -s -w "\n%{http_code}" -X POST "${{ secrets.APP_URL }}/api/cron/retention-sweep" \
+          url="${{ secrets.APP_URL }}/api/cron/retention-sweep"
+          if [ "$DRY_RUN" = "true" ]; then
+            url="${url}?dryRun=1"
+          fi
+
+          response=$(curl -s -w "\n%{http_code}" -X POST "$url" \
             -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
             -H "Content-Type: application/json")
 

--- a/app/(authenticated)/dashboard/settings/_components/delete-form.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/delete-form.tsx
@@ -79,8 +79,10 @@ export const DeleteForm = ({ user }: DeleteFormProps) => {
 				</h2>
 				<p className="mt-1 text-muted-foreground text-sm leading-6">
 					No longer want to use our service? You can delete your account here.
-					This action is not reversible. All information related to this account
-					will be deleted permanently.
+					This cannot be undone. Your profile and login details will be deleted.
+					Cases you created are kept only where another person or team has Admin
+					access; otherwise they are deleted and collaborators lose access. Your
+					name is removed from your comments.
 				</p>
 			</div>
 

--- a/app/api/cron/retention-sweep/route.ts
+++ b/app/api/cron/retention-sweep/route.ts
@@ -1,0 +1,46 @@
+import { apiError, apiErrorFromUnknown, apiSuccess } from "@/lib/api-response";
+import { AppError } from "@/lib/errors";
+import { runRetentionSweep } from "@/lib/services/retention-service";
+
+/**
+ * Inactive-account data-retention sweep (cron job)
+ *
+ * @description Warns, then deletes, accounts inactive for two years since
+ * last login: a warning email 30 days before deletion, a final reminder 7
+ * days before, then deletion via the same path as self-service account
+ * deletion. Protected by CRON_SECRET environment variable.
+ *
+ * @header Authorization - Bearer token matching CRON_SECRET env var
+ * @query dryRun - Set to "1" to compute counts without sending emails, writing warning timestamps, or deleting anyone
+ * @response 200 - { success: true, dryRun: boolean, warned30: number, warned7: number, deleted: number, skipped: number }
+ * @response 401 - Unauthorised (invalid or missing token)
+ * @response 500 - Server error
+ * @tag Cron
+ */
+export async function POST(request: Request) {
+	try {
+		const authHeader = request.headers.get("authorization");
+		const token = authHeader?.replace("Bearer ", "") ?? null;
+		const { searchParams } = new URL(request.url);
+		const dryRun = searchParams.get("dryRun") === "1";
+
+		const result = await runRetentionSweep(token, { dryRun });
+
+		if ("error" in result) {
+			return apiError(
+				new AppError({
+					code: result.error === "Unauthorised" ? "UNAUTHORISED" : "INTERNAL",
+					message: result.error,
+				})
+			);
+		}
+
+		return apiSuccess({
+			success: true,
+			dryRun,
+			...result.data,
+		});
+	} catch (error) {
+		return apiErrorFromUnknown(error);
+	}
+}

--- a/docs/database/schema.dbml
+++ b/docs/database/schema.dbml
@@ -36,6 +36,8 @@ Table users {
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime [not null]
   lastLoginAt DateTime [note: 'Most recent login timestamp for audit purposes']
+  retentionWarning30SentAt DateTime [note: 'When the 30-day inactive-account deletion warning was sent']
+  retentionWarning7SentAt DateTime [note: 'When the 7-day final deletion reminder was sent']
   teamMemberships team_members [not null]
   createdTeams teams [not null]
   createdCases assurance_cases [not null]

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -3,6 +3,7 @@ import type { NextAuthOptions } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import GithubProvider from "next-auth/providers/github";
 import GoogleProvider from "next-auth/providers/google";
+import { logger } from "@/lib/logger";
 
 dotenv.config(); // Explicitly load environment variables
 
@@ -103,10 +104,22 @@ export async function authenticateWithPrisma(
 			}
 		: {};
 
-	await prisma.user.update({
-		where: { id: user.id },
-		data: { ...loginResetFields(), ...upgradeFields },
-	});
+	// Best-effort (vincent, review round 1): this write did not exist at all
+	// before the retention feature, so a valid login must not start failing
+	// because of it. A failure here means lastLoginAt/the retention-warning
+	// reset (and an opportunistic password-hash upgrade, if any) are missed
+	// for this login — logged, not thrown.
+	try {
+		await prisma.user.update({
+			where: { id: user.id },
+			data: { ...loginResetFields(), ...upgradeFields },
+		});
+	} catch (error) {
+		logger.error("Failed to record login / reset retention warnings", {
+			userId: user.id,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
 
 	return {
 		id: user.id,
@@ -263,7 +276,7 @@ async function linkGoogleToUser(
  * @param expiresAt - Token expiry timestamp
  * @param linkToUserId - If provided, links Google to this existing user instead of creating/finding by email
  */
-async function authenticateGoogleWithPrisma(
+export async function authenticateGoogleWithPrisma(
 	profile: {
 		sub?: string;
 		email?: string | null;

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -14,6 +14,25 @@ dotenv.config(); // Explicitly load environment variables
 export const LINK_COOKIE_NAME = "tea_link_user_id";
 
 /**
+ * Fields written on every successful login, regardless of provider.
+ * Resetting the two retention-warning timestamps here (not just recording
+ * `lastLoginAt`) is what makes "logging in resets the clock" true — a user
+ * who returns after a warning starts a fresh two-year cycle instead of
+ * being deleted on a clock that kept running while they were away.
+ */
+function loginResetFields(): {
+	lastLoginAt: Date;
+	retentionWarning30SentAt: null;
+	retentionWarning7SentAt: null;
+} {
+	return {
+		lastLoginAt: new Date(),
+		retentionWarning30SentAt: null,
+		retentionWarning7SentAt: null,
+	};
+}
+
+/**
  * Builds the token data object for Google OAuth updates.
  * Extracted to reduce cognitive complexity in the main function.
  */
@@ -33,7 +52,7 @@ function buildGoogleTokenData(
  * Authenticates a user using Prisma.
  * Verifies password against stored hash and upgrades to argon2id if needed.
  */
-async function authenticateWithPrisma(
+export async function authenticateWithPrisma(
 	username: string,
 	password: string
 ): Promise<{
@@ -75,17 +94,19 @@ async function authenticateWithPrisma(
 		return null;
 	}
 
-	// Upgrade password hash to argon2id if using legacy algorithm
-	if (needsUpgrade) {
-		const newHash = await hashPassword(password);
-		await prisma.user.update({
-			where: { id: user.id },
-			data: {
-				passwordHash: newHash,
+	// Upgrade password hash to argon2id if using legacy algorithm, and
+	// record the login (resets the retention-warning clock) either way.
+	const upgradeFields = needsUpgrade
+		? {
+				passwordHash: await hashPassword(password),
 				passwordAlgorithm: "argon2id",
-			},
-		});
-	}
+			}
+		: {};
+
+	await prisma.user.update({
+		where: { id: user.id },
+		data: { ...loginResetFields(), ...upgradeFields },
+	});
 
 	return {
 		id: user.id,
@@ -149,6 +170,7 @@ async function authenticateGitHubWithPrisma(
 				// Don't change authProvider when linking - user keeps their original provider
 				...(accessToken && { githubAccessToken: accessToken }),
 				...(tokenExpiresAt && { githubTokenExpiresAt: tokenExpiresAt }),
+				...loginResetFields(),
 			},
 		});
 
@@ -174,6 +196,7 @@ async function authenticateGitHubWithPrisma(
 				// Store access token for GitHub API calls (e.g., importing cases from repos)
 				...(accessToken && { githubAccessToken: accessToken }),
 				...(tokenExpiresAt && { githubTokenExpiresAt: tokenExpiresAt }),
+				...loginResetFields(),
 			},
 		});
 	} else {
@@ -223,6 +246,7 @@ async function linkGoogleToUser(
 			googleId,
 			googleEmail: email,
 			...tokenData,
+			...loginResetFields(),
 		},
 	});
 
@@ -280,7 +304,12 @@ async function authenticateGoogleWithPrisma(
 	if (existingUser) {
 		await prisma.user.update({
 			where: { id: existingUser.id },
-			data: { googleId, googleEmail: email, ...tokenData },
+			data: {
+				googleId,
+				googleEmail: email,
+				...tokenData,
+				...loginResetFields(),
+			},
 		});
 		return { id: existingUser.id };
 	}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -21,3 +21,28 @@ export function calculateDaysRemaining(deletedAt: Date): number {
 	);
 	return Math.max(0, TRASH_RETENTION_DAYS - daysSinceDeleted);
 }
+
+// ============================================
+// ACCOUNT RETENTION (inactive-account deletion)
+// ============================================
+
+/** Years of inactivity since last login (or account creation, if never logged in) before an account becomes eligible for deletion. */
+export const RETENTION_INACTIVITY_YEARS = 2;
+
+/** Days before the computed deletion date that the first warning email is sent. */
+export const RETENTION_WARNING_30_DAYS_BEFORE = 30;
+
+/** Days before the computed deletion date that the final reminder email is sent. */
+export const RETENTION_WARNING_7_DAYS_BEFORE = 7;
+
+/**
+ * Minimum days that must have elapsed since the 30-day warning was sent
+ * before the 7-day reminder can be sent. Combined with
+ * `RETENTION_DELETE_MIN_GAP_DAYS`, this guarantees every account gets its
+ * full 30 days of notice even if it is already years overdue the first
+ * time the sweep runs — the first run can only warn, never delete.
+ */
+export const RETENTION_WARNING_7_MIN_GAP_DAYS = 23;
+
+/** Minimum days that must have elapsed since the 7-day reminder was sent before deletion proceeds. */
+export const RETENTION_DELETE_MIN_GAP_DAYS = 7;

--- a/lib/services/case-trash-service.ts
+++ b/lib/services/case-trash-service.ts
@@ -1,6 +1,6 @@
-import { timingSafeCompare } from "@/lib/auth/timing-safe";
 import { calculateDaysRemaining, TRASH_RETENTION_DAYS } from "@/lib/constants";
 import { prisma } from "@/lib/prisma";
+import { requireCronSecret } from "@/lib/services/cron-auth";
 import type { ServiceResult } from "@/types/service";
 
 // ============================================
@@ -227,15 +227,9 @@ export async function purgeCase(userId: string, caseId: string): ServiceResult {
 export async function purgeExpiredCases(
 	authToken: string | null
 ): ServiceResult<PurgeResult> {
-	const cronSecret = process.env.CRON_SECRET;
-
-	if (!cronSecret) {
-		console.error("CRON_SECRET environment variable not set");
-		return { error: "Server configuration error" };
-	}
-
-	if (!(authToken && timingSafeCompare(authToken, cronSecret))) {
-		return { error: "Unauthorised" };
+	const auth = requireCronSecret(authToken);
+	if (!auth.authorised) {
+		return { error: auth.error };
 	}
 
 	try {

--- a/lib/services/cron-auth.ts
+++ b/lib/services/cron-auth.ts
@@ -1,0 +1,32 @@
+import { timingSafeCompare } from "@/lib/auth/timing-safe";
+import { logger } from "@/lib/logger";
+
+export type CronAuthResult =
+	| { authorised: true }
+	| { authorised: false; error: string };
+
+/**
+ * Shared CRON_SECRET guard for every cron-triggered service
+ * (`purgeExpiredCases`, `sweepHealthStaleness`, `runRetentionSweep`). Fails
+ * closed if `CRON_SECRET` isn't configured, and compares with
+ * `timingSafeCompare` so response timing can't be used to guess the secret.
+ *
+ * Extracted from three near-identical copies (vincent, review round 1) —
+ * behaviour is unchanged from each call site's inline version, including
+ * the exact error strings ("Server configuration error" / "Unauthorised")
+ * existing tests assert on.
+ */
+export function requireCronSecret(token: string | null): CronAuthResult {
+	const cronSecret = process.env.CRON_SECRET;
+
+	if (!cronSecret) {
+		logger.error("CRON_SECRET environment variable not set");
+		return { authorised: false, error: "Server configuration error" };
+	}
+
+	if (!(token && timingSafeCompare(token, cronSecret))) {
+		return { authorised: false, error: "Unauthorised" };
+	}
+
+	return { authorised: true };
+}

--- a/lib/services/email-service.ts
+++ b/lib/services/email-service.ts
@@ -344,7 +344,7 @@ function formatRetentionDate(date: Date): string {
 
 /**
  * Send the 30-day inactive-account deletion warning.
- * Draft copy — Chris to approve the final wording (TEA data-retention issue).
+ * Copy approved by Chris, 2026-09-07 (verbatim; only the HTML wrapper is ours).
  */
 export async function sendRetentionWarningEmail(
 	params: RetentionWarningEmailParams
@@ -353,7 +353,7 @@ export async function sendRetentionWarningEmail(
 	const loginUrl = `${APP_URL}/login`;
 	const formattedDate = formatRetentionDate(deletionDate);
 
-	const subject = `Your ${APP_NAME} account will be deleted on ${formattedDate}`;
+	const subject = `Your ${APP_NAME} account is scheduled for deletion`;
 
 	const htmlContent = `
 <!DOCTYPE html>
@@ -373,19 +373,21 @@ export async function sendRetentionWarningEmail(
 
     <p>Hello ${username},</p>
 
-    <p>We have not seen you log in to ${APP_NAME} for two years, so under our data retention policy your account is scheduled for deletion on <strong>${formattedDate}</strong>.</p>
+    <p>You have not logged in to the ${APP_NAME} for two years. Under our data retention policy, your account is scheduled for deletion on ${formattedDate}.</p>
 
-    <p>To keep your account, simply log in before that date:</p>
+    <p>To keep your account, log in before that date: <a href="${loginUrl}">${loginUrl}</a>. Logging in cancels the deletion.</p>
 
-    <div style="text-align: center; margin: 30px 0;">
-      <a href="${loginUrl}" style="background: #1a1f2e; color: white; padding: 14px 28px; text-decoration: none; border-radius: 6px; font-weight: 600; display: inline-block;">
-        Log in to keep your account
-      </a>
-    </div>
+    <p>If you do nothing, this is what happens on ${formattedDate}:</p>
 
-    <p>If you would rather keep a copy of your work, log in and export your cases before the deletion date. Deletion removes your profile and login details permanently; any cases you created are transferred to a system account so shared work is not lost, and your name is removed from your comments.</p>
+    <ul>
+      <li>Your profile and login details are deleted permanently.</li>
+      <li>Each case you created is handled in one of two ways. If another person has Admin access to the case, the case is kept and they become responsible for it. If nobody else has Admin access, the case is deleted, and anyone you shared it with loses access.</li>
+      <li>Your name is removed from any comments you left on cases that are kept.</li>
+    </ul>
 
-    <p style="color: #666; font-size: 14px;">You will get one more reminder 7 days before deletion. If you do nothing, your account and data will be permanently deleted on ${formattedDate}.</p>
+    <p>If you want a copy of your work, log in and export your cases before ${formattedDate}.</p>
+
+    <p>You will receive one final reminder seven days before the deletion date.</p>
   </div>
 
   <div style="text-align: center; padding: 20px; color: #999; font-size: 12px;">
@@ -396,18 +398,21 @@ export async function sendRetentionWarningEmail(
 `;
 
 	const plainTextContent = `
-Your account is scheduled for deletion
-
 Hello ${username},
 
-We have not seen you log in to ${APP_NAME} for two years, so under our data retention policy your account is scheduled for deletion on ${formattedDate}.
+You have not logged in to the ${APP_NAME} for two years. Under our data retention policy, your account is scheduled for deletion on ${formattedDate}.
 
-To keep your account, simply log in before that date:
-${loginUrl}
+To keep your account, log in before that date: ${loginUrl}. Logging in cancels the deletion.
 
-If you would rather keep a copy of your work, log in and export your cases before the deletion date. Deletion removes your profile and login details permanently; any cases you created are transferred to a system account so shared work is not lost, and your name is removed from your comments.
+If you do nothing, this is what happens on ${formattedDate}:
 
-You will get one more reminder 7 days before deletion. If you do nothing, your account and data will be permanently deleted on ${formattedDate}.
+- Your profile and login details are deleted permanently.
+- Each case you created is handled in one of two ways. If another person has Admin access to the case, the case is kept and they become responsible for it. If nobody else has Admin access, the case is deleted, and anyone you shared it with loses access.
+- Your name is removed from any comments you left on cases that are kept.
+
+If you want a copy of your work, log in and export your cases before ${formattedDate}.
+
+You will receive one final reminder seven days before the deletion date.
 
 ---
 ${APP_NAME}
@@ -418,7 +423,7 @@ ${APP_NAME}
 
 /**
  * Send the final 7-day inactive-account deletion reminder.
- * Draft copy — Chris to approve the final wording (TEA data-retention issue).
+ * Copy approved by Chris, 2026-09-07 (verbatim; only the HTML wrapper is ours).
  */
 export async function sendRetentionFinalReminderEmail(
 	params: RetentionWarningEmailParams
@@ -427,7 +432,7 @@ export async function sendRetentionFinalReminderEmail(
 	const loginUrl = `${APP_URL}/login`;
 	const formattedDate = formatRetentionDate(deletionDate);
 
-	const subject = `Final reminder: your ${APP_NAME} account will be deleted on ${formattedDate}`;
+	const subject = `Final reminder: your ${APP_NAME} account will be deleted in 7 days`;
 
 	const htmlContent = `
 <!DOCTYPE html>
@@ -443,21 +448,17 @@ export async function sendRetentionFinalReminderEmail(
   </div>
 
   <div style="background: #ffffff; padding: 30px; border: 1px solid #e1e1e1; border-top: none; border-radius: 0 0 10px 10px;">
-    <h2 style="color: #1a1f2e; margin-top: 0;">This is your final reminder</h2>
+    <h2 style="color: #1a1f2e; margin-top: 0;">Final reminder</h2>
 
     <p>Hello ${username},</p>
 
-    <p>This is a follow-up to our earlier warning: your ${APP_NAME} account has still not been used, and it will be permanently deleted in <strong>7 days</strong>, on <strong>${formattedDate}</strong>.</p>
+    <p>This is a follow-up to our earlier warning. Your ${APP_NAME} account has still not been used, and it will be permanently deleted on ${formattedDate}, seven days from now.</p>
 
-    <p>To keep your account, log in before that date:</p>
+    <p>To keep your account, log in before that date: <a href="${loginUrl}">${loginUrl}</a>. Logging in cancels the deletion.</p>
 
-    <div style="text-align: center; margin: 30px 0;">
-      <a href="${loginUrl}" style="background: #1a1f2e; color: white; padding: 14px 28px; text-decoration: none; border-radius: 6px; font-weight: 600; display: inline-block;">
-        Log in to keep your account
-      </a>
-    </div>
+    <p>If you do nothing, your profile and login details will be deleted and cannot be recovered. Cases you created will be kept only where another person has Admin access to them; otherwise they will be deleted and anyone you shared them with will lose access. Your name will be removed from any comments on cases that are kept.</p>
 
-    <p>If you want to keep a copy of your work, log in and export your cases now — after ${formattedDate} your profile and login details will be permanently deleted and cannot be recovered. Any cases you created will be transferred to a system account so shared work is not lost, and your name will be removed from your comments.</p>
+    <p>If you want a copy of your work, log in and export your cases now.</p>
   </div>
 
   <div style="text-align: center; padding: 20px; color: #999; font-size: 12px;">
@@ -468,16 +469,15 @@ export async function sendRetentionFinalReminderEmail(
 `;
 
 	const plainTextContent = `
-This is your final reminder
-
 Hello ${username},
 
-This is a follow-up to our earlier warning: your ${APP_NAME} account has still not been used, and it will be permanently deleted in 7 days, on ${formattedDate}.
+This is a follow-up to our earlier warning. Your ${APP_NAME} account has still not been used, and it will be permanently deleted on ${formattedDate}, seven days from now.
 
-To keep your account, log in before that date:
-${loginUrl}
+To keep your account, log in before that date: ${loginUrl}. Logging in cancels the deletion.
 
-If you want to keep a copy of your work, log in and export your cases now — after ${formattedDate} your profile and login details will be permanently deleted and cannot be recovered. Any cases you created will be transferred to a system account so shared work is not lost, and your name will be removed from your comments.
+If you do nothing, your profile and login details will be deleted and cannot be recovered. Cases you created will be kept only where another person has Admin access to them; otherwise they will be deleted and anyone you shared them with will lose access. Your name will be removed from any comments on cases that are kept.
+
+If you want a copy of your work, log in and export your cases now.
 
 ---
 ${APP_NAME}

--- a/lib/services/email-service.ts
+++ b/lib/services/email-service.ts
@@ -33,6 +33,13 @@ interface AccountDeletedEmailParams {
 	username: string;
 }
 
+interface RetentionWarningEmailParams {
+	/** The date deletion will actually happen if the account stays inactive — see the callers in retention-service.ts for how this is computed. */
+	deletionDate: Date;
+	to: string;
+	username: string;
+}
+
 /**
  * Get the Azure Communication Services email client.
  * Returns null if not configured (for development/testing).
@@ -319,6 +326,158 @@ What this means:
 If you did not request this deletion, please contact our support team immediately.
 
 We're sorry to see you go. If you ever want to return, you're always welcome to create a new account.
+
+---
+${APP_NAME}
+`;
+
+	return await sendEmail(to, subject, htmlContent, plainTextContent);
+}
+
+function formatRetentionDate(date: Date): string {
+	return date.toLocaleDateString("en-GB", {
+		day: "numeric",
+		month: "long",
+		year: "numeric",
+	});
+}
+
+/**
+ * Send the 30-day inactive-account deletion warning.
+ * Draft copy — Chris to approve the final wording (TEA data-retention issue).
+ */
+export async function sendRetentionWarningEmail(
+	params: RetentionWarningEmailParams
+): Promise<EmailResult> {
+	const { to, username, deletionDate } = params;
+	const loginUrl = `${APP_URL}/login`;
+	const formattedDate = formatRetentionDate(deletionDate);
+
+	const subject = `Your ${APP_NAME} account will be deleted on ${formattedDate}`;
+
+	const htmlContent = `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${subject}</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #f5f5f5;">
+  <div style="background: #1a1f2e; padding: 24px 30px; border-radius: 10px 10px 0 0; text-align: center;">
+    <img src="${TEA_LOGO_BASE64}" alt="${APP_NAME}" style="max-width: 280px; height: auto;">
+  </div>
+
+  <div style="background: #ffffff; padding: 30px; border: 1px solid #e1e1e1; border-top: none; border-radius: 0 0 10px 10px;">
+    <h2 style="color: #1a1f2e; margin-top: 0;">Your account is scheduled for deletion</h2>
+
+    <p>Hello ${username},</p>
+
+    <p>We have not seen you log in to ${APP_NAME} for two years, so under our data retention policy your account is scheduled for deletion on <strong>${formattedDate}</strong>.</p>
+
+    <p>To keep your account, simply log in before that date:</p>
+
+    <div style="text-align: center; margin: 30px 0;">
+      <a href="${loginUrl}" style="background: #1a1f2e; color: white; padding: 14px 28px; text-decoration: none; border-radius: 6px; font-weight: 600; display: inline-block;">
+        Log in to keep your account
+      </a>
+    </div>
+
+    <p>If you would rather keep a copy of your work, log in and export your cases before the deletion date. Deletion removes your profile and login details permanently; any cases you created are transferred to a system account so shared work is not lost, and your name is removed from your comments.</p>
+
+    <p style="color: #666; font-size: 14px;">You will get one more reminder 7 days before deletion. If you do nothing, your account and data will be permanently deleted on ${formattedDate}.</p>
+  </div>
+
+  <div style="text-align: center; padding: 20px; color: #999; font-size: 12px;">
+    <p>&copy; ${new Date().getFullYear()} ${APP_NAME}. All rights reserved.</p>
+  </div>
+</body>
+</html>
+`;
+
+	const plainTextContent = `
+Your account is scheduled for deletion
+
+Hello ${username},
+
+We have not seen you log in to ${APP_NAME} for two years, so under our data retention policy your account is scheduled for deletion on ${formattedDate}.
+
+To keep your account, simply log in before that date:
+${loginUrl}
+
+If you would rather keep a copy of your work, log in and export your cases before the deletion date. Deletion removes your profile and login details permanently; any cases you created are transferred to a system account so shared work is not lost, and your name is removed from your comments.
+
+You will get one more reminder 7 days before deletion. If you do nothing, your account and data will be permanently deleted on ${formattedDate}.
+
+---
+${APP_NAME}
+`;
+
+	return await sendEmail(to, subject, htmlContent, plainTextContent);
+}
+
+/**
+ * Send the final 7-day inactive-account deletion reminder.
+ * Draft copy — Chris to approve the final wording (TEA data-retention issue).
+ */
+export async function sendRetentionFinalReminderEmail(
+	params: RetentionWarningEmailParams
+): Promise<EmailResult> {
+	const { to, username, deletionDate } = params;
+	const loginUrl = `${APP_URL}/login`;
+	const formattedDate = formatRetentionDate(deletionDate);
+
+	const subject = `Final reminder: your ${APP_NAME} account will be deleted on ${formattedDate}`;
+
+	const htmlContent = `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${subject}</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #f5f5f5;">
+  <div style="background: #1a1f2e; padding: 24px 30px; border-radius: 10px 10px 0 0; text-align: center;">
+    <img src="${TEA_LOGO_BASE64}" alt="${APP_NAME}" style="max-width: 280px; height: auto;">
+  </div>
+
+  <div style="background: #ffffff; padding: 30px; border: 1px solid #e1e1e1; border-top: none; border-radius: 0 0 10px 10px;">
+    <h2 style="color: #1a1f2e; margin-top: 0;">This is your final reminder</h2>
+
+    <p>Hello ${username},</p>
+
+    <p>This is a follow-up to our earlier warning: your ${APP_NAME} account has still not been used, and it will be permanently deleted in <strong>7 days</strong>, on <strong>${formattedDate}</strong>.</p>
+
+    <p>To keep your account, log in before that date:</p>
+
+    <div style="text-align: center; margin: 30px 0;">
+      <a href="${loginUrl}" style="background: #1a1f2e; color: white; padding: 14px 28px; text-decoration: none; border-radius: 6px; font-weight: 600; display: inline-block;">
+        Log in to keep your account
+      </a>
+    </div>
+
+    <p>If you want to keep a copy of your work, log in and export your cases now — after ${formattedDate} your profile and login details will be permanently deleted and cannot be recovered. Any cases you created will be transferred to a system account so shared work is not lost, and your name will be removed from your comments.</p>
+  </div>
+
+  <div style="text-align: center; padding: 20px; color: #999; font-size: 12px;">
+    <p>&copy; ${new Date().getFullYear()} ${APP_NAME}. All rights reserved.</p>
+  </div>
+</body>
+</html>
+`;
+
+	const plainTextContent = `
+This is your final reminder
+
+Hello ${username},
+
+This is a follow-up to our earlier warning: your ${APP_NAME} account has still not been used, and it will be permanently deleted in 7 days, on ${formattedDate}.
+
+To keep your account, log in before that date:
+${loginUrl}
+
+If you want to keep a copy of your work, log in and export your cases now — after ${formattedDate} your profile and login details will be permanently deleted and cannot be recovered. Any cases you created will be transferred to a system account so shared work is not lost, and your name will be removed from your comments.
 
 ---
 ${APP_NAME}

--- a/lib/services/health-staleness-sweep-service.ts
+++ b/lib/services/health-staleness-sweep-service.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { timingSafeCompare } from "@/lib/auth/timing-safe";
 import { prisma } from "@/lib/prisma";
+import { requireCronSecret } from "@/lib/services/cron-auth";
 import {
 	type HealthState,
 	isHealthStateStale,
@@ -183,15 +183,9 @@ async function sweepCaseClaims(
 export async function sweepHealthStaleness(
 	authToken: string | null
 ): ServiceResult<HealthStalenessSweepResult> {
-	const cronSecret = process.env.CRON_SECRET;
-
-	if (!cronSecret) {
-		console.error("CRON_SECRET environment variable not set");
-		return { error: "Server configuration error" };
-	}
-
-	if (!(authToken && timingSafeCompare(authToken, cronSecret))) {
-		return { error: "Unauthorised" };
+	const auth = requireCronSecret(authToken);
+	if (!auth.authorised) {
+		return { error: auth.error };
 	}
 
 	try {

--- a/lib/services/retention-service.ts
+++ b/lib/services/retention-service.ts
@@ -1,4 +1,3 @@
-import { timingSafeCompare } from "@/lib/auth/timing-safe";
 import {
 	RETENTION_DELETE_MIN_GAP_DAYS,
 	RETENTION_INACTIVITY_YEARS,
@@ -6,12 +5,17 @@ import {
 	RETENTION_WARNING_7_MIN_GAP_DAYS,
 	RETENTION_WARNING_30_DAYS_BEFORE,
 } from "@/lib/constants";
+import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
+import { requireCronSecret } from "@/lib/services/cron-auth";
 import {
 	sendRetentionFinalReminderEmail,
 	sendRetentionWarningEmail,
 } from "@/lib/services/email-service";
-import { deleteAccountForRetention } from "@/lib/services/user-management-service";
+import {
+	checkDeletable,
+	deleteAccountForRetention,
+} from "@/lib/services/user-management-service";
 import type { ServiceResult } from "@/types/service";
 
 // ============================================
@@ -137,6 +141,34 @@ function candidateCutoff(now: Date): Date {
 type RetentionOutcome = "deleted" | "skipped" | "warned30" | "warned7";
 
 /**
+ * Claims the 30-day-warning slot for this candidate and returns whether
+ * THIS call won it. `updateMany` with a `retentionWarning30SentAt: null`
+ * guard is the compare-and-swap (QA round 1 gap): if two sweeps overlap
+ * (e.g. a slow run plus the next scheduled trigger), only the first
+ * `updateMany` to reach Postgres matches the guard and returns `count: 1`;
+ * the second sees the row already stamped, matches nothing, and must not
+ * also send the email. Same shape for the 7-day reminder below.
+ */
+async function claimWarning30(
+	candidateId: string,
+	now: Date
+): Promise<boolean> {
+	const { count } = await prisma.user.updateMany({
+		where: { id: candidateId, retentionWarning30SentAt: null },
+		data: { retentionWarning30SentAt: now },
+	});
+	return count === 1;
+}
+
+async function claimWarning7(candidateId: string, now: Date): Promise<boolean> {
+	const { count } = await prisma.user.updateMany({
+		where: { id: candidateId, retentionWarning7SentAt: null },
+		data: { retentionWarning7SentAt: now },
+	});
+	return count === 1;
+}
+
+/**
  * Carries out `decideAction`'s verdict for one candidate and reports which
  * result bucket it landed in. Split out of `runRetentionSweep` purely to
  * keep that function's cognitive complexity down — the two functions
@@ -151,48 +183,54 @@ async function applyRetentionAction(
 
 	if (action.type === "delete") {
 		if (dryRun) {
-			return "deleted";
+			// Mirror the real path's pre-checks (QA round 1, D2) so dry-run and
+			// real counts agree on exactly the accounts that would be skipped.
+			const deletable = await checkDeletable(candidate.id);
+			return deletable.deletable ? "deleted" : "skipped";
 		}
 		const result = await deleteAccountForRetention(candidate.id);
 		if ("error" in result) {
-			console.error(
-				`Retention sweep: failed to delete user ${candidate.id}: ${result.error}`
-			);
+			logger.error("Retention sweep: failed to delete user", {
+				userId: candidate.id,
+				error: result.error,
+			});
 			return "skipped";
 		}
 		return "deleted";
 	}
 
 	if (action.type === "warn7") {
-		if (!dryRun) {
-			await sendRetentionFinalReminderEmail({
-				to: candidate.email,
-				username: candidate.username,
-				deletionDate: addDays(now, RETENTION_DELETE_MIN_GAP_DAYS),
-			});
-			await prisma.user.update({
-				where: { id: candidate.id },
-				data: { retentionWarning7SentAt: now },
-			});
+		if (dryRun) {
+			return "warned7";
 		}
+		const won = await claimWarning7(candidate.id, now);
+		if (!won) {
+			return "skipped";
+		}
+		await sendRetentionFinalReminderEmail({
+			to: candidate.email,
+			username: candidate.username,
+			deletionDate: addDays(now, RETENTION_DELETE_MIN_GAP_DAYS),
+		});
 		return "warned7";
 	}
 
 	if (action.type === "warn30") {
-		if (!dryRun) {
-			await sendRetentionWarningEmail({
-				to: candidate.email,
-				username: candidate.username,
-				deletionDate: addDays(
-					now,
-					RETENTION_WARNING_7_MIN_GAP_DAYS + RETENTION_DELETE_MIN_GAP_DAYS
-				),
-			});
-			await prisma.user.update({
-				where: { id: candidate.id },
-				data: { retentionWarning30SentAt: now },
-			});
+		if (dryRun) {
+			return "warned30";
 		}
+		const won = await claimWarning30(candidate.id, now);
+		if (!won) {
+			return "skipped";
+		}
+		await sendRetentionWarningEmail({
+			to: candidate.email,
+			username: candidate.username,
+			deletionDate: addDays(
+				now,
+				RETENTION_WARNING_7_MIN_GAP_DAYS + RETENTION_DELETE_MIN_GAP_DAYS
+			),
+		});
 		return "warned30";
 	}
 
@@ -207,7 +245,8 @@ async function applyRetentionAction(
  * Sweeps for accounts inactive for two years: sends the 30-day warning,
  * then (>=23 days later) the 7-day final reminder, then (>=7 days after
  * that) deletes the account via `deleteAccountForRetention`. Guarded by
- * CRON_SECRET exactly as `purgeExpiredCases` in `case-trash-service.ts` is.
+ * CRON_SECRET exactly as `purgeExpiredCases` in `case-trash-service.ts` is
+ * (both now share `requireCronSecret`, `lib/services/cron-auth.ts`).
  *
  * Excludes `authProvider: SYSTEM` (integration system users never log in
  * and must never be swept). There is no `deletedAt`/soft-delete concept on
@@ -222,15 +261,10 @@ export async function runRetentionSweep(
 	options: { dryRun?: boolean } = {}
 ): ServiceResult<RetentionSweepResult> {
 	const { dryRun = false } = options;
-	const cronSecret = process.env.CRON_SECRET;
 
-	if (!cronSecret) {
-		console.error("CRON_SECRET environment variable not set");
-		return { error: "Server configuration error" };
-	}
-
-	if (!(authToken && timingSafeCompare(authToken, cronSecret))) {
-		return { error: "Unauthorised" };
+	const auth = requireCronSecret(authToken);
+	if (!auth.authorised) {
+		return { error: auth.error };
 	}
 
 	try {
@@ -268,17 +302,19 @@ export async function runRetentionSweep(
 			try {
 				counts[await applyRetentionAction(candidate, now, dryRun)]++;
 			} catch (error) {
-				console.error(
-					`Retention sweep: error processing user ${candidate.id}:`,
-					error
-				);
+				logger.error("Retention sweep: error processing user", {
+					userId: candidate.id,
+					error: error instanceof Error ? error.message : String(error),
+				});
 				counts.skipped++;
 			}
 		}
 
 		return { data: counts };
 	} catch (error) {
-		console.error("Failed to run retention sweep:", error);
+		logger.error("Failed to run retention sweep", {
+			error: error instanceof Error ? error.message : String(error),
+		});
 		return { error: "Failed to run retention sweep" };
 	}
 }

--- a/lib/services/retention-service.ts
+++ b/lib/services/retention-service.ts
@@ -169,60 +169,105 @@ async function claimWarning7(candidateId: string, now: Date): Promise<boolean> {
 }
 
 /**
- * Carries out `decideAction`'s verdict for one candidate and reports which
- * result bucket it landed in. Split out of `runRetentionSweep` purely to
- * keep that function's cognitive complexity down — the two functions
- * together are the sweep's per-user logic.
+ * Reverses a claim made moments ago by THIS call (vincent, review round 2,
+ * should-fix): if the send that followed the claim throws, the warning was
+ * never actually delivered, so the stamp must not stand — otherwise the
+ * user is "warned on record" but never warned, and (worse, on the 7-day
+ * stage) one step closer to a deletion nothing ever told them about.
+ * Guarded on the field still holding the exact timestamp this call wrote,
+ * so it can only ever undo its own claim, never a different run's.
  */
-async function applyRetentionAction(
+async function resetWarning30(
+	candidateId: string,
+	claimedAt: Date
+): Promise<void> {
+	await prisma.user.updateMany({
+		where: { id: candidateId, retentionWarning30SentAt: claimedAt },
+		data: { retentionWarning30SentAt: null },
+	});
+}
+
+async function resetWarning7(
+	candidateId: string,
+	claimedAt: Date
+): Promise<void> {
+	await prisma.user.updateMany({
+		where: { id: candidateId, retentionWarning7SentAt: claimedAt },
+		data: { retentionWarning7SentAt: null },
+	});
+}
+
+async function handleDelete(
+	candidateId: string,
+	dryRun: boolean
+): Promise<RetentionOutcome> {
+	if (dryRun) {
+		// Mirror the real path's pre-checks (QA round 1, D2) so dry-run and
+		// real counts agree on exactly the accounts that would be skipped.
+		const deletable = await checkDeletable(candidateId);
+		return deletable.deletable ? "deleted" : "skipped";
+	}
+	const result = await deleteAccountForRetention(candidateId);
+	if ("error" in result) {
+		logger.error("Retention sweep: failed to delete user", {
+			userId: candidateId,
+			error: result.error,
+		});
+		return "skipped";
+	}
+	return "deleted";
+}
+
+/**
+ * Claims, sends, and stamps the 7-day reminder — or, if the send throws
+ * after the claim succeeded, undoes the claim and logs distinctly
+ * (vincent, review round 2, should-fix) so the next sweep retries instead
+ * of leaving the user "warned on record" but never actually warned.
+ */
+async function handleWarn7(
 	candidate: RetentionCandidate,
 	now: Date,
 	dryRun: boolean
 ): Promise<RetentionOutcome> {
-	const action = decideAction(candidate, now);
-
-	if (action.type === "delete") {
-		if (dryRun) {
-			// Mirror the real path's pre-checks (QA round 1, D2) so dry-run and
-			// real counts agree on exactly the accounts that would be skipped.
-			const deletable = await checkDeletable(candidate.id);
-			return deletable.deletable ? "deleted" : "skipped";
-		}
-		const result = await deleteAccountForRetention(candidate.id);
-		if ("error" in result) {
-			logger.error("Retention sweep: failed to delete user", {
-				userId: candidate.id,
-				error: result.error,
-			});
-			return "skipped";
-		}
-		return "deleted";
+	if (dryRun) {
+		return "warned7";
 	}
-
-	if (action.type === "warn7") {
-		if (dryRun) {
-			return "warned7";
-		}
-		const won = await claimWarning7(candidate.id, now);
-		if (!won) {
-			return "skipped";
-		}
+	const won = await claimWarning7(candidate.id, now);
+	if (!won) {
+		return "skipped";
+	}
+	try {
 		await sendRetentionFinalReminderEmail({
 			to: candidate.email,
 			username: candidate.username,
 			deletionDate: addDays(now, RETENTION_DELETE_MIN_GAP_DAYS),
 		});
-		return "warned7";
+	} catch (error) {
+		await resetWarning7(candidate.id, now);
+		logger.error("retention.warning_send_failed", {
+			userId: candidate.id,
+			stage: "warn7",
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return "skipped";
 	}
+	return "warned7";
+}
 
-	if (action.type === "warn30") {
-		if (dryRun) {
-			return "warned30";
-		}
-		const won = await claimWarning30(candidate.id, now);
-		if (!won) {
-			return "skipped";
-		}
+/** Same shape as `handleWarn7`, for the 30-day warning. */
+async function handleWarn30(
+	candidate: RetentionCandidate,
+	now: Date,
+	dryRun: boolean
+): Promise<RetentionOutcome> {
+	if (dryRun) {
+		return "warned30";
+	}
+	const won = await claimWarning30(candidate.id, now);
+	if (!won) {
+		return "skipped";
+	}
+	try {
 		await sendRetentionWarningEmail({
 			to: candidate.email,
 			username: candidate.username,
@@ -231,10 +276,41 @@ async function applyRetentionAction(
 				RETENTION_WARNING_7_MIN_GAP_DAYS + RETENTION_DELETE_MIN_GAP_DAYS
 			),
 		});
-		return "warned30";
+	} catch (error) {
+		await resetWarning30(candidate.id, now);
+		logger.error("retention.warning_send_failed", {
+			userId: candidate.id,
+			stage: "warn30",
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return "skipped";
 	}
+	return "warned30";
+}
 
-	return "skipped";
+/**
+ * Carries out `decideAction`'s verdict for one candidate and reports which
+ * result bucket it landed in. Split out of `runRetentionSweep` (and split
+ * further into `handleDelete`/`handleWarn7`/`handleWarn30`) purely to keep
+ * cognitive complexity down — together they are the sweep's per-user logic.
+ */
+async function applyRetentionAction(
+	candidate: RetentionCandidate,
+	now: Date,
+	dryRun: boolean
+): Promise<RetentionOutcome> {
+	const action = decideAction(candidate, now);
+
+	switch (action.type) {
+		case "delete":
+			return await handleDelete(candidate.id, dryRun);
+		case "warn7":
+			return await handleWarn7(candidate, now, dryRun);
+		case "warn30":
+			return await handleWarn30(candidate, now, dryRun);
+		default:
+			return "skipped";
+	}
 }
 
 // ============================================

--- a/lib/services/retention-service.ts
+++ b/lib/services/retention-service.ts
@@ -1,0 +1,284 @@
+import { timingSafeCompare } from "@/lib/auth/timing-safe";
+import {
+	RETENTION_DELETE_MIN_GAP_DAYS,
+	RETENTION_INACTIVITY_YEARS,
+	RETENTION_WARNING_7_DAYS_BEFORE,
+	RETENTION_WARNING_7_MIN_GAP_DAYS,
+	RETENTION_WARNING_30_DAYS_BEFORE,
+} from "@/lib/constants";
+import { prisma } from "@/lib/prisma";
+import {
+	sendRetentionFinalReminderEmail,
+	sendRetentionWarningEmail,
+} from "@/lib/services/email-service";
+import { deleteAccountForRetention } from "@/lib/services/user-management-service";
+import type { ServiceResult } from "@/types/service";
+
+// ============================================
+// OUTPUT INTERFACES
+// ============================================
+
+export interface RetentionSweepResult {
+	deleted: number;
+	skipped: number;
+	warned7: number;
+	warned30: number;
+}
+
+// ============================================
+// DATE HELPERS
+// ============================================
+
+function addDays(date: Date, days: number): Date {
+	const result = new Date(date);
+	result.setUTCDate(result.getUTCDate() + days);
+	return result;
+}
+
+function addYears(date: Date, years: number): Date {
+	const result = new Date(date);
+	result.setUTCFullYear(result.getUTCFullYear() + years);
+	return result;
+}
+
+/** Whole and fractional days elapsed from `earlier` to `later`. */
+function daysBetween(earlier: Date, later: Date): number {
+	return (later.getTime() - earlier.getTime()) / (1000 * 60 * 60 * 24);
+}
+
+// ============================================
+// ELIGIBILITY
+// ============================================
+
+interface RetentionCandidate {
+	authProvider: string;
+	createdAt: Date;
+	email: string;
+	id: string;
+	lastLoginAt: Date | null;
+	retentionWarning7SentAt: Date | null;
+	retentionWarning30SentAt: Date | null;
+	username: string;
+}
+
+type RetentionAction =
+	| { type: "delete" }
+	| { type: "none" }
+	| { type: "warn30" }
+	| { type: "warn7" };
+
+/**
+ * Decides what, if anything, happens to a candidate this run.
+ *
+ * The "sent >= N days ago" gates are the safety property this whole sweep
+ * depends on: they guarantee an account that is already years overdue the
+ * first time this ever runs can only be warned, never deleted, because
+ * `warn7` requires the 30-day warning to already be at least 23 days old,
+ * and `delete` requires the 7-day reminder to already be at least 7 days
+ * old. Neither can be true on a first run, however overdue the account is.
+ */
+function decideAction(
+	candidate: Pick<
+		RetentionCandidate,
+		| "createdAt"
+		| "lastLoginAt"
+		| "retentionWarning30SentAt"
+		| "retentionWarning7SentAt"
+	>,
+	now: Date
+): RetentionAction {
+	const lastActivity = candidate.lastLoginAt ?? candidate.createdAt;
+	const deleteAt = addYears(lastActivity, RETENTION_INACTIVITY_YEARS);
+	const warn30At = addDays(deleteAt, -RETENTION_WARNING_30_DAYS_BEFORE);
+	const warn7At = addDays(deleteAt, -RETENTION_WARNING_7_DAYS_BEFORE);
+
+	const {
+		retentionWarning30SentAt: warn30SentAt,
+		retentionWarning7SentAt: warn7SentAt,
+	} = candidate;
+
+	if (
+		now >= deleteAt &&
+		warn7SentAt !== null &&
+		daysBetween(warn7SentAt, now) >= RETENTION_DELETE_MIN_GAP_DAYS
+	) {
+		return { type: "delete" };
+	}
+
+	if (
+		now >= warn7At &&
+		warn7SentAt === null &&
+		warn30SentAt !== null &&
+		daysBetween(warn30SentAt, now) >= RETENTION_WARNING_7_MIN_GAP_DAYS
+	) {
+		return { type: "warn7" };
+	}
+
+	if (now >= warn30At && warn30SentAt === null) {
+		return { type: "warn30" };
+	}
+
+	return { type: "none" };
+}
+
+/**
+ * Coarse pre-filter cutoff for the DB query: any user whose last activity
+ * is old enough that they *could* be due at least the 30-day warning.
+ * `decideAction` re-derives the exact thresholds per user afterwards — this
+ * is only here so the sweep doesn't load every user in the platform.
+ */
+function candidateCutoff(now: Date): Date {
+	return addDays(
+		addYears(now, -RETENTION_INACTIVITY_YEARS),
+		RETENTION_WARNING_30_DAYS_BEFORE
+	);
+}
+
+type RetentionOutcome = "deleted" | "skipped" | "warned30" | "warned7";
+
+/**
+ * Carries out `decideAction`'s verdict for one candidate and reports which
+ * result bucket it landed in. Split out of `runRetentionSweep` purely to
+ * keep that function's cognitive complexity down — the two functions
+ * together are the sweep's per-user logic.
+ */
+async function applyRetentionAction(
+	candidate: RetentionCandidate,
+	now: Date,
+	dryRun: boolean
+): Promise<RetentionOutcome> {
+	const action = decideAction(candidate, now);
+
+	if (action.type === "delete") {
+		if (dryRun) {
+			return "deleted";
+		}
+		const result = await deleteAccountForRetention(candidate.id);
+		if ("error" in result) {
+			console.error(
+				`Retention sweep: failed to delete user ${candidate.id}: ${result.error}`
+			);
+			return "skipped";
+		}
+		return "deleted";
+	}
+
+	if (action.type === "warn7") {
+		if (!dryRun) {
+			await sendRetentionFinalReminderEmail({
+				to: candidate.email,
+				username: candidate.username,
+				deletionDate: addDays(now, RETENTION_DELETE_MIN_GAP_DAYS),
+			});
+			await prisma.user.update({
+				where: { id: candidate.id },
+				data: { retentionWarning7SentAt: now },
+			});
+		}
+		return "warned7";
+	}
+
+	if (action.type === "warn30") {
+		if (!dryRun) {
+			await sendRetentionWarningEmail({
+				to: candidate.email,
+				username: candidate.username,
+				deletionDate: addDays(
+					now,
+					RETENTION_WARNING_7_MIN_GAP_DAYS + RETENTION_DELETE_MIN_GAP_DAYS
+				),
+			});
+			await prisma.user.update({
+				where: { id: candidate.id },
+				data: { retentionWarning30SentAt: now },
+			});
+		}
+		return "warned30";
+	}
+
+	return "skipped";
+}
+
+// ============================================
+// SERVICE FUNCTION
+// ============================================
+
+/**
+ * Sweeps for accounts inactive for two years: sends the 30-day warning,
+ * then (>=23 days later) the 7-day final reminder, then (>=7 days after
+ * that) deletes the account via `deleteAccountForRetention`. Guarded by
+ * CRON_SECRET exactly as `purgeExpiredCases` in `case-trash-service.ts` is.
+ *
+ * Excludes `authProvider: SYSTEM` (integration system users never log in
+ * and must never be swept). There is no `deletedAt`/soft-delete concept on
+ * `User` — deletion here is a hard delete of the row — so "already deleted"
+ * users are excluded simply by not existing to be queried.
+ *
+ * `dryRun: true` computes and returns the same counts without sending any
+ * email, writing any warning timestamp, or deleting any account.
+ */
+export async function runRetentionSweep(
+	authToken: string | null,
+	options: { dryRun?: boolean } = {}
+): ServiceResult<RetentionSweepResult> {
+	const { dryRun = false } = options;
+	const cronSecret = process.env.CRON_SECRET;
+
+	if (!cronSecret) {
+		console.error("CRON_SECRET environment variable not set");
+		return { error: "Server configuration error" };
+	}
+
+	if (!(authToken && timingSafeCompare(authToken, cronSecret))) {
+		return { error: "Unauthorised" };
+	}
+
+	try {
+		const now = new Date();
+		const cutoff = candidateCutoff(now);
+
+		const candidates: RetentionCandidate[] = await prisma.user.findMany({
+			where: {
+				authProvider: { not: "SYSTEM" },
+				OR: [
+					{ lastLoginAt: { lte: cutoff } },
+					{ lastLoginAt: null, createdAt: { lte: cutoff } },
+				],
+			},
+			select: {
+				id: true,
+				email: true,
+				username: true,
+				authProvider: true,
+				createdAt: true,
+				lastLoginAt: true,
+				retentionWarning30SentAt: true,
+				retentionWarning7SentAt: true,
+			},
+		});
+
+		const counts: RetentionSweepResult = {
+			warned30: 0,
+			warned7: 0,
+			deleted: 0,
+			skipped: 0,
+		};
+
+		for (const candidate of candidates) {
+			try {
+				counts[await applyRetentionAction(candidate, now, dryRun)]++;
+			} catch (error) {
+				console.error(
+					`Retention sweep: error processing user ${candidate.id}:`,
+					error
+				);
+				counts.skipped++;
+			}
+		}
+
+		return { data: counts };
+	} catch (error) {
+		console.error("Failed to run retention sweep:", error);
+		return { error: "Failed to run retention sweep" };
+	}
+}

--- a/lib/services/user-management-service.ts
+++ b/lib/services/user-management-service.ts
@@ -274,6 +274,20 @@ const SYSTEM_USER_EMAIL = "system@tea-platform.internal";
 const SYSTEM_USER_USERNAME = "system";
 
 /**
+ * Options for the account-deletion transaction. No existing shared
+ * interactive-transaction constant in this repo (checked: `case-import-
+ * service.ts` deliberately keeps Prisma's default 5s timeout because its
+ * transaction does a fixed, small number of round trips regardless of
+ * payload size). This transaction's round trips scale with how much
+ * history the user has (owned cases, teams, comments, elements,
+ * permissions granted), so a user with a lot of it can plausibly exceed
+ * the 5s default (vincent, review round 2, should-fix) — widened here,
+ * not globally.
+ */
+const DELETION_TRANSACTION_TIMEOUT_MS = 30_000;
+const DELETION_TRANSACTION_MAX_WAIT_MS = 10_000;
+
+/**
  * Gets or creates the generic fallback system user for ownership transfer
  * (used when a human account is deleted).
  *
@@ -446,8 +460,19 @@ async function partitionCasesToKeepOrTrash(
 			},
 			select: { caseId: true },
 		}),
+		// A team-ADMIN grant only counts as "another admin" if the team has a
+		// member other than the user being deleted (vincent, review round 2,
+		// blocker): a team of one is the deleted user themselves, and
+		// `runAccountDeletionTransaction`'s team-handling step deletes exactly
+		// that kind of team, cascading its CaseTeamPermission away — a case
+		// "kept" on a team-of-one grant would end up owned by the system
+		// account with no permissions for anyone, orphaned and never trashed.
 		tx.caseTeamPermission.findMany({
-			where: { caseId: { in: caseIds }, permission: "ADMIN" },
+			where: {
+				caseId: { in: caseIds },
+				permission: "ADMIN",
+				team: { members: { some: { userId: { not: userId } } } },
+			},
 			select: { caseId: true },
 		}),
 	]);
@@ -498,91 +523,109 @@ async function partitionCasesToKeepOrTrash(
  * (`checkDeletable`, password) before calling this.
  */
 async function runAccountDeletionTransaction(userId: string): Promise<void> {
-	await prisma.$transaction(async (tx) => {
-		const systemUserId = await getOrCreateSystemUser(tx);
+	await prisma.$transaction(
+		async (tx) => {
+			const systemUserId = await getOrCreateSystemUser(tx);
 
-		const ownedCases = await tx.assuranceCase.findMany({
-			where: { createdById: userId },
-			select: { id: true },
-		});
-		const { toKeep, toTrash } = await partitionCasesToKeepOrTrash(
-			tx,
-			userId,
-			ownedCases.map((c) => c.id)
-		);
+			const ownedCases = await tx.assuranceCase.findMany({
+				where: { createdById: userId },
+				select: { id: true },
+			});
+			const { toKeep, toTrash } = await partitionCasesToKeepOrTrash(
+				tx,
+				userId,
+				ownedCases.map((c) => c.id)
+			);
 
-		if (toKeep.length > 0) {
-			await tx.assuranceCase.updateMany({
-				where: { id: { in: toKeep } },
+			if (toKeep.length > 0) {
+				await tx.assuranceCase.updateMany({
+					where: { id: { in: toKeep } },
+					data: { createdById: systemUserId },
+				});
+			}
+
+			if (toTrash.length > 0) {
+				await tx.assuranceCase.updateMany({
+					where: { id: { in: toTrash } },
+					data: {
+						createdById: systemUserId,
+						deletedAt: new Date(),
+						deletedById: systemUserId,
+					},
+				});
+			}
+
+			// Handle teams created by user
+			const ownedTeams = await tx.team.findMany({
+				where: { createdById: userId },
+				include: {
+					members: {
+						where: { userId: { not: userId } },
+						orderBy: { joinedAt: "asc" },
+						take: 1,
+					},
+				},
+			});
+
+			// Split into transfers (each to a different new owner, so one
+			// updateMany can't set them all) and member-less teams (all get the
+			// same treatment, so one deleteMany replaces N round trips).
+			const teamTransfers: { newOwnerId: string; teamId: string }[] = [];
+			const teamIdsToDelete: string[] = [];
+			for (const team of ownedTeams) {
+				const newOwnerId = team.members[0]?.userId;
+				if (newOwnerId) {
+					teamTransfers.push({ teamId: team.id, newOwnerId });
+				} else {
+					teamIdsToDelete.push(team.id);
+				}
+			}
+
+			for (const { teamId, newOwnerId } of teamTransfers) {
+				await tx.team.update({
+					where: { id: teamId },
+					data: { createdById: newOwnerId },
+				});
+			}
+
+			if (teamIdsToDelete.length > 0) {
+				await tx.team.deleteMany({ where: { id: { in: teamIdsToDelete } } });
+			}
+
+			// Anonymise comments (transfer to system user)
+			await tx.comment.updateMany({
+				where: { authorId: userId },
+				data: { authorId: systemUserId },
+			});
+
+			// Also handle release comments if they exist
+			await tx.releaseComment.updateMany({
+				where: { authorId: userId },
+				data: { authorId: systemUserId },
+			});
+
+			// Transfer created elements to system user (for audit trail)
+			await tx.assuranceElement.updateMany({
+				where: { createdById: userId },
 				data: { createdById: systemUserId },
 			});
-		}
 
-		if (toTrash.length > 0) {
-			await tx.assuranceCase.updateMany({
-				where: { id: { in: toTrash } },
-				data: {
-					createdById: systemUserId,
-					deletedAt: new Date(),
-					deletedById: systemUserId,
-				},
+			// Reassign permissions this user granted — on their own cases and on
+			// others' — to the system user. Real ON DELETE RESTRICT FK, no cascade.
+			await tx.casePermission.updateMany({
+				where: { grantedById: userId },
+				data: { grantedById: systemUserId },
 			});
+
+			// Delete the user (cascades: RefreshToken, TeamMember, CasePermission
+			// held BY this user, GitHubRepository)
+			await tx.user.delete({ where: { id: userId } });
+		},
+		{
+			timeout: DELETION_TRANSACTION_TIMEOUT_MS,
+			maxWait: DELETION_TRANSACTION_MAX_WAIT_MS,
 		}
-
-		// Handle teams created by user
-		const ownedTeams = await tx.team.findMany({
-			where: { createdById: userId },
-			include: {
-				members: {
-					where: { userId: { not: userId } },
-					orderBy: { joinedAt: "asc" },
-					take: 1,
-				},
-			},
-		});
-
-		for (const team of ownedTeams) {
-			if (team.members.length > 0) {
-				// Transfer ownership to first remaining member
-				await tx.team.update({
-					where: { id: team.id },
-					data: { createdById: team.members[0]?.userId },
-				});
-			} else {
-				// No other members - delete the team
-				await tx.team.delete({ where: { id: team.id } });
-			}
-		}
-
-		// Anonymise comments (transfer to system user)
-		await tx.comment.updateMany({
-			where: { authorId: userId },
-			data: { authorId: systemUserId },
-		});
-
-		// Also handle release comments if they exist
-		await tx.releaseComment.updateMany({
-			where: { authorId: userId },
-			data: { authorId: systemUserId },
-		});
-
-		// Transfer created elements to system user (for audit trail)
-		await tx.assuranceElement.updateMany({
-			where: { createdById: userId },
-			data: { createdById: systemUserId },
-		});
-
-		// Reassign permissions this user granted — on their own cases and on
-		// others' — to the system user. Real ON DELETE RESTRICT FK, no cascade.
-		await tx.casePermission.updateMany({
-			where: { grantedById: userId },
-			data: { grantedById: systemUserId },
-		});
-
-		// Delete the user (cascades: RefreshToken, TeamMember, CasePermission
-		// held BY this user, GitHubRepository)
-		await tx.user.delete({ where: { id: userId } });
-	});
+	);
 }
 
 /**

--- a/lib/services/user-management-service.ts
+++ b/lib/services/user-management-service.ts
@@ -383,66 +383,133 @@ export async function deleteAccount(
 			}
 		}
 
-		// Perform deletion in transaction
-		await prisma.$transaction(async (tx) => {
-			const systemUserId = await getOrCreateSystemUser(tx);
-
-			// Transfer owned cases to system user
-			await tx.assuranceCase.updateMany({
-				where: { createdById: userId },
-				data: { createdById: systemUserId },
-			});
-
-			// Handle teams created by user
-			const ownedTeams = await tx.team.findMany({
-				where: { createdById: userId },
-				include: {
-					members: {
-						where: { userId: { not: userId } },
-						orderBy: { joinedAt: "asc" },
-						take: 1,
-					},
-				},
-			});
-
-			for (const team of ownedTeams) {
-				if (team.members.length > 0) {
-					// Transfer ownership to first remaining member
-					await tx.team.update({
-						where: { id: team.id },
-						data: { createdById: team.members[0]?.userId },
-					});
-				} else {
-					// No other members - delete the team
-					await tx.team.delete({ where: { id: team.id } });
-				}
-			}
-
-			// Anonymise comments (transfer to system user)
-			await tx.comment.updateMany({
-				where: { authorId: userId },
-				data: { authorId: systemUserId },
-			});
-
-			// Also handle release comments if they exist
-			await tx.releaseComment.updateMany({
-				where: { authorId: userId },
-				data: { authorId: systemUserId },
-			});
-
-			// Transfer created elements to system user (for audit trail)
-			await tx.assuranceElement.updateMany({
-				where: { createdById: userId },
-				data: { createdById: systemUserId },
-			});
-
-			// Delete the user (cascades: RefreshToken, TeamMember, CasePermission)
-			await tx.user.delete({ where: { id: userId } });
-		});
+		await runAccountDeletionTransaction(userId);
 
 		return { data: true };
 	} catch (error) {
 		console.error("Error deleting account:", error);
+		return { error: "Failed to delete account" };
+	}
+}
+
+/**
+ * The cascade shared by every account-deletion path: transfers owned cases,
+ * teams, comments and elements to the system user (audit trail — this is
+ * anonymisation, not deletion, of that content), then hard-deletes the
+ * user row (cascades: RefreshToken, TeamMember, CasePermission). Callers
+ * are responsible for their own pre-flight checks (password, owned
+ * integrations) before calling this.
+ */
+async function runAccountDeletionTransaction(userId: string): Promise<void> {
+	await prisma.$transaction(async (tx) => {
+		const systemUserId = await getOrCreateSystemUser(tx);
+
+		// Transfer owned cases to system user
+		await tx.assuranceCase.updateMany({
+			where: { createdById: userId },
+			data: { createdById: systemUserId },
+		});
+
+		// Handle teams created by user
+		const ownedTeams = await tx.team.findMany({
+			where: { createdById: userId },
+			include: {
+				members: {
+					where: { userId: { not: userId } },
+					orderBy: { joinedAt: "asc" },
+					take: 1,
+				},
+			},
+		});
+
+		for (const team of ownedTeams) {
+			if (team.members.length > 0) {
+				// Transfer ownership to first remaining member
+				await tx.team.update({
+					where: { id: team.id },
+					data: { createdById: team.members[0]?.userId },
+				});
+			} else {
+				// No other members - delete the team
+				await tx.team.delete({ where: { id: team.id } });
+			}
+		}
+
+		// Anonymise comments (transfer to system user)
+		await tx.comment.updateMany({
+			where: { authorId: userId },
+			data: { authorId: systemUserId },
+		});
+
+		// Also handle release comments if they exist
+		await tx.releaseComment.updateMany({
+			where: { authorId: userId },
+			data: { authorId: systemUserId },
+		});
+
+		// Transfer created elements to system user (for audit trail)
+		await tx.assuranceElement.updateMany({
+			where: { createdById: userId },
+			data: { createdById: systemUserId },
+		});
+
+		// Delete the user (cascades: RefreshToken, TeamMember, CasePermission)
+		await tx.user.delete({ where: { id: userId } });
+	});
+}
+
+/**
+ * Deletes an account on the platform's own initiative (data retention),
+ * not the user's — the password-free counterpart to `deleteAccount` used
+ * by the retention sweep (`lib/services/retention-service.ts`). Shares
+ * `deleteAccount`'s cascade and confirmation email, and additionally logs
+ * a security event so the deletion has an audit trail distinct from a
+ * self-service one.
+ *
+ * Like `deleteAccount`, a user who owns integrations cannot be deleted
+ * (the FK from `Integration.ownerId` is `ON DELETE RESTRICT` — ADR 0002 v2
+ * §2.4). The retention sweep treats that as a per-user skip, not a reason
+ * to abort the run.
+ */
+export async function deleteAccountForRetention(userId: string): ServiceResult {
+	try {
+		const user = await prisma.user.findUnique({
+			where: { id: userId },
+			select: { id: true, email: true, username: true },
+		});
+
+		if (!user) {
+			return { error: "User not found" };
+		}
+
+		const ownedIntegrationCount = await countIntegrationsOwnedBy(userId);
+		if ("error" in ownedIntegrationCount) {
+			return ownedIntegrationCount;
+		}
+		if (ownedIntegrationCount.data > 0) {
+			const count = ownedIntegrationCount.data;
+			return {
+				error: `Remove your ${count} integration${count === 1 ? "" : "s"} before deleting your account`,
+			};
+		}
+
+		await runAccountDeletionTransaction(userId);
+
+		const { sendAccountDeletedEmail } = await import(
+			"@/lib/services/email-service"
+		);
+		await sendAccountDeletedEmail({ to: user.email, username: user.username });
+
+		const { logSecurityEvent } = await import("@/lib/audit/security-log");
+		logSecurityEvent({
+			event: "account_deleted",
+			severity: "medium",
+			metadata: { userId, reason: "retention" },
+		});
+
+		return { data: true };
+	} catch (error) {
+		console.error("Error deleting account for retention:", error);
 		return { error: "Failed to delete account" };
 	}
 }

--- a/lib/services/user-management-service.ts
+++ b/lib/services/user-management-service.ts
@@ -312,24 +312,56 @@ async function getOrCreateSystemUser(
 }
 
 /**
- * Deletes a user account.
- * Transfers owned cases and anonymises comments before deletion.
- * Requires password confirmation for local auth users.
+ * Whether `userId`'s account can be deleted at all, independent of *how*
+ * it is being deleted (self-service with a password, or the retention
+ * sweep without one). Extracted (QA round 1, D2) so the retention sweep's
+ * dry-run branch can report exactly the same skip a real run would hit,
+ * instead of the dry-run and real counts disagreeing on accounts an
+ * integration blocks.
  *
  * Integrations are NOT silently cascade-deleted: `Integration.ownerId` is an
  * unconditional `ON DELETE RESTRICT` (ADR 0002 v2 §2.4 — a revoked
  * integration keeps its accountability trail, so its owner reference must
- * never silently vanish). Without the pre-check below, `tx.user.delete`
- * would throw a raw Postgres P2003 that the catch-all below flattens into
- * an unhelpful "Failed to delete account". Checking
- * `countIntegrationsOwnedBy` first turns that into a clean, typed,
- * actionable error instead — "Remove your N integration(s) before deleting
- * your account". Reassignment has no path in 1.0 (vincent minor, review
- * round 2 — this used to promise "reassign or remove"; only removal is
- * actually offered), so the message promises only that. `countIntegrationsOwnedBy`
- * is a `COUNT(*)`, not the full `getIntegrationsOwnedBy` row fetch this
- * pre-check used to do (vincent minor, work item 7) — `getIntegrationsOwnedBy`
- * itself is unchanged and still used elsewhere.
+ * never silently vanish). Without this check, `tx.user.delete` would throw
+ * a raw Postgres P2003 that the caller's catch-all flattens into an
+ * unhelpful "Failed to delete account". Checking `countIntegrationsOwnedBy`
+ * first turns that into a clean, typed, actionable error instead —
+ * "Remove your N integration(s) before deleting your account".
+ */
+export async function checkDeletable(
+	userId: string
+): Promise<{ deletable: true } | { deletable: false; error: string }> {
+	const user = await prisma.user.findUnique({
+		where: { id: userId },
+		select: { id: true },
+	});
+
+	if (!user) {
+		return { deletable: false, error: "User not found" };
+	}
+
+	const ownedIntegrationCount = await countIntegrationsOwnedBy(userId);
+	if ("error" in ownedIntegrationCount) {
+		return { deletable: false, error: ownedIntegrationCount.error };
+	}
+	if (ownedIntegrationCount.data > 0) {
+		const count = ownedIntegrationCount.data;
+		return {
+			deletable: false,
+			error: `Remove your ${count} integration${count === 1 ? "" : "s"} before deleting your account`,
+		};
+	}
+
+	return { deletable: true };
+}
+
+/**
+ * Deletes a user account. Transfers owned cases and anonymises comments
+ * before deletion (see `runAccountDeletionTransaction` for the case-by-case
+ * keep/trash rule). Requires password confirmation for local auth users.
+ * Reassignment has no path in 1.0 (vincent minor, review round 2 — this
+ * used to promise "reassign or remove"; only removal is actually offered),
+ * so `checkDeletable`'s message promises only that.
  */
 export async function deleteAccount(
 	userId: string,
@@ -351,15 +383,9 @@ export async function deleteAccount(
 			return { error: "User not found" };
 		}
 
-		const ownedIntegrationCount = await countIntegrationsOwnedBy(userId);
-		if ("error" in ownedIntegrationCount) {
-			return ownedIntegrationCount;
-		}
-		if (ownedIntegrationCount.data > 0) {
-			const count = ownedIntegrationCount.data;
-			return {
-				error: `Remove your ${count} integration${count === 1 ? "" : "s"} before deleting your account`,
-			};
+		const deletable = await checkDeletable(userId);
+		if (!deletable.deletable) {
+			return { error: deletable.error };
 		}
 
 		// Verify password for local auth users
@@ -393,22 +419,115 @@ export async function deleteAccount(
 }
 
 /**
- * The cascade shared by every account-deletion path: transfers owned cases,
- * teams, comments and elements to the system user (audit trail — this is
- * anonymisation, not deletion, of that content), then hard-deletes the
- * user row (cascades: RefreshToken, TeamMember, CasePermission). Callers
- * are responsible for their own pre-flight checks (password, owned
- * integrations) before calling this.
+ * Splits `userId`'s created cases into those to keep (authorship
+ * reassigned to the system account, as before) and those to trash, per
+ * Chris's ruling (2026-09-07): a case is kept only if at least one OTHER
+ * principal already holds ADMIN on it — another user's direct
+ * `CasePermission` at ADMIN, or a team's `CaseTeamPermission` at ADMIN
+ * (Chris: "fair assumption, I'm okay with this"). Otherwise nobody but the
+ * deleted user could ever administer it, so it is trashed rather than
+ * silently orphaned under the system account.
+ */
+async function partitionCasesToKeepOrTrash(
+	tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
+	userId: string,
+	caseIds: string[]
+): Promise<{ toKeep: string[]; toTrash: string[] }> {
+	if (caseIds.length === 0) {
+		return { toKeep: [], toTrash: [] };
+	}
+
+	const [adminUserPermissions, adminTeamPermissions] = await Promise.all([
+		tx.casePermission.findMany({
+			where: {
+				caseId: { in: caseIds },
+				permission: "ADMIN",
+				userId: { not: userId },
+			},
+			select: { caseId: true },
+		}),
+		tx.caseTeamPermission.findMany({
+			where: { caseId: { in: caseIds }, permission: "ADMIN" },
+			select: { caseId: true },
+		}),
+	]);
+
+	const casesWithOtherAdmin = new Set([
+		...adminUserPermissions.map((p) => p.caseId),
+		...adminTeamPermissions.map((p) => p.caseId),
+	]);
+
+	const toKeep: string[] = [];
+	const toTrash: string[] = [];
+	for (const caseId of caseIds) {
+		(casesWithOtherAdmin.has(caseId) ? toKeep : toTrash).push(caseId);
+	}
+	return { toKeep, toTrash };
+}
+
+/**
+ * The cascade shared by every account-deletion path.
+ *
+ * Cases the user created: kept (authorship reassigned to the system
+ * account, as before) if another principal already holds ADMIN on them,
+ * otherwise soft-deleted into the trash — `deletedAt`/`deletedById`, same
+ * as `case-trash-service.ts`'s `softDeleteCase`, so the existing
+ * `purge-trash` cron removes them permanently after the usual retention
+ * window. This is a full disappearance for every collaborator, verified
+ * against `listUserCases`/`listSharedCases` and `fetchCaseFromPrisma`/
+ * `canAccessCase`, which all filter `deletedAt: null` unconditionally for
+ * every viewer, not just the owner — a trashed case is invisible to
+ * collaborators exactly like it is to the deleted user, so soft-delete
+ * satisfies "disappears from the accounts of any collaborators" without
+ * needing a hard delete.
+ *
+ * Comments and elements are anonymised (transferred to the system account)
+ * exactly as before, on kept AND trashed cases alike — trashing a case
+ * does not touch its children, only `deletedAt` on the case row, so their
+ * `createdById`/`authorId` FKs still need a home until the purge cron
+ * removes the whole case tree.
+ *
+ * `CasePermission.grantedById` is reassigned too (QA round 1, D1): it is a
+ * real `ON DELETE RESTRICT` FK with no cascade, so any user who ever
+ * shared ANY case — including one they don't own — could not previously
+ * delete their own account (P2003, silently flattened to "Failed to
+ * delete account" one level up). Covers permissions granted on the user's
+ * own cases and on other people's.
+ *
+ * Callers are responsible for their own pre-flight checks
+ * (`checkDeletable`, password) before calling this.
  */
 async function runAccountDeletionTransaction(userId: string): Promise<void> {
 	await prisma.$transaction(async (tx) => {
 		const systemUserId = await getOrCreateSystemUser(tx);
 
-		// Transfer owned cases to system user
-		await tx.assuranceCase.updateMany({
+		const ownedCases = await tx.assuranceCase.findMany({
 			where: { createdById: userId },
-			data: { createdById: systemUserId },
+			select: { id: true },
 		});
+		const { toKeep, toTrash } = await partitionCasesToKeepOrTrash(
+			tx,
+			userId,
+			ownedCases.map((c) => c.id)
+		);
+
+		if (toKeep.length > 0) {
+			await tx.assuranceCase.updateMany({
+				where: { id: { in: toKeep } },
+				data: { createdById: systemUserId },
+			});
+		}
+
+		if (toTrash.length > 0) {
+			await tx.assuranceCase.updateMany({
+				where: { id: { in: toTrash } },
+				data: {
+					createdById: systemUserId,
+					deletedAt: new Date(),
+					deletedById: systemUserId,
+				},
+			});
+		}
 
 		// Handle teams created by user
 		const ownedTeams = await tx.team.findMany({
@@ -453,7 +572,15 @@ async function runAccountDeletionTransaction(userId: string): Promise<void> {
 			data: { createdById: systemUserId },
 		});
 
-		// Delete the user (cascades: RefreshToken, TeamMember, CasePermission)
+		// Reassign permissions this user granted — on their own cases and on
+		// others' — to the system user. Real ON DELETE RESTRICT FK, no cascade.
+		await tx.casePermission.updateMany({
+			where: { grantedById: userId },
+			data: { grantedById: systemUserId },
+		});
+
+		// Delete the user (cascades: RefreshToken, TeamMember, CasePermission
+		// held BY this user, GitHubRepository)
 		await tx.user.delete({ where: { id: userId } });
 	});
 }
@@ -465,11 +592,6 @@ async function runAccountDeletionTransaction(userId: string): Promise<void> {
  * `deleteAccount`'s cascade and confirmation email, and additionally logs
  * a security event so the deletion has an audit trail distinct from a
  * self-service one.
- *
- * Like `deleteAccount`, a user who owns integrations cannot be deleted
- * (the FK from `Integration.ownerId` is `ON DELETE RESTRICT` — ADR 0002 v2
- * §2.4). The retention sweep treats that as a per-user skip, not a reason
- * to abort the run.
  */
 export async function deleteAccountForRetention(userId: string): ServiceResult {
 	try {
@@ -482,15 +604,9 @@ export async function deleteAccountForRetention(userId: string): ServiceResult {
 			return { error: "User not found" };
 		}
 
-		const ownedIntegrationCount = await countIntegrationsOwnedBy(userId);
-		if ("error" in ownedIntegrationCount) {
-			return ownedIntegrationCount;
-		}
-		if (ownedIntegrationCount.data > 0) {
-			const count = ownedIntegrationCount.data;
-			return {
-				error: `Remove your ${count} integration${count === 1 ? "" : "s"} before deleting your account`,
-			};
+		const deletable = await checkDeletable(userId);
+		if (!deletable.deletable) {
+			return { error: deletable.error };
 		}
 
 		await runAccountDeletionTransaction(userId);

--- a/prisma/migrations/20260907000000_add_retention_warning_fields/migration.sql
+++ b/prisma/migrations/20260907000000_add_retention_warning_fields/migration.sql
@@ -1,0 +1,16 @@
+-- TEA — Data retention: inactive-account deletion warning tracking.
+--
+-- Two nullable timestamps recording when each stage of the retention
+-- warning sequence was sent to a user: a 30-day warning, then a 7-day
+-- final reminder. `runRetentionSweep` (lib/services/retention-service.ts)
+-- reads them to send each warning exactly once, and to guarantee an
+-- account already years overdue on its first-ever sweep can only be
+-- warned, never deleted, on that run.
+--
+-- Both are cleared on every successful login (every place `lastLoginAt`
+-- is written, lib/auth/config.ts), so a user who returns after a warning
+-- starts a fresh two-year cycle rather than being deleted on a clock that
+-- kept running while they were away.
+ALTER TABLE "users"
+  ADD COLUMN "retention_warning_30_sent_at" TIMESTAMP(3),
+  ADD COLUMN "retention_warning_7_sent_at" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,6 +72,10 @@ model User {
   updatedAt            DateTime     @updatedAt @map("updated_at")
   lastLoginAt          DateTime?    @map("last_login_at") /// Most recent login timestamp for audit purposes
 
+  // Data retention (inactive-account deletion) — cleared on every login
+  retentionWarning30SentAt DateTime? @map("retention_warning_30_sent_at") /// When the 30-day inactive-account deletion warning was sent
+  retentionWarning7SentAt  DateTime? @map("retention_warning_7_sent_at") /// When the 7-day final deletion reminder was sent
+
   // Relations
   teamMemberships      TeamMember[]
   createdTeams         Team[]             @relation("TeamCreator")

--- a/src/__tests__/integration/api-cron-retention-sweep-route.test.ts
+++ b/src/__tests__/integration/api-cron-retention-sweep-route.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import { createTestUser } from "../utils/prisma-factories";
+
+const CRON_SECRET = "test-cron-secret";
+
+beforeEach(() => {
+	vi.stubEnv("CRON_SECRET", CRON_SECRET);
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+function addDays(date: Date, days: number): Date {
+	const result = new Date(date);
+	result.setUTCDate(result.getUTCDate() + days);
+	return result;
+}
+
+function addYears(date: Date, years: number): Date {
+	const result = new Date(date);
+	result.setUTCFullYear(result.getUTCFullYear() + years);
+	return result;
+}
+
+/** A lastLoginAt that is already one day past the 30-day-warning threshold. */
+function dueForWarn30(now: Date): Date {
+	return addDays(addDays(addYears(now, -2), 30), -1);
+}
+
+function retentionSweepRequest(
+	options: { dryRun?: boolean; token?: string | null } = {}
+): Request {
+	const url = new URL("http://localhost:3000/api/cron/retention-sweep");
+	if (options.dryRun) {
+		url.searchParams.set("dryRun", "1");
+	}
+
+	const headers = new Headers();
+	if (options.token) {
+		headers.set("authorization", `Bearer ${options.token}`);
+	}
+
+	return new Request(url, { method: "POST", headers });
+}
+
+describe("POST /api/cron/retention-sweep — auth", () => {
+	it("returns a 401 envelope with no Authorization header", async () => {
+		const { POST } = await import("@/app/api/cron/retention-sweep/route");
+		const response = await POST(retentionSweepRequest());
+
+		expect(response.status).toBe(401);
+		const body = await response.json();
+		expect(body).toEqual({ error: "Unauthorised", code: "UNAUTHORISED" });
+	});
+
+	it("returns a 401 envelope for the wrong bearer token", async () => {
+		const { POST } = await import("@/app/api/cron/retention-sweep/route");
+		const response = await POST(
+			retentionSweepRequest({ token: "wrong-secret" })
+		);
+
+		expect(response.status).toBe(401);
+		const body = await response.json();
+		expect(body).toEqual({ error: "Unauthorised", code: "UNAUTHORISED" });
+	});
+
+	it("returns a 500 envelope when CRON_SECRET is not configured (INTERNAL, not UNAUTHORISED)", async () => {
+		vi.unstubAllEnvs();
+
+		const { POST } = await import("@/app/api/cron/retention-sweep/route");
+		const response = await POST(retentionSweepRequest({ token: CRON_SECRET }));
+
+		expect(response.status).toBe(500);
+		const body = await response.json();
+		expect(body).toEqual({
+			error: "Server configuration error",
+			code: "INTERNAL",
+		});
+	});
+});
+
+describe("POST /api/cron/retention-sweep — real path", () => {
+	it("returns 200 with all-zero counts when no user is due", async () => {
+		const { POST } = await import("@/app/api/cron/retention-sweep/route");
+		const response = await POST(retentionSweepRequest({ token: CRON_SECRET }));
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toEqual({
+			success: true,
+			dryRun: false,
+			warned30: 0,
+			warned7: 0,
+			deleted: 0,
+			skipped: 0,
+		});
+	});
+
+	it("warns and stamps the field for a due user on the real path", async () => {
+		const user = await createTestUser({
+			lastLoginAt: dueForWarn30(new Date()),
+		});
+
+		const { POST } = await import("@/app/api/cron/retention-sweep/route");
+		const response = await POST(retentionSweepRequest({ token: CRON_SECRET }));
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toEqual({
+			success: true,
+			dryRun: false,
+			warned30: 1,
+			warned7: 0,
+			deleted: 0,
+			skipped: 0,
+		});
+
+		const inDb = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(inDb?.retentionWarning30SentAt).not.toBeNull();
+	});
+});
+
+describe("POST /api/cron/retention-sweep — dry run", () => {
+	it("reports counts but writes nothing for a due user with ?dryRun=1", async () => {
+		const user = await createTestUser({
+			lastLoginAt: dueForWarn30(new Date()),
+		});
+
+		const { POST } = await import("@/app/api/cron/retention-sweep/route");
+		const response = await POST(
+			retentionSweepRequest({ token: CRON_SECRET, dryRun: true })
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toEqual({
+			success: true,
+			dryRun: true,
+			warned30: 1,
+			warned7: 0,
+			deleted: 0,
+			skipped: 0,
+		});
+
+		const inDb = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(inDb?.retentionWarning30SentAt).toBeNull();
+	});
+});

--- a/src/__tests__/integration/auth-config.test.ts
+++ b/src/__tests__/integration/auth-config.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { authenticateWithPrisma } from "@/lib/auth/config";
+import { hashPassword } from "@/lib/auth/password-service";
+import prisma from "@/lib/prisma";
+import { createTestUser } from "../utils/prisma-factories";
+
+const TEST_PASSWORD = "correct horse battery staple";
+
+describe("authenticateWithPrisma — login clears retention warnings", () => {
+	it("records lastLoginAt and clears both retention-warning timestamps on a successful login", async () => {
+		const passwordHash = await hashPassword(TEST_PASSWORD);
+		const user = await createTestUser({
+			passwordHash,
+			passwordAlgorithm: "argon2id",
+			lastLoginAt: new Date("2020-01-01T00:00:00Z"),
+			retentionWarning30SentAt: new Date("2026-01-01T00:00:00Z"),
+			retentionWarning7SentAt: new Date("2026-01-20T00:00:00Z"),
+		});
+
+		const result = await authenticateWithPrisma(user.username, TEST_PASSWORD);
+		expect(result).not.toBeNull();
+
+		const updated = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(updated?.lastLoginAt).not.toBeNull();
+		expect(updated?.lastLoginAt?.getTime()).toBeGreaterThan(
+			new Date("2020-01-01T00:00:00Z").getTime()
+		);
+		expect(updated?.retentionWarning30SentAt).toBeNull();
+		expect(updated?.retentionWarning7SentAt).toBeNull();
+	});
+
+	it("does not touch lastLoginAt or the retention-warning timestamps on a failed login", async () => {
+		const passwordHash = await hashPassword(TEST_PASSWORD);
+		const originalLastLogin = new Date("2020-01-01T00:00:00Z");
+		const user = await createTestUser({
+			passwordHash,
+			passwordAlgorithm: "argon2id",
+			lastLoginAt: originalLastLogin,
+			retentionWarning30SentAt: new Date("2026-01-01T00:00:00Z"),
+		});
+
+		const result = await authenticateWithPrisma(
+			user.username,
+			"wrong-password"
+		);
+		expect(result).toBeNull();
+
+		const unchanged = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(unchanged?.lastLoginAt?.getTime()).toBe(originalLastLogin.getTime());
+		expect(unchanged?.retentionWarning30SentAt).not.toBeNull();
+	});
+});

--- a/src/__tests__/integration/auth-config.test.ts
+++ b/src/__tests__/integration/auth-config.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
 	authenticateGoogleWithPrisma,
 	authenticateWithPrisma,
 } from "@/lib/auth/config";
 import { hashPassword } from "@/lib/auth/password-service";
+import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
 import { createTestUser } from "../utils/prisma-factories";
 
@@ -51,6 +52,42 @@ describe("authenticateWithPrisma — login clears retention warnings", () => {
 		const unchanged = await prisma.user.findUnique({ where: { id: user.id } });
 		expect(unchanged?.lastLoginAt?.getTime()).toBe(originalLastLogin.getTime());
 		expect(unchanged?.retentionWarning30SentAt).not.toBeNull();
+	});
+
+	it("still succeeds when the user row vanishes between the password check and the best-effort reset write (QA round 2, item f)", async () => {
+		const passwordHash = await hashPassword(TEST_PASSWORD);
+		const user = await createTestUser({
+			passwordHash,
+			passwordAlgorithm: "argon2id",
+		});
+
+		const errorSpy = vi.spyOn(logger, "error");
+		const passwordService = await import("@/lib/auth/password-service");
+		const originalVerify = passwordService.verifyPassword;
+		const verifySpy = vi
+			.spyOn(passwordService, "verifyPassword")
+			.mockImplementation(async (...args) => {
+				const verifyResult = await originalVerify(...args);
+				// Delete the row for real, between the password check and the
+				// best-effort reset write — no Prisma mocking involved.
+				await prisma.user.delete({ where: { id: user.id } });
+				return verifyResult;
+			});
+
+		const result = await authenticateWithPrisma(user.username, TEST_PASSWORD);
+
+		expect(result).not.toBeNull();
+		expect(result?.id).toBe(user.id);
+		expect(errorSpy).toHaveBeenCalledWith(
+			"Failed to record login / reset retention warnings",
+			expect.objectContaining({ userId: user.id })
+		);
+
+		const gone = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(gone).toBeNull();
+
+		verifySpy.mockRestore();
+		errorSpy.mockRestore();
 	});
 });
 

--- a/src/__tests__/integration/auth-config.test.ts
+++ b/src/__tests__/integration/auth-config.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { authenticateWithPrisma } from "@/lib/auth/config";
+import {
+	authenticateGoogleWithPrisma,
+	authenticateWithPrisma,
+} from "@/lib/auth/config";
 import { hashPassword } from "@/lib/auth/password-service";
 import prisma from "@/lib/prisma";
 import { createTestUser } from "../utils/prisma-factories";
@@ -48,5 +51,32 @@ describe("authenticateWithPrisma — login clears retention warnings", () => {
 		const unchanged = await prisma.user.findUnique({ where: { id: user.id } });
 		expect(unchanged?.lastLoginAt?.getTime()).toBe(originalLastLogin.getTime());
 		expect(unchanged?.retentionWarning30SentAt).not.toBeNull();
+	});
+});
+
+describe("authenticateGoogleWithPrisma — OAuth login clears retention warnings", () => {
+	it("records lastLoginAt and clears both retention-warning timestamps when an existing user signs in with Google", async () => {
+		const user = await createTestUser({
+			lastLoginAt: new Date("2020-01-01T00:00:00Z"),
+			retentionWarning30SentAt: new Date("2026-01-01T00:00:00Z"),
+			retentionWarning7SentAt: new Date("2026-01-20T00:00:00Z"),
+		});
+
+		const result = await authenticateGoogleWithPrisma({
+			sub: "google-sub-123",
+			email: user.email,
+			name: "Test User",
+		});
+
+		expect(result).not.toBeNull();
+		expect(result?.id).toBe(user.id);
+
+		const updated = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(updated?.lastLoginAt?.getTime()).toBeGreaterThan(
+			new Date("2020-01-01T00:00:00Z").getTime()
+		);
+		expect(updated?.retentionWarning30SentAt).toBeNull();
+		expect(updated?.retentionWarning7SentAt).toBeNull();
+		expect(updated?.googleId).toBe("google-sub-123");
 	});
 });

--- a/src/__tests__/integration/retention-service.test.ts
+++ b/src/__tests__/integration/retention-service.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/lib/prisma";
+import { sendRetentionWarningEmail } from "@/lib/services/email-service";
 import { runRetentionSweep } from "@/lib/services/retention-service";
 import { expectError, expectSuccess } from "../utils/assertion-helpers";
 import {
@@ -8,6 +9,17 @@ import {
 	createTestPermission,
 	createTestUser,
 } from "../utils/prisma-factories";
+
+// Wrapped (not stubbed): defaults to the REAL implementation, overridden
+// per-test to simulate a send failure after the atomic claim.
+vi.mock("@/lib/services/email-service", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@/lib/services/email-service")>();
+	return {
+		...actual,
+		sendRetentionWarningEmail: vi.fn(actual.sendRetentionWarningEmail),
+	};
+});
 
 const CRON_SECRET = "test-cron-secret";
 
@@ -386,5 +398,47 @@ describe("runRetentionSweep — double-send guard", () => {
 		const firstData = expectSuccess(first);
 		const secondData = expectSuccess(second);
 		expect(firstData.warned7 + secondData.warned7).toBe(1);
+	});
+});
+
+/**
+ * Vincent, review round 2 (should-fix): stamp-then-send meant a send
+ * failure after the atomic claim was never retried — the user ends up
+ * "warned on record" but never actually warned. The stamp must be undone
+ * on a send failure so the next sweep retries.
+ */
+describe("runRetentionSweep — resets the stamp when the send fails after the claim", () => {
+	afterEach(() => {
+		vi.mocked(sendRetentionWarningEmail).mockRestore();
+	});
+
+	it("resets retentionWarning30SentAt to null and counts skipped when the email throws, then succeeds on the next sweep", async () => {
+		const now = new Date();
+		const lastLoginAt = addDays(warn30ThresholdActivity(now), -1);
+		const user = await createTestUser({ lastLoginAt });
+
+		vi.mocked(sendRetentionWarningEmail).mockImplementationOnce(() => {
+			throw new Error("simulated send failure");
+		});
+
+		const first = expectSuccess(await runRetentionSweep(CRON_SECRET));
+		expect(first.warned30).toBe(0);
+		expect(first.skipped).toBe(1);
+
+		const afterFailure = await prisma.user.findUnique({
+			where: { id: user.id },
+		});
+		expect(afterFailure?.retentionWarning30SentAt).toBeNull();
+
+		// Mock restored (afterEach on the PREVIOUS test would not have run
+		// yet for this assertion, but mockImplementationOnce already reverted
+		// to the wrapped real implementation) — the next sweep sends for real.
+		const second = expectSuccess(await runRetentionSweep(CRON_SECRET));
+		expect(second.warned30).toBe(1);
+
+		const afterRetry = await prisma.user.findUnique({
+			where: { id: user.id },
+		});
+		expect(afterRetry?.retentionWarning30SentAt).not.toBeNull();
 	});
 });

--- a/src/__tests__/integration/retention-service.test.ts
+++ b/src/__tests__/integration/retention-service.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import prisma from "@/lib/prisma";
 import { runRetentionSweep } from "@/lib/services/retention-service";
 import { expectError, expectSuccess } from "../utils/assertion-helpers";
-import { createTestUser } from "../utils/prisma-factories";
+import {
+	createTestIntegrationWithSystemUser,
+	createTestUser,
+} from "../utils/prisma-factories";
 
 const CRON_SECRET = "test-cron-secret";
 
@@ -246,5 +249,77 @@ describe("runRetentionSweep — dry run", () => {
 
 		const inDb = await prisma.user.findUnique({ where: { id: user.id } });
 		expect(inDb).not.toBeNull();
+	});
+});
+
+/**
+ * QA round 1, D2: the dry-run `delete` branch used to report "deleted"
+ * unconditionally, without running the same pre-checks
+ * (`checkDeletable`) the real path does — so dry-run and real counts
+ * disagreed on exactly the accounts the rollout dry-run check exists to
+ * catch (an owned integration blocks real deletion via `ON DELETE
+ * RESTRICT`).
+ */
+describe("runRetentionSweep — dry-run matches the real path (QA round 1, D2)", () => {
+	it("reports skipped, not deleted, in DRY-RUN for a user who owns an integration", async () => {
+		const now = new Date();
+		const lastLoginAt = addYears(now, -5);
+		const user = await createTestUser({
+			lastLoginAt,
+			retentionWarning30SentAt: addDays(now, -30),
+			retentionWarning7SentAt: addDays(now, -7),
+		});
+		await createTestIntegrationWithSystemUser(user.id);
+
+		const dryRunResult = expectSuccess(
+			await runRetentionSweep(CRON_SECRET, { dryRun: true })
+		);
+		expect(dryRunResult.deleted).toBe(0);
+		expect(dryRunResult.skipped).toBe(1);
+	});
+
+	it("agrees with the REAL run: both skip, neither deletes, for the same integration-owning user", async () => {
+		const now = new Date();
+		const lastLoginAt = addYears(now, -5);
+		const user = await createTestUser({
+			lastLoginAt,
+			retentionWarning30SentAt: addDays(now, -30),
+			retentionWarning7SentAt: addDays(now, -7),
+		});
+		await createTestIntegrationWithSystemUser(user.id);
+
+		const dryRunResult = expectSuccess(
+			await runRetentionSweep(CRON_SECRET, { dryRun: true })
+		);
+		const realResult = expectSuccess(await runRetentionSweep(CRON_SECRET));
+
+		expect(dryRunResult.deleted).toBe(realResult.deleted);
+		expect(dryRunResult.skipped).toBe(realResult.skipped);
+
+		const inDb = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(inDb).not.toBeNull();
+	});
+});
+
+/**
+ * QA round 1 gap: overlapping sweeps could double-send a warning email
+ * because the "already sent?" check and the "stamp it sent" write were two
+ * separate operations. `claimWarning30`/`claimWarning7` close the gap with
+ * an atomic `updateMany` guarded on the field still being `null`.
+ */
+describe("runRetentionSweep — double-send guard", () => {
+	it("sends the 30-day warning exactly once when two sweeps race for the same user", async () => {
+		const now = new Date();
+		const lastLoginAt = addDays(warn30ThresholdActivity(now), -1);
+		await createTestUser({ lastLoginAt });
+
+		const [first, second] = await Promise.all([
+			runRetentionSweep(CRON_SECRET),
+			runRetentionSweep(CRON_SECRET),
+		]);
+
+		const firstData = expectSuccess(first);
+		const secondData = expectSuccess(second);
+		expect(firstData.warned30 + secondData.warned30).toBe(1);
 	});
 });

--- a/src/__tests__/integration/retention-service.test.ts
+++ b/src/__tests__/integration/retention-service.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
-import { sendRetentionWarningEmail } from "@/lib/services/email-service";
+import {
+	sendRetentionFinalReminderEmail,
+	sendRetentionWarningEmail,
+} from "@/lib/services/email-service";
 import { runRetentionSweep } from "@/lib/services/retention-service";
 import { expectError, expectSuccess } from "../utils/assertion-helpers";
 import {
@@ -18,6 +22,9 @@ vi.mock("@/lib/services/email-service", async (importOriginal) => {
 	return {
 		...actual,
 		sendRetentionWarningEmail: vi.fn(actual.sendRetentionWarningEmail),
+		sendRetentionFinalReminderEmail: vi.fn(
+			actual.sendRetentionFinalReminderEmail
+		),
 	};
 });
 
@@ -440,5 +447,91 @@ describe("runRetentionSweep — resets the stamp when the send fails after the c
 			where: { id: user.id },
 		});
 		expect(afterRetry?.retentionWarning30SentAt).not.toBeNull();
+	});
+
+	/**
+	 * QA round 3, item b: same shape as the 30-day test above, for the
+	 * 7-day stage — the fix batch only covered the 30-day side.
+	 */
+	it("resets retentionWarning7SentAt to null and counts skipped when the email throws, then succeeds on the next sweep", async () => {
+		const now = new Date();
+		const lastLoginAt = addDays(warn7ThresholdActivity(now), -1);
+		const user = await createTestUser({
+			lastLoginAt,
+			retentionWarning30SentAt: addDays(now, -23),
+		});
+
+		vi.mocked(sendRetentionFinalReminderEmail).mockImplementationOnce(() => {
+			throw new Error("simulated send failure");
+		});
+		const errorSpy = vi.spyOn(logger, "error");
+
+		const first = expectSuccess(await runRetentionSweep(CRON_SECRET));
+		expect(first.warned7).toBe(0);
+		expect(first.skipped).toBe(1);
+
+		expect(errorSpy).toHaveBeenCalledWith(
+			"retention.warning_send_failed",
+			expect.objectContaining({ userId: user.id, stage: "warn7" })
+		);
+
+		const afterFailure = await prisma.user.findUnique({
+			where: { id: user.id },
+		});
+		expect(afterFailure?.retentionWarning7SentAt).toBeNull();
+
+		const second = expectSuccess(await runRetentionSweep(CRON_SECRET));
+		expect(second.warned7).toBe(1);
+
+		const afterRetry = await prisma.user.findUnique({
+			where: { id: user.id },
+		});
+		expect(afterRetry?.retentionWarning7SentAt).not.toBeNull();
+
+		errorSpy.mockRestore();
+	});
+});
+
+/**
+ * QA round 3, item b: two sweeps race for the same candidate and the
+ * winner's send throws. By construction this cannot corrupt a claim the
+ * OTHER run made — `claimWarning30`'s atomic `updateMany` guarantees only
+ * one process ever wins the null-to-timestamp transition, so the loser
+ * returns "skipped" before ever attempting a send, and never reaches the
+ * reset call at all. Only the actual winner can call `resetWarning30`, and
+ * it is guarded on the exact timestamp that winner itself wrote.
+ */
+describe("runRetentionSweep — concurrent sweeps where the winner's send throws", () => {
+	afterEach(() => {
+		vi.mocked(sendRetentionWarningEmail).mockRestore();
+	});
+
+	it("calls send exactly once, ends with the field null, and recovers on the next sweep", async () => {
+		const now = new Date();
+		const lastLoginAt = addDays(warn30ThresholdActivity(now), -1);
+		const user = await createTestUser({ lastLoginAt });
+
+		// Always throws — only the winner of the atomic claim ever reaches
+		// this mock; the loser returns "skipped" without calling it.
+		vi.mocked(sendRetentionWarningEmail).mockImplementation(() => {
+			throw new Error("simulated send failure (race)");
+		});
+
+		const [first, second] = await Promise.all([
+			runRetentionSweep(CRON_SECRET),
+			runRetentionSweep(CRON_SECRET),
+		]);
+
+		const firstData = expectSuccess(first);
+		const secondData = expectSuccess(second);
+		expect(firstData.warned30 + secondData.warned30).toBe(0);
+		expect(sendRetentionWarningEmail).toHaveBeenCalledTimes(1);
+
+		const afterRace = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(afterRace?.retentionWarning30SentAt).toBeNull();
+
+		vi.mocked(sendRetentionWarningEmail).mockRestore();
+		const third = expectSuccess(await runRetentionSweep(CRON_SECRET));
+		expect(third.warned30).toBe(1);
 	});
 });

--- a/src/__tests__/integration/retention-service.test.ts
+++ b/src/__tests__/integration/retention-service.test.ts
@@ -3,7 +3,9 @@ import prisma from "@/lib/prisma";
 import { runRetentionSweep } from "@/lib/services/retention-service";
 import { expectError, expectSuccess } from "../utils/assertion-helpers";
 import {
+	createTestCase,
 	createTestIntegrationWithSystemUser,
+	createTestPermission,
 	createTestUser,
 } from "../utils/prisma-factories";
 
@@ -32,6 +34,11 @@ function addYears(date: Date, years: number): Date {
 /** The lastActivity time at which the 30-day warning threshold falls exactly now. */
 function warn30ThresholdActivity(now: Date): Date {
 	return addDays(addYears(now, -2), 30);
+}
+
+/** The lastActivity time at which the 7-day reminder threshold falls exactly now. */
+function warn7ThresholdActivity(now: Date): Date {
+	return addDays(addYears(now, -2), 7);
 }
 
 describe("runRetentionSweep — auth", () => {
@@ -299,6 +306,46 @@ describe("runRetentionSweep — dry-run matches the real path (QA round 1, D2)",
 		const inDb = await prisma.user.findUnique({ where: { id: user.id } });
 		expect(inDb).not.toBeNull();
 	});
+
+	it("agrees on an integration owner (skipped) AND a D1-shaped user (deleted) in the SAME batch (QA round 2, item b)", async () => {
+		const now = new Date();
+		const lastLoginAt = addYears(now, -5);
+
+		const integrationOwner = await createTestUser({
+			lastLoginAt,
+			retentionWarning30SentAt: addDays(now, -30),
+			retentionWarning7SentAt: addDays(now, -7),
+		});
+		await createTestIntegrationWithSystemUser(integrationOwner.id);
+
+		const d1User = await createTestUser({
+			lastLoginAt,
+			retentionWarning30SentAt: addDays(now, -30),
+			retentionWarning7SentAt: addDays(now, -7),
+		});
+		const viewer = await createTestUser();
+		const sharedCase = await createTestCase(d1User.id, {
+			name: "D1-shaped user's shared case",
+		});
+		await createTestPermission(sharedCase.id, viewer.id, d1User.id, "VIEW");
+
+		const dryRunResult = expectSuccess(
+			await runRetentionSweep(CRON_SECRET, { dryRun: true })
+		);
+		expect(dryRunResult.skipped).toBe(1);
+		expect(dryRunResult.deleted).toBe(1);
+
+		const realResult = expectSuccess(await runRetentionSweep(CRON_SECRET));
+		expect(realResult.skipped).toBe(dryRunResult.skipped);
+		expect(realResult.deleted).toBe(dryRunResult.deleted);
+
+		expect(
+			await prisma.user.findUnique({ where: { id: integrationOwner.id } })
+		).not.toBeNull();
+		expect(
+			await prisma.user.findUnique({ where: { id: d1User.id } })
+		).toBeNull();
+	});
 });
 
 /**
@@ -321,5 +368,23 @@ describe("runRetentionSweep — double-send guard", () => {
 		const firstData = expectSuccess(first);
 		const secondData = expectSuccess(second);
 		expect(firstData.warned30 + secondData.warned30).toBe(1);
+	});
+
+	it("sends the 7-day reminder exactly once when two sweeps race for the same user (QA round 2, item d)", async () => {
+		const now = new Date();
+		const lastLoginAt = addDays(warn7ThresholdActivity(now), -1);
+		await createTestUser({
+			lastLoginAt,
+			retentionWarning30SentAt: addDays(now, -23),
+		});
+
+		const [first, second] = await Promise.all([
+			runRetentionSweep(CRON_SECRET),
+			runRetentionSweep(CRON_SECRET),
+		]);
+
+		const firstData = expectSuccess(first);
+		const secondData = expectSuccess(second);
+		expect(firstData.warned7 + secondData.warned7).toBe(1);
 	});
 });

--- a/src/__tests__/integration/retention-service.test.ts
+++ b/src/__tests__/integration/retention-service.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import { runRetentionSweep } from "@/lib/services/retention-service";
+import { expectError, expectSuccess } from "../utils/assertion-helpers";
+import { createTestUser } from "../utils/prisma-factories";
+
+const CRON_SECRET = "test-cron-secret";
+
+beforeEach(() => {
+	vi.stubEnv("CRON_SECRET", CRON_SECRET);
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+function addDays(date: Date, days: number): Date {
+	const result = new Date(date);
+	result.setUTCDate(result.getUTCDate() + days);
+	return result;
+}
+
+function addYears(date: Date, years: number): Date {
+	const result = new Date(date);
+	result.setUTCFullYear(result.getUTCFullYear() + years);
+	return result;
+}
+
+/** The lastActivity time at which the 30-day warning threshold falls exactly now. */
+function warn30ThresholdActivity(now: Date): Date {
+	return addDays(addYears(now, -2), 30);
+}
+
+describe("runRetentionSweep — auth", () => {
+	it("refuses with no CRON_SECRET configured", async () => {
+		vi.unstubAllEnvs();
+		expectError(
+			await runRetentionSweep("anything"),
+			"Server configuration error"
+		);
+	});
+
+	it("refuses a missing token", async () => {
+		expectError(await runRetentionSweep(null), "Unauthorised");
+	});
+
+	it("refuses a wrong token", async () => {
+		expectError(await runRetentionSweep("wrong-secret"), "Unauthorised");
+	});
+
+	it("accepts the correct token", async () => {
+		expectSuccess(await runRetentionSweep(CRON_SECRET));
+	});
+});
+
+describe("runRetentionSweep — 30-day warning fencepost", () => {
+	it("does not warn a user who is one day short of the 30-day-before threshold", async () => {
+		const now = new Date();
+		const lastLoginAt = addDays(warn30ThresholdActivity(now), 1);
+		const user = await createTestUser({ lastLoginAt });
+
+		const result = expectSuccess(await runRetentionSweep(CRON_SECRET));
+		expect(result.warned30).toBe(0);
+
+		const inDb = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(inDb?.retentionWarning30SentAt).toBeNull();
+	});
+
+	it("warns a user who is one day past the 30-day-before threshold", async () => {
+		const now = new Date();
+		const lastLoginAt = addDays(warn30ThresholdActivity(now), -1);
+		const user = await createTestUser({ lastLoginAt });
+
+		const result = expectSuccess(await runRetentionSweep(CRON_SECRET));
+		expect(result.warned30).toBe(1);
+		expect(result.deleted).toBe(0);
+		expect(result.warned7).toBe(0);
+
+		const inDb = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(inDb?.retentionWarning30SentAt).not.toBeNull();
+	});
+
+	it("falls back to createdAt when lastLoginAt is null", async () => {
+		const now = new Date();
+		const createdAt = addDays(warn30ThresholdActivity(now), -1);
+		const user = await createTestUser({ lastLoginAt: null, createdAt });
+
+		const result = expectSuccess(await runRetentionSweep(CRON_SECRET));
+		expect(result.warned30).toBe(1);
+
+		const inDb = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(inDb?.retentionWarning30SentAt).not.toBeNull();
+	});
+});
+
+describe("runRetentionSweep — 7-day reminder gate", () => {
+	it("does not send the 7-day reminder before the 30-day warning is 23 days old", async () => {
+		const now = new Date();
+		// Very overdue, so now is already past the 7-day-before threshold too.
+		const lastLoginAt = addYears(now, -5);
+		const user = await createTestUser({
+			lastLoginAt,
+			retentionWarning30SentAt: addDays(now, -5), // only 5 days old, not 23
+		});
+
+		const result = expectSuccess(await runRetentionSweep(CRON_SECRET));
+		expect(result.warned7).toBe(0);
+		expect(result.warned30).toBe(0); // already sent, so not sent again
+		expect(result.deleted).toBe(0);
+
+		const inDb = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(inDb?.retentionWarning7SentAt).toBeNull();
+	});
+
+	it("sends the 7-day reminder once the 30-day warning is at least 23 days old", async () => {
+		const now = new Date();
+		const lastLoginAt = addYears(now, -5);
+		const user = await createTestUser({
+			lastLoginAt,
+			retentionWarning30SentAt: addDays(now, -23),
+		});
+
+		const result = expectSuccess(await runRetentionSweep(CRON_SECRET));
+		expect(result.warned7).toBe(1);
+		expect(result.deleted).toBe(0);
+
+		const inDb = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(inDb?.retentionWarning7SentAt).not.toBeNull();
+	});
+});
+
+describe("runRetentionSweep — deletion gate", () => {
+	it("does not delete before the 7-day reminder is 7 days old", async () => {
+		const now = new Date();
+		const lastLoginAt = addYears(now, -5);
+		const user = await createTestUser({
+			lastLoginAt,
+			retentionWarning30SentAt: addDays(now, -30),
+			retentionWarning7SentAt: addDays(now, -3),
+		});
+
+		const result = expectSuccess(await runRetentionSweep(CRON_SECRET));
+		expect(result.deleted).toBe(0);
+
+		const inDb = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(inDb).not.toBeNull();
+	});
+
+	it("deletes once the 7-day reminder is at least 7 days old", async () => {
+		const now = new Date();
+		const lastLoginAt = addYears(now, -5);
+		const user = await createTestUser({
+			lastLoginAt,
+			retentionWarning30SentAt: addDays(now, -30),
+			retentionWarning7SentAt: addDays(now, -7),
+		});
+
+		const result = expectSuccess(await runRetentionSweep(CRON_SECRET));
+		expect(result.deleted).toBe(1);
+
+		const inDb = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(inDb).toBeNull();
+	});
+});
+
+describe("runRetentionSweep — SYSTEM exclusion", () => {
+	it("never sweeps a SYSTEM auth-provider user, however overdue", async () => {
+		const now = new Date();
+		const user = await createTestUser({
+			authProvider: "SYSTEM",
+			lastLoginAt: addYears(now, -10),
+		});
+
+		const result = expectSuccess(await runRetentionSweep(CRON_SECRET));
+
+		const inDb = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(inDb).not.toBeNull();
+		expect(inDb?.retentionWarning30SentAt).toBeNull();
+		expect(result.deleted).toBe(0);
+	});
+});
+
+describe("runRetentionSweep — first-run safety property", () => {
+	it("an account already 5 years inactive on its first sweep gets a warning, never a deletion", async () => {
+		const now = new Date();
+		const user = await createTestUser({ lastLoginAt: addYears(now, -5) });
+
+		const result = expectSuccess(await runRetentionSweep(CRON_SECRET));
+		expect(result.warned30).toBe(1);
+		expect(result.warned7).toBe(0);
+		expect(result.deleted).toBe(0);
+
+		const inDb = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(inDb).not.toBeNull();
+		expect(inDb?.retentionWarning30SentAt).not.toBeNull();
+		expect(inDb?.retentionWarning7SentAt).toBeNull();
+	});
+});
+
+describe("runRetentionSweep — idempotency", () => {
+	it("a second immediate run sends nothing new for an already-warned user", async () => {
+		const now = new Date();
+		const user = await createTestUser({ lastLoginAt: addYears(now, -5) });
+
+		const first = expectSuccess(await runRetentionSweep(CRON_SECRET));
+		expect(first.warned30).toBe(1);
+
+		const second = expectSuccess(await runRetentionSweep(CRON_SECRET));
+		expect(second.warned30).toBe(0);
+		expect(second.warned7).toBe(0);
+		expect(second.deleted).toBe(0);
+
+		const inDb = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(inDb).not.toBeNull();
+	});
+});
+
+describe("runRetentionSweep — dry run", () => {
+	it("computes counts without writing a warning timestamp or sending anything", async () => {
+		const now = new Date();
+		const lastLoginAt = addDays(warn30ThresholdActivity(now), -1);
+		const user = await createTestUser({ lastLoginAt });
+
+		const result = expectSuccess(
+			await runRetentionSweep(CRON_SECRET, { dryRun: true })
+		);
+		expect(result.warned30).toBe(1);
+
+		const inDb = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(inDb?.retentionWarning30SentAt).toBeNull();
+	});
+
+	it("does not delete an account due for deletion", async () => {
+		const now = new Date();
+		const lastLoginAt = addYears(now, -5);
+		const user = await createTestUser({
+			lastLoginAt,
+			retentionWarning30SentAt: addDays(now, -30),
+			retentionWarning7SentAt: addDays(now, -7),
+		});
+
+		const result = expectSuccess(
+			await runRetentionSweep(CRON_SECRET, { dryRun: true })
+		);
+		expect(result.deleted).toBe(1);
+
+		const inDb = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(inDb).not.toBeNull();
+	});
+});

--- a/src/__tests__/integration/user-management-service.test.ts
+++ b/src/__tests__/integration/user-management-service.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import prisma from "@/lib/prisma";
 import { reassignIntegrationOwner } from "@/lib/services/integration-registry-service";
-import { deleteAccount } from "@/lib/services/user-management-service";
+import {
+	deleteAccount,
+	deleteAccountForRetention,
+} from "@/lib/services/user-management-service";
 import { expectError, expectSuccess } from "../utils/assertion-helpers";
 import {
 	createTestCase,
@@ -151,5 +154,52 @@ describe("deleteAccount — owned-integrations block (ADR 0002 v2 §2.4)", () =>
 		await createTestIntegrationWithSystemUser(otherOwner.id);
 
 		expectSuccess(await deleteAccount(owner.id));
+	});
+});
+
+/**
+ * `deleteAccountForRetention` is the password-free counterpart used by the
+ * retention sweep (`lib/services/retention-service.ts`) — it shares
+ * `deleteAccount`'s cascade without requiring a password.
+ */
+describe("deleteAccountForRetention", () => {
+	it("deletes the user and reassigns their owned case, without a password", async () => {
+		const owner = await createTestUser();
+		const ownedCase = await createTestCase(owner.id, {
+			name: "Retention case",
+		});
+
+		expectSuccess(await deleteAccountForRetention(owner.id));
+
+		const deletedUser = await prisma.user.findUnique({
+			where: { id: owner.id },
+		});
+		expect(deletedUser).toBeNull();
+
+		const updatedCase = await prisma.assuranceCase.findUniqueOrThrow({
+			where: { id: ownedCase.id },
+		});
+		expect(updatedCase.createdById).not.toBe(owner.id);
+	});
+
+	it("refuses with the same typed error as deleteAccount when the user owns an integration", async () => {
+		const owner = await createTestUser();
+		await createTestIntegrationWithSystemUser(owner.id);
+
+		const result = await deleteAccountForRetention(owner.id);
+
+		expectError(result, SINGLE_INTEGRATION_BLOCK_PATTERN);
+
+		const stillThere = await prisma.user.findUnique({
+			where: { id: owner.id },
+		});
+		expect(stillThere).not.toBeNull();
+	});
+
+	it("returns an error for a non-existent user", async () => {
+		expectError(
+			await deleteAccountForRetention("00000000-0000-0000-0000-000000000000"),
+			"User not found"
+		);
 	});
 });

--- a/src/__tests__/integration/user-management-service.test.ts
+++ b/src/__tests__/integration/user-management-service.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/services/user-management-service";
 import { expectError, expectSuccess } from "../utils/assertion-helpers";
 import {
+	addTeamMember,
 	createTestCase,
 	createTestIntegrationWithSystemUser,
 	createTestPermission,
@@ -229,10 +230,38 @@ describe("deleteAccount — kept vs trashed cases (Chris's deletion rule)", () =
 		expect(updatedCase.createdById).not.toBe(owner.id);
 	});
 
-	it("keeps a case when a team holds ADMIN via CaseTeamPermission, with no other individual admin", async () => {
+	it("keeps a case when a team holds ADMIN via CaseTeamPermission AND has a member besides the deleted owner", async () => {
+		const owner = await createTestUser({ authProvider: "GITHUB" });
+		const otherMember = await createTestUser();
+		const testCase = await createTestCase(owner.id, {
+			name: "Team-admin case (team of two)",
+		});
+		const team = await createTestTeam(owner.id);
+		await addTeamMember(team.id, otherMember.id);
+		await createTestTeamPermission(testCase.id, team.id, owner.id, "ADMIN");
+
+		expectSuccess(await deleteAccount(owner.id));
+
+		const updatedCase = await prisma.assuranceCase.findUniqueOrThrow({
+			where: { id: testCase.id },
+		});
+		expect(updatedCase.deletedAt).toBeNull();
+	});
+
+	/**
+	 * Vincent, review round 2 (blocker): a team-ADMIN grant only counts as
+	 * "another admin" if the team has a member other than the deleted user.
+	 * A "team of one" IS the deleted user — `createTestTeam` creates exactly
+	 * that (the creator as its only member) — and `runAccountDeletionTransaction`
+	 * deletes precisely this shape of team, cascading its CaseTeamPermission
+	 * away. Without the fix, this case would be marked "kept" but end up
+	 * owned by the system account with no permission for anyone: orphaned,
+	 * never trashed, never purged.
+	 */
+	it("trashes a case when the only ADMIN-holding team has no member besides the deleted owner (team of one)", async () => {
 		const owner = await createTestUser({ authProvider: "GITHUB" });
 		const testCase = await createTestCase(owner.id, {
-			name: "Team-admin case",
+			name: "Team-admin case (team of one)",
 		});
 		const team = await createTestTeam(owner.id);
 		await createTestTeamPermission(testCase.id, team.id, owner.id, "ADMIN");
@@ -242,7 +271,15 @@ describe("deleteAccount — kept vs trashed cases (Chris's deletion rule)", () =
 		const updatedCase = await prisma.assuranceCase.findUniqueOrThrow({
 			where: { id: testCase.id },
 		});
-		expect(updatedCase.deletedAt).toBeNull();
+		expect(updatedCase.deletedAt).not.toBeNull();
+
+		// The team-of-one is deleted by the team-handling step, which cascades
+		// its CaseTeamPermission away — this is the exact sequence the
+		// blocker warned about, so assert the permission is really gone too.
+		const teamStillExists = await prisma.team.findUnique({
+			where: { id: team.id },
+		});
+		expect(teamStillExists).toBeNull();
 	});
 
 	it("trashes a case when the only other access is VIEW/EDIT/COMMENT, not ADMIN", async () => {

--- a/src/__tests__/integration/user-management-service.test.ts
+++ b/src/__tests__/integration/user-management-service.test.ts
@@ -9,6 +9,9 @@ import { expectError, expectSuccess } from "../utils/assertion-helpers";
 import {
 	createTestCase,
 	createTestIntegrationWithSystemUser,
+	createTestPermission,
+	createTestTeam,
+	createTestTeamPermission,
 	createTestUser,
 } from "../utils/prisma-factories";
 
@@ -201,5 +204,134 @@ describe("deleteAccountForRetention", () => {
 			await deleteAccountForRetention("00000000-0000-0000-0000-000000000000"),
 			"User not found"
 		);
+	});
+});
+
+/**
+ * Chris's ruling (2026-09-07): a case the deleted user created is KEPT
+ * (authorship reassigned to the system account, as before) only if another
+ * principal already holds ADMIN on it — otherwise it is trashed so it
+ * disappears for every collaborator too.
+ */
+describe("deleteAccount — kept vs trashed cases (Chris's deletion rule)", () => {
+	it("keeps a case (does not trash it) when another user holds ADMIN via CasePermission", async () => {
+		const owner = await createTestUser({ authProvider: "GITHUB" });
+		const admin = await createTestUser();
+		const testCase = await createTestCase(owner.id, { name: "Co-admin case" });
+		await createTestPermission(testCase.id, admin.id, owner.id, "ADMIN");
+
+		expectSuccess(await deleteAccount(owner.id));
+
+		const updatedCase = await prisma.assuranceCase.findUniqueOrThrow({
+			where: { id: testCase.id },
+		});
+		expect(updatedCase.deletedAt).toBeNull();
+		expect(updatedCase.createdById).not.toBe(owner.id);
+	});
+
+	it("keeps a case when a team holds ADMIN via CaseTeamPermission, with no other individual admin", async () => {
+		const owner = await createTestUser({ authProvider: "GITHUB" });
+		const testCase = await createTestCase(owner.id, {
+			name: "Team-admin case",
+		});
+		const team = await createTestTeam(owner.id);
+		await createTestTeamPermission(testCase.id, team.id, owner.id, "ADMIN");
+
+		expectSuccess(await deleteAccount(owner.id));
+
+		const updatedCase = await prisma.assuranceCase.findUniqueOrThrow({
+			where: { id: testCase.id },
+		});
+		expect(updatedCase.deletedAt).toBeNull();
+	});
+
+	it("trashes a case when the only other access is VIEW/EDIT/COMMENT, not ADMIN", async () => {
+		const owner = await createTestUser({ authProvider: "GITHUB" });
+		const editor = await createTestUser();
+		const testCase = await createTestCase(owner.id, {
+			name: "Collaborator-only case",
+		});
+		await createTestPermission(testCase.id, editor.id, owner.id, "EDIT");
+
+		expectSuccess(await deleteAccount(owner.id));
+
+		const updatedCase = await prisma.assuranceCase.findUniqueOrThrow({
+			where: { id: testCase.id },
+		});
+		expect(updatedCase.deletedAt).not.toBeNull();
+		// Trashed cases are hidden from EVERY viewer, not just the deleted
+		// owner — listUserCases/listSharedCases and fetchCaseFromPrisma all
+		// filter deletedAt: null unconditionally (verified by reading those
+		// services), so the editor loses access exactly like a hard delete
+		// would show them, without needing one.
+		const { listSharedCases } = await import(
+			"@/lib/services/case-fetch-service"
+		);
+		const shared = expectSuccess(await listSharedCases(editor.id));
+		expect(shared.find((c) => c.id === testCase.id)).toBeUndefined();
+	});
+
+	it("trashes a case with no collaborators at all", async () => {
+		const owner = await createTestUser({ authProvider: "GITHUB" });
+		const testCase = await createTestCase(owner.id, { name: "Solo case" });
+
+		expectSuccess(await deleteAccount(owner.id));
+
+		const updatedCase = await prisma.assuranceCase.findUniqueOrThrow({
+			where: { id: testCase.id },
+		});
+		expect(updatedCase.deletedAt).not.toBeNull();
+	});
+});
+
+/**
+ * QA round 1, D1: `CasePermission.grantedById` is a real `ON DELETE
+ * RESTRICT` FK with no cascade — deleting a user who had ever granted a
+ * permission (on their own case OR someone else's) used to throw P2003,
+ * flattened to "Failed to delete account".
+ */
+describe("deleteAccount — grantedById reassignment (QA round 1, D1)", () => {
+	it("succeeds when the user granted a permission on their OWN case", async () => {
+		const owner = await createTestUser({ authProvider: "GITHUB" });
+		const viewer = await createTestUser();
+		const testCase = await createTestCase(owner.id, {
+			name: "Shared by owner",
+		});
+		const permission = await createTestPermission(
+			testCase.id,
+			viewer.id,
+			owner.id,
+			"VIEW"
+		);
+
+		expectSuccess(await deleteAccount(owner.id));
+
+		const updatedPermission = await prisma.casePermission.findUniqueOrThrow({
+			where: { id: permission.id },
+		});
+		expect(updatedPermission.grantedById).not.toBe(owner.id);
+	});
+
+	it("succeeds when the user granted a permission on SOMEONE ELSE'S case (an admin who invited others)", async () => {
+		const caseOwner = await createTestUser();
+		const admin = await createTestUser({ authProvider: "GITHUB" });
+		const viewer = await createTestUser();
+		const testCase = await createTestCase(caseOwner.id, {
+			name: "Owned by someone else",
+		});
+		await createTestPermission(testCase.id, admin.id, caseOwner.id, "ADMIN");
+		const grantedPermission = await createTestPermission(
+			testCase.id,
+			viewer.id,
+			admin.id,
+			"VIEW"
+		);
+
+		expectSuccess(await deleteAccount(admin.id));
+
+		const updatedPermission = await prisma.casePermission.findUniqueOrThrow({
+			where: { id: grantedPermission.id },
+		});
+		expect(updatedPermission.grantedById).not.toBe(admin.id);
 	});
 });

--- a/src/__tests__/integration/user-management-service.test.ts
+++ b/src/__tests__/integration/user-management-service.test.ts
@@ -334,4 +334,25 @@ describe("deleteAccount — grantedById reassignment (QA round 1, D1)", () => {
 		});
 		expect(updatedPermission.grantedById).not.toBe(admin.id);
 	});
+
+	it("deleteAccountForRetention succeeds when the user granted a permission on their OWN case (QA round 2, item a)", async () => {
+		const owner = await createTestUser();
+		const viewer = await createTestUser();
+		const testCase = await createTestCase(owner.id, {
+			name: "Shared by owner (retention)",
+		});
+		const permission = await createTestPermission(
+			testCase.id,
+			viewer.id,
+			owner.id,
+			"VIEW"
+		);
+
+		expectSuccess(await deleteAccountForRetention(owner.id));
+
+		const updatedPermission = await prisma.casePermission.findUniqueOrThrow({
+			where: { id: permission.id },
+		});
+		expect(updatedPermission.grantedById).not.toBe(owner.id);
+	});
 });

--- a/src/__tests__/integration/user-management-service.test.ts
+++ b/src/__tests__/integration/user-management-service.test.ts
@@ -282,6 +282,56 @@ describe("deleteAccount — kept vs trashed cases (Chris's deletion rule)", () =
 		expect(teamStillExists).toBeNull();
 	});
 
+	/**
+	 * QA round 3, item a(iv): a case can carry more than one ADMIN-holding
+	 * team at once — one qualifying (a member besides the deleted owner),
+	 * one not (team of one). Only one needs to qualify for the case to be
+	 * kept, and each team is still handled on its own merits by the
+	 * team-handling step (the team-of-one is deleted, the team-of-two is
+	 * transferred), independent of the keep/trash decision they jointly fed.
+	 */
+	it("keeps a case with two ADMIN-holding teams, one of each kind — the qualifying one keeps it, the team-of-one is still deleted", async () => {
+		const owner = await createTestUser({ authProvider: "GITHUB" });
+		const otherMember = await createTestUser();
+		const testCase = await createTestCase(owner.id, {
+			name: "Two teams, one qualifies",
+		});
+
+		const teamOfOne = await createTestTeam(owner.id, { name: "Team of one" });
+		await createTestTeamPermission(
+			testCase.id,
+			teamOfOne.id,
+			owner.id,
+			"ADMIN"
+		);
+
+		const teamOfTwo = await createTestTeam(owner.id, { name: "Team of two" });
+		await addTeamMember(teamOfTwo.id, otherMember.id);
+		await createTestTeamPermission(
+			testCase.id,
+			teamOfTwo.id,
+			owner.id,
+			"ADMIN"
+		);
+
+		expectSuccess(await deleteAccount(owner.id));
+
+		const updatedCase = await prisma.assuranceCase.findUniqueOrThrow({
+			where: { id: testCase.id },
+		});
+		expect(updatedCase.deletedAt).toBeNull();
+
+		const teamOfOneAfter = await prisma.team.findUnique({
+			where: { id: teamOfOne.id },
+		});
+		expect(teamOfOneAfter).toBeNull();
+
+		const teamOfTwoAfter = await prisma.team.findUniqueOrThrow({
+			where: { id: teamOfTwo.id },
+		});
+		expect(teamOfTwoAfter.createdById).toBe(otherMember.id);
+	});
+
 	it("trashes a case when the only other access is VIEW/EDIT/COMMENT, not ADMIN", async () => {
 		const owner = await createTestUser({ authProvider: "GITHUB" });
 		const editor = await createTestUser();
@@ -391,5 +441,64 @@ describe("deleteAccount — grantedById reassignment (QA round 1, D1)", () => {
 			where: { id: permission.id },
 		});
 		expect(updatedPermission.grantedById).not.toBe(owner.id);
+	});
+});
+
+/**
+ * QA round 3, item c: `runAccountDeletionTransaction`'s round trips scale
+ * with how much history the deleted user has (owned cases, teams, comments,
+ * elements, permissions granted) — vincent's review round 2 should-fix
+ * widened the interactive transaction's timeout to 30s (maxWait 10s) for
+ * exactly this reason. Asserts the outcomes are all correct at scale, not
+ * wall-clock — a slow CI runner proves nothing about correctness, and a
+ * flaky timing assertion is worse than no assertion.
+ */
+describe("deleteAccount — bulk deletion within the transaction budget (QA round 3, item c)", () => {
+	it("deletes a user owning 40 cases and 15 teams (mixed transfer/delete) and resolves every case and team correctly", async () => {
+		const owner = await createTestUser({ authProvider: "GITHUB" });
+		const otherMember = await createTestUser();
+
+		const CASE_COUNT = 40;
+		for (let i = 0; i < CASE_COUNT; i++) {
+			await createTestCase(owner.id, { name: `Bulk case ${i}` });
+		}
+
+		const TEAM_COUNT = 15;
+		const teamIds: string[] = [];
+		for (let i = 0; i < TEAM_COUNT; i++) {
+			const team = await createTestTeam(owner.id, { name: `Bulk team ${i}` });
+			teamIds.push(team.id);
+			// Half get a second member (transfer), half stay team-of-one (delete).
+			if (i % 2 === 0) {
+				await addTeamMember(team.id, otherMember.id);
+			}
+		}
+
+		expectSuccess(await deleteAccount(owner.id));
+
+		const deletedUser = await prisma.user.findUnique({
+			where: { id: owner.id },
+		});
+		expect(deletedUser).toBeNull();
+
+		const casesAfter = await prisma.assuranceCase.findMany({
+			where: { name: { startsWith: "Bulk case " } },
+		});
+		expect(casesAfter).toHaveLength(CASE_COUNT);
+		for (const c of casesAfter) {
+			// None of the 40 had another admin, so all trash rather than keep.
+			expect(c.deletedAt).not.toBeNull();
+			expect(c.createdById).not.toBe(owner.id);
+		}
+
+		const teamsAfter = await prisma.team.findMany({
+			where: { id: { in: teamIds } },
+		});
+		// Half (even i) had a second member and transferred; half (odd i)
+		// were team-of-one and were deleted outright.
+		expect(teamsAfter).toHaveLength(Math.ceil(TEAM_COUNT / 2));
+		for (const t of teamsAfter) {
+			expect(t.createdById).toBe(otherMember.id);
+		}
 	});
 });

--- a/src/__tests__/utils/prisma-factories.ts
+++ b/src/__tests__/utils/prisma-factories.ts
@@ -39,6 +39,10 @@ type UserOverrides = Partial<{
 	firstName: string;
 	lastName: string;
 	emailVerified: boolean;
+	createdAt: Date;
+	lastLoginAt: Date | null;
+	retentionWarning30SentAt: Date | null;
+	retentionWarning7SentAt: Date | null;
 }>;
 
 export function createTestUser(overrides: UserOverrides = {}): Promise<User> {
@@ -53,6 +57,10 @@ export function createTestUser(overrides: UserOverrides = {}): Promise<User> {
 			firstName: overrides.firstName,
 			lastName: overrides.lastName,
 			emailVerified: overrides.emailVerified ?? false,
+			createdAt: overrides.createdAt,
+			lastLoginAt: overrides.lastLoginAt,
+			retentionWarning30SentAt: overrides.retentionWarning30SentAt,
+			retentionWarning7SentAt: overrides.retentionWarning7SentAt,
 		},
 	});
 }


### PR DESCRIPTION
## What

Makes the published data-retention policy true, and applies a ruling on what account deletion does to a user's cases.

**Retention sweep.** A daily job (`POST /api/cron/retention-sweep`, `CRON_SECRET`, scheduled by `.github/workflows/retention-sweep.yml` like the trash purge) finds accounts with no login for two years, sends a warning email 30 days before deletion and a final reminder 7 days before, then deletes the account. Safety rules: nothing is deleted without both warnings on record and aged (≥ 30 and ≥ 7 days), so the first ever run can only warn; warning stamps are claimed atomically (no double-send under overlapping runs) and undone if the email fails to send (so the next sweep retries); logging in clears the warnings; system/integration principals are excluded; users who own an integration are skipped and counted; `?dryRun=1` (and a `workflow_dispatch` input defaulting to dry-run) reports without writing. Email text approved.

**Login tracking.** `lastLoginAt` was not written on any login path before this change; it now is (credentials, GitHub, Google, linking), with the credentials-path write made best-effort so it can never fail a login.

**Deletion rule (both the sweep and self-service "delete my account", which share the core).** For each case the user created: kept (authorship reassigned to the system account) only if another user, or a team with at least one other member, holds Admin on it; otherwise soft-deleted into the trash, where it is invisible to every collaborator and purged by the existing cron. Permissions the user granted are reassigned (previously an unhandled foreign key that made account deletion fail for anyone who had ever shared a case). Explicit 30 s transaction budget; team handling batched. The settings dialog copy states the rule.

## Review chain

- Rounds: build → QA FAIL (2 defects) / review approve-with-nits → fix batch → QA PASS / review REQUEST-CHANGES (team-of-one blocker, stamp-reset, transaction budget) → fix batch → QA PASS / review APPROVE.
- Reviewed 734e76e3; final 5fd7584e adds four tests only.
- Integration 1158/1158, unit 1457/1457, lint and typecheck clean at 5fd7584e.
- Fallow (no coverage locally, tooling issue filed): introduced complexity limited to `decideAction` (11) and the cron route (5), both accepted; clone group from the cron-secret guard removed by extracting `requireCronSecret`; dead code 0.

## Rollout

- Merging to `staging` reseeds the staging database (existing behaviour) and does not start the schedule (`schedule:` runs only from `main`).
- Before promoting to `main`: run the sweep on staging in dry-run and read the counts (`workflow_dispatch` with `dry_run: true`, or `curl -X POST <staging>/api/cron/retention-sweep?dryRun=1 -H "Authorization: Bearer $CRON_SECRET"`).
- Follow-ups filed: correct the policy page to the rule above; self-service deletion never sent its confirmation email; six user-reference columns lack database foreign keys; email templates do not HTML-escape the username.