### PR TITLE
chore(logging): finish the console.* sweep and enforce noConsole

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,6 @@ and do not "fix" it incidentally — it is tracked work.
   viewer is lazy-loaded via dynamic `import()`) — static analysers miss both;
   check MDX and dynamic imports before declaring anything in
   `components/docs/curriculum/` dead.
-- Scattered `console.*` calls — being replaced by the structured logger.
 
 ## Open decisions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,10 @@ deploy`; nothing else may touch the schema. Therefore:
 ## Observability
 
 - No raw `console.*` in app code. Use the structured logger (logs to stdout so
-  containerised/self-hosted deployments work unchanged).
+  containerised/self-hosted deployments work unchanged). Biome's
+  `suspicious/noConsole` rule enforces this as a lint error; `lib/logger.ts`,
+  test files, `scripts/`, `prisma/seed/`, and `e2e/` are exempt because
+  console output is their actual interface, not a logging gap.
 - Telemetry is OpenTelemetry-based; Azure App Insights is an optional exporter
   activated by env var only. Never wire a vendor SDK outside that seam —
   forkability is a requirement.

--- a/app/api/cases/[id]/events/route.ts
+++ b/app/api/cases/[id]/events/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import { requireAuthSession } from "@/lib/api-response";
+import { logger } from "@/lib/logger";
 import { sseConnectionManager } from "@/lib/services/sse-connection-manager";
