### PR TITLE
feat(landing): add privacy policy page and correct retention docs

### DIFF
--- a/app/(landing)/privacy-policy/__tests__/page.test.tsx
+++ b/app/(landing)/privacy-policy/__tests__/page.test.tsx
@@ -8,6 +8,12 @@ const DRIVE_FILE_SENTENCE_REGEX =
 	/we ask for the.*permission\. This lets the Platform see, create and change/;
 const GOOGLE_API_POLICY_REGEX = /Google API Services User Data Policy/;
 const CHRIS_PLACEHOLDER_REGEX = /\[Chris: confirm the Institute/;
+const KEPT_UNDER_ADMIN_REGEX = /kept under that Admin/;
+const NO_OTHER_ADMIN_DELETED_REGEX = /no other Admin are deleted/;
+const NAME_REMOVED_FROM_COMMENTS_REGEX = /name is removed from comments/;
+const TWO_YEARS_REGEX = /two years/;
+const THIRTY_DAYS_REGEX = /30 days/;
+const SEVEN_DAYS_REGEX = /7 days/;
 
 describe("PrivacyPolicyPage", () => {
 	beforeEach(() => {
@@ -94,6 +100,43 @@ describe("PrivacyPolicyPage", () => {
 
 			expect(screen.getByText(CHRIS_PLACEHOLDER_REGEX)).toBeInTheDocument();
 		});
+
+		it("should list all six categories of data collected", () => {
+			render(<PrivacyPolicyPage />);
+
+			const bulletLeaders = [
+				"Account details.",
+				"Sign-in identifiers.",
+				"Google Drive access tokens.",
+				"Your content.",
+				"Activity and security records.",
+				"Emails we send you.",
+			];
+
+			for (const leader of bulletLeaders) {
+				expect(screen.getByText(leader)).toBeInTheDocument();
+			}
+		});
+
+		it("should explain what happens to cases and comments on deletion", () => {
+			render(<PrivacyPolicyPage />);
+
+			expect(screen.getByText(KEPT_UNDER_ADMIN_REGEX)).toBeInTheDocument();
+			expect(
+				screen.getByText(NO_OTHER_ADMIN_DELETED_REGEX)
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(NAME_REMOVED_FROM_COMMENTS_REGEX)
+			).toBeInTheDocument();
+		});
+
+		it("should state the retention timelines", () => {
+			render(<PrivacyPolicyPage />);
+
+			expect(screen.getByText(TWO_YEARS_REGEX)).toBeInTheDocument();
+			expect(screen.getByText(THIRTY_DAYS_REGEX)).toBeInTheDocument();
+			expect(screen.getByText(SEVEN_DAYS_REGEX)).toBeInTheDocument();
+		});
 	});
 
 	describe("Accessibility", () => {
@@ -101,6 +144,18 @@ describe("PrivacyPolicyPage", () => {
 			const { container } = render(<PrivacyPolicyPage />);
 			const results = await axe(container);
 			expect(results.violations).toHaveLength(0);
+		});
+
+		it("should have proper heading hierarchy", () => {
+			render(<PrivacyPolicyPage />);
+
+			// Should have exactly one h1
+			const h1Elements = screen.getAllByRole("heading", { level: 1 });
+			expect(h1Elements).toHaveLength(1);
+
+			// Should have multiple h2 elements
+			const h2Elements = screen.getAllByRole("heading", { level: 2 });
+			expect(h2Elements.length).toBeGreaterThan(0);
 		});
 	});
 });

--- a/app/(landing)/privacy-policy/__tests__/page.test.tsx
+++ b/app/(landing)/privacy-policy/__tests__/page.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import PrivacyPolicyPage from "../page";
+
+// Top-level regex patterns for performance
+const DRIVE_FILE_SENTENCE_REGEX =
+	/we ask for the.*permission\. This lets the Platform see, create and change/;
+const GOOGLE_API_POLICY_REGEX = /Google API Services User Data Policy/;
+const CHRIS_PLACEHOLDER_REGEX = /\[Chris: confirm the Institute/;
+
+describe("PrivacyPolicyPage", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("Page Rendering", () => {
+		it("should render without crashing", () => {
+			render(<PrivacyPolicyPage />);
+			expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
+		});
+
+		it("should display the correct page title", () => {
+			render(<PrivacyPolicyPage />);
+			const title = screen.getByRole("heading", {
+				level: 1,
+				name: "Privacy Notice for the Trustworthy and Ethical Assurance Platform",
+			});
+			expect(title).toBeInTheDocument();
+		});
+
+		it("should render all section headings", () => {
+			render(<PrivacyPolicyPage />);
+
+			const expectedHeadings = [
+				"What we collect",
+				"Why we use it",
+				"Google user data",
+				"How long we keep it",
+				"Deleting your data",
+				"Where it is stored",
+				"Changes and questions",
+			];
+
+			for (const heading of expectedHeadings) {
+				expect(
+					screen.getByRole("heading", { name: heading })
+				).toBeInTheDocument();
+			}
+		});
+	});
+
+	describe("Content Completeness", () => {
+		it("should describe the drive.file scope", () => {
+			render(<PrivacyPolicyPage />);
+
+			expect(screen.getByText("drive.file")).toBeInTheDocument();
+			expect(screen.getByText(DRIVE_FILE_SENTENCE_REGEX)).toBeInTheDocument();
+		});
+
+		it("should link to the data retention policy", () => {
+			render(<PrivacyPolicyPage />);
+
+			const retentionLink = screen.getByRole("link", {
+				name: "Data Retention Policy",
+			});
+			expect(retentionLink).toBeInTheDocument();
+			expect(retentionLink).toHaveAttribute(
+				"href",
+				"/docs/data-retention-policy"
+			);
+		});
+
+		it("should link to the Cookie Notice", () => {
+			render(<PrivacyPolicyPage />);
+
+			const cookieLink = screen.getByRole("link", { name: "Cookie Notice" });
+			expect(cookieLink).toBeInTheDocument();
+			expect(cookieLink).toHaveAttribute("href", "/cookie-policy");
+		});
+
+		it("should open external Google links in a new tab", () => {
+			render(<PrivacyPolicyPage />);
+
+			const googlePolicyLink = screen.getByRole("link", {
+				name: GOOGLE_API_POLICY_REGEX,
+			});
+			expect(googlePolicyLink).toHaveAttribute("target", "_blank");
+			expect(googlePolicyLink).toHaveAttribute("rel", "noopener noreferrer");
+		});
+
+		it("should render the unresolved Chris placeholders as visible text", () => {
+			render(<PrivacyPolicyPage />);
+
+			expect(screen.getByText(CHRIS_PLACEHOLDER_REGEX)).toBeInTheDocument();
+		});
+	});
+
+	describe("Accessibility", () => {
+		it("should have no accessibility violations", async () => {
+			const { container } = render(<PrivacyPolicyPage />);
+			const results = await axe(container);
+			expect(results.violations).toHaveLength(0);
+		});
+	});
+});

--- a/app/(landing)/privacy-policy/page.tsx
+++ b/app/(landing)/privacy-policy/page.tsx
@@ -1,0 +1,205 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+	title: "Privacy Policy | TEA Platform",
+};
+
+const PrivacyPolicyPage = () => {
+	return (
+		<div className="bg-background px-6 py-32 lg:px-8">
+			<div className="mx-auto max-w-3xl text-base/7 text-muted-foreground">
+				<h1 className="mt-2 text-pretty font-semibold text-4xl text-foreground tracking-tight sm:text-5xl">
+					Privacy Notice for the Trustworthy and Ethical Assurance Platform
+				</h1>
+				<p className="mt-6 text-xl/8">
+					This notice explains what personal data the Trustworthy and Ethical
+					Assurance (TEA) Platform (&quot;we&quot;, &quot;us&quot;) collects,
+					why, how long we keep it, and how you can remove it. The Platform is
+					provided by The Alan Turing Institute{" "}
+					<strong>
+						[Chris: confirm the Institute is the data controller and whether to
+						link the Institute&apos;s own privacy notice]
+					</strong>
+					. Contact: tea@turing.ac.uk.
+				</p>
+
+				<div className="mt-16 max-w-3xl">
+					<h2 className="text-pretty font-semibold text-3xl text-foreground tracking-tight">
+						What we collect
+					</h2>
+					<ul className="mt-6 ml-8 max-w-xl list-disc text-muted-foreground">
+						<li>
+							<em>Account details.</em> Your email address, a username, and
+							optionally your first name, last name and a profile picture. If
+							you register with a password, we store a hash of it, never the
+							password itself.
+						</li>
+						<li>
+							<em>Sign-in identifiers.</em> If you sign in with GitHub or
+							Google, we store the identifier and email address that provider
+							gives us so we can recognise you next time.
+						</li>
+						<li>
+							<em>Google Drive access tokens.</em> If you connect Google Drive,
+							we store the access and refresh tokens Google issues so the
+							Platform can act on your Drive on your behalf (see &quot;Google
+							user data&quot; below).
+						</li>
+						<li>
+							<em>Your content.</em> The assurance cases you create, their
+							elements, comments, and any evidence files you upload. If you
+							publish a case to Discover, its content is public.
+						</li>
+						<li>
+							<em>Activity and security records.</em> The time of your most
+							recent login, and a security log of sign-in and account events
+							that records the action, the time, your IP address and your
+							browser type. We use this to detect misuse and to investigate
+							security incidents.
+						</li>
+						<li>
+							<em>Emails we send you.</em> Account emails (welcome, password
+							reset, account deletion, and the inactivity warnings described in
+							the retention policy) are sent through Microsoft Azure
+							Communication Services.
+						</li>
+					</ul>
+					<p className="mt-6">
+						We use only essential cookies, for signing you in and keeping your
+						session. See the{" "}
+						<Link className="text-primary underline" href="/cookie-policy">
+							Cookie Notice
+						</Link>
+						.
+					</p>
+				</div>
+
+				<div className="mt-16 max-w-3xl">
+					<h2 className="text-pretty font-semibold text-3xl text-foreground tracking-tight">
+						Why we use it
+					</h2>
+					<p className="mt-6">
+						To run your account, to let you build and share assurance cases, to
+						send the account emails above, and to keep the Platform secure. We
+						do not sell personal data, use it for advertising, or share it with
+						third parties except the providers that host and deliver the service
+						(Microsoft Azure for hosting, storage and email; GitHub and Google
+						when you choose to sign in or connect with them).
+					</p>
+				</div>
+
+				<div className="mt-16 max-w-3xl">
+					<h2 className="text-pretty font-semibold text-3xl text-foreground tracking-tight">
+						Google user data
+					</h2>
+					<p className="mt-6">
+						When you connect Google, we ask for the <code>drive.file</code>{" "}
+						permission. This lets the Platform see, create and change{" "}
+						<strong>
+							only the files it creates in your Drive, or that you open with it
+						</strong>
+						. It does not give us access to the rest of your Drive. We use it to
+						create a TEA folder in your Drive and to save exports of your cases
+						there when you ask, and to read back files you have chosen to link
+						to a case.
+					</p>
+					<p className="mt-6">
+						The tokens are stored in our database and sent only over encrypted
+						connections. We use them only to make the Drive requests you
+						trigger. We do not use Google user data for advertising, do not sell
+						it, and do not let humans read it except with your permission, for
+						security purposes, or to comply with the law. Our use of information
+						received from Google APIs adheres to the{" "}
+						<a
+							className="text-primary underline"
+							href="https://developers.google.com/terms/api-services-user-data-policy"
+							rel="noopener noreferrer"
+							target="_blank"
+						>
+							Google API Services User Data Policy
+						</a>
+						, including the Limited Use requirements.
+					</p>
+					<p className="mt-6">
+						You can disconnect Google at any time from{" "}
+						<strong>Settings → Connected accounts</strong>, which deletes the
+						stored tokens, or by revoking the Platform&apos;s access from your{" "}
+						<a
+							className="text-primary underline"
+							href="https://myaccount.google.com/permissions"
+							rel="noopener noreferrer"
+							target="_blank"
+						>
+							Google account permissions
+						</a>
+						.
+					</p>
+				</div>
+
+				<div className="mt-16 max-w-3xl">
+					<h2 className="text-pretty font-semibold text-3xl text-foreground tracking-tight">
+						How long we keep it
+					</h2>
+					<p className="mt-6">
+						We keep your account and content while you use the Platform. If you
+						do not log in for two years we warn you by email 30 days and 7 days
+						before deleting the account, and then delete it. The full rules are
+						in the{" "}
+						<Link
+							className="text-primary underline"
+							href="/docs/data-retention-policy"
+						>
+							Data Retention Policy
+						</Link>
+						.
+					</p>
+				</div>
+
+				<div className="mt-16 max-w-3xl">
+					<h2 className="text-pretty font-semibold text-3xl text-foreground tracking-tight">
+						Deleting your data
+					</h2>
+					<p className="mt-6">
+						You can delete your account from <strong>Settings</strong>. When an
+						account is deleted: cases you own that have another Admin are kept
+						under that Admin; cases with no other Admin are deleted; your name
+						is removed from comments on cases that are kept; your account
+						details, sign-in identifiers and tokens are deleted. If you own any
+						integrations you must remove them first.
+					</p>
+				</div>
+
+				<div className="mt-16 max-w-3xl">
+					<h2 className="text-pretty font-semibold text-3xl text-foreground tracking-tight">
+						Where it is stored
+					</h2>
+					<p className="mt-6">
+						The Platform runs on Microsoft Azure{" "}
+						<strong>
+							[Chris: region — UK South? — confirm before stating]
+						</strong>
+						.
+					</p>
+				</div>
+
+				<div className="mt-16 max-w-3xl">
+					<h2 className="text-pretty font-semibold text-3xl text-foreground tracking-tight">
+						Changes and questions
+					</h2>
+					<p className="mt-6">
+						We will update this notice when the Platform&apos;s data handling
+						changes and show the date of the last change here. Questions:
+						tea@turing.ac.uk.
+					</p>
+				</div>
+
+				<div className="mt-16 max-w-3xl">
+					<p className="mt-6 italic">Last updated: September 2026</p>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default PrivacyPolicyPage;

--- a/components/demo/landing/footer.tsx
+++ b/components/demo/landing/footer.tsx
@@ -7,6 +7,7 @@ const navigation = {
 		{ name: "Platform", href: "/dashboard" },
 		{ name: "Discover", href: "/discover" },
 		{ name: "Documentation", href: "/docs" },
+		{ name: "Privacy Policy", href: "/privacy-policy" },
 		{ name: "Cookie Policy", href: "/cookie-policy" },
 	],
 	social: [

--- a/content/data-retention-policy.mdx
+++ b/content/data-retention-policy.mdx
@@ -1,10 +1,12 @@
 # Data Retention Policy
 
-This policy explains how long we keep your data and what happens to inactive accounts.
+This policy explains how long we keep your data and what happens to inactive accounts. See our [Privacy Notice](/privacy-policy) for what data we hold and why.
 
 ## How long we keep your data
 
-We keep your account and assurance cases for as long as you're actively using the platform. If you stop using your account, we'll keep your data for **2 years** after your last login before taking any action.
+We keep your account and assurance cases for as long as you're actively using the platform. If you stop using your account, we'll keep your data for **2 years** since your last login, or since your account was created if you have never logged in, before taking any action.
+
+We check for inactive accounts daily. Integration (system) accounts are exempt from inactivity deletion.
 
 ## What happens to inactive accounts
 
@@ -25,13 +27,14 @@ Before deletion, you'll have the opportunity to:
 
 ## What gets deleted
 
-When we delete an inactive account, we remove:
+When we delete an inactive account:
 
-- Your user profile and login details
-- All assurance cases you created, including any shared with others
-- Any comments or evidence you uploaded
+- Cases you own that have another Admin are kept under that Admin
+- Cases with no other Admin are deleted
+- Your name is removed from your comments on cases that are kept
+- Your account details, sign-in identifiers and connected-account tokens are deleted
 
-If you've shared cases with collaborators, they will lose access when your account is deleted. We recommend transferring important shared work to another team member before your account becomes inactive.
+Collaborators keep access to cases that are kept under another Admin. If a case has no other Admin, collaborators lose access when it is deleted. We recommend transferring important shared work to another team member before your account becomes inactive.
 
 ## Questions
 
@@ -39,4 +42,4 @@ If you have questions about this policy or your data, contact us at [tea@turing.
 
 ---
 
-*Last updated: January 2026*
+*Last updated: September 2026*

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -15,6 +15,7 @@ export const PUBLIC_ROUTES = [
 	"/docs",
 	"/auth-error",
 	"/cookie-policy",
+	"/privacy-policy",
 	"/feedback",
 	"/forgot-password",
 	"/reset-password",


### PR DESCRIPTION
## What

- New public page `/privacy-policy`, laid out like the cookie notice, stating what the Platform collects, why, how long it is kept, and how to remove it — including the Google user-data section (`drive.file` scope, Limited Use statement) that Google's OAuth verification requires.
- "Privacy Policy" added to the site footer; the privacy and data-retention pages link to each other.
- `content/data-retention-policy.mdx` corrected to the shipped retention behaviour: two years since last login (or creation if never logged in); daily check; cases with another Admin are kept under that Admin, others deleted; the user's name is removed from comments on kept cases; integration (system) accounts exempt.
- `/privacy-policy` added to `PUBLIC_ROUTES` so unauthenticated visitors (Google's reviewer) can read it.

## Two placeholders to fill before merge

The page renders two bracketed `[Chris: …]` notes on purpose — the data-controller line and the Azure region. They need the final wording on this PR before it ships.

## Verification

- Unit project: 116 files / 1494 tests green on the landing commit; 13 tests on the new page (rendering, every disclosed data category, deletion facts, retention numbers, heading hierarchy, axe).
- `ultracite check` clean; no type errors in touched files.
- fallow 3.20.0 `audit --changed-since origin/staging`: pass, 0 introduced findings.
- Live check on a dev server: `/privacy-policy` 200 unauthenticated, `/dashboard` still 307.
- Every deletion/retention claim on both pages checked against `user-management-service.ts` and `retention-service.ts`.
