### PR TITLE
chore(logging): migrate components/hooks console.* sites to the structured logger

### DIFF
--- a/components/cases/case-media-preview.tsx
+++ b/components/cases/case-media-preview.tsx
@@ -43,8 +43,7 @@
 //           setAssuranceCase(json);
 //           setIsLoading(false);
 //         })
-//         .catch((err) => {
-//           console.error(err);
+//         .catch((_err) => {
 //           // TODO show error to user
 //         });
 

--- a/components/cases/comments-form.tsx
+++ b/components/cases/comments-form.tsx
@@ -10,6 +10,7 @@ import {
 	FormLabel,
 	FormMessage,
 } from "@/components/ui/form";
+import { logger } from "@/lib/logger";
 import {
 	type CommentFormInput,
 	commentFormSchema,
@@ -18,6 +19,8 @@ import type { CommentResponse } from "@/lib/services/comment-service";
 import useStore from "@/store/store";
 import { Button } from "../ui/button";
 import { Textarea } from "../ui/textarea";
+
+const log = logger.child({ component: "comments-form" });
 
 interface CommentsFormProps {
 	node: {
@@ -66,7 +69,7 @@ const CommentsForm: React.FC<CommentsFormProps> = ({
 			});
 
 			if (!response.ok) {
-				console.error("Failed to create comment:", response.status);
+				log.error("Failed to create comment", { status: response.status });
 				return;
 			}
 
@@ -103,7 +106,7 @@ const CommentsForm: React.FC<CommentsFormProps> = ({
 			// Clear form input
 			form.setValue("comment", "");
 		} catch (error) {
-			console.error("Error creating comment:", error);
+			log.error("Error creating comment", { error });
 		} finally {
 			setLoading(false);
 		}

--- a/components/cases/node-comment.tsx
+++ b/components/cases/node-comment.tsx
@@ -9,10 +9,13 @@ import {
 } from "react";
 import type { Node } from "reactflow";
 import { useCaseEvents } from "@/hooks/use-case-events";
+import { logger } from "@/lib/logger";
 import useStore from "@/store/store";
 import { Skeleton } from "../ui/skeleton";
 import CommentsFeed from "./comments-feed";
 import CommentsForm from "./comments-form";
+
+const log = logger.child({ component: "node-comment" });
 
 /** Event types that trigger a comments refetch */
 const COMMENT_EVENTS = [
@@ -75,14 +78,14 @@ const NodeComment = ({
 			});
 
 			if (!response.ok) {
-				console.error("Failed to fetch comments:", response.status);
+				log.error("Failed to fetch comments", { status: response.status });
 				return [];
 			}
 
 			const result = await response.json();
 			return Array.isArray(result) ? result : [];
 		} catch (error) {
-			console.error("Error fetching comments:", error);
+			log.error("Error fetching comments", { error });
 			return [];
 		} finally {
 			setLoading(false);

--- a/components/cases/trash-list.tsx
+++ b/components/cases/trash-list.tsx
@@ -15,8 +15,11 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { formatShortDate } from "@/lib/date";
+import { logger } from "@/lib/logger";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
+
+const log = logger.child({ component: "trash-list" });
 
 export interface TrashedCase {
 	createdAt: string;
@@ -79,7 +82,7 @@ export function TrashList({ cases }: TrashListProps) {
 			});
 			router.refresh();
 		} catch (error) {
-			console.error("Error restoring case:", error);
+			log.error("Error restoring case", { error });
 			toast({
 				title: "Error",
 				description:
@@ -115,7 +118,7 @@ export function TrashList({ cases }: TrashListProps) {
 			});
 			router.refresh();
 		} catch (error) {
-			console.error("Error purging case:", error);
+			log.error("Error purging case", { error });
 			toast({
 				title: "Error",
 				description:

--- a/components/layout/cookie-consent.tsx
+++ b/components/layout/cookie-consent.tsx
@@ -55,7 +55,7 @@ export default function CookieConsent({
 				}, 700);
 			}
 		} catch (_e) {
-			// console.log("Error: ", e);
+			// Silently ignore cookie-consent read failures.
 		}
 	}, [demo]);
 

--- a/components/modals/migration-modal.tsx
+++ b/components/modals/migration-modal.tsx
@@ -9,7 +9,10 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Modal } from "@/components/ui/modal";
 import { useMigrationModal } from "@/hooks/use-migration-modal";
+import { logger } from "@/lib/logger";
 import { Button } from "../ui/button";
+
+const log = logger.child({ component: "migration-modal" });
 
 export const MigrationModal = () => {
 	const migrationModal = useMigrationModal();
@@ -36,10 +39,10 @@ export const MigrationModal = () => {
 			});
 
 			if (!response.ok) {
-				console.error("Failed to mark migration notice as seen");
+				log.error("Failed to mark migration notice as seen");
 			}
 		} catch (error) {
-			console.error("Error marking migration notice as seen:", error);
+			log.error("Error marking migration notice as seen", { error });
 		} finally {
 			setIsSubmitting(false);
 			migrationModal.onClose();

--- a/components/sharing/_case-sharing/use-case-permissions.ts
+++ b/components/sharing/_case-sharing/use-case-permissions.ts
@@ -1,6 +1,7 @@
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import type { UseFormReturn } from "react-hook-form";
+import { logger } from "@/lib/logger";
 import type { ShareByEmailSchemaInput } from "@/lib/schemas/permission";
 import { toastError } from "@/lib/toast";
 import type {
@@ -8,6 +9,8 @@ import type {
 	TeamPermission,
 	UserPermission,
 } from "./permission-components";
+
+const log = logger.child({ component: "use-case-permissions" });
 
 export { shareByEmailSchema as shareFormSchema } from "@/lib/schemas/permission";
 export type ShareFormValues = ShareByEmailSchemaInput;
@@ -86,7 +89,7 @@ export function useCasePermissions({
 				});
 			}
 		} catch (err) {
-			console.error("Failed to fetch permissions:", err);
+			log.error("Failed to fetch permissions", { error: err });
 			setError("Failed to load permissions");
 			toastError("Failed to load permissions");
 		} finally {
@@ -102,7 +105,7 @@ export function useCasePermissions({
 				setUserTeams(data);
 			}
 		} catch (err) {
-			console.error("Failed to fetch teams:", err);
+			log.error("Failed to fetch teams", { error: err });
 			setError("Failed to load teams");
 			toastError("Failed to load teams");
 		}
@@ -154,7 +157,7 @@ export function useCasePermissions({
 			}
 		} catch (err) {
 			setError("An error occurred while sharing");
-			console.error(err);
+			log.error("Failed to share case by email", { error: err });
 		}
 	};
 
@@ -179,7 +182,7 @@ export function useCasePermissions({
 				router.refresh();
 			}
 		} catch (err) {
-			console.error("Failed to share with team:", err);
+			log.error("Failed to share with team", { error: err });
 			toastError("Failed to share with team");
 		}
 	};
@@ -208,7 +211,7 @@ export function useCasePermissions({
 				router.refresh();
 			}
 		} catch (err) {
-			console.error("Failed to update permission:", err);
+			log.error("Failed to update permission", { error: err });
 			toastError("Failed to update permission");
 		}
 	};