+
+const log = logger.child({ component: "sse-route" });
 
 /**
  * Validates case access for the user.
@@ -90,7 +93,7 @@ export async function GET(
 		cancel() {
 			// This is called when the client disconnects
 			sseConnectionManager.removeConnection(caseId, connectionId);
-			console.log(`[SSE] Client disconnected: ${connectionId}`);
+			log.info("Client disconnected", { connectionId });
 		},
 	});
 

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import { logger } from "@/lib/logger";
+
+const log = logger.child({ component: "global-error" });
+
 export default function GlobalError({
 	error,
 	reset,
@@ -7,7 +11,7 @@ export default function GlobalError({
 	error: Error & { digest?: string };
 	reset: () => void;
 }) {
-	console.error("Global error:", error);
+	log.error("Global error", { error });
 
 	return (
 		<html lang="en">

--- a/app/uploads/[...path]/route.ts
+++ b/app/uploads/[...path]/route.ts
@@ -4,7 +4,10 @@ import { extname, resolve, sep } from "node:path";
 import { Readable } from "node:stream";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
 import { getMimeTypeFromExtension } from "@/lib/services/blob-storage-service";
+
+const log = logger.child({ component: "uploads" });
 
 /**
  * Serves locally-stored uploads (self-hosted / `USE_LOCAL_STORAGE=true`
@@ -137,11 +140,7 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
 	// stream so the connection aborts/truncates instead of hanging or
 	// crashing the process.
 	nodeStream.on("error", (err) => {
-		// No structured logger exists in this codebase yet (CLAUDE.md names
-		// one; other server code paths without one use console.error too) —
-		// this is the same prevailing pattern, not a deviation introduced
-		// here.
-		console.error("[uploads] stream error after response started:", err);
+		log.error("Stream error after response started", { error: err });
 		nodeStream.destroy();
 	});
 

--- a/biome.json
+++ b/biome.json
@@ -60,6 +60,7 @@
         "noBarrelFile": "off"
       },
       "suspicious": {
+        "noConsole": "error",
         "noUnknownAtRules": "off"
       }
     }
@@ -89,10 +90,31 @@
       "linter": {
         "rules": {
           "suspicious": {
+            "noConsole": "off",
             "noExplicitAny": "off"
           },
           "style": {
             "noNonNullAssertion": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["lib/logger.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["scripts/**", "prisma/seed/**", "e2e/**"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
           }
         }
       }

--- a/components/docs/curriculum/case-viewer-wrapper.tsx
+++ b/components/docs/curriculum/case-viewer-wrapper.tsx
@@ -2,7 +2,10 @@
 import { lazy, Suspense, useEffect, useState } from "react";
 import type { Node } from "reactflow";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { logger } from "@/lib/logger";
 import type { CaseExportNested, ReactFlowNodeData } from "@/types/curriculum";
+
+const log = logger.child({ component: "case-viewer-wrapper" });
 
 // Lazy load EnhancedInteractiveCaseViewer to avoid 730+ module import at startup
 const EnhancedInteractiveCaseViewer = lazy(
@@ -85,7 +88,7 @@ const CaseViewerWrapper = ({
 			} catch (err) {
 				const errorMessage =
 					err instanceof Error ? err.message : "Unknown error occurred";
-				console.error(`Error loading case file '${caseFile}':`, err);
+				log.error("Error loading case file", { caseFile, error: err });
 				setState({ data: null, error: errorMessage, loading: false });
 			}
 		};

--- a/components/docs/curriculum/enhanced-interactive-case-viewer.tsx
+++ b/components/docs/curriculum/enhanced-interactive-case-viewer.tsx
@@ -55,8 +55,11 @@ import {
 	transformCaseToReactFlow,
 } from "@/lib/docs/case-data-transformer";
 import { getLayoutedElements } from "@/lib/docs/elk-layout";
+import { logger } from "@/lib/logger";
 import type { CaseExportNested, ReactFlowNodeData } from "@/types/curriculum";
 import "reactflow/dist/style.css";
+
+const log = logger.child({ component: "enhanced-interactive-case-viewer" });
 
 import { AnimationProvider } from "./enhanced/animations";
 import CreateNodePopover from "./enhanced/dialogs/create-node-popover";
@@ -516,9 +519,10 @@ const EnhancedInteractiveCaseViewerInner = ({
 					)
 				);
 			} else {
-				console.warn(
-					`Invalid connection: ${sourceNode.type} cannot connect to ${targetNode.type}`
-				);
+				log.warn("Invalid connection", {
+					sourceType: sourceNode.type,
+					targetType: targetNode.type,
+				});
 			}
 		},
 		[nodes, setEdges, enableEnhancedEdges]
@@ -667,7 +671,7 @@ const EnhancedInteractiveCaseViewerInner = ({
 
 	useEffect(() => {
 		if (!caseData) {
-			console.warn("No caseData provided to EnhancedInteractiveCaseViewer");
+			log.warn("No caseData provided to EnhancedInteractiveCaseViewer");
 			return;
 		}
 

--- a/components/docs/curriculum/enhanced-interactive-case-viewer.tsx
+++ b/components/docs/curriculum/enhanced-interactive-case-viewer.tsx
@@ -59,8 +59,6 @@ import { logger } from "@/lib/logger";
 import type { CaseExportNested, ReactFlowNodeData } from "@/types/curriculum";
 import "reactflow/dist/style.css";
 
-const log = logger.child({ component: "enhanced-interactive-case-viewer" });
-
 import { AnimationProvider } from "./enhanced/animations";
 import CreateNodePopover from "./enhanced/dialogs/create-node-popover";
 import { edgeTypes } from "./enhanced/edges";
@@ -68,6 +66,8 @@ import { NodeStateManager, nodeTypes } from "./enhanced/nodes";
 import { isValidConnection } from "./enhanced/nodes/node-types";
 import type { NodeDataUpdate } from "./enhanced/utils/theme-config";
 import { ThemeContext } from "./enhanced/utils/theme-config";
+
+const log = logger.child({ component: "enhanced-interactive-case-viewer" });
 
 // ========================================================================
 // Helper Functions for Node Operations

--- a/components/docs/curriculum/enhanced/edges/index.ts
+++ b/components/docs/curriculum/enhanced/edges/index.ts
@@ -7,6 +7,9 @@
  */
 
 import type { Edge } from "reactflow";
