### PR TITLE
chore(logging): migrate lib/ console.* sites to the structured logger

### DIFF
--- a/lib/__tests__/errors.test.ts
+++ b/lib/__tests__/errors.test.ts
@@ -148,40 +148,28 @@ describe("handleError", () => {
 	});
 
 	it("wraps a plain Error as INTERNAL", () => {
-		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {
-			/* suppress */
-		});
 		const original = new Error("something broke");
 		const result = handleError(original);
 
 		expect(result).toBeInstanceOf(AppError);
 		expect(result.code).toBe("INTERNAL");
 		expect(result.cause).toBe(original);
-		consoleSpy.mockRestore();
 	});
 
 	it("maps TimeoutError to GATEWAY_TIMEOUT (504), not INTERNAL", () => {
-		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {
-			/* suppress */
-		});
 		const original = new TimeoutError(15_000);
 		const result = handleError(original);
 
 		expect(result).toBeInstanceOf(AppError);
 		expect(result.code).toBe("GATEWAY_TIMEOUT");
 		expect(result.statusCode).toBe(504);
-		consoleSpy.mockRestore();
 	});
 
 	it("wraps non-Error values as INTERNAL", () => {
-		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {
-			/* suppress */
-		});
 		const result = handleError("string error");
 
 		expect(result).toBeInstanceOf(AppError);
 		expect(result.code).toBe("INTERNAL");
-		consoleSpy.mockRestore();
 	});
 
 	it("maps pg-pool's queued-wait timeout message to DB_UNAVAILABLE (503), not INTERNAL", () => {
@@ -226,9 +214,6 @@ describe("handleError", () => {
 	});
 
 	it("stays INTERNAL/500 for an unrelated error whose message merely contains the pool-timeout string", () => {
-		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {
-			/* suppress */
-		});
 		const original = new Error(
 			"Upstream vendor API said: timeout exceeded when trying to connect to their sandbox"
 		);
@@ -237,7 +222,6 @@ describe("handleError", () => {
 
 		expect(result.code).toBe("INTERNAL");
 		expect(result.statusCode).toBe(500);
-		consoleSpy.mockRestore();
 	});
 });
 

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -5,6 +5,8 @@ import GithubProvider from "next-auth/providers/github";
 import GoogleProvider from "next-auth/providers/google";
 import { logger } from "@/lib/logger";
 
+const log = logger.child({ component: "config" });
+
 dotenv.config(); // Explicitly load environment variables
 
 /**
@@ -115,7 +117,7 @@ export async function authenticateWithPrisma(
 			data: { ...loginResetFields(), ...upgradeFields },
 		});
 	} catch (error) {
-		logger.error("Failed to record login / reset retention warnings", {
+		log.error("Failed to record login / reset retention warnings", {
 			userId: user.id,
 			error: error instanceof Error ? error.message : String(error),
 		});
@@ -154,7 +156,7 @@ async function authenticateGitHubWithPrisma(
 	const email = profile?.email;
 
 	if (!email) {
-		console.error("GitHub OAuth: No email provided");
+		log.error("GitHub OAuth: No email provided");
 		return null;
 	}
 
@@ -293,7 +295,7 @@ export async function authenticateGoogleWithPrisma(
 	const email = profile?.email;
 
 	if (!email) {
-		console.error("Google OAuth: No email provided");
+		log.error("Google OAuth: No email provided");
 		return null;
 	}
 

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -5,7 +5,7 @@ import GithubProvider from "next-auth/providers/github";
 import GoogleProvider from "next-auth/providers/google";
 import { logger } from "@/lib/logger";
 
-const log = logger.child({ component: "config" });
+const log = logger.child({ component: "auth-config" });
 
 dotenv.config(); // Explicitly load environment variables
 

--- a/lib/case/image-export.ts
+++ b/lib/case/image-export.ts
@@ -14,6 +14,9 @@ import {
 	waitForRender,
 } from "@/lib/case/document-export";
 import type { LayoutDirection } from "@/lib/case/layout-helper";
+import { logger } from "@/lib/logger";
+
+const log = logger.child({ component: "image-export" });
 
 export type ImageFormat = "svg" | "png";
 export type ImageScale = 1 | 2 | 3;
@@ -202,7 +205,7 @@ async function captureAndDownload(
 			saveAs(blob, filename);
 		}
 	} catch (error) {
-		console.error("Export failed:", error);
+		log.error("Export failed", { error });
 		throw error;
 	} finally {
 		// Always restore original styles

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,6 +1,8 @@
 import { resolveDbPoolTimeoutMs } from "@/lib/db-pool-config";
 import { logger } from "@/lib/logger";
 
+const log = logger.child({ component: "errors" });
+
 /**
  * Classifies errors for consistent handling across API routes, server actions, and services.
  */
@@ -148,7 +150,7 @@ export function handleError(error: unknown): AppError {
 	// class import here, and matching by `.name` avoids a circular import
 	// between `lib/errors.ts` and `lib/with-timeout.ts`.
 	if (error instanceof Error && error.name === "TimeoutError") {
-		console.error("[handleError] request timed out:", error.message);
+		log.error("Request timed out", { op: "handleError", error: error.message });
 		return gatewayTimeout(
 			"The request took too long to complete. Please try again."
 		);
@@ -161,7 +163,7 @@ export function handleError(error: unknown): AppError {
 	// production logs from any other unhandled error (see "TEA —
 	// Pool-timeout errors indistinguishable from generic 500s").
 	if (error instanceof Error && isPoolAcquireTimeoutError(error)) {
-		logger.error("Database connection pool acquisition timed out", {
+		log.error("Database connection pool acquisition timed out", {
 			event: "db.pool.acquire_timeout",
 			timeoutMs: resolveDbPoolTimeoutMs(),
 		});
@@ -171,7 +173,7 @@ export function handleError(error: unknown): AppError {
 	const message =
 		error instanceof Error ? error.message : "An unexpected error occurred";
 
-	console.error("[handleError]", error);
+	log.error("handleError", { error });
 
 	return new AppError({
 		code: "INTERNAL",

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -150,7 +150,7 @@ export function handleError(error: unknown): AppError {
 	// class import here, and matching by `.name` avoids a circular import
 	// between `lib/errors.ts` and `lib/with-timeout.ts`.
 	if (error instanceof Error && error.name === "TimeoutError") {
-		log.error("Request timed out", { op: "handleError", error: error.message });
+		log.error("Request timed out", { error });
 		return gatewayTimeout(
 			"The request took too long to complete. Please try again."
 		);

--- a/lib/services/case-batch-update-service.ts
+++ b/lib/services/case-batch-update-service.ts
@@ -10,6 +10,7 @@ import type {
 	ElementChange,
 	UpdateElementData,
 } from "@/lib/case/tree-diff";
+import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
 import { validateElementName } from "@/lib/schemas/element-validation";
 import {
@@ -24,6 +25,8 @@ import type {
 	Prisma,
 	ElementType as PrismaElementType,
 } from "@/src/generated/prisma";
+
+const log = logger.child({ component: "case-batch-update-service" });
 
 /**
  * ADR 0004 D3 write rule (author-declared, machine-proposable, never
@@ -1199,7 +1202,7 @@ export async function applyBatchUpdate(
 			},
 		};
 	} catch (error) {
-		console.error("Batch update failed:", error);
+		log.error("Batch update failed", { error });
 		return {
 			error:
 				error instanceof Error ? error.message : "Failed to apply batch update",

--- a/lib/services/case-export-service.ts
+++ b/lib/services/case-export-service.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
 import type {
 	AssertionStatus,
@@ -11,6 +12,8 @@ import {
 	buildTreeFromElements,
 	type ElementWithLinks,
 } from "@/lib/transforms/build-tree";
+
+const log = logger.child({ component: "case-export-service" });
 
 export interface ExportOptions {
 	includeComments?: boolean;
@@ -297,7 +300,7 @@ export async function exportCase(
 
 		return { data: exportData };
 	} catch (error) {
-		console.error("Failed to export case:", error);
+		log.error("Failed to export case", { error });
 		return { error: "Failed to export case" };
 	}
 }

--- a/lib/services/case-fetch-service.ts
+++ b/lib/services/case-fetch-service.ts
@@ -1,4 +1,5 @@
 import { compareIdentifiers } from "@/lib/case/identifier-utils";
+import { logger } from "@/lib/logger";
 import { canAccessCase, getCasePermission } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import type { UpdateAssuranceCaseInput } from "@/lib/schemas/assurance-case";
@@ -10,6 +11,8 @@ import type {
 } from "@/lib/services/case-response-types";
 import type { Prisma } from "@/src/generated/prisma";
 import type { ServiceResult } from "@/types/service";
+
+const log = logger.child({ component: "case-fetch-service" });
 
 // ---------------------------------------------------------------------------
 // Types (derived from Prisma query shape)
@@ -355,7 +358,7 @@ export async function listUserCases(
 			})),
 		};
 	} catch (error) {
-		console.error("[listUserCases]", { userId, error });
+		log.error("listUserCases", { userId, error });
 		return { error: "Failed to fetch cases" };
 	}
 }
@@ -420,7 +423,7 @@ export async function listSharedCases(
 			})),
 		};
 	} catch (error) {
-		console.error("[listSharedCases]", { userId, error });
+		log.error("listSharedCases", { userId, error });
 		return { error: "Failed to fetch shared cases" };
 	}
 }
@@ -459,7 +462,7 @@ export async function createCase(
 
 		return { data: { id: newCase.id } };
 	} catch (error) {
-		console.error("[createCase]", { userId, error });
+		log.error("createCase", { userId, error });
 		return { error: "Failed to create case" };
 	}
 }

--- a/lib/services/case-image-service.ts
+++ b/lib/services/case-image-service.ts
@@ -5,6 +5,10 @@
  * Screenshots are uploaded to Azure Blob Storage (or local fallback in development).
  */
 
+import { logger } from "@/lib/logger";
+
+const log = logger.child({ component: "case-image-service" });
+
 // Throttle duration in milliseconds (30 minutes)
 const SCREENSHOT_THROTTLE_MS = 30 * 60 * 1000;
 
@@ -67,7 +71,7 @@ export async function getCaseImage(
 			},
 		};
 	} catch (error) {
-		console.error("[getCaseImage]", { userId, caseId, error });
+		log.error("getCaseImage", { userId, caseId, error });
 		return { error: "Failed to fetch case image" };
 	}
 }
@@ -157,7 +161,7 @@ export async function uploadCaseImage(
 			},
 		};
 	} catch (error) {
-		console.error("[uploadCaseImage]", { userId, caseId, error });
+		log.error("uploadCaseImage", { userId, caseId, error });
 		return { error: "Failed to upload case image" };
 	}
 }

--- a/lib/services/case-import-service.ts
+++ b/lib/services/case-import-service.ts
@@ -1,7 +1,10 @@
+import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
 import type { CaseExportV2, ElementV2 } from "@/lib/schemas/case-export";
 import { detectAndValidate } from "@/lib/schemas/version-detection";
 import { Prisma } from "@/src/generated/prisma";
+
+const log = logger.child({ component: "case-import-service" });
 
 // Derived from `prisma.$transaction`'s own callback parameter — same pattern
 // as `publish-service.ts` / `slug-service.ts` (kept local rather than
@@ -663,7 +666,7 @@ export async function importCase(
 			},
 		};
 	} catch (error) {
-		console.error("Failed to import case:", error);
+		log.error("Failed to import case", { error });
 		return { error: "Failed to import case" };
 	}
 }

--- a/lib/services/case-information-service.ts
+++ b/lib/services/case-information-service.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger";
 import { canAccessCase } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import {
@@ -7,6 +8,8 @@ import {
 } from "@/lib/schemas/case-information";
 import type { CaseInformation } from "@/src/generated/prisma";
 import type { ServiceResult } from "@/types/service";
+
+const log = logger.child({ component: "case-information-service" });
 
 /**
  * Failure shape for `requireCaseInformationComplete` — a plain `error`
@@ -63,7 +66,7 @@ export async function getCaseInformation(
 		});
 		return { data: record };
 	} catch (error) {
-		console.error("Failed to get case information:", error);
+		log.error("Failed to get case information", { error });
 		return { error: "Failed to fetch case information" };
 	}
 }
@@ -110,7 +113,7 @@ export async function upsertCaseInformation(
 		});
 		return { data: record };
 	} catch (error) {
-		console.error("Failed to upsert case information:", error);
+		log.error("Failed to upsert case information", { error });
 		return { error: "Failed to save case information" };
 	}
 }
@@ -133,7 +136,7 @@ export async function deleteCaseInformation(
 		await prisma.caseInformation.deleteMany({ where: { caseId } });
 		return { data: true };
 	} catch (error) {
-		console.error("Failed to delete case information:", error);
+		log.error("Failed to delete case information", { error });
 		return { error: "Failed to delete case information" };
 	}
 }

--- a/lib/services/case-permission-service.ts
+++ b/lib/services/case-permission-service.ts
@@ -1,7 +1,10 @@
+import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
 import { createCaseInvite } from "@/lib/services/case-invite-service";
 import type { PermissionLevel } from "@/src/generated/prisma";
 import type { ServiceResult } from "@/types/service";
+
+const log = logger.child({ component: "case-permission-service" });
 
 // ============================================
 // INPUT INTERFACES
@@ -210,7 +213,7 @@ export async function listCasePermissions(
 			},
 		};
 	} catch (error) {
-		console.error("Failed to list case permissions:", error);
+		log.error("Failed to list case permissions", { error });
 		return { error: "Failed to list permissions" };
 	}
 }
@@ -338,7 +341,7 @@ export async function shareByEmail(
 			},
 		};
 	} catch (error) {
-		console.error("Failed to share case:", error);
+		log.error("Failed to share case", { error });
 		return { error: "Failed to share case" };
 	}
 }
@@ -415,7 +418,7 @@ export async function shareWithTeam(
 			},
 		};
 	} catch (error) {
-		console.error("Failed to share case with team:", error);
+		log.error("Failed to share case with team", { error });
 		return { error: "Failed to share case with team" };
 	}
 }
@@ -491,7 +494,7 @@ export async function updateUserPermission(
 			},
 		};
 	} catch (error) {
-		console.error("Failed to update permission:", error);
+		log.error("Failed to update permission", { error });
 		return { error: "Failed to update permission" };
 	}
 }
@@ -555,7 +558,7 @@ export async function updateTeamPermission(
 			},
 		};
 	} catch (error) {
-		console.error("Failed to update team permission:", error);
+		log.error("Failed to update team permission", { error });
 		return { error: "Failed to update team permission" };
 	}
 }
@@ -591,7 +594,7 @@ export async function revokeUserPermission(
 
 		return { data: true };
 	} catch (error) {
-		console.error("Failed to revoke permission:", error);
+		log.error("Failed to revoke permission", { error });
 		return { error: "Failed to revoke permission" };
 	}
 }
@@ -627,7 +630,7 @@ export async function revokeTeamPermission(
 
 		return { data: true };
 	} catch (error) {
-		console.error("Failed to revoke team permission:", error);
+		log.error("Failed to revoke team permission", { error });
 		return { error: "Failed to revoke team permission" };
 	}
 }

--- a/lib/services/case-trash-service.ts
+++ b/lib/services/case-trash-service.ts
@@ -1,7 +1,10 @@
 import { calculateDaysRemaining, TRASH_RETENTION_DAYS } from "@/lib/constants";
+import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
 import { requireCronSecret } from "@/lib/services/cron-auth";
 import type { ServiceResult } from "@/types/service";
+
+const log = logger.child({ component: "case-trash-service" });
 
 // ============================================
 // OUTPUT INTERFACES
@@ -100,7 +103,7 @@ export async function listTrashedCases(
 
 		return { data: { cases } };
 	} catch (error) {
-		console.error("Failed to list trashed cases:", error);
+		log.error("Failed to list trashed cases", { error });
 		return { error: "Failed to fetch trash" };
 	}
 }
@@ -152,7 +155,7 @@ export async function softDeleteCase(
 
 		return { data: true };
 	} catch (error) {
-		console.error("Failed to soft-delete case:", error);
+		log.error("Failed to soft-delete case", { error });
 		return { error: "Failed to delete case" };
 	}
 }
@@ -186,7 +189,7 @@ export async function restoreCase(
 
 		return { data: true };
 	} catch (error) {
-		console.error("Failed to restore case:", error);
+		log.error("Failed to restore case", { error });
 		return { error: "Failed to restore case" };
 	}
 }
@@ -215,7 +218,7 @@ export async function purgeCase(userId: string, caseId: string): ServiceResult {
 
 		return { data: true };
 	} catch (error) {
-		console.error("Failed to purge case:", error);
+		log.error("Failed to purge case", { error });
 		return { error: "Failed to purge case" };
 	}
 }
@@ -245,7 +248,7 @@ export async function purgeExpiredCases(
 			},
 		});
 
-		console.log(`Purged ${result.count} expired cases from trash`);
+		log.info("Purged expired cases from trash", { count: result.count });
 
 		return {
 			data: {
@@ -254,7 +257,7 @@ export async function purgeExpiredCases(
 			},
 		};
 	} catch (error) {
-		console.error("Failed to purge expired cases:", error);
+		log.error("Failed to purge expired cases", { error });
 		return { error: "Failed to purge trash" };
 	}
 }

--- a/lib/services/connected-accounts-service.ts
+++ b/lib/services/connected-accounts-service.ts
@@ -5,6 +5,9 @@
  */
 
 import { googleNeedsReauthorisation } from "@/lib/auth/google-account-status";
+import { logger } from "@/lib/logger";
+
+const log = logger.child({ component: "connected-accounts-service" });
 
 // ============================================
 // Types
@@ -163,7 +166,7 @@ export async function getConnectedAccounts(
 			},
 		};
 	} catch (error) {
-		console.error("[getConnectedAccounts]", { userId, error });
+		log.error("getConnectedAccounts", { userId, error });
 		return { error: "Failed to fetch connected accounts" };
 	}
 }
@@ -239,7 +242,7 @@ export async function unlinkProvider(
 
 		return { data: null };
 	} catch (error) {
-		console.error("[unlinkProvider]", { userId, provider, error });
+		log.error("unlinkProvider", { userId, provider, error });
 		return { error: "Failed to unlink provider" };
 	}
 }

--- a/lib/services/discover-service.ts
+++ b/lib/services/discover-service.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
 import {
 	type PublishedSnapshotMeta,
@@ -6,6 +7,8 @@ import {
 import { getSectorDisplayName } from "@/lib/sectors";
 import type { PublishableItemType } from "@/src/generated/prisma";
 import type { ServiceResult } from "@/types/service";
+
+const log = logger.child({ component: "discover-service" });
 
 /**
  * Discover data access (ADR 0003 §4/§6) — reads exclusively from the frozen
@@ -101,7 +104,7 @@ export async function getPublishedItems(): ServiceResult<
 		});
 		return { data: records.map(toSummary) };
 	} catch (error) {
-		console.error("Failed to list published items:", error);
+		log.error("Failed to list published items", { error });
 		return { error: "Failed to fetch published items" };
 	}
 }
@@ -127,7 +130,7 @@ export async function getPublishedItemBySlug(
 
 		return { data: { ...toSummary(record), content: record.content } };
 	} catch (error) {
-		console.error("Failed to fetch published item by slug:", error);
+		log.error("Failed to fetch published item by slug", { error });
 		return { error: "Failed to fetch published item" };
 	}
 }

--- a/lib/services/element-service.ts
+++ b/lib/services/element-service.ts
@@ -1,5 +1,6 @@
 import { getCorePrefix } from "@/lib/element-names/prefix-registry";
 import { toPrefix, toPrismaType } from "@/lib/element-types";
+import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
 import type {
 	CreateElementSchemaOutput,
@@ -23,6 +24,8 @@ import type {
 	ElementType as PrismaElementType,
 } from "@/src/generated/prisma";
 import type { ServiceResult } from "@/types/service";
+
+const log = logger.child({ component: "element-service" });
 
 /**
  * Create element input — extends the Zod schema output with API-layer fields
@@ -947,7 +950,7 @@ export async function createElement(
 			intendedParentId
 		);
 	} catch (error) {
-		console.error("Failed to create element:", error);
+		log.error("Failed to create element", { error });
 		return { error: "Failed to create element" };
 	}
 }
@@ -981,7 +984,7 @@ export async function getElement(
 
 		return { data: transformToResponse(element) };
 	} catch (error) {
-		console.error("Failed to get element:", error);
+		log.error("Failed to get element", { error });
 		return { error: "Failed to get element" };
 	}
 }
@@ -1268,7 +1271,7 @@ export async function updateElement(
 
 		return { data: transformToResponse(element) };
 	} catch (error) {
-		console.error("Failed to update element:", error);
+		log.error("Failed to update element", { error });
 		return { error: "Failed to update element" };
 	}
 }
@@ -1342,7 +1345,7 @@ export async function deleteElement(
 
 		return { data: true };
 	} catch (error) {
-		console.error("Failed to delete element:", error);
+		log.error("Failed to delete element", { error });
 		return { error: "Failed to delete element" };
 	}
 }
@@ -1396,7 +1399,7 @@ export async function detachElement(
 
 		return { data: true };
 	} catch (error) {
-		console.error("Failed to detach element:", error);
+		log.error("Failed to detach element", { error });
 		return { error: "Failed to detach element" };
 	}
 }
@@ -1495,7 +1498,7 @@ export async function attachElement(
 
 		return { data: true };
 	} catch (error) {
-		console.error("Failed to attach element:", error);
+		log.error("Failed to attach element", { error });
 		return { error: "Failed to attach element" };
 	}
 }
@@ -1615,7 +1618,7 @@ export async function moveElement(
 
 		return { data: true };
 	} catch (error) {
-		console.error("[moveElement]", { elementId, newParentId, userId, error });
+		log.error("moveElement", { elementId, newParentId, userId, error });
 		return { error: "Failed to move element" };
 	}
 }
@@ -1650,7 +1653,7 @@ export async function getSandboxElements(
 
 		return { data: elements.map(transformToResponse) };
 	} catch (error) {
-		console.error("Failed to get sandbox elements:", error);
+		log.error("Failed to get sandbox elements", { error });
 		return { error: "Failed to get sandbox elements" };
 	}
 }
@@ -1706,7 +1709,7 @@ export async function restoreElement(
 
 		return { data: true };
 	} catch (error) {
-		console.error("Failed to restore element:", error);
+		log.error("Failed to restore element", { error });
 		return { error: "Failed to restore element" };
 	}
 }

--- a/lib/services/email-service.ts
+++ b/lib/services/email-service.ts
@@ -1,5 +1,8 @@
 import { EmailClient } from "@azure/communication-email";
+import { logger } from "@/lib/logger";
 import { escapeHtml } from "../sanitize-html";
+
+const log = logger.child({ component: "email-service" });
 
 // Configuration
 const ACS_CONNECTION_STRING = process.env.ACS_CONNECTION_STRING;
@@ -56,7 +59,7 @@ interface RetentionWarningEmailParams {
  */
 function getEmailClient(): EmailClient | null {
 	if (!ACS_CONNECTION_STRING) {
-		console.warn(
+		log.warn(
 			"ACS_CONNECTION_STRING not configured - emails will be logged only"
 		);
 		return null;
@@ -79,11 +82,11 @@ async function sendEmail(
 
 	if (!client) {
 		// Development fallback - log the email
-		console.log("=== EMAIL (Development Mode) ===");
-		console.log(`To: ${to}`);
-		console.log(`Subject: ${subject}`);
-		console.log(`Content: ${plainTextContent}`);
-		console.log("================================");
+		log.info("Email (development mode)", {
+			to,
+			subject,
+			content: plainTextContent,
+		});
 		return { data: { messageId: `dev-${Date.now()}` } };
 	}
 
@@ -111,7 +114,7 @@ async function sendEmail(
 			error: result.error?.message || "Email sending failed",
 		};
 	} catch (error) {
-		console.error("Email sending error:", error);
+		log.error("Email sending error", { error });
 		return {
 			error: error instanceof Error ? error.message : "Unknown email error",
 		};

--- a/lib/services/health-evidence-service.ts
+++ b/lib/services/health-evidence-service.ts
@@ -1,10 +1,13 @@
 import { createHash } from "node:crypto";
+import { logger } from "@/lib/logger";
 import { canAccessCase } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import { EVIDENCE_FORMAT_VERSION } from "@/lib/schemas/health-evidence";
 import { assertPluginEnabledForUser } from "@/lib/services/plugin-enablement-service";
 import type { PluginHealthEvidence } from "@/src/generated/prisma";
 import type { ServiceResult } from "@/types/service";
+
+const log = logger.child({ component: "health-evidence-service" });
 
 /**
  * The health plugin's append-only evidence log (ADR 0001 §2, relocated by
@@ -273,7 +276,7 @@ export async function appendHealthEvidence(
 
 		return { data: { evidence: record, caseId } };
 	} catch (error) {
-		console.error("Failed to append health evidence:", error);
+		log.error("Failed to append health evidence", { error });
 		return { error: "Failed to append health evidence" };
 	}
 }
@@ -295,7 +298,7 @@ export async function listHealthEvidence(
 		});
 		return { data: records };
 	} catch (error) {
-		console.error("Failed to list health evidence:", error);
+		log.error("Failed to list health evidence", { error });
 		return { error: "Failed to list health evidence" };
 	}
 }

--- a/lib/services/health-scoring-service.ts
+++ b/lib/services/health-scoring-service.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
 import {
 	type PluginDataLocation,
@@ -15,6 +16,8 @@ import type {
 	Prisma,
 } from "@/src/generated/prisma";
 import type { ServiceResult } from "@/types/service";
+
+const log = logger.child({ component: "health-scoring-service" });
 
 /**
  * The health plugin's scoring rule (ADR 0002 v2 §3, ADR 0001 §4): v1 is
@@ -186,7 +189,7 @@ export async function recomputeHealthScore(
 			select: { verdict: true, evaluatedAt: true },
 		});
 	} catch (error) {
-		console.error("Failed to read evidence for scoring:", error);
+		log.error("Failed to read evidence for scoring", { error });
 		return { error: "Failed to compute health score" };
 	}
 
@@ -320,7 +323,7 @@ export async function readHealthState(
 			select: { caseId: true, deletedAt: true, elementType: true },
 		});
 	} catch (error) {
-		console.error("Failed to resolve claim for health state read:", error);
+		log.error("Failed to resolve claim for health state read", { error });
 		return { error: "Failed to read health state" };
 	}
 	if (

--- a/lib/services/health-staleness-sweep-service.ts
+++ b/lib/services/health-staleness-sweep-service.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
 import { requireCronSecret } from "@/lib/services/cron-auth";
 import {
@@ -9,6 +10,8 @@ import { upsertCaseLevelPluginData } from "@/lib/services/plugin-data-service";
 import { emitSSEEvent } from "@/lib/services/sse-connection-manager";
 import type { Prisma } from "@/src/generated/prisma";
 import type { ServiceResult } from "@/types/service";
+
+const log = logger.child({ component: "health-staleness-sweep-service" });
 
 /**
  * The health plugin's staleness sweeper (ADR 0002 v2 §3: "the existing
@@ -212,7 +215,7 @@ export async function sweepHealthStaleness(
 				// must not abort the sweep for every other case still queued —
 				// each case gets its own shot, in whatever order the Map iterates.
 				failedCaseCount++;
-				console.error(`Failed to sweep case ${caseId} staleness:`, error);
+				log.error("Failed to sweep case staleness", { caseId, error });
 			}
 		}
 
@@ -224,7 +227,7 @@ export async function sweepHealthStaleness(
 
 		return { data: { casesNotified, staleClaimsNotified } };
 	} catch (error) {
-		console.error("Failed to sweep health staleness:", error);
+		log.error("Failed to sweep health staleness", { error });
 		return { error: "Failed to sweep health staleness" };
 	}
 }

--- a/lib/services/plugin-data-service.ts
+++ b/lib/services/plugin-data-service.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger";
 import { canAccessCase } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import { assertPluginEnabledForUser } from "@/lib/services/plugin-enablement-service";
@@ -7,6 +8,8 @@ import {
 	Prisma,
 } from "@/src/generated/prisma";
 import type { ServiceResult } from "@/types/service";
+
+const log = logger.child({ component: "plugin-data-service" });
 
 /**
  * Namespaced read/write access over the tier-1 `PluginData` model (ADR 0002
@@ -241,7 +244,7 @@ export async function readPluginData(
 		});
 		return { data: record };
 	} catch (error) {
-		console.error("Failed to read plugin data:", error);
+		log.error("Failed to read plugin data", { error });
 		return { error: "Failed to read plugin data" };
 	}
 }
@@ -264,7 +267,7 @@ export async function listPluginDataForCase(
 		});
 		return { data: records };
 	} catch (error) {
-		console.error("Failed to list plugin data:", error);
+		log.error("Failed to list plugin data", { error });
 		return { error: "Failed to list plugin data" };
 	}
 }
@@ -297,7 +300,7 @@ export async function writePluginData(
 			: await upsertCaseLevelPluginData(pluginId, location.caseId, data);
 		return { data: record };
 	} catch (error) {
-		console.error("Failed to write plugin data:", error);
+		log.error("Failed to write plugin data", { error });
 		return { error: "Failed to write plugin data" };
 	}
 }
@@ -333,7 +336,7 @@ export async function deletePluginData(
 		});
 		return { data: true };
 	} catch (error) {
-		console.error("Failed to delete plugin data:", error);
+		log.error("Failed to delete plugin data", { error });
 		return { error: "Failed to delete plugin data" };
 	}
 }

--- a/lib/services/plugin-enablement-service.ts
+++ b/lib/services/plugin-enablement-service.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger";
 import {
 	getManifestEntry,
 	isPluginAvailableForDeployment,
@@ -10,6 +11,8 @@ import type {
 	Prisma,
 } from "@/src/generated/prisma";
 import type { ServiceResult } from "@/types/service";
+
+const log = logger.child({ component: "plugin-enablement-service" });
 
 /**
  * Resolves effective plugin enablement per ADR 0002 v2 §2.2: a plugin is ON
@@ -120,7 +123,7 @@ export async function resolveEffectivePluginState(
 			data: { enabled: true, availableAtDeployment: true, disabledAt: null },
 		};
 	} catch (error) {
-		console.error("Failed to resolve plugin state:", error);
+		log.error("Failed to resolve plugin state", { error });
 		return { error: "Failed to resolve plugin state" };
 	}
 }
@@ -205,7 +208,7 @@ export async function getUserPluginSettings(
 		});
 		return { data: row?.settings ?? null };
 	} catch (error) {
-		console.error("Failed to read plugin settings:", error);
+		log.error("Failed to read plugin settings", { error });
 		return { error: "Failed to read plugin settings" };
 	}
 }
@@ -254,7 +257,7 @@ export async function setPluginEnabledForUser(
 		});
 		return { data: state };
 	} catch (error) {
-		console.error("Failed to set plugin enablement:", error);
+		log.error("Failed to set plugin enablement", { error });
 		return { error: "Failed to update plugin state" };
 	}
 }

--- a/lib/services/publish-service.ts
+++ b/lib/services/publish-service.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger";
 import { canAccessCase } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import { exportCase } from "@/lib/services/case-export-service";
@@ -14,6 +15,8 @@ import type {
 } from "@/lib/services/publish-service.types";
 import { generateUniqueSlug } from "@/lib/services/slug-service";
 import type { Prisma } from "@/src/generated/prisma";
+
+const log = logger.child({ component: "publish-service" });
 
 // Derived from `prisma.$transaction`'s own callback parameter — same pattern
 // as `slug-service.ts` (kept local rather than imported: `Prisma.
@@ -258,7 +261,7 @@ export async function publishAssuranceCase(
 			data: { publishedId: publishedCase.id, publishedAt: now },
 		};
 	} catch (error) {
-		console.error("Failed to publish case:", error);
+		log.error("Failed to publish case", { error });
 		return { error: "Failed to publish case" };
 	}
 }
@@ -331,7 +334,7 @@ export async function unpublishAssuranceCase(
 
 		return { data: { success: true as const } };
 	} catch (error) {
-		console.error("Failed to unpublish case:", error);
+		log.error("Failed to unpublish case", { error });
 		return { error: "Failed to unpublish case" };
 	}
 }
@@ -421,10 +424,9 @@ export async function getFullPublishStatus(
 		latestPublished = publishedVersions[0] ?? null;
 	} catch (error) {
 		// Log but don't fail - legacy table may have issues
-		console.warn(
-			"Failed to fetch published versions (legacy table issue):",
-			error
-		);
+		log.warn("Failed to fetch published versions (legacy table issue)", {
+			error,
+		});
 	}
 
 	// Detect changes using content-based comparison
@@ -435,7 +437,7 @@ export async function getFullPublishStatus(
 			hasChanges =
 				"data" in changeResult ? changeResult.data.hasChanges : false;
 		} catch (error) {
-			console.warn("Failed to detect changes:", error);
+			log.warn("Failed to detect changes", { error });
 		}
 	}
 
@@ -542,7 +544,7 @@ export async function updatePublishedCase(
 			data: { publishedId: newPublished.id, publishedAt: now },
 		};
 	} catch (error) {
-		console.error("Failed to update published case:", error);
+		log.error("Failed to update published case", { error });
 		return { error: "Failed to update published case" };
 	}
 }

--- a/lib/services/sse-connection-manager.ts
+++ b/lib/services/sse-connection-manager.ts
@@ -5,6 +5,10 @@
  * Tracks active connections per case and broadcasts events to subscribers.
  */
 
+import { logger } from "@/lib/logger";
+
+const log = logger.child({ component: "sse-connection-manager" });
+
 export type SSEEventType =
 	| "case:updated"
 	| "comment:created"
@@ -71,10 +75,11 @@ class SSEConnectionManager {
 			});
 		}
 
-		console.log(
-			`[SSE] Connection added: ${connectionId} for case ${caseId}. ` +
-				`Total connections for case: ${caseConnections?.size ?? 0}`
-		);
+		log.info("SSE connection added", {
+			connectionId,
+			caseId,
+			totalConnectionsForCase: caseConnections?.size ?? 0,
+		});
 	}
 
 	/**
@@ -84,10 +89,11 @@ class SSEConnectionManager {
 		const caseConnections = this.connections.get(caseId);
 		if (caseConnections) {
 			caseConnections.delete(connectionId);
-			console.log(
-				`[SSE] Connection removed: ${connectionId} from case ${caseId}. ` +
-					`Remaining connections: ${caseConnections.size}`
-			);
+			log.info("SSE connection removed", {
+				connectionId,
+				caseId,
+				remainingConnections: caseConnections.size,
+			});
 
 			// Clean up empty case entries
 			if (caseConnections.size === 0) {
@@ -122,10 +128,11 @@ class SSEConnectionManager {
 			this.removeConnection(event.caseId, connectionId);
 		}
 
-		console.log(
-			`[SSE] Broadcast event ${event.type} to case ${event.caseId}. ` +
-				`Recipients: ${caseConnections.size - deadConnections.length}`
-		);
+		log.info("SSE broadcast event", {
+			eventType: event.type,
+			caseId: event.caseId,
+			recipients: caseConnections.size - deadConnections.length,
+		});
 	}
 
 	/**

--- a/lib/services/team-member-service.ts
+++ b/lib/services/team-member-service.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger";
 import {
 	isLastTeamAdmin,
 	validateTeamAdmin,
@@ -6,6 +7,8 @@ import {
 import { prisma } from "@/lib/prisma";
 import type { TeamRole } from "@/src/generated/prisma";
 import type { ServiceResult } from "@/types/service";
+
+const log = logger.child({ component: "team-member-service" });
 
 // ============================================
 // INPUT INTERFACES
@@ -111,7 +114,7 @@ export async function getTeamMembers(
 
 		return { data: members.map(transformMemberToResponse) };
 	} catch (error) {
-		console.error("Failed to get team members:", error);
+		log.error("Failed to get team members", { error });
 		return { error: "Failed to get team members" };
 	}
 }
@@ -190,7 +193,7 @@ export async function addTeamMember(
 
 		return { data: { member: transformMemberToResponse(member) } };
 	} catch (error) {
-		console.error("Failed to add team member:", error);
+		log.error("Failed to add team member", { error });
 		return { error: "Failed to add team member" };
 	}
 }
@@ -253,7 +256,7 @@ export async function updateMemberRole(
 
 		return { data: transformMemberToResponse(member) };
 	} catch (error) {
-		console.error("Failed to update member role:", error);
+		log.error("Failed to update member role", { error });
 		return { error: "Failed to update member role" };
 	}
 }
@@ -299,7 +302,7 @@ export async function removeMember(
 
 		return { data: true };
 	} catch (error) {
-		console.error("Failed to remove member:", error);
+		log.error("Failed to remove member", { error });
 		return { error: "Failed to remove member" };
 	}
 }
@@ -339,7 +342,7 @@ export async function leaveTeam(userId: string, teamId: string): ServiceResult {
 
 		return { data: true };
 	} catch (error) {
-		console.error("Failed to leave team:", error);
+		log.error("Failed to leave team", { error });
 		return { error: "Failed to leave team" };
 	}
 }

--- a/lib/services/team-service.ts
+++ b/lib/services/team-service.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger";
 import { validateTeamAdmin } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import type {
@@ -6,6 +7,8 @@ import type {
 } from "@/lib/schemas/team";
 import type { TeamRole } from "@/src/generated/prisma";
 import type { ServiceResult } from "@/types/service";
+
+const log = logger.child({ component: "team-service" });
 
 // ============================================
 // INPUT INTERFACES — derived from Zod schemas
@@ -179,7 +182,7 @@ export async function createTeam(
 
 		return { data: transformToResponse(team, "ADMIN") };
 	} catch (error) {
-		console.error("Failed to create team:", error);
+		log.error("Failed to create team", { error });
 		return { error: "Failed to create team" };
 	}
 }
@@ -225,7 +228,7 @@ export async function getTeam(
 
 		return { data: transformToResponse(team, userMembership.role) };
 	} catch (error) {
-		console.error("Failed to get team:", error);
+		log.error("Failed to get team", { error });
 		return { error: "Failed to get team" };
 	}
 }
@@ -261,7 +264,7 @@ export async function listUserTeams(
 
 		return { data: teams };
 	} catch (error) {
-		console.error("Failed to list teams:", error);
+		log.error("Failed to list teams", { error });
 		return { error: "Failed to list teams" };
 	}
 }
@@ -321,7 +324,7 @@ export async function updateTeam(
 
 		return { data: transformToResponse(team, userMembership?.role) };
 	} catch (error) {
-		console.error("Failed to update team:", error);
+		log.error("Failed to update team", { error });
 		return { error: "Failed to update team" };
 	}
 }
@@ -347,7 +350,7 @@ export async function deleteTeam(
 
 		return { data: true };
 	} catch (error) {
-		console.error("Failed to delete team:", error);
+		log.error("Failed to delete team", { error });
 		return { error: "Failed to delete team" };
 	}
 }
@@ -391,7 +394,7 @@ export async function getTeamBySlug(
 
 		return { data: transformToResponse(team, userMembership.role) };
 	} catch (error) {
-		console.error("Failed to get team:", error);
+		log.error("Failed to get team", { error });
 		return { error: "Failed to get team" };
 	}
 }

--- a/lib/services/tour-service.ts
+++ b/lib/services/tour-service.ts
@@ -5,6 +5,10 @@
  * that guide users through core features of the TEA Platform.
  */
 
+import { logger } from "@/lib/logger";
+
+const log = logger.child({ component: "tour-service" });
+
 const KNOWN_TOUR_IDS = ["dashboard", "case-canvas", "demo-case"] as const;
 
 type KnownTourId = (typeof KNOWN_TOUR_IDS)[number];
@@ -35,7 +39,7 @@ export async function getCompletedTours(
 
 		return { data: user?.completedTours ?? [] };
 	} catch (error) {
-		console.error("[getCompletedTours]", { userId, error });
+		log.error("getCompletedTours", { userId, error });
 		return { error: "Failed to fetch completed tours" };
 	}
 }
@@ -84,7 +88,7 @@ export async function markTourCompleted(
 
 		return { data: updated.completedTours };
 	} catch (error) {
-		console.error("[markTourCompleted]", { userId, tourId, error });
+		log.error("markTourCompleted", { userId, tourId, error });
 		return { error: "Failed to mark tour as completed" };
 	}
 }

--- a/lib/services/user-management-service.ts
+++ b/lib/services/user-management-service.ts
@@ -3,6 +3,7 @@ import {
 	type PasswordAlgorithm,
 	verifyPassword,
 } from "@/lib/auth/password-service";
+import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
 import { countIntegrationsOwnedBy } from "@/lib/services/integration-registry-service";
 import {
@@ -11,6 +12,8 @@ import {
 	validateUsername,
 } from "@/lib/validation/validators";
 import type { ServiceResult } from "@/types/service";
+
+const log = logger.child({ component: "user-management-service" });
 
 // ============================================
 // Types
@@ -186,7 +189,7 @@ export async function updateUserProfile(
 			data: toProfileData(user),
 		};
 	} catch (error) {
-		console.error("Error updating user profile:", error);
+		log.error("Error updating user profile", { error });
 		return { error: "Failed to update profile" };
 	}
 }
@@ -261,7 +264,7 @@ export async function changePassword(
 
 		return { data: true };
 	} catch (error) {
-		console.error("Error changing password:", error);
+		log.error("Error changing password", { error });
 		return { error: "Failed to change password" };
 	}
 }
