### PR TITLE
Promote staging to main: privacy policy page, Google revocation handling

### DIFF
--- a/actions/integrations.ts
+++ b/actions/integrations.ts
@@ -11,20 +11,32 @@ interface DriveFile {
 
 /**
  * Checks whether the current user has connected their Google Drive account.
+ *
+ * `needsReauthorisation` distinguishes "linked Google, but Drive access was
+ * lost (e.g. revoked)" from "never connected Google at all" — both report
+ * `connected: false`, but only the former should offer a "Reconnect" action
+ * instead of a first-time "Sign in" one.
  */
 export async function checkGoogleDriveAccess(): Promise<{
 	connected: boolean;
+	needsReauthorisation: boolean;
 }> {
 	const session = await validateSession();
 	if (!session) {
-		return { connected: false };
+		return { connected: false, needsReauthorisation: false };
 	}
 
-	const { hasGoogleToken } = await import(
+	const { hasGoogleToken, needsGoogleReauthorisation } = await import(
 		"@/lib/services/google-drive-service"
 	);
 	const connected = await hasGoogleToken(session.userId);
-	return { connected };
+	// `hasGoogleToken` may itself have just cleared a revoked refresh token
+	// (see google-drive-service.ts's TOKEN_REVOKED handling), so this read
+	// happens after it to pick up that write in the same request.
+	const needsReauthorisation = connected
+		? false
+		: await needsGoogleReauthorisation(session.userId);
+	return { connected, needsReauthorisation };
 }
 
 /**

--- a/app/(authenticated)/dashboard/settings/_components/__tests__/connected-accounts-form.test.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/__tests__/connected-accounts-form.test.tsx
@@ -4,7 +4,10 @@ import {
 	renderWithoutProviders,
 	screen,
 } from "@/src/__tests__/utils/test-utils";
-import { ConnectedAccountsForm } from "../connected-accounts-form";
+import {
+	ConnectedAccountsForm,
+	providerStatus,
+} from "../connected-accounts-form";
 
 const ACCESS_REVOKED_REGEX = /access was revoked/i;
 const DISCONNECT_BUTTON_REGEX = /disconnect/i;
@@ -60,5 +63,39 @@ describe("ConnectedAccountsForm", () => {
 		expect(
 			screen.queryByRole("button", { name: "Reconnect" })
 		).not.toBeInTheDocument();
+	});
+});
+
+describe("providerStatus", () => {
+	it("returns the warning dot, needs-re-authorisation label, and revocation description when needsReauthorisation is true", () => {
+		expect(
+			providerStatus({
+				connected: true,
+				needsReauthorisation: true,
+				details: "user@example.com",
+			})
+		).toEqual({
+			dotClass: "bg-warning",
+			label: "Connected — needs re-authorisation",
+			description:
+				"Google reported that access was revoked. Reconnect to restore Drive backup.",
+		});
+	});
+
+	it("returns the success dot and details (falling back to 'Connected') when connected and healthy", () => {
+		expect(
+			providerStatus({ connected: true, details: "user@example.com" })
+		).toEqual({ dotClass: "bg-success", label: "user@example.com" });
+		expect(providerStatus({ connected: true })).toEqual({
+			dotClass: "bg-success",
+			label: "Connected",
+		});
+	});
+
+	it("returns the muted dot and 'Not connected' label when not connected", () => {
+		expect(providerStatus({ connected: false })).toEqual({
+			dotClass: "bg-muted-foreground",
+			label: "Not connected",
+		});
 	});
 });

--- a/app/(authenticated)/dashboard/settings/_components/__tests__/connected-accounts-form.test.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/__tests__/connected-accounts-form.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { ConnectedAccountsData } from "@/lib/services/connected-accounts-service";
+import {
+	renderWithoutProviders,
+	screen,
+} from "@/src/__tests__/utils/test-utils";
+import { ConnectedAccountsForm } from "../connected-accounts-form";
+
+const ACCESS_REVOKED_REGEX = /access was revoked/i;
+const DISCONNECT_BUTTON_REGEX = /disconnect/i;
+
+function makeData(
+	overrides: Partial<ConnectedAccountsData["google"]> = {}
+): ConnectedAccountsData {
+	return {
+		canUnlinkGitHub: true,
+		canUnlinkGoogle: true,
+		github: { connected: false },
+		google: {
+			connected: true,
+			email: "user@example.com",
+			hasDriveAccess: false,
+			needsReauthorisation: true,
+			...overrides,
+		},
+		hasPassword: true,
+		primaryAuthProvider: "LOCAL",
+	};
+}
+
+describe("ConnectedAccountsForm", () => {
+	it("shows the needs-re-authorisation state with a Reconnect button when Google's Drive tokens are gone", () => {
+		renderWithoutProviders(<ConnectedAccountsForm data={makeData()} />);
+
+		expect(
+			screen.getByText("Connected — needs re-authorisation")
+		).toBeInTheDocument();
+		expect(screen.getByText(ACCESS_REVOKED_REGEX)).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Reconnect" })
+		).toBeInTheDocument();
+		// Disconnect stays available in this state — the identity is still
+		// linked, only Drive access needs restoring.
+		expect(
+			screen.getByRole("button", { name: DISCONNECT_BUTTON_REGEX })
+		).toBeInTheDocument();
+	});
+
+	it("shows the normal Connected state, with no Reconnect button, when Drive access is healthy", () => {
+		renderWithoutProviders(
+			<ConnectedAccountsForm
+				data={makeData({ hasDriveAccess: true, needsReauthorisation: false })}
+			/>
+		);
+
+		expect(screen.getByText("user@example.com")).toBeInTheDocument();
+		expect(
+			screen.queryByText("Connected — needs re-authorisation")
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Reconnect" })
+		).not.toBeInTheDocument();
+	});
+});

--- a/app/(authenticated)/dashboard/settings/_components/connected-accounts-form.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/connected-accounts-form.tsx
@@ -51,6 +51,41 @@ function GoogleIcon({ className }: { className?: string }) {
 	);
 }
 
+export interface ProviderStatus {
+	description?: string;
+	dotClass: string;
+	label: string;
+}
+
+/**
+ * Pure derivation of a provider card's status dot colour, label, and
+ * optional description line, from its connection state. Exported for direct
+ * unit testing — one case per state (connected, needs re-authorisation,
+ * not connected).
+ */
+export function providerStatus({
+	connected,
+	needsReauthorisation,
+	details,
+}: {
+	connected: boolean;
+	details?: string;
+	needsReauthorisation?: boolean;
+}): ProviderStatus {
+	if (needsReauthorisation) {
+		return {
+			dotClass: "bg-warning",
+			label: "Connected — needs re-authorisation",
+			description:
+				"Google reported that access was revoked. Reconnect to restore Drive backup.",
+		};
+	}
+	if (connected) {
+		return { dotClass: "bg-success", label: details ?? "Connected" };
+	}
+	return { dotClass: "bg-muted-foreground", label: "Not connected" };
+}
+
 /**
  * Provider card component for displaying connection status
  */
@@ -77,18 +112,7 @@ function ProviderCard({
 	onDisconnect: () => void;
 	loading: boolean;
 }) {
-	let statusText: string;
-	let statusDotClass: string;
-	if (needsReauthorisation) {
-		statusText = "Connected — needs re-authorisation";
-		statusDotClass = "bg-warning";
-	} else if (connected) {
-		statusText = details ?? "Connected";
-		statusDotClass = "bg-success";
-	} else {
-		statusText = "Not connected";
-		statusDotClass = "bg-muted-foreground";
-	}
+	const status = providerStatus({ connected, needsReauthorisation, details });
 
 	return (
 		<div className="flex items-center justify-between rounded-lg border border-border bg-card p-4">
@@ -100,15 +124,12 @@ function ProviderCard({
 					<div className="flex items-center gap-2">
 						<span className="font-medium">{name}</span>
 						<span
-							className={`inline-flex h-2 w-2 rounded-full ${statusDotClass}`}
+							className={`inline-flex h-2 w-2 rounded-full ${status.dotClass}`}
 						/>
 					</div>
-					<p className="text-muted-foreground text-sm">{statusText}</p>
-					{needsReauthorisation && (
-						<p className="mt-1 text-warning text-xs">
-							Google reported that access was revoked. Reconnect to restore
-							Drive backup.
-						</p>
+					<p className="text-muted-foreground text-sm">{status.label}</p>
+					{status.description && (
+						<p className="mt-1 text-warning text-xs">{status.description}</p>
 					)}
 				</div>
 			</div>

--- a/app/(authenticated)/dashboard/settings/_components/connected-accounts-form.tsx
+++ b/app/(authenticated)/dashboard/settings/_components/connected-accounts-form.tsx
@@ -58,6 +58,7 @@ function ProviderCard({
 	name,
 	icon,
 	connected,
+	needsReauthorisation,
 	details,
 	canUnlink,
 	unlinkReason,
@@ -68,6 +69,7 @@ function ProviderCard({
 	name: string;
 	icon: React.ReactNode;
 	connected: boolean;
+	needsReauthorisation?: boolean;
 	details?: string;
 	canUnlink: boolean;
 	unlinkReason?: string;
@@ -75,6 +77,19 @@ function ProviderCard({
 	onDisconnect: () => void;
 	loading: boolean;
 }) {
+	let statusText: string;
+	let statusDotClass: string;
+	if (needsReauthorisation) {
+		statusText = "Connected — needs re-authorisation";
+		statusDotClass = "bg-warning";
+	} else if (connected) {
+		statusText = details ?? "Connected";
+		statusDotClass = "bg-success";
+	} else {
+		statusText = "Not connected";
+		statusDotClass = "bg-muted-foreground";
+	}
+
 	return (
 		<div className="flex items-center justify-between rounded-lg border border-border bg-card p-4">
 			<div className="flex items-center gap-3">
@@ -85,21 +100,24 @@ function ProviderCard({
 					<div className="flex items-center gap-2">
 						<span className="font-medium">{name}</span>
 						<span
-							className={`inline-flex h-2 w-2 rounded-full ${
-								connected ? "bg-success" : "bg-muted-foreground"
-							}`}
+							className={`inline-flex h-2 w-2 rounded-full ${statusDotClass}`}
 						/>
 					</div>
-					{connected && details ? (
-						<p className="text-muted-foreground text-sm">{details}</p>
-					) : (
-						<p className="text-muted-foreground text-sm">
-							{connected ? "Connected" : "Not connected"}
+					<p className="text-muted-foreground text-sm">{statusText}</p>
+					{needsReauthorisation && (
+						<p className="mt-1 text-warning text-xs">
+							Google reported that access was revoked. Reconnect to restore
+							Drive backup.
 						</p>
 					)}
 				</div>
 			</div>
-			<div>
+			<div className="flex items-center gap-2">
+				{needsReauthorisation && (
+					<Button onClick={onConnect} size="sm" variant="outline">
+						Reconnect
+					</Button>
+				)}
 				{connected ? (
 					<TooltipProvider>
 						<Tooltip>
@@ -227,6 +245,7 @@ export function ConnectedAccountsForm({ data }: ConnectedAccountsFormProps) {
 						icon={<GoogleIcon className="h-5 w-5" />}
 						loading={loading === "google"}
 						name="Google"
+						needsReauthorisation={data.google.needsReauthorisation}
 						onConnect={() => handleConnect("google")}
 						onDisconnect={() => handleDisconnectClick("google")}
 						unlinkReason="You cannot disconnect Google because it is your only way to sign in. Connect another provider first."

--- a/app/(landing)/privacy-policy/__tests__/page.test.tsx
+++ b/app/(landing)/privacy-policy/__tests__/page.test.tsx
@@ -8,6 +8,12 @@ const DRIVE_FILE_SENTENCE_REGEX =
 	/we ask for the.*permission\. This lets the Platform see, create and change/;
 const GOOGLE_API_POLICY_REGEX = /Google API Services User Data Policy/;
 const CHRIS_PLACEHOLDER_REGEX = /\[Chris: confirm the Institute/;
+const KEPT_UNDER_ADMIN_REGEX = /kept under that Admin/;
+const NO_OTHER_ADMIN_DELETED_REGEX = /no other Admin are deleted/;
+const NAME_REMOVED_FROM_COMMENTS_REGEX = /name is removed from comments/;
+const TWO_YEARS_REGEX = /two years/;
+const THIRTY_DAYS_REGEX = /30 days/;
+const SEVEN_DAYS_REGEX = /7 days/;
 
 describe("PrivacyPolicyPage", () => {
 	beforeEach(() => {
@@ -94,6 +100,43 @@ describe("PrivacyPolicyPage", () => {
 
 			expect(screen.getByText(CHRIS_PLACEHOLDER_REGEX)).toBeInTheDocument();
 		});
+
+		it("should list all six categories of data collected", () => {
+			render(<PrivacyPolicyPage />);
+
+			const bulletLeaders = [
+				"Account details.",
+				"Sign-in identifiers.",
+				"Google Drive access tokens.",
+				"Your content.",
+				"Activity and security records.",
+				"Emails we send you.",
+			];
+
+			for (const leader of bulletLeaders) {
+				expect(screen.getByText(leader)).toBeInTheDocument();
+			}
+		});
+
+		it("should explain what happens to cases and comments on deletion", () => {
+			render(<PrivacyPolicyPage />);
+
+			expect(screen.getByText(KEPT_UNDER_ADMIN_REGEX)).toBeInTheDocument();
+			expect(
+				screen.getByText(NO_OTHER_ADMIN_DELETED_REGEX)
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(NAME_REMOVED_FROM_COMMENTS_REGEX)
+			).toBeInTheDocument();
+		});
+
+		it("should state the retention timelines", () => {
+			render(<PrivacyPolicyPage />);
+
+			expect(screen.getByText(TWO_YEARS_REGEX)).toBeInTheDocument();
+			expect(screen.getByText(THIRTY_DAYS_REGEX)).toBeInTheDocument();
+			expect(screen.getByText(SEVEN_DAYS_REGEX)).toBeInTheDocument();
+		});
 	});
 
 	describe("Accessibility", () => {
@@ -101,6 +144,18 @@ describe("PrivacyPolicyPage", () => {
 			const { container } = render(<PrivacyPolicyPage />);
 			const results = await axe(container);
 			expect(results.violations).toHaveLength(0);
+		});
+
+		it("should have proper heading hierarchy", () => {
+			render(<PrivacyPolicyPage />);
+
+			// Should have exactly one h1
+			const h1Elements = screen.getAllByRole("heading", { level: 1 });
+			expect(h1Elements).toHaveLength(1);
+
+			// Should have multiple h2 elements
+			const h2Elements = screen.getAllByRole("heading", { level: 2 });
+			expect(h2Elements.length).toBeGreaterThan(0);
 		});
 	});
 });

--- a/app/(landing)/privacy-policy/__tests__/page.test.tsx
+++ b/app/(landing)/privacy-policy/__tests__/page.test.tsx
@@ -7,7 +7,11 @@ import PrivacyPolicyPage from "../page";
 const DRIVE_FILE_SENTENCE_REGEX =
 	/we ask for the.*permission\. This lets the Platform see, create and change/;
 const GOOGLE_API_POLICY_REGEX = /Google API Services User Data Policy/;
-const CHRIS_PLACEHOLDER_REGEX = /\[Chris: confirm the Institute/;
+const DATA_CONTROLLER_REGEX =
+	/is the data controller for the personal data described here/;
+const LEGITIMATE_INTERESTS_REGEX = /legitimate interests/;
+const UK_SOUTH_REGEX = /UK South/;
+const CHRIS_PLACEHOLDER_REGEX = /\[Chris:/;
 const KEPT_UNDER_ADMIN_REGEX = /kept under that Admin/;
 const NO_OTHER_ADMIN_DELETED_REGEX = /no other Admin are deleted/;
 const NAME_REMOVED_FROM_COMMENTS_REGEX = /name is removed from comments/;
@@ -80,9 +84,13 @@ describe("PrivacyPolicyPage", () => {
 		it("should link to the Cookie Notice", () => {
 			render(<PrivacyPolicyPage />);
 
-			const cookieLink = screen.getByRole("link", { name: "Cookie Notice" });
-			expect(cookieLink).toBeInTheDocument();
-			expect(cookieLink).toHaveAttribute("href", "/cookie-policy");
+			const cookieLinks = screen.getAllByRole("link", {
+				name: "Cookie Notice",
+			});
+			expect(cookieLinks.length).toBeGreaterThan(0);
+			for (const cookieLink of cookieLinks) {
+				expect(cookieLink).toHaveAttribute("href", "/cookie-policy");
+			}
 		});
 
 		it("should open external Google links in a new tab", () => {
@@ -95,10 +103,38 @@ describe("PrivacyPolicyPage", () => {
 			expect(googlePolicyLink).toHaveAttribute("rel", "noopener noreferrer");
 		});
 
-		it("should render the unresolved Chris placeholders as visible text", () => {
+		it("should name the Institute as data controller and link its privacy notice", () => {
 			render(<PrivacyPolicyPage />);
 
-			expect(screen.getByText(CHRIS_PLACEHOLDER_REGEX)).toBeInTheDocument();
+			expect(screen.getByText(DATA_CONTROLLER_REGEX)).toBeInTheDocument();
+			const noticeLink = screen.getByRole("link", { name: "privacy notice" });
+			expect(noticeLink).toHaveAttribute(
+				"href",
+				"https://www.turing.ac.uk/turing-policy-statement-legal/privacy-policy"
+			);
+			expect(noticeLink).toHaveAttribute("target", "_blank");
+			expect(noticeLink).toHaveAttribute("rel", "noopener noreferrer");
+		});
+
+		it("should state the lawful basis for processing", () => {
+			render(<PrivacyPolicyPage />);
+
+			expect(
+				screen.getByRole("heading", { name: "Our lawful basis" })
+			).toBeInTheDocument();
+			expect(screen.getByText(LEGITIMATE_INTERESTS_REGEX)).toBeInTheDocument();
+		});
+
+		it("should state the hosting region", () => {
+			render(<PrivacyPolicyPage />);
+
+			expect(screen.getByText(UK_SOUTH_REGEX)).toBeInTheDocument();
+		});
+
+		it("should not render any unresolved Chris placeholders", () => {
+			const { container } = render(<PrivacyPolicyPage />);
+
+			expect(container.textContent).not.toMatch(CHRIS_PLACEHOLDER_REGEX);
 		});
 
 		it("should list all six categories of data collected", () => {

--- a/app/(landing)/privacy-policy/__tests__/page.test.tsx
+++ b/app/(landing)/privacy-policy/__tests__/page.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import PrivacyPolicyPage from "../page";
+
+// Top-level regex patterns for performance
+const DRIVE_FILE_SENTENCE_REGEX =
+	/we ask for the.*permission\. This lets the Platform see, create and change/;
+const GOOGLE_API_POLICY_REGEX = /Google API Services User Data Policy/;
+const CHRIS_PLACEHOLDER_REGEX = /\[Chris: confirm the Institute/;
+
+describe("PrivacyPolicyPage", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("Page Rendering", () => {
+		it("should render without crashing", () => {
+			render(<PrivacyPolicyPage />);
+			expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
+		});
+
+		it("should display the correct page title", () => {
+			render(<PrivacyPolicyPage />);
+			const title = screen.getByRole("heading", {
+				level: 1,
+				name: "Privacy Notice for the Trustworthy and Ethical Assurance Platform",
+			});
+			expect(title).toBeInTheDocument();
+		});
+
+		it("should render all section headings", () => {
+			render(<PrivacyPolicyPage />);
+
+			const expectedHeadings = [
+				"What we collect",
+				"Why we use it",
+				"Google user data",
+				"How long we keep it",
+				"Deleting your data",
+				"Where it is stored",
+				"Changes and questions",
+			];
+
+			for (const heading of expectedHeadings) {
+				expect(
+					screen.getByRole("heading", { name: heading })
+				).toBeInTheDocument();
+			}
+		});
+	});
+
+	describe("Content Completeness", () => {
+		it("should describe the drive.file scope", () => {
+			render(<PrivacyPolicyPage />);
+
+			expect(screen.getByText("drive.file")).toBeInTheDocument();
+			expect(screen.getByText(DRIVE_FILE_SENTENCE_REGEX)).toBeInTheDocument();
+		});
+
+		it("should link to the data retention policy", () => {
+			render(<PrivacyPolicyPage />);
+
+			const retentionLink = screen.getByRole("link", {
+				name: "Data Retention Policy",
+			});
+			expect(retentionLink).toBeInTheDocument();
+			expect(retentionLink).toHaveAttribute(
+				"href",
+				"/docs/data-retention-policy"
+			);
+		});
+
+		it("should link to the Cookie Notice", () => {
+			render(<PrivacyPolicyPage />);
+
+			const cookieLink = screen.getByRole("link", { name: "Cookie Notice" });
+			expect(cookieLink).toBeInTheDocument();
+			expect(cookieLink).toHaveAttribute("href", "/cookie-policy");
+		});
+
+		it("should open external Google links in a new tab", () => {
+			render(<PrivacyPolicyPage />);
+
+			const googlePolicyLink = screen.getByRole("link", {
+				name: GOOGLE_API_POLICY_REGEX,
+			});
+			expect(googlePolicyLink).toHaveAttribute("target", "_blank");
+			expect(googlePolicyLink).toHaveAttribute("rel", "noopener noreferrer");
+		});
+
+		it("should render the unresolved Chris placeholders as visible text", () => {
+			render(<PrivacyPolicyPage />);
+
+			expect(screen.getByText(CHRIS_PLACEHOLDER_REGEX)).toBeInTheDocument();
+		});
+	});
+
+	describe("Accessibility", () => {
+		it("should have no accessibility violations", async () => {
+			const { container } = render(<PrivacyPolicyPage />);
+			const results = await axe(container);
+			expect(results.violations).toHaveLength(0);
+		});
+	});
+});

--- a/app/(landing)/privacy-policy/page.tsx
+++ b/app/(landing)/privacy-policy/page.tsx
@@ -1,0 +1,205 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+	title: "Privacy Policy | TEA Platform",
+};
+
+const PrivacyPolicyPage = () => {
+	return (
+		<div className="bg-background px-6 py-32 lg:px-8">
+			<div className="mx-auto max-w-3xl text-base/7 text-muted-foreground">
+				<h1 className="mt-2 text-pretty font-semibold text-4xl text-foreground tracking-tight sm:text-5xl">
+					Privacy Notice for the Trustworthy and Ethical Assurance Platform
+				</h1>
+				<p className="mt-6 text-xl/8">
+					This notice explains what personal data the Trustworthy and Ethical
+					Assurance (TEA) Platform (&quot;we&quot;, &quot;us&quot;) collects,
+					why, how long we keep it, and how you can remove it. The Platform is
+					provided by The Alan Turing Institute{" "}
+					<strong>
+						[Chris: confirm the Institute is the data controller and whether to
+						link the Institute&apos;s own privacy notice]
+					</strong>
+					. Contact: tea@turing.ac.uk.
+				</p>
+
+				<div className="mt-16 max-w-3xl">
+					<h2 className="text-pretty font-semibold text-3xl text-foreground tracking-tight">
+						What we collect
+					</h2>
+					<ul className="mt-6 ml-8 max-w-xl list-disc text-muted-foreground">
+						<li>
+							<em>Account details.</em> Your email address, a username, and
+							optionally your first name, last name and a profile picture. If
+							you register with a password, we store a hash of it, never the
+							password itself.
+						</li>
+						<li>
+							<em>Sign-in identifiers.</em> If you sign in with GitHub or
+							Google, we store the identifier and email address that provider
+							gives us so we can recognise you next time.
+						</li>
+						<li>
+							<em>Google Drive access tokens.</em> If you connect Google Drive,
+							we store the access and refresh tokens Google issues so the
+							Platform can act on your Drive on your behalf (see &quot;Google
+							user data&quot; below).
+						</li>
+						<li>
+							<em>Your content.</em> The assurance cases you create, their
+							elements, comments, and any evidence files you upload. If you
+							publish a case to Discover, its content is public.
+						</li>
+						<li>
+							<em>Activity and security records.</em> The time of your most
+							recent login, and a security log of sign-in and account events
+							that records the action, the time, your IP address and your
+							browser type. We use this to detect misuse and to investigate
+							security incidents.
+						</li>
+						<li>
+							<em>Emails we send you.</em> Account emails (welcome, password
+							reset, account deletion, and the inactivity warnings described in
+							the retention policy) are sent through Microsoft Azure
+							Communication Services.
+						</li>
+					</ul>
+					<p className="mt-6">
+						We use only essential cookies, for signing you in and keeping your
+						session. See the{" "}
+						<Link className="text-primary underline" href="/cookie-policy">
+							Cookie Notice
+						</Link>
+						.
+					</p>
+				</div>
+
+				<div className="mt-16 max-w-3xl">
+					<h2 className="text-pretty font-semibold text-3xl text-foreground tracking-tight">
+						Why we use it
+					</h2>
+					<p className="mt-6">
+						To run your account, to let you build and share assurance cases, to
+						send the account emails above, and to keep the Platform secure. We
+						do not sell personal data, use it for advertising, or share it with
+						third parties except the providers that host and deliver the service
+						(Microsoft Azure for hosting, storage and email; GitHub and Google
+						when you choose to sign in or connect with them).
+					</p>
+				</div>
+
+				<div className="mt-16 max-w-3xl">
+					<h2 className="text-pretty font-semibold text-3xl text-foreground tracking-tight">
+						Google user data
+					</h2>
+					<p className="mt-6">
+						When you connect Google, we ask for the <code>drive.file</code>{" "}
+						permission. This lets the Platform see, create and change{" "}
+						<strong>
+							only the files it creates in your Drive, or that you open with it
+						</strong>
+						. It does not give us access to the rest of your Drive. We use it to
+						create a TEA folder in your Drive and to save exports of your cases
+						there when you ask, and to read back files you have chosen to link
+						to a case.
+					</p>
+					<p className="mt-6">
+						The tokens are stored in our database and sent only over encrypted
+						connections. We use them only to make the Drive requests you
+						trigger. We do not use Google user data for advertising, do not sell
+						it, and do not let humans read it except with your permission, for
+						security purposes, or to comply with the law. Our use of information
+						received from Google APIs adheres to the{" "}
+						<a
+							className="text-primary underline"
+							href="https://developers.google.com/terms/api-services-user-data-policy"
+							rel="noopener noreferrer"
+							target="_blank"
+						>
+							Google API Services User Data Policy
+						</a>
+						, including the Limited Use requirements.
+					</p>
+					<p className="mt-6">
+						You can disconnect Google at any time from{" "}
+						<strong>Settings → Connected accounts</strong>, which deletes the
+						stored tokens, or by revoking the Platform&apos;s access from your{" "}
+						<a
+							className="text-primary underline"
+							href="https://myaccount.google.com/permissions"
+							rel="noopener noreferrer"
+							target="_blank"
+						>
+							Google account permissions
+						</a>
+						.
+					</p>
+				</div>
+
+				<div className="mt-16 max-w-3xl">
+					<h2 className="text-pretty font-semibold text-3xl text-foreground tracking-tight">
+						How long we keep it
+					</h2>
+					<p className="mt-6">
+						We keep your account and content while you use the Platform. If you
+						do not log in for two years we warn you by email 30 days and 7 days
+						before deleting the account, and then delete it. The full rules are
+						in the{" "}
+						<Link
+							className="text-primary underline"
+							href="/docs/data-retention-policy"
+						>
+							Data Retention Policy
+						</Link>
+						.
+					</p>
+				</div>
+
+				<div className="mt-16 max-w-3xl">
+					<h2 className="text-pretty font-semibold text-3xl text-foreground tracking-tight">
+						Deleting your data
+					</h2>
+					<p className="mt-6">
+						You can delete your account from <strong>Settings</strong>. When an
+						account is deleted: cases you own that have another Admin are kept
+						under that Admin; cases with no other Admin are deleted; your name
+						is removed from comments on cases that are kept; your account
+						details, sign-in identifiers and tokens are deleted. If you own any
+						integrations you must remove them first.
+					</p>
+				</div>
+
+				<div className="mt-16 max-w-3xl">
+					<h2 className="text-pretty font-semibold text-3xl text-foreground tracking-tight">
+						Where it is stored
+					</h2>
+					<p className="mt-6">
+						The Platform runs on Microsoft Azure{" "}
+						<strong>
+							[Chris: region — UK South? — confirm before stating]
+						</strong>
+						.
+					</p>
+				</div>
+
+				<div className="mt-16 max-w-3xl">
+					<h2 className="text-pretty font-semibold text-3xl text-foreground tracking-tight">
+						Changes and questions
+					</h2>
+					<p className="mt-6">
+						We will update this notice when the Platform&apos;s data handling
+						changes and show the date of the last change here. Questions:
+						tea@turing.ac.uk.
+					</p>
+				</div>
+
+				<div className="mt-16 max-w-3xl">
+					<p className="mt-6 italic">Last updated: September 2026</p>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default PrivacyPolicyPage;

--- a/app/(landing)/privacy-policy/page.tsx
+++ b/app/(landing)/privacy-policy/page.tsx
@@ -16,12 +16,20 @@ const PrivacyPolicyPage = () => {
 					This notice explains what personal data the Trustworthy and Ethical
 					Assurance (TEA) Platform (&quot;we&quot;, &quot;us&quot;) collects,
 					why, how long we keep it, and how you can remove it. The Platform is
-					provided by The Alan Turing Institute{" "}
-					<strong>
-						[Chris: confirm the Institute is the data controller and whether to
-						link the Institute&apos;s own privacy notice]
-					</strong>
-					. Contact: tea@turing.ac.uk.
+					provided by The Alan Turing Institute, which is the data controller
+					for the personal data described here. This notice summarises what the
+					Platform does with your data; the Institute&apos;s full{" "}
+					<a
+						className="text-primary underline"
+						href="https://www.turing.ac.uk/turing-policy-statement-legal/privacy-policy"
+						rel="noopener noreferrer"
+						target="_blank"
+					>
+						privacy notice
+					</a>{" "}
+					has the legal and contact details, including how to contact the
+					Institute&apos;s Data Protection Officer. Contact for the Platform:
+					tea@turing.ac.uk.
 				</p>
 
 				<div className="mt-16 max-w-3xl">
@@ -86,6 +94,24 @@ const PrivacyPolicyPage = () => {
 						third parties except the providers that host and deliver the service
 						(Microsoft Azure for hosting, storage and email; GitHub and Google
 						when you choose to sign in or connect with them).
+					</p>
+				</div>
+
+				<div className="mt-16 max-w-3xl">
+					<h2 className="text-pretty font-semibold text-3xl text-foreground tracking-tight">
+						Our lawful basis
+					</h2>
+					<p className="mt-6">
+						We process your account details and your contributions to the
+						Platform because it is necessary for the legitimate interests of The
+						Alan Turing Institute: to provide and run the Platform, to conduct
+						research and further the work of the Institute, and to evaluate and
+						improve the service. The Platform uses only essential cookies, which
+						do not require your consent (see the{" "}
+						<Link className="text-primary underline" href="/cookie-policy">
+							Cookie Notice
+						</Link>
+						). We do not run a mailing list or newsletter from the Platform.
 					</p>
 				</div>
 
@@ -175,11 +201,10 @@ const PrivacyPolicyPage = () => {
 						Where it is stored
 					</h2>
 					<p className="mt-6">
-						The Platform runs on Microsoft Azure{" "}
-						<strong>
-							[Chris: region — UK South? — confirm before stating]
-						</strong>
-						.
+						The Platform runs on Microsoft Azure in the United Kingdom: the
+						application, database and file storage are in the UK South region,
+						and account emails are sent through Azure Communication Services
+						with its data location set to the UK.
 					</p>
 				</div>
 

--- a/components/demo/landing/footer.tsx
+++ b/components/demo/landing/footer.tsx
@@ -7,6 +7,7 @@ const navigation = {
 		{ name: "Platform", href: "/dashboard" },
 		{ name: "Discover", href: "/discover" },
 		{ name: "Documentation", href: "/docs" },
+		{ name: "Privacy Policy", href: "/privacy-policy" },
 		{ name: "Cookie Policy", href: "/cookie-policy" },
 	],
 	social: [

--- a/components/modals/_import-modal/google-drive-import-tab.tsx
+++ b/components/modals/_import-modal/google-drive-import-tab.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { signIn } from "next-auth/react";
 import { DrivePicker } from "@/components/google/drive-picker";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -50,12 +49,19 @@ export function GoogleIcon({ className }: { className?: string }) {
  * Renders the Google Drive connection prompt when not connected.
  */
 function GoogleConnectPrompt() {
+	// Uses the same account-link flow as Settings → Connected accounts
+	// (`/api/auth/link/google`) rather than next-auth's `signIn`, which signs
+	// the user in without re-granting Drive access.
+	const handleConnect = () => {
+		window.location.href = "/api/auth/link/google";
+	};
+
 	return (
 		<div className="space-y-4 text-center">
 			<p className="text-muted-foreground text-sm">
 				Connect your Google account to import cases from Google Drive.
 			</p>
-			<Button onClick={() => signIn("google")} variant="outline">
+			<Button onClick={handleConnect} variant="outline">
 				<GoogleIcon className="mr-2 h-4 w-4" />
 				Sign in with Google
 			</Button>

--- a/components/modals/_share-modal/google-backup-section.tsx
+++ b/components/modals/_share-modal/google-backup-section.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Cloud, Loader2 } from "lucide-react";
-import { signIn } from "next-auth/react";
 import { useEffect, useState } from "react";
 import type { AssuranceCaseResponse } from "@/lib/services/case-response-types";
 import type { toast as ToastFn } from "@/lib/toast";
@@ -52,6 +51,7 @@ export function GoogleBackupSection({
 	className,
 }: GoogleBackupSectionProps) {
 	const [googleConnected, setGoogleConnected] = useState<boolean | null>(null);
+	const [needsReauthorisation, setNeedsReauthorisation] = useState(false);
 	const [backupLoading, setBackupLoading] = useState(false);
 
 	// Check Google connection status when modal opens
@@ -59,10 +59,20 @@ export function GoogleBackupSection({
 		if (exportModal.isOpen && googleConnected === null) {
 			import("@/actions/integrations")
 				.then(({ checkGoogleDriveAccess }) => checkGoogleDriveAccess())
-				.then((result) => setGoogleConnected(result.connected))
+				.then((result) => {
+					setGoogleConnected(result.connected);
+					setNeedsReauthorisation(result.needsReauthorisation);
+				})
 				.catch(() => setGoogleConnected(false));
 		}
 	}, [exportModal.isOpen, googleConnected]);
+
+	// Starts the same account-link flow Settings → Connected accounts uses
+	// (`/api/auth/link/google`) rather than next-auth's `signIn`, which signs
+	// the user in without re-granting Drive access.
+	const handleReconnect = () => {
+		window.location.href = "/api/auth/link/google";
+	};
 
 	const handleBackupToDrive = async () => {
 		if (!assuranceCase?.id) {
@@ -118,11 +128,15 @@ export function GoogleBackupSection({
 			{googleConnected === false && (
 				<div className="space-y-2">
 					<p className="text-muted-foreground text-sm">
-						Connect your Google account to backup cases to Google Drive.
+						{needsReauthorisation
+							? "Google reported that access was revoked. Reconnect to restore Drive backup."
+							: "Connect your Google account to backup cases to Google Drive."}
 					</p>
-					<Button onClick={() => signIn("google")} variant="outline">
+					<Button onClick={handleReconnect} variant="outline">
 						<GoogleIcon className="mr-2 h-4 w-4" />
-						Sign in with Google
+						{needsReauthorisation
+							? "Reconnect Google Drive"
+							: "Sign in with Google"}
 					</Button>
 				</div>
 			)}

--- a/content/data-retention-policy.mdx
+++ b/content/data-retention-policy.mdx
@@ -1,10 +1,12 @@
 # Data Retention Policy
 
-This policy explains how long we keep your data and what happens to inactive accounts.
+This policy explains how long we keep your data and what happens to inactive accounts. See our [Privacy Notice](/privacy-policy) for what data we hold and why.
 
 ## How long we keep your data
 
-We keep your account and assurance cases for as long as you're actively using the platform. If you stop using your account, we'll keep your data for **2 years** after your last login before taking any action.
+We keep your account and assurance cases for as long as you're actively using the platform. If you stop using your account, we'll keep your data for **2 years** since your last login, or since your account was created if you have never logged in, before taking any action.
+
+We check for inactive accounts daily. Integration (system) accounts are exempt from inactivity deletion.
 
 ## What happens to inactive accounts
 
@@ -25,13 +27,14 @@ Before deletion, you'll have the opportunity to:
 
 ## What gets deleted
 
-When we delete an inactive account, we remove:
+When we delete an inactive account:
 
-- Your user profile and login details
-- All assurance cases you created, including any shared with others
-- Any comments or evidence you uploaded
+- Cases you own that have another Admin are kept under that Admin
+- Cases with no other Admin are deleted
+- Your name is removed from your comments on cases that are kept
+- Your account details, sign-in identifiers and connected-account tokens are deleted
 
-If you've shared cases with collaborators, they will lose access when your account is deleted. We recommend transferring important shared work to another team member before your account becomes inactive.
+Collaborators keep access to cases that are kept under another Admin. If a case has no other Admin, collaborators lose access when it is deleted. We recommend transferring important shared work to another team member before your account becomes inactive.
 
 ## Questions
 
@@ -39,4 +42,4 @@ If you have questions about this policy or your data, contact us at [tea@turing.
 
 ---
 
-*Last updated: January 2026*
+*Last updated: September 2026*

--- a/lib/auth/google-account-status.ts
+++ b/lib/auth/google-account-status.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure predicate: true when a user record has a linked Google identity but
+ * no Drive refresh token — access was revoked, or Drive access was never
+ * granted with offline access. Distinguishes "needs to reconnect Drive"
+ * from "never connected Google at all".
+ *
+ * Kept in its own module (no Prisma, no `googleapis`) rather than in
+ * `lib/services/google-drive-service.ts`, so importing it doesn't drag in
+ * that service's module-level Prisma client — `connected-accounts-service.ts`
+ * needs the predicate but deliberately keeps Prisma access dynamic
+ * (`await import("@/lib/prisma")`), so it can be imported from client-side
+ * test files with no `DATABASE_URL` set. The single definition shared by
+ * `google-drive-service.ts`'s `needsGoogleReauthorisation` (the DB-reading
+ * wrapper) and `connected-accounts-service.ts`'s `getConnectedAccounts`,
+ * which already has both fields from its own query.
+ */
+export function googleNeedsReauthorisation(user: {
+	googleId: string | null;
+	googleRefreshToken: string | null;
+}): boolean {
+	return !!user.googleId && !user.googleRefreshToken;
+}

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -15,6 +15,7 @@ export const PUBLIC_ROUTES = [
 	"/docs",
 	"/auth-error",
 	"/cookie-policy",
+	"/privacy-policy",
 	"/feedback",
 	"/forgot-password",
 	"/reset-password",

--- a/lib/services/connected-accounts-service.ts
+++ b/lib/services/connected-accounts-service.ts
@@ -32,6 +32,12 @@ export interface ConnectedAccountsData {
 		tokenExpiry?: Date | null;
 		/** Whether user has granted Drive access (has refresh token) */
 		hasDriveAccess: boolean;
+		/**
+		 * Identity linked (`googleId` set) but Drive access has been lost — the
+		 * refresh token is gone, most often because Google reported the grant
+		 * revoked. Distinguishes "reconnect Drive" from "never connected".
+		 */
+		needsReauthorisation: boolean;
 	};
 	/** Whether the user has a password set (can use email/password login) */
 	hasPassword: boolean;
@@ -145,6 +151,7 @@ export async function getConnectedAccounts(
 					email: user.googleEmail ?? undefined,
 					tokenExpiry: user.googleTokenExpiresAt,
 					hasDriveAccess: !!user.googleRefreshToken,
+					needsReauthorisation: hasGoogle && !user.googleRefreshToken,
 				},
 				canUnlinkGitHub,
 				canUnlinkGoogle,

--- a/lib/services/connected-accounts-service.ts
+++ b/lib/services/connected-accounts-service.ts
@@ -4,6 +4,8 @@
  * Handles OAuth provider connection status and unlinking for user accounts.
  */
 
+import { googleNeedsReauthorisation } from "@/lib/auth/google-account-status";
+
 // ============================================
 // Types
 // ============================================
@@ -151,7 +153,10 @@ export async function getConnectedAccounts(
 					email: user.googleEmail ?? undefined,
 					tokenExpiry: user.googleTokenExpiresAt,
 					hasDriveAccess: !!user.googleRefreshToken,
-					needsReauthorisation: hasGoogle && !user.googleRefreshToken,
+					needsReauthorisation: googleNeedsReauthorisation({
+						googleId: user.googleId,
+						googleRefreshToken: user.googleRefreshToken,
+					}),
 				},
 				canUnlinkGitHub,
 				canUnlinkGoogle,

--- a/lib/services/google-drive-service.ts
+++ b/lib/services/google-drive-service.ts
@@ -7,6 +7,7 @@
 
 import { Readable } from "node:stream";
 import { google } from "googleapis";
+import { googleNeedsReauthorisation } from "@/lib/auth/google-account-status";
 import type { ErrorCode } from "@/lib/errors";
 import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
@@ -170,6 +171,90 @@ function isGoogleRevocationError(error: unknown): boolean {
 }
 
 /**
+ * Clears a user's Drive tokens after Google reports the grant revoked
+ * (`invalid_grant`), keeping `googleId`/`googleEmail` so Google sign-in
+ * still works, logs the event, and returns the `TOKEN_REVOKED` result for
+ * `getUserGoogleTokens`'s catch block to hand back.
+ */
+async function clearRevokedGoogleTokens(
+	userId: string,
+	error: unknown
+): Promise<TokenFetchResult> {
+	await prisma.user.update({
+		where: { id: userId },
+		data: {
+			googleAccessToken: null,
+			googleRefreshToken: null,
+			googleTokenExpiresAt: null,
+		},
+	});
+	logger.warn("Google access revoked; cleared stored Drive tokens", {
+		userId,
+		error: error instanceof Error ? error.message : String(error),
+	});
+	return { tokenError: "TOKEN_REVOKED" };
+}
+
+const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+
+/** True once `expiresAt` is within 5 minutes of now, or already past. A null
+ * `expiresAt` (no expiry recorded) is treated as not expiring. */
+function isTokenExpiringSoon(expiresAt: Date | null): boolean {
+	if (!expiresAt) {
+		return false;
+	}
+	return expiresAt.getTime() - TOKEN_EXPIRY_BUFFER_MS < Date.now();
+}
+
+/**
+ * Attempts to refresh an expiring/expired Google access token, updating the
+ * stored token/expiry on success. On failure, distinguishes a revoked grant
+ * (`invalid_grant` -> TOKEN_REVOKED, stored tokens cleared) from any other
+ * refresh failure (REFRESH_FAILED, stored tokens left untouched — may be
+ * transient).
+ */
+async function refreshGoogleAccessToken(
+	userId: string,
+	refreshToken: string
+): Promise<TokenFetchResult> {
+	try {
+		const oauth2Client = new google.auth.OAuth2(
+			process.env.GOOGLE_CLIENT_ID,
+			process.env.GOOGLE_CLIENT_SECRET
+		);
+		oauth2Client.setCredentials({ refresh_token: refreshToken });
+
+		const { credentials } = await oauth2Client.refreshAccessToken();
+
+		if (!credentials.access_token) {
+			throw new Error("No access token in refresh response");
+		}
+
+		await prisma.user.update({
+			where: { id: userId },
+			data: {
+				googleAccessToken: credentials.access_token,
+				googleTokenExpiresAt: credentials.expiry_date
+					? new Date(credentials.expiry_date)
+					: null,
+			},
+		});
+
+		return { accessToken: credentials.access_token, refreshToken };
+	} catch (error) {
+		if (isGoogleRevocationError(error)) {
+			return await clearRevokedGoogleTokens(userId, error);
+		}
+
+		logger.warn("Failed to refresh Google token", {
+			userId,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return { tokenError: "REFRESH_FAILED" };
+	}
+}
+
+/**
  * Retrieves and potentially refreshes the user's Google tokens.
  *
  * Distinguishes four failure shapes so callers can produce the truthful
@@ -196,75 +281,18 @@ async function getUserGoogleTokens(userId: string): Promise<TokenFetchResult> {
 		return { tokenError: "NO_TOKEN" };
 	}
 
-	// Check if token is expired or will expire soon (5 min buffer)
-	const now = new Date();
-	const expiresAt = user.googleTokenExpiresAt;
-	const bufferMs = 5 * 60 * 1000;
-
-	if (expiresAt && expiresAt.getTime() - bufferMs < now.getTime()) {
-		// Token expired or expiring soon - attempt refresh
-		if (!user.googleRefreshToken) {
-			return { tokenError: "TOKEN_EXPIRED" };
-		}
-
-		try {
-			const oauth2Client = new google.auth.OAuth2(
-				process.env.GOOGLE_CLIENT_ID,
-				process.env.GOOGLE_CLIENT_SECRET
-			);
-			oauth2Client.setCredentials({
-				refresh_token: user.googleRefreshToken,
-			});
-
-			const { credentials } = await oauth2Client.refreshAccessToken();
-
-			if (!credentials.access_token) {
-				throw new Error("No access token in refresh response");
-			}
-
-			// Update stored tokens
-			await prisma.user.update({
-				where: { id: userId },
-				data: {
-					googleAccessToken: credentials.access_token,
-					googleTokenExpiresAt: credentials.expiry_date
-						? new Date(credentials.expiry_date)
-						: null,
-				},
-			});
-
-			return {
-				accessToken: credentials.access_token,
-				refreshToken: user.googleRefreshToken,
-			};
-		} catch (error) {
-			if (isGoogleRevocationError(error)) {
-				await prisma.user.update({
-					where: { id: userId },
-					data: {
-						googleAccessToken: null,
-						googleRefreshToken: null,
-						googleTokenExpiresAt: null,
-					},
-				});
-				logger.warn("Google access revoked; cleared stored Drive tokens", {
-					userId,
-				});
-				return { tokenError: "TOKEN_REVOKED" };
-			}
-
-			logger.warn("Failed to refresh Google token", {
-				userId,
-				error: error instanceof Error ? error.message : String(error),
-			});
-			return { tokenError: "REFRESH_FAILED" };
-		}
+	if (!isTokenExpiringSoon(user.googleTokenExpiresAt)) {
+		return {
+			accessToken: user.googleAccessToken,
+			refreshToken: user.googleRefreshToken,
+		};
 	}
 
-	return {
-		accessToken: user.googleAccessToken,
-		refreshToken: user.googleRefreshToken,
-	};
+	if (!user.googleRefreshToken) {
+		return { tokenError: "TOKEN_EXPIRED" };
+	}
+
+	return refreshGoogleAccessToken(userId, user.googleRefreshToken);
 }
 
 const TOKEN_ERROR_MESSAGES: Record<
@@ -568,5 +596,8 @@ export async function needsGoogleReauthorisation(
 		where: { id: userId },
 		select: { googleId: true, googleRefreshToken: true },
 	});
-	return !!user?.googleId && !user?.googleRefreshToken;
+	return googleNeedsReauthorisation({
+		googleId: user?.googleId ?? null,
+		googleRefreshToken: user?.googleRefreshToken ?? null,
+	});
 }

--- a/lib/services/google-drive-service.ts
+++ b/lib/services/google-drive-service.ts
@@ -19,6 +19,7 @@ export type GoogleDriveErrorCode =
 	| "NO_TOKEN"
 	| "TOKEN_EXPIRED"
 	| "REFRESH_FAILED"
+	| "TOKEN_REVOKED"
 	| "NOT_FOUND"
 	| "FORBIDDEN"
 	| "API_ERROR";
@@ -59,6 +60,7 @@ export const DRIVE_ERROR_MAP: Record<GoogleDriveErrorCode, ErrorCode> = {
 	NO_TOKEN: "FORBIDDEN",
 	TOKEN_EXPIRED: "UNAUTHORISED",
 	REFRESH_FAILED: "UNAUTHORISED",
+	TOKEN_REVOKED: "UNAUTHORISED",
 	NOT_FOUND: "NOT_FOUND",
 	FORBIDDEN: "FORBIDDEN",
 	API_ERROR: "INTERNAL",
@@ -135,19 +137,50 @@ type TokenFetchResult =
 	| {
 			tokenError: Extract<
 				GoogleDriveErrorCode,
-				"NO_TOKEN" | "TOKEN_EXPIRED" | "REFRESH_FAILED"
+				"NO_TOKEN" | "TOKEN_EXPIRED" | "REFRESH_FAILED" | "TOKEN_REVOKED"
 			>;
 	  };
 
 /**
+ * True when a caught refresh error is Google reporting the grant has been
+ * revoked (`invalid_grant`), rather than a transient failure. The
+ * `googleapis` client throws a `GaxiosError` whose Google-returned error
+ * body lands at `error.response.data.error`; some paths only surface it in
+ * the message text (e.g. "invalid_grant: Token has been expired or
+ * revoked."), so both are checked.
+ */
+function isGoogleRevocationError(error: unknown): boolean {
+	if (typeof error !== "object" || error === null) {
+		return false;
+	}
+	const record = error as Record<string, unknown>;
+	const response = record.response;
+	if (typeof response === "object" && response !== null) {
+		const data = (response as Record<string, unknown>).data;
+		if (
+			typeof data === "object" &&
+			data !== null &&
+			(data as Record<string, unknown>).error === "invalid_grant"
+		) {
+			return true;
+		}
+	}
+	const message = error instanceof Error ? error.message : String(error);
+	return message.includes("invalid_grant");
+}
+
+/**
  * Retrieves and potentially refreshes the user's Google tokens.
  *
- * Distinguishes three failure shapes so callers can produce the truthful
+ * Distinguishes four failure shapes so callers can produce the truthful
  * `GoogleDriveErrorCode` instead of collapsing every failure into one code:
  * - no access token stored at all -> NO_TOKEN
  * - token expired/expiring soon, and no refresh token to try -> TOKEN_EXPIRED
- * - token expired/expiring soon, refresh attempted and failed (threw, or
- *   returned a response with no access_token) -> REFRESH_FAILED
+ * - token expired/expiring soon, refresh attempted and Google reports the
+ *   grant revoked (`invalid_grant`) -> TOKEN_REVOKED (stored tokens cleared)
+ * - token expired/expiring soon, refresh attempted and failed for any other
+ *   reason (threw, or returned a response with no access_token) ->
+ *   REFRESH_FAILED (stored tokens left untouched — may be transient)
  */
 async function getUserGoogleTokens(userId: string): Promise<TokenFetchResult> {
 	const user = await prisma.user.findUnique({
@@ -205,6 +238,21 @@ async function getUserGoogleTokens(userId: string): Promise<TokenFetchResult> {
 				refreshToken: user.googleRefreshToken,
 			};
 		} catch (error) {
+			if (isGoogleRevocationError(error)) {
+				await prisma.user.update({
+					where: { id: userId },
+					data: {
+						googleAccessToken: null,
+						googleRefreshToken: null,
+						googleTokenExpiresAt: null,
+					},
+				});
+				logger.warn("Google access revoked; cleared stored Drive tokens", {
+					userId,
+				});
+				return { tokenError: "TOKEN_REVOKED" };
+			}
+
 			logger.warn("Failed to refresh Google token", {
 				userId,
 				error: error instanceof Error ? error.message : String(error),
@@ -222,7 +270,7 @@ async function getUserGoogleTokens(userId: string): Promise<TokenFetchResult> {
 const TOKEN_ERROR_MESSAGES: Record<
 	Extract<
 		GoogleDriveErrorCode,
-		"NO_TOKEN" | "TOKEN_EXPIRED" | "REFRESH_FAILED"
+		"NO_TOKEN" | "TOKEN_EXPIRED" | "REFRESH_FAILED" | "TOKEN_REVOKED"
 	>,
 	string
 > = {
@@ -232,6 +280,8 @@ const TOKEN_ERROR_MESSAGES: Record<
 		"Google token has expired and no refresh token is available. Please sign in with Google again.",
 	REFRESH_FAILED:
 		"Failed to refresh the Google token. Please sign in with Google again.",
+	TOKEN_REVOKED:
+		"Google access was revoked. Reconnect Google Drive in Settings.",
 };
 
 /**
@@ -500,4 +550,23 @@ export async function listBackupFiles(
 export async function hasGoogleToken(userId: string): Promise<boolean> {
 	const tokens = await getUserGoogleTokens(userId);
 	return !("tokenError" in tokens);
+}
+
+/**
+ * True when the user has a linked Google identity but no working Drive
+ * refresh token — access was revoked (see `TOKEN_REVOKED` above) or Drive
+ * access was never granted with offline access. Distinguishes "needs to
+ * reconnect Drive" from "never connected Google at all", both of which
+ * `hasGoogleToken` reports as `false`.
+ *
+ * @param userId - The user's ID
+ */
+export async function needsGoogleReauthorisation(
+	userId: string
+): Promise<boolean> {
+	const user = await prisma.user.findUnique({
+		where: { id: userId },
+		select: { googleId: true, googleRefreshToken: true },
+	});
+	return !!user?.googleId && !user?.googleRefreshToken;
 }

--- a/src/__tests__/integration/connected-accounts-service.test.ts
+++ b/src/__tests__/integration/connected-accounts-service.test.ts
@@ -43,6 +43,7 @@ describe("getConnectedAccounts", () => {
 		}
 		expect(result.data.google.connected).toBe(true);
 		expect(result.data.google.hasDriveAccess).toBe(true);
+		expect(result.data.google.needsReauthorisation).toBe(false);
 	});
 
 	it("reports hasDriveAccess false when Google is connected without a refresh token", async () => {
@@ -56,6 +57,21 @@ describe("getConnectedAccounts", () => {
 		}
 		expect(result.data.google.connected).toBe(true);
 		expect(result.data.google.hasDriveAccess).toBe(false);
+		// Identity linked, Drive tokens gone — this is the "needs
+		// re-authorisation" state, not "not connected".
+		expect(result.data.google.needsReauthorisation).toBe(true);
+	});
+
+	it("reports needsReauthorisation false when Google was never connected", async () => {
+		const user = await createTestUser();
+
+		const result = await getConnectedAccounts(user.id);
+		expect("data" in result).toBe(true);
+		if (!("data" in result)) {
+			throw new Error("expected success");
+		}
+		expect(result.data.google.connected).toBe(false);
+		expect(result.data.google.needsReauthorisation).toBe(false);
 	});
 });
 

--- a/src/__tests__/integration/google-drive-service.test.ts
+++ b/src/__tests__/integration/google-drive-service.test.ts
@@ -196,6 +196,55 @@ describe("hasGoogleToken / getUserGoogleTokens (via hasGoogleToken)", () => {
 		);
 	});
 
+	it("clears the stored tokens and reports TOKEN_REVOKED when Google's refresh error carries invalid_grant in the response body", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id, {
+			googleTokenExpiresAt: new Date(Date.now() - 60 * 1000),
+		});
+		const revokedError = Object.assign(new Error("invalid_grant"), {
+			response: { data: { error: "invalid_grant" } },
+		});
+		mockRefreshAccessToken.mockRejectedValueOnce(revokedError);
+
+		const { uploadBackupToDrive } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		const result = await uploadBackupToDrive(user.id, "Case", "{}");
+
+		expect("error" in result).toBe(true);
+		if (!("error" in result)) {
+			throw new Error("expected failure");
+		}
+		expect(result.driveError.code).toBe("TOKEN_REVOKED");
+
+		const updated = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(updated?.googleAccessToken).toBeNull();
+		expect(updated?.googleRefreshToken).toBeNull();
+		expect(updated?.googleTokenExpiresAt).toBeNull();
+		// googleId/googleEmail survive so Google sign-in still works.
+		expect(updated?.googleId).toBe("google-test-id");
+		expect(updated?.googleEmail).toBe("googleuser@example.com");
+	});
+
+	it("clears the stored tokens and reports TOKEN_REVOKED when only the error message text carries invalid_grant", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id, {
+			googleTokenExpiresAt: new Date(Date.now() - 60 * 1000),
+		});
+		mockRefreshAccessToken.mockRejectedValueOnce(
+			new Error("invalid_grant: Token has been expired or revoked.")
+		);
+
+		const { hasGoogleToken } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		expect(await hasGoogleToken(user.id)).toBe(false);
+
+		const updated = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(updated?.googleAccessToken).toBeNull();
+		expect(updated?.googleRefreshToken).toBeNull();
+	});
+
 	it("returns false and leaves the user row unchanged when the refresh response carries no access_token", async () => {
 		const user = await createTestUser();
 		const originalExpiry = new Date(Date.now() - 60 * 1000);
@@ -662,9 +711,10 @@ describe("listBackupFiles", () => {
 });
 
 describe("DRIVE_ERROR_MAP", () => {
-	// All six codes are now produced somewhere in this service: TOKEN_EXPIRED
-	// (expired token, no refresh token) and REFRESH_FAILED (refresh attempted
-	// and failed) from `getUserGoogleTokens`/`createDriveClient`; FORBIDDEN
+	// All seven codes are now produced somewhere in this service: TOKEN_EXPIRED
+	// (expired token, no refresh token), REFRESH_FAILED (refresh attempted
+	// and failed) and TOKEN_REVOKED (refresh attempted, Google reports
+	// invalid_grant) from `getUserGoogleTokens`/`createDriveClient`; FORBIDDEN
 	// and NOT_FOUND from a 403/404 thrown by the Drive SDK, classified by
 	// `classifyGoogleApiError`. Route-level tests proving each maps to the
 	// right status live in `api-cases-backup-gdrive.test.ts` and
@@ -677,9 +727,41 @@ describe("DRIVE_ERROR_MAP", () => {
 			NO_TOKEN: "FORBIDDEN",
 			TOKEN_EXPIRED: "UNAUTHORISED",
 			REFRESH_FAILED: "UNAUTHORISED",
+			TOKEN_REVOKED: "UNAUTHORISED",
 			NOT_FOUND: "NOT_FOUND",
 			FORBIDDEN: "FORBIDDEN",
 			API_ERROR: "INTERNAL",
 		});
+	});
+});
+
+describe("needsGoogleReauthorisation", () => {
+	it("returns false when the user has never linked Google", async () => {
+		const user = await createTestUser();
+
+		const { needsGoogleReauthorisation } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		expect(await needsGoogleReauthorisation(user.id)).toBe(false);
+	});
+
+	it("returns false when Google is linked and the refresh token is present", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id);
+
+		const { needsGoogleReauthorisation } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		expect(await needsGoogleReauthorisation(user.id)).toBe(false);
+	});
+
+	it("returns true when Google is linked but the refresh token is gone", async () => {
+		const user = await createTestUser();
+		await setGoogleTokens(user.id, { googleRefreshToken: null });
+
+		const { needsGoogleReauthorisation } = await import(
+			"@/lib/services/google-drive-service"
+		);
+		expect(await needsGoogleReauthorisation(user.id)).toBe(true);
 	});
 });

--- a/src/__tests__/integration/integrations-actions.test.ts
+++ b/src/__tests__/integration/integrations-actions.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import prisma from "@/lib/prisma";
+import { mockAuth, mockNoAuth } from "../utils/auth-helpers";
+import { createTestUser } from "../utils/prisma-factories";
+
+vi.mock("@/lib/auth/validate-session", () => ({
+	validateSession: vi.fn().mockResolvedValue(null),
+}));
+
+/**
+ * Mock boundary: `googleapis` only, exactly as `google-drive-service.test.ts`
+ * sets it up — `checkGoogleDriveAccess` delegates every token check to
+ * `lib/services/google-drive-service.ts`, so this file exercises that same
+ * seam rather than mocking the service module directly.
+ */
+const { mockSetCredentials, mockRefreshAccessToken } = vi.hoisted(() => ({
+	mockSetCredentials: vi.fn(),
+	mockRefreshAccessToken: vi.fn(),
+}));
+
+vi.mock("googleapis", () => {
+	class OAuth2 {
+		setCredentials = mockSetCredentials;
+		refreshAccessToken = mockRefreshAccessToken;
+	}
+	return { google: { auth: { OAuth2 }, drive: vi.fn() } };
+});
+
+beforeEach(async () => {
+	await mockNoAuth();
+	vi.clearAllMocks();
+});
+
+describe("checkGoogleDriveAccess", () => {
+	it("returns {connected: false, needsReauthorisation: false} when there is no session", async () => {
+		const { checkGoogleDriveAccess } = await import("@/actions/integrations");
+
+		expect(await checkGoogleDriveAccess()).toEqual({
+			connected: false,
+			needsReauthorisation: false,
+		});
+	});
+
+	it("returns {connected: false, needsReauthorisation: false} for a user who never linked Google", async () => {
+		const user = await createTestUser();
+		await mockAuth(user.id, user.username, user.email);
+
+		const { checkGoogleDriveAccess } = await import("@/actions/integrations");
+
+		expect(await checkGoogleDriveAccess()).toEqual({
+			connected: false,
+			needsReauthorisation: false,
+		});
+	});
+
+	it("clears a revoked refresh token and returns {connected: false, needsReauthorisation: true} in the same call", async () => {
+		const user = await createTestUser();
+		await prisma.user.update({
+			where: { id: user.id },
+			data: {
+				googleId: "google-test-id",
+				googleEmail: "googleuser@example.com",
+				googleAccessToken: "stale-token",
+				googleRefreshToken: "stale-refresh-token",
+				googleTokenExpiresAt: new Date(Date.now() - 60 * 1000),
+			},
+		});
+		await mockAuth(user.id, user.username, user.email);
+		mockRefreshAccessToken.mockRejectedValueOnce(
+			Object.assign(new Error("invalid_grant"), {
+				response: { data: { error: "invalid_grant" } },
+			})
+		);
+
+		const { checkGoogleDriveAccess } = await import("@/actions/integrations");
+		const result = await checkGoogleDriveAccess();
+
+		expect(result).toEqual({ connected: false, needsReauthorisation: true });
+
+		// The clearing happened inside this same call — `hasGoogleToken` runs
+		// first and writes the cleared columns before `needsReauthorisation`
+		// is read.
+		const updated = await prisma.user.findUnique({ where: { id: user.id } });
+		expect(updated?.googleRefreshToken).toBeNull();
+		expect(updated?.googleAccessToken).toBeNull();
+		expect(updated?.googleId).toBe("google-test-id");
+	});
+});


### PR DESCRIPTION
## Promotion: staging → main

Carries today's three PRs; no database migrations.

- **#944** — new public `/privacy-policy` page, footer link, data-retention page corrected to the shipped behaviour, route made public.
- **#946** — privacy page wording confirmed with the Institute's Data Protection Manager: data controller, link to the Institute's full privacy notice, "Our lawful basis" section, hosting region (UK South; email data location UK).
- **#945** — Google Drive: when Google reports the grant revoked, stored tokens are cleared; Settings shows "Connected — needs re-authorisation" with Reconnect; Share dialog and import tab reconnect through the account-link route.

Each was gated on its own PR (tests, lint, coverage-mapped structural quality, QA and code review). The Structural Quality check on this PR audits the whole delta as one change and is expected to fail; it is not a required check on `main`.

Release effect: `feat(landing)` → minor bump (v0.7.0).

After merge: verify `https://assuranceplatform.azurewebsites.net/privacy-policy` returns 200 unauthenticated, then set it as the OAuth consent-screen privacy-policy URL and resume Google's verification review.