+import { logger } from "@/lib/logger";
+
+const log = logger.child({ component: "edge-presets" });
 
 // AnimatedEdge and variants
 export {
@@ -301,7 +304,7 @@ export const edgeStylePresets: Record<string, EdgeStylePreset> = {
 export function applyEdgePreset(edge: Edge, presetName: string): Edge {
 	const preset = edgeStylePresets[presetName];
 	if (!preset) {
-		console.warn(`Edge preset "${presetName}" not found`);
+		log.warn("Edge preset not found", { presetName });
 		return edge;
 	}
 

--- a/components/docs/curriculum/enhanced/nodes/use-node-state.ts
+++ b/components/docs/curriculum/enhanced/nodes/use-node-state.ts
@@ -29,6 +29,9 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Edge, Node } from "reactflow";
+import { logger } from "@/lib/logger";
+
+const log = logger.child({ component: "use-node-state" });
 
 /**
  * Configuration options for the node state hook
@@ -112,7 +115,7 @@ const loadFromStorage = (key: string | null): NodeStatesMap => {
 		const saved = localStorage.getItem(key);
 		return saved ? JSON.parse(saved) : {};
 	} catch (error) {
-		console.error("Failed to load node state from localStorage:", error);
+		log.error("Failed to load node state from localStorage", { error });
 		return {};
 	}
 };
@@ -130,7 +133,7 @@ const saveToStorage = (key: string | null, state: NodeStatesMap): void => {
 	try {
 		localStorage.setItem(key, JSON.stringify(state));
 	} catch (error) {
-		console.error("Failed to save node state to localStorage:", error);
+		log.error("Failed to save node state to localStorage", { error });
 	}
 };
 

--- a/components/docs/curriculum/progress-storage.ts
+++ b/components/docs/curriculum/progress-storage.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { logger } from "@/lib/logger";
 import type { ProgressData, Task } from "@/types/curriculum";
 
 /**
@@ -7,6 +8,8 @@ import type { ProgressData, Task } from "@/types/curriculum";
  *
  * Handles saving and loading progress for modules across pages and sessions
  */
+
+const log = logger.child({ component: "progress-storage" });
 
 const STORAGE_PREFIX = "tea-module-progress";
 
@@ -49,13 +52,13 @@ export const loadProgress = (
 
 		// Validate data structure
 		if (!(data.tasks && data.moduleId && data.courseId)) {
-			console.warn("Invalid progress data structure, resetting");
+			log.warn("Invalid progress data structure, resetting");
 			return null;
 		}
 
 		return data;
 	} catch (error) {
-		console.error("Error loading progress:", error);
+		log.error("Error loading progress", { error });
 		return null;
 	}
 };
@@ -90,7 +93,7 @@ export const saveProgress = (
 		localStorage.setItem(key, JSON.stringify(data));
 		return true;
 	} catch (error) {
-		console.error("Error saving progress:", error);
+		log.error("Error saving progress", { error });
 		return false;
 	}
 };
@@ -108,7 +111,7 @@ export const clearProgress = (courseId: string, moduleId: string): boolean => {
 		localStorage.removeItem(key);
 		return true;
 	} catch (error) {
-		console.error("Error clearing progress:", error);
+		log.error("Error clearing progress", { error });
 		return false;
 	}
 };
@@ -137,7 +140,7 @@ export const getAllProgress = (): Record<string, StoredProgressData> => {
 
 		return allProgress;
 	} catch (error) {
-		console.error("Error getting all progress:", error);
+		log.error("Error getting all progress", { error });
 		return {};
 	}
 };


### PR DESCRIPTION
Third and final PR of the logging sweep (after #949 and #950). Migrates the last raw `console.*` calls in app code to the structured logger in `lib/logger.ts`, then turns on Biome's `suspicious/noConsole` rule so the sweep cannot regress.

## What changed

- **`app/` — 3 sites** (`global-error.tsx`, `api/cases/[id]/events/route.ts`, `uploads/[...path]/route.ts`): child loggers per file; caught values passed as `{ error }` fields; bracketed prefixes folded into the message; levels mapped 1:1.
- **`components/docs/curriculum/` — 11 sites in 5 files**: same rules. This area is live, MDX-imported code, so it is migrated rather than exempted.
- **`biome.json`**: `suspicious/noConsole: "error"`. Exempt: `lib/logger.ts` (the one legitimate `console` user, its browser fallback), test files, and `scripts/**`, `prisma/seed/**`, `e2e/**` (console output is their interface). Biome's fix for this rule is unsafe-tier only, so `pnpm format` will not delete log lines.
- **`CLAUDE.md`**: the Observability bullet now says the rule is enforced and lists the exemptions; the stale "scattered console.* calls" legacy note is removed.

After this PR: `grep -rE 'console\.(log|warn|error|info|debug)\(' app components lib hooks store` (tests and `lib/logger.ts` excluded) returns nothing, and lint fails on any new one.

## Verification

- `pnpm lint` — 813 files, clean with the rule active; a probe `console.warn` in `app/global-error.tsx` fails lint as expected.
- `pnpm typecheck` — clean.
- Unit 1502/1502 (117 files); integration 1173/1173 (77 files).
- Fallow (`fallow@3.20.0 audit --changed-since origin/staging`): pass, 0 introduced findings across 10 changed files. Touched functions without tests are all low complexity (cyclomatic ≤ 4), so the coverage-weighted gate should not fire.
- Fork check: `next build` + standalone server start with no `ACS_*` / `APPLICATIONINSIGHTS_*` variables set — no errors, no raw console output on stdout.

## Follow-ups (not in this PR)

- `dotenv` prints two promotional "tip" lines to stdout at server start; worth silencing for the clean-stdout promise.
- NextAuth warns when `NEXTAUTH_URL` is unset on a bare fork.
- The dev-mode email preview logging is tracked separately.