@@ -427,7 +430,7 @@ export async function deleteAccount(
 
 		return { data: true };
 	} catch (error) {
-		console.error("Error deleting account:", error);
+		log.error("Error deleting account", { error });
 		return { error: "Failed to delete account" };
 	}
 }
@@ -668,7 +671,7 @@ export async function deleteAccountForRetention(userId: string): ServiceResult {
 
 		return { data: true };
 	} catch (error) {
-		console.error("Error deleting account for retention:", error);
+		log.error("Error deleting account for retention", { error });
 		return { error: "Failed to delete account" };
 	}
 }

--- a/lib/services/user-service.ts
+++ b/lib/services/user-service.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
 import type { ConnectedAccountsData } from "@/lib/services/connected-accounts-service";
 import {
@@ -6,6 +7,8 @@ import {
 	validateUsername,
 } from "@/lib/validation/validators";
 import type { ServiceResult } from "@/types/service";
+
+const log = logger.child({ component: "user-service" });
 
 // ============================================
 // INPUT INTERFACES
@@ -114,7 +117,7 @@ export async function registerUser(
 			},
 		};
 	} catch (error) {
-		console.error("Failed to register user:", error);
+		log.error("Failed to register user", { error });
 		return { error: "Failed to create account. Please try again." };
 	}
 }
