### PR TITLE
ci(release): merge main back into staging after each release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,3 +65,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: npx semantic-release
+
+      - name: Merge main back into staging
+        # After a release, main carries the release commit (version bump + changelog)
+        # that staging lacks, which makes every promotion PR "behind main". Merge it
+        # back so the next promotion needs no manual "Update branch". [skip ci] so the
+        # push triggers no staging build or reseed; the version bump deploys with the
+        # next real staging change. Never --force; a merge conflict fails this step
+        # (git's default behaviour) and is resolved by hand.
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main staging
+          if git merge-base --is-ancestor origin/main origin/staging; then
+            echo "staging already contains main; nothing to merge"
+            exit 0
+          fi
+          git checkout -B staging origin/staging
+          git merge --no-ff origin/main -m "chore: merge main into staging after release [skip ci]"
+          git push origin staging


### PR DESCRIPTION
## What

One new step at the end of the release workflow: after `semantic-release` has committed the version bump and changelog to `main`, merge `main` back into `staging` and push.

Why: that release commit is the only thing `main` ever has that `staging` lacks, and it is what makes every promotion PR "behind main" and needs a manual **Update branch** (which also rebuilds and reseeds staging mid-review). This automates that same merge, immediately after the release.

- Direction rule unchanged: code still reaches `main` only through a staging promotion; only the release commit flows back.
- `[skip ci]` on the back-merge commit, so the push triggers no staging build or reseed; the version bump deploys with the next real staging change.
- Skips itself when `staging` already contains `main`. Never `--force`. A merge conflict or a rejected push fails the step visibly on the Actions tab; the release itself has already completed by then.
- Pushes with the same `RELEASE_TOKEN` credential the checkout already uses; no new secret.

First exercised on the promotion after this lands on `main`; the promotion that carries it still needs the manual routine once.

## Verification

- actionlint v1.7.12 with shellcheck 0.10.0: clean.
- Shell logic run verbatim against the live `main`/`staging` refs (push replaced by an echo): takes the skip path today; with a simulated release commit it takes the merge path cleanly and the resulting commit message carries `[skip ci]`.
- Security review: no secret referenced or logged; the step reads only `origin/main` and `origin/staging`, never event-payload data.
