### PR TITLE
chore(release): correct version metadata to 0.6.0 (and bring main into staging)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to the TEA Platform will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0](https://github.com/alan-turing-institute/AssurancePlatform/compare/v0.5.1...v1.0.0) (2026-09-08)
+## [0.6.0](https://github.com/alan-turing-institute/AssurancePlatform/compare/v0.5.1...v0.6.0) (2026-09-08)
 
 ## [0.5.1](https://github.com/alan-turing-institute/AssurancePlatform/compare/v0.5.0...v0.5.1) (2026-09-07)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tea-platform-frontend",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "private": true,
   "scripts": {
     "prepare": "git config core.hooksPath .githooks || true",


### PR DESCRIPTION
Two things in one small PR.

**Version correction.** The automated release on this morning's promotion (#940) read a breaking-change marker in the August case-study retirement commit and tagged v1.0.0. The 1.0 release is scheduled for 23 September, so the tag and GitHub release have been replaced by **v0.6.0 on the same commit**. This commit aligns `package.json` and the changelog heading (published on the docs site) with that. The next automated release will be 0.6.1.

**Back-merge.** The branch is cut from `main`, so merging it also brings `main`'s two commits (the #940 merge and the release commit) into `staging` — the same thing the "Update branch" button on #942 would do. After this merges, #942 is no longer behind and can be merged directly.

Diff of real change: 2 lines (`package.json` version, `CHANGELOG.md` heading). No code, no tests affected.