@@ -148,7 +151,7 @@ export async function dismissMigrationNotice(
 
 		return { data: null };
 	} catch (error) {
-		console.error("[dismissMigrationNotice]", { userId, error });
+		log.error("dismissMigrationNotice", { userId, error });
 		return { error: "Failed to dismiss migration notice" };
 	}
 }
@@ -183,7 +186,7 @@ export async function getUserById(
 			},
 		};
 	} catch (error) {
-		console.error("Failed to get user:", error);
+		log.error("Failed to get user", { error });
 		return { error: "Failed to get user" };
 	}
 }
@@ -251,7 +254,7 @@ export async function getUserProfile(
 			},
 		};
 	} catch (error) {
-		console.error("[getUserProfile]", { userId, error });
+		log.error("getUserProfile", { userId, error });
 		return { error: "Failed to fetch user profile" };
 	}
 }
@@ -325,7 +328,7 @@ export async function getCurrentUser(
 			},
 		};
 	} catch (error) {
-		console.error("[getCurrentUser]", { userId, error });
+		log.error("getCurrentUser", { userId, error });
 		return { error: "Failed to fetch user" };
 	}
 }

--- a/src/__tests__/integration/auth-config.test.ts
+++ b/src/__tests__/integration/auth-config.test.ts
@@ -4,8 +4,8 @@ import {
 	authenticateWithPrisma,
 } from "@/lib/auth/config";
 import { hashPassword } from "@/lib/auth/password-service";
