### PR TITLE
fix(landing): confirm data controller, lawful basis and hosting region on the privacy page

### DIFF
--- a/app/(landing)/privacy-policy/__tests__/page.test.tsx
+++ b/app/(landing)/privacy-policy/__tests__/page.test.tsx
@@ -7,7 +7,11 @@ import PrivacyPolicyPage from "../page";
 const DRIVE_FILE_SENTENCE_REGEX =
 	/we ask for the.*permission\. This lets the Platform see, create and change/;
 const GOOGLE_API_POLICY_REGEX = /Google API Services User Data Policy/;
-const CHRIS_PLACEHOLDER_REGEX = /\[Chris: confirm the Institute/;
+const DATA_CONTROLLER_REGEX =
+	/is the data controller for the personal data described here/;
+const LEGITIMATE_INTERESTS_REGEX = /legitimate interests/;
+const UK_SOUTH_REGEX = /UK South/;
+const CHRIS_PLACEHOLDER_REGEX = /\[Chris:/;
 const KEPT_UNDER_ADMIN_REGEX = /kept under that Admin/;
 const NO_OTHER_ADMIN_DELETED_REGEX = /no other Admin are deleted/;
 const NAME_REMOVED_FROM_COMMENTS_REGEX = /name is removed from comments/;
@@ -80,9 +84,13 @@ describe("PrivacyPolicyPage", () => {
 		it("should link to the Cookie Notice", () => {
 			render(<PrivacyPolicyPage />);
 
-			const cookieLink = screen.getByRole("link", { name: "Cookie Notice" });
-			expect(cookieLink).toBeInTheDocument();
-			expect(cookieLink).toHaveAttribute("href", "/cookie-policy");
+			const cookieLinks = screen.getAllByRole("link", {
+				name: "Cookie Notice",
+			});
+			expect(cookieLinks.length).toBeGreaterThan(0);
+			for (const cookieLink of cookieLinks) {
+				expect(cookieLink).toHaveAttribute("href", "/cookie-policy");
+			}
 		});
 
 		it("should open external Google links in a new tab", () => {
@@ -95,10 +103,38 @@ describe("PrivacyPolicyPage", () => {
 			expect(googlePolicyLink).toHaveAttribute("rel", "noopener noreferrer");
 		});
 
-		it("should render the unresolved Chris placeholders as visible text", () => {
+		it("should name the Institute as data controller and link its privacy notice", () => {
 			render(<PrivacyPolicyPage />);
 
-			expect(screen.getByText(CHRIS_PLACEHOLDER_REGEX)).toBeInTheDocument();
+			expect(screen.getByText(DATA_CONTROLLER_REGEX)).toBeInTheDocument();
+			const noticeLink = screen.getByRole("link", { name: "privacy notice" });
+			expect(noticeLink).toHaveAttribute(
+				"href",
+				"https://www.turing.ac.uk/turing-policy-statement-legal/privacy-policy"
+			);
+			expect(noticeLink).toHaveAttribute("target", "_blank");
+			expect(noticeLink).toHaveAttribute("rel", "noopener noreferrer");
+		});
+
+		it("should state the lawful basis for processing", () => {
+			render(<PrivacyPolicyPage />);
+
+			expect(
+				screen.getByRole("heading", { name: "Our lawful basis" })
+			).toBeInTheDocument();
+			expect(screen.getByText(LEGITIMATE_INTERESTS_REGEX)).toBeInTheDocument();
+		});
+
+		it("should state the hosting region", () => {
+			render(<PrivacyPolicyPage />);
+
+			expect(screen.getByText(UK_SOUTH_REGEX)).toBeInTheDocument();
+		});
+
+		it("should not render any unresolved Chris placeholders", () => {
+			const { container } = render(<PrivacyPolicyPage />);
+
+			expect(container.textContent).not.toMatch(CHRIS_PLACEHOLDER_REGEX);
 		});
 
 		it("should list all six categories of data collected", () => {

--- a/app/(landing)/privacy-policy/page.tsx
+++ b/app/(landing)/privacy-policy/page.tsx
@@ -16,12 +16,20 @@ const PrivacyPolicyPage = () => {
 					This notice explains what personal data the Trustworthy and Ethical
 					Assurance (TEA) Platform (&quot;we&quot;, &quot;us&quot;) collects,
 					why, how long we keep it, and how you can remove it. The Platform is
-					provided by The Alan Turing Institute{" "}
-					<strong>
-						[Chris: confirm the Institute is the data controller and whether to
-						link the Institute&apos;s own privacy notice]
-					</strong>
-					. Contact: tea@turing.ac.uk.
+					provided by The Alan Turing Institute, which is the data controller
+					for the personal data described here. This notice summarises what the
+					Platform does with your data; the Institute&apos;s full{" "}
+					<a
+						className="text-primary underline"
+						href="https://www.turing.ac.uk/turing-policy-statement-legal/privacy-policy"
+						rel="noopener noreferrer"
+						target="_blank"
+					>
+						privacy notice
+					</a>{" "}
+					has the legal and contact details, including how to contact the
+					Institute&apos;s Data Protection Officer. Contact for the Platform:
+					tea@turing.ac.uk.
 				</p>
 
 				<div className="mt-16 max-w-3xl">
@@ -86,6 +94,24 @@ const PrivacyPolicyPage = () => {
 						third parties except the providers that host and deliver the service
 						(Microsoft Azure for hosting, storage and email; GitHub and Google
 						when you choose to sign in or connect with them).
+					</p>
+				</div>
+
+				<div className="mt-16 max-w-3xl">
+					<h2 className="text-pretty font-semibold text-3xl text-foreground tracking-tight">
+						Our lawful basis
+					</h2>
+					<p className="mt-6">
+						We process your account details and your contributions to the
+						Platform because it is necessary for the legitimate interests of The
+						Alan Turing Institute: to provide and run the Platform, to conduct
+						research and further the work of the Institute, and to evaluate and
+						improve the service. The Platform uses only essential cookies, which
+						do not require your consent (see the{" "}
+						<Link className="text-primary underline" href="/cookie-policy">
+							Cookie Notice
+						</Link>
+						). We do not run a mailing list or newsletter from the Platform.
 					</p>
 				</div>
 
@@ -175,11 +201,10 @@ const PrivacyPolicyPage = () => {
 						Where it is stored
 					</h2>
 					<p className="mt-6">
-						The Platform runs on Microsoft Azure{" "}
-						<strong>
-							[Chris: region — UK South? — confirm before stating]
-						</strong>
-						.
+						The Platform runs on Microsoft Azure in the United Kingdom: the
+						application, database and file storage are in the UK South region,
+						and account emails are sent through Azure Communication Services
+						with its data location set to the UK.
 					</p>
 				</div>
 


### PR DESCRIPTION
## What

Follow-up to #944. Replaces the two bracketed `[Chris: …]` placeholders on `/privacy-policy` with confirmed wording, and adds the section the page was missing:

- **Data controller:** The Alan Turing Institute, with a link to the Institute's full privacy notice for legal and Data Protection Officer contact details (confirmed with the Institute's Data Protection Manager).
- **New section "Our lawful basis":** legitimate interests of the Institute for account details and platform contributions; only essential cookies, so no consent-based processing; no mailing list from the Platform.
- **Where it is stored:** Microsoft Azure in the UK — application, database and file storage in UK South; account email through Azure Communication Services with data location UK (verified against the subscription's resources).

Tests: placeholder-rendering test removed; assertions added for the data-controller sentence and Institute link attributes, the lawful-basis heading and wording, the region, and a guard that no `[Chris:` text remains.

## Verification

- Unit project: 117 files / 1502 tests green on the landing commit; 16 tests on the page.
- `ultracite check` clean; no type errors in the touched files; react-doctor 100/100.
- fallow 3.20.0 `audit --changed-since origin/staging`: warn — one duplication finding, the standard section wrapper (div/h2/p classes) that the new section shares with the cookie-policy page; no logic. A shared section component for the two policy pages would remove it and is a separate follow-up.