@@ -232,7 +235,7 @@ export function useCasePermissions({
 				router.refresh();
 			}
 		} catch (err) {
-			console.error("Failed to revoke permission:", err);
+			log.error("Failed to revoke permission", { error: err });
 			toastError("Failed to revoke permission");
 		}
 	};

--- a/components/teams/team-member-list.tsx
+++ b/components/teams/team-member-list.tsx
@@ -15,7 +15,10 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useInviteMemberModal } from "@/hooks/use-invite-member-modal";
+import { logger } from "@/lib/logger";
 import { cn } from "@/lib/utils";
+
+const log = logger.child({ component: "team-member-list" });
 
 interface TeamMember {
 	id: string;
@@ -89,7 +92,7 @@ export function TeamMemberList({
 				router.refresh();
 			}
 		} catch (error) {
-			console.error("Failed to update role:", error);
+			log.error("Failed to update role", { error });
 		}
 	};
 

--- a/components/ui/error-boundary.tsx
+++ b/components/ui/error-boundary.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { Component, type ReactNode } from "react";
+import { logger } from "@/lib/logger";
+
+const log = logger.child({ component: "error-boundary" });
 
 type ErrorBoundaryProps = {
 	children: ReactNode;
@@ -50,7 +53,10 @@ export class ErrorBoundary extends Component<
 	}
 
 	componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
-		console.error("[ErrorBoundary]", error, errorInfo);
+		log.error("Error boundary caught an error", {
+			error,
+			componentStack: errorInfo.componentStack,
+		});
 	}
 
 	reset = (): void => {

--- a/hooks/use-case-events.ts
+++ b/hooks/use-case-events.ts
@@ -1,10 +1,13 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { logger } from "@/lib/logger";
 import type {
 	SSEEvent,
 	SSEEventType,
 } from "@/lib/services/sse-connection-manager";
+
+const log = logger.child({ component: "use-case-events" });
 
 type ConnectionStatus = "disconnected" | "connecting" | "connected" | "error";
 
@@ -185,7 +188,7 @@ export function useCaseEvents({
 					setLastEvent(event);
 					onEventRef.current?.(event);
 				} catch (error) {
-					console.error("[SSE] Failed to parse event:", error);
+					log.error("Failed to parse SSE event", { error });
 				}
 			});
 		}