-import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
+import { captureLogs } from "../helpers/capture-logs";
 import { createTestUser } from "../utils/prisma-factories";
 
 const TEST_PASSWORD = "correct horse battery staple";
@@ -61,7 +61,7 @@ describe("authenticateWithPrisma — login clears retention warnings", () => {
 			passwordAlgorithm: "argon2id",
 		});
 
-		const errorSpy = vi.spyOn(logger, "error");
+		const logs = captureLogs();
 		const passwordService = await import("@/lib/auth/password-service");
 		const originalVerify = passwordService.verifyPassword;
 		const verifySpy = vi
@@ -74,20 +74,28 @@ describe("authenticateWithPrisma — login clears retention warnings", () => {
 				return verifyResult;
 			});
 
-		const result = await authenticateWithPrisma(user.username, TEST_PASSWORD);
+		try {
+			const result = await authenticateWithPrisma(user.username, TEST_PASSWORD);
 
-		expect(result).not.toBeNull();
-		expect(result?.id).toBe(user.id);
-		expect(errorSpy).toHaveBeenCalledWith(
-			"Failed to record login / reset retention warnings",
-			expect.objectContaining({ userId: user.id })
-		);
+			expect(result).not.toBeNull();
+			expect(result?.id).toBe(user.id);
 
-		const gone = await prisma.user.findUnique({ where: { id: user.id } });
-		expect(gone).toBeNull();
+			const failureEntry = logs.entries.find(
+				(entry) =>
+					entry.msg === "Failed to record login / reset retention warnings"
+			);
+			expect(failureEntry).toMatchObject({
+				level: "error",
+				component: "auth-config",
+				userId: user.id,
+			});
 
-		verifySpy.mockRestore();
-		errorSpy.mockRestore();
+			const gone = await prisma.user.findUnique({ where: { id: user.id } });
+			expect(gone).toBeNull();
+		} finally {
+			verifySpy.mockRestore();
+			logs.restore();
+		}
 	});
 });
 