--- a/hooks/use-change-detection.ts
+++ b/hooks/use-change-detection.ts
@@ -174,7 +174,7 @@ export function useChangeDetection({
 			const message =
 				err instanceof Error ? err.message : "Failed to detect changes";
 			setState((prev) => ({ ...prev, isLoading: false, error: message }));
-			log.error("Change detection failed", { message });
+			log.error("Change detection failed", { error: err, message });
 		}
 	}, [caseId, includeDetails]);
 

--- a/hooks/use-change-detection.ts
+++ b/hooks/use-change-detection.ts
@@ -1,6 +1,9 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { logger } from "@/lib/logger";
+
+const log = logger.child({ component: "use-change-detection" });
 
 interface ChangeSummary {
 	addedElements: number;
@@ -171,7 +174,7 @@ export function useChangeDetection({
 			const message =
 				err instanceof Error ? err.message : "Failed to detect changes";
 			setState((prev) => ({ ...prev, isLoading: false, error: message }));
-			console.error("[useChangeDetection] Error:", message);
+			log.error("Change detection failed", { message });
 		}
 	}, [caseId, includeDetails]);
 

--- a/hooks/use-history.ts
+++ b/hooks/use-history.ts
@@ -1,10 +1,13 @@
 "use client";
 
 import { useCallback } from "react";
+import { logger } from "@/lib/logger";
 import { applyRedo, applyUndo } from "@/lib/services/history-service";
 import { toastError, toastSuccess } from "@/lib/toast";
 import useHistoryStore from "@/store/history-store";
 import useStore from "@/store/store";
+
+const log = logger.child({ component: "use-history" });
 
 /**
  * Hook for managing undo/redo operations in the diagram editor.
@@ -43,7 +46,7 @@ export function useHistory() {
 				setAssuranceCase(data);
 			}
 		} catch (error) {
-			console.error("Failed to refetch case:", error);
+			log.error("Failed to refetch case", { error });
 		}
 	}, [assuranceCase?.id, setAssuranceCase]);
 
@@ -78,7 +81,7 @@ export function useHistory() {
 
 			toastSuccess(`Undid: ${entry.description}`);
 		} catch (error) {
-			console.error("Undo failed:", error);
+			log.error("Undo failed", { error });
 			toastError("Undo failed - element may have been modified");
 		} finally {
 			setIsApplying(false);
@@ -115,7 +118,7 @@ export function useHistory() {
 
 			toastSuccess(`Redid: ${entry.description}`);
 		} catch (error) {
-			console.error("Redo failed:", error);
+			log.error("Redo failed", { error });
 			toastError("Redo failed - element may have been modified");
 		} finally {
 			setIsApplying(false);

--- a/hooks/use-previous.tsx
+++ b/hooks/use-previous.tsx
@@ -12,8 +12,6 @@ import { useEffect, useRef } from "react";
  * @example
  * function MyComponent({ prop }) {
  *   const prevProp = usePrevious(prop);
- *   console.log('Current prop:', prop);
- *   console.log('Previous prop:', prevProp);
  *   return <div>{prop}</div>;
  * }
  */


### PR DESCRIPTION
## Summary

Part 2 of 3 of the console-to-structured-logger sweep for 1.0. Replaces the 21 remaining raw `console.*` calls under `components/` and `hooks/` with the structured logger from #929 (`logger.child({ component })` per file, one JSON line per event), and removes three comment-only `console` mentions so the textual check is clean.

- 1:1 level mapping (every site here was `console.error` → `log.error`)
- caught errors passed as a field (`{ error }`), serialised to `{name, message, stack}` by the logger; never interpolated into the message
- message wording kept apart from trailing colons and bracketed prefixes
- `error-boundary.tsx` logs `{ error, componentStack }`
- no behaviour changes; return values, toasts, `setError`, `finally` blocks untouched
- `lib/logger.ts`, `lib/**`, `app/**`, `store/**` untouched (parts 1 and 3)

The browser fallback (`console[level]` when there is no `process.stdout`) is already in the logger, so client files need no runtime guard.

## Verification

- `grep -rE 'console\.(log|warn|error|info|debug)\('` over `components/` + `hooks/` (tests and `components/docs` excluded): 0
- `pnpm lint`: 813 files, clean · `pnpm typecheck`: clean
- `pnpm test:unit`: 1502/1502 (117 files) · `pnpm test:coverage:check`: 1502/1502
- fallow 3.20.0 audit `--base origin/staging`: no issues in 13 changed files, 0 introduced
- QA and code review both passed; one review fix applied (`use-change-detection.ts` now passes the caught error alongside the derived message)

## Follow-up (not in this PR)

`components/cases/case-media-preview.tsx` is ~90 lines of commented-out legacy code — a deletion candidate.