### PR DESCRIPTION
## Summary

Part 1 of 3 of the console-to-structured-logger sweep for 1.0. Replaces the 92 remaining raw `console.*` calls under `lib/` (27 files, almost all in `lib/services/`) with the structured logger from #929: one `logger.child({ component })` per file, one JSON line per event.

- 1:1 level mapping (`console.error` → `error`, `console.warn` → `warn`, `console.log` → `info`)
- caught errors passed as a field (`{ error }`), serialised to `{name, message, stack}` by the logger; never interpolated into the message. Prisma errors therefore reach the log without `meta`/`query`
- message wording kept apart from trailing colons and bracketed prefixes; identifiers previously interpolated into template literals (`caseId`, `connectionId`, purge `count`, …) are now named fields
- the dev-mode email preview (five `console.log` lines) is one `info` entry with `to`/`subject`/`content` fields, behind the same `if (!client)` guard as before
- `lib/errors.ts` and `lib/auth/config.ts`, which already imported the logger, now use a child logger for all their sites
- no behaviour changes; return values, thrown errors, result shapes untouched
- `lib/logger.ts` untouched; nothing outside `lib/` (parts 2 and 3)

Tests: `lib/__tests__/errors.test.ts` drops four `console.error` spies that asserted nothing (the logger is silent under `NODE_ENV=test`); `src/__tests__/integration/auth-config.test.ts` captures the log entry through the logger's sink seam instead of spying on the shared `logger` object, which cannot see a child logger's calls. The new assertion also pins `level` and `component`.

## Verification

- `grep -rE 'console\.(log|warn|error|info|debug)\('` over `lib/` (tests excluded): 0
- `pnpm lint`: 813 files, clean · `pnpm typecheck`: clean
- `pnpm test:unit`: 1502/1502 (117 files) · `pnpm test:integration`: 1173/1173 (77 files) · `pnpm test:coverage:check`: floors met
- fallow 3.20.0 audit under CI's invocation: `warn`, exit 0; 0 new complexity, 0 dead code. It reports one "introduced" duplicate: the pre-existing `getTeam`/`getTeamBySlug` clone in `team-service.ts`, whose baseline entry no longer matches after three lines were added at the top of the file. Not new duplication; the dupes baseline will be re-saved on its own commit with part 3.
- QA and code review passed on the final head.

## Follow-ups (not in this PR)

- The dev-mode email fallback logs the full plain-text body (which for a password reset includes the token) whenever no email provider is configured. Pre-existing; tracked separately as a fix to gate on environment and redact the body.
- `email-service.ts` uses a relative import for `sanitize-html`; two identical "Failed to get team" messages in `team-service.ts` (both pre-existing).